### PR TITLE
Add watch package

### DIFF
--- a/watch/pubsub_test.go
+++ b/watch/pubsub_test.go
@@ -10,7 +10,7 @@ func TestPubSub(t *testing.T) {
 
 	// Create 5 subscribers. Each one only subscribes to events that are
 	// multiples of the subscriber number.
-	var chans [5]chan interface{}
+	var chans [5]chan Event
 	chans[0] = pub.subscribe()
 	for i := 1; i < 5; i++ {
 		chans[i] = pub.subscribeTopic(createTopicFunc(i + 1))
@@ -23,7 +23,7 @@ func TestPubSub(t *testing.T) {
 	// Send 1000 events. This should not hang even though nothing is
 	// reading from the subscriber channels yet.
 	for i := 0; i < 1000; i++ {
-		pub.publish(i)
+		pub.publish(Event{Payload: i})
 	}
 
 	// Make sure the subscribers get all the appropriate
@@ -32,8 +32,8 @@ func TestPubSub(t *testing.T) {
 		for j := 0; j < 5; j++ {
 			if i%(j+1) == 0 {
 				event := <-chans[j]
-				if i != event.(int) {
-					t.Fatalf("event mismatch: chan %d received %d, expected %d", j, event.(int), i)
+				if i != event.Payload.(int) {
+					t.Fatalf("event mismatch: chan %d received %d, expected %d", j, event.Payload.(int), i)
 				}
 			}
 		}
@@ -60,12 +60,12 @@ func TestPubSub(t *testing.T) {
 	}
 
 	// Make sure that a send at this point doesn't blow up.
-	pub.publish(1234)
+	pub.publish(Event{Payload: 1234})
 }
 
 func createTopicFunc(i int) topicFunc {
-	return func(x interface{}) bool {
-		xi := x.(int)
+	return func(x Event) bool {
+		xi := x.Payload.(int)
 		return (xi%i == 0)
 	}
 }

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,0 +1,76 @@
+package watch
+
+// Queue is the structure used to publish events and watch for them.
+type Queue struct {
+	pub *publisher
+}
+
+// Event is a struct wrapping objects sent through the queue.
+type Event struct {
+	// Tags lists the filter tags that apply to this object. This is not a
+	// map because items are expected to only have a few tags at most (for
+	// example, the type of RPC request they encapsulate).
+	Tags []string
+	// Payload is the actual object being passed through the queue.
+	Payload interface{}
+}
+
+// Filter allows configuration of the items that will be seen by a watcher.
+type Filter struct {
+	// Tags lists the tag strings that this filter will match. It will
+	// match an item that has any of the strings (OR match).
+	Tags []string
+}
+
+// NewQueue creates a new publish/subscribe queue which supports watchers.
+// The channels that it will create for subscriptions will have the buffer
+// size specified by buffer.
+func NewQueue(buffer int) *Queue {
+	return &Queue{
+		pub: newPublisher(buffer),
+	}
+}
+
+// Watch returns a channel which will receive all items published to the
+// queue from this point, until StopWatch is closed.
+func (q *Queue) Watch() chan Event {
+	return q.pub.subscribe()
+}
+
+// FilteredWatch returns a channel which will receive all events published to
+// the queue from this point that match the provided filter. StopWatch will
+// stop the flow of events and close the channel.
+func (q *Queue) FilteredWatch(filter *Filter) chan Event {
+	if filter == nil {
+		return q.pub.subscribe()
+	}
+	return q.pub.subscribeTopic(func(item Event) bool {
+		for _, filterTag := range filter.Tags {
+			for _, itemTag := range item.Tags {
+				if filterTag == itemTag {
+					return true
+				}
+			}
+		}
+
+		return false
+	})
+}
+
+// CallbackWatch returns a channel which will receive all events published to
+// the queue from this point that pass the check in the provided callback
+// function. StopWatch will stop the flow of events and close the channel.
+func (q *Queue) CallbackWatch(topicFunc topicFunc) chan Event {
+	return q.pub.subscribeTopic(topicFunc)
+}
+
+// StopWatch stops a watcher from receiving further events, and closes its
+// channel.
+func (q *Queue) StopWatch(ch chan Event) {
+	q.pub.evict(ch)
+}
+
+// Publish adds an item to the queue.
+func (q *Queue) Publish(item Event) {
+	q.pub.publish(item)
+}

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,0 +1,62 @@
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWatch(t *testing.T) {
+	// Create a queue
+	q := NewQueue(0)
+
+	// Create filtered watchers
+	c1 := q.FilteredWatch(&Filter{Tags: []string{"t1"}})
+	c2 := q.FilteredWatch(&Filter{Tags: []string{"t2"}})
+
+	// Publish items on the queue
+	q.Publish(Event{Tags: []string{"t1"}, Payload: "foo"})
+	q.Publish(Event{Tags: []string{"t2"}, Payload: "bar"})
+	q.Publish(Event{Tags: []string{"t1", "t2"}, Payload: "foobar"})
+	q.Publish(Event{Tags: []string{"t3"}, Payload: "baz"})
+
+	if (<-c1).Payload.(string) != "foo" {
+		t.Fatal(`expected "foo" on c1`)
+	}
+	if (<-c1).Payload.(string) != "foobar" {
+		t.Fatal(`expected "foobar" on c1`)
+	}
+	if (<-c2).Payload.(string) != "bar" {
+		t.Fatal(`expected "bar" on c2`)
+	}
+	if (<-c2).Payload.(string) != "foobar" {
+		t.Fatal(`expected "foobar" on c2`)
+	}
+
+	q.StopWatch(c1)
+
+	select {
+	case _, ok := <-c1:
+		if ok {
+			t.Fatal("unexpected value on c1")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected c1 to be closed")
+	}
+
+	q.Publish(Event{Tags: []string{"t1", "t2"}, Payload: "foobar"})
+
+	if (<-c2).Payload.(string) != "foobar" {
+		t.Fatal(`expected "foobar" on c2`)
+	}
+
+	q.StopWatch(c2)
+
+	select {
+	case _, ok := <-c2:
+		if ok {
+			t.Fatal("unexpected value on c2")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected c2 to be closed")
+	}
+}


### PR DESCRIPTION
This commit adds a watch package based on a publish/subscribe queue. The publish/subscribe implementation corrects some problems with the one used by the PoC. Events are guaranteed not to be missed, and guaranteed to be delivered in the same order they were published. Slow consumers will not block the goroutine that calls publish.

This implementation is a bit mutex-heavy - all subscriber-level enqueueing and dequeueing is done with a queue-level lock held - but that should only matter if many subscribers watch the same queue. If this use case ends up being important, the dequeueing process can be changed to use finer-grained locking.

On top of the publish/subscribe internals, there's a public API to create and destroy watchers. This allows the use of tags for filtering, or alternatively a callback function be specified to filter events.
