### PR TITLE
identity: provide nice identifier generation

### DIFF
--- a/identity/doc.go
+++ b/identity/doc.go
@@ -1,0 +1,17 @@
+// Package identity provides functionality for generating and manager
+// identifiers within swarm. This includes entity identification, such as that
+// of Job, Task and Network but also cryptographically-secure Node identity.
+//
+// Random Identifiers
+//
+// Identifiers provided by this package are cryptographically-strong, random
+// 128 bit numbers encoded in Base36. This method is preferred over UUID4 since
+// it requires less storage and leverages the full 128 bits of entropy.
+//
+// Generating an identifier is simple. Simply call the `NewID` function, check
+// the error and proceed:
+//
+// 	id, err := NewID()
+// 	if err != nil { /* ... handle it, please ... */ }
+//
+package identity

--- a/identity/randomid.go
+++ b/identity/randomid.go
@@ -1,0 +1,56 @@
+package identity
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"math/big"
+)
+
+var (
+	// idReader is used for random id generation. This declaration allows us to
+	// replace it for testing.
+	idReader = rand.Reader
+)
+
+// parameters for random identifier generation. We can tweak this when there is
+// time for further analysis.
+const (
+	randomIDEntropyBytes = 16
+	randomIDBase         = 36
+
+	// To ensure that all identifiers are fixed length, we make sure they
+	// get padded out to 25 characters, which is the maximum for the base36
+	// representation of 128-bit identifiers.
+	//
+	// For academics,  f5lxx1zz5pnorynqglhzmsp33  == 2^128 - 1. This value
+	// was calculated from floor(log(2^128-1, 36)) + 1.
+	//
+	// See http://mathworld.wolfram.com/NumberLength.html for more information.
+	maxRandomIDLength = 25
+)
+
+// NewID generates a new identifier for use where random identifiers with low
+// collision probability are required.
+//
+// With the parameters in this package, the generated identifier will provide
+// 128 bits of entropy encoded with base36. Leading padding is added if the
+// string is less 25 bytes. We do not intend to maintain this interface, so
+// identifiers should be treated opaquely.
+//
+// The only errors returned by NewID are related to reading the random source.
+// These should be rare, but please make sure to check the error because the
+// result of degraded or absent randomness can be disasterous. In the future,
+// errors may be less rare if another identifier generation scheme is
+// leveraged.
+func NewID() (string, error) {
+	var p [randomIDEntropyBytes]byte
+
+	if _, err := io.ReadFull(idReader, p[:]); err != nil {
+		return "", err
+	}
+
+	var nn big.Int
+	nn.SetBytes(p[:])
+	return fmt.Sprintf("%0[1]*s", maxRandomIDLength, nn.Text(randomIDBase)), nil
+}

--- a/identity/randomid_test.go
+++ b/identity/randomid_test.go
@@ -1,0 +1,36 @@
+package identity
+
+import (
+	"math/big"
+	"math/rand"
+	"testing"
+)
+
+func TestGenerateGUID(t *testing.T) {
+	idReader = rand.New(rand.NewSource(0))
+
+	for i := 0; i < 1000; i++ {
+		guid, err := NewID()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var i big.Int
+		_, ok := i.SetString(guid, randomIDBase)
+		if !ok {
+			t.Fatal("id should be base 36", i, guid)
+		}
+
+		// To ensure that all identifiers are fixed length, we make sure they
+		// get padded out to 25 characters, which is the maximum for the base36
+		// representation of 128-bit identifiers.
+		//
+		// For academics,  f5lxx1zz5pnorynqglhzmsp33  == 2^128 - 1. This value
+		// was calculated from floor(log(2^128-1, 36)) + 1.
+		//
+		// See http://mathworld.wolfram.com/NumberLength.html for more information.
+		if len(guid) != maxRandomIDLength {
+			t.Fatalf("len(%s) != %v", guid, maxRandomIDLength)
+		}
+	}
+}


### PR DESCRIPTION
This package provides the first parts of the identity package. The first
main component provides human-compatible random identifier generation.
Unlike UUIDs, they provide the full 128 bits of entropy while encoded in
a format that saves 11 bytes. Generated identifiers are also case
insensitive.

Rough parameterization is provided as notes in case we want to tune the
entropy. Identifiers that are under the maximum number of bytes for a
base36, 128-bit number (25 bytes) are padded out with leading zeros.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @diogomonica 
