### PR TITLE
Fix proto file indentation

### DIFF
--- a/api/types.proto
+++ b/api/types.proto
@@ -79,12 +79,12 @@ message Spec {
 	}
 	
 	message ServiceJob {
-       int64 instances = 1;
+		int64 instances = 1;
 	}
 
 	message BatchJob {
-       int64 completions = 1;
-       int64 paralellism = 2;
+		int64 completions = 1;
+		int64 paralellism = 2;
 	}
 
 	message GlobalJob {
@@ -97,8 +97,8 @@ message Spec {
 		oneof job {
 			ServiceJob service = 1;
 			BatchJob batch = 2;
-            GlobalJob global = 3;
-            CronJob cron = 4;
+			GlobalJob global = 3;
+			CronJob cron = 4;
 		}
 	}
 	


### PR DESCRIPTION
Cosmetic fix: a few lines used tabs instead of spaces.

Edit: Meant to say "spaces instead of tabs".

@stevvooe 
