### PR TITLE
Refactor Store interface

### DIFF
--- a/scheduler/planner/planner.go
+++ b/scheduler/planner/planner.go
@@ -2,6 +2,7 @@ package planner
 
 import (
 	"container/list"
+	"errors"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
@@ -51,20 +52,20 @@ func (p *Planner) Run() {
 			Checks: []state.NodeCheckFunc{state.NodeCheckStatus}})
 
 	// Queue all unassigned tasks before watching for changes.
-	tx, err := p.store.BeginRead()
-	if err != nil {
-		log.Errorf("Error starting transaction: %v", err)
-	} else {
+	err := p.store.View(func(tx state.ReadTx) error {
 		tasks, err := tx.Tasks().Find(state.ByNodeID(""))
 		if err != nil {
 			log.Errorf("Error finding unassigned tasks: %v", err)
-		} else {
-			for _, t := range tasks {
-				log.Infof("Queueing %#v", t)
-				p.enqueue(t)
-			}
+			return nil
 		}
-		tx.Close()
+		for _, t := range tasks {
+			log.Infof("Queueing %#v", t)
+			p.enqueue(t)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Errorf("Error in transaction: %v", err)
 	}
 	p.tick()
 
@@ -130,24 +131,25 @@ func (p *Planner) tick() {
 
 // scheduleTask schedules a single task.
 func (p *Planner) scheduleTask(t *api.Task) bool {
-	tx, err := p.store.Begin()
+	err := p.store.Update(func(tx state.Tx) error {
+		node := p.selectNodeForTask(t, tx)
+		if node == nil {
+			err := errors.New("No nodes available to assign tasks to")
+			log.Info(err)
+			return err
+		}
+
+		log.Infof("Assigning task %s to node %s", t.ID, node.Spec.ID)
+		t.NodeID = node.Spec.ID
+		t.Status.State = api.TaskStatus_ASSIGNED
+		if err := tx.Tasks().Update(t); err != nil {
+			log.Error(err)
+			return err
+		}
+		return nil
+	})
 	if err != nil {
-		log.Errorf("Error starting transaction: %v", err)
 		return false
-	}
-	defer tx.Close()
-
-	node := p.selectNodeForTask(t, tx)
-	if node == nil {
-		log.Info("No nodes available to assign tasks to")
-		return false
-	}
-
-	log.Infof("Assigning task %s to node %s", t.ID, node.Spec.ID)
-	t.NodeID = node.Spec.ID
-	t.Status.State = api.TaskStatus_ASSIGNED
-	if err := tx.Tasks().Update(t); err != nil {
-		log.Error(err)
 	}
 	return true
 }

--- a/state/apply.go
+++ b/state/apply.go
@@ -9,40 +9,29 @@ import (
 // Apply takes an item from the event stream of one Store and applies it to
 // a second Store.
 func Apply(store Store, item watch.Event) (err error) {
-	tx, err := store.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		closeErr := tx.Close()
-		if closeErr != nil && err == nil {
-			err = closeErr
+	return store.Update(func(tx Tx) error {
+		switch v := item.Payload.(type) {
+		case EventCreateTask:
+			return tx.Tasks().Create(v.Task)
+		case EventUpdateTask:
+			return tx.Tasks().Update(v.Task)
+		case EventDeleteTask:
+			return tx.Tasks().Delete(v.Task.ID)
+
+		case EventCreateJob:
+			return tx.Jobs().Create(v.Job)
+		case EventUpdateJob:
+			return tx.Jobs().Update(v.Job)
+		case EventDeleteJob:
+			return tx.Jobs().Delete(v.Job.ID)
+
+		case EventCreateNode:
+			return tx.Nodes().Create(v.Node)
+		case EventUpdateNode:
+			return tx.Nodes().Update(v.Node)
+		case EventDeleteNode:
+			return tx.Nodes().Delete(v.Node.Spec.ID)
 		}
-	}()
-
-	switch v := item.Payload.(type) {
-	case EventCreateTask:
-		return tx.Tasks().Create(v.Task)
-	case EventUpdateTask:
-		return tx.Tasks().Update(v.Task)
-	case EventDeleteTask:
-		return tx.Tasks().Delete(v.Task.ID)
-
-	case EventCreateJob:
-		return tx.Jobs().Create(v.Job)
-	case EventUpdateJob:
-		return tx.Jobs().Update(v.Job)
-	case EventDeleteJob:
-		return tx.Jobs().Delete(v.Job.ID)
-
-	case EventCreateNode:
-		return tx.Nodes().Create(v.Node)
-	case EventUpdateNode:
-		return tx.Nodes().Update(v.Node)
-	case EventDeleteNode:
-		return tx.Nodes().Delete(v.Node.Spec.ID)
-
-	}
-
-	return errors.New("unrecognized event type")
+		return errors.New("unrecognized event type")
+	})
 }

--- a/state/doc.go
+++ b/state/doc.go
@@ -2,20 +2,22 @@
 //
 // The primary interface is Store, which abstracts storage of this cluster
 // state. Store exposes a transactional interface for both reads and writes.
-// To begin a read, BeginRead() returns a ReadTx object that exposes the state
-// in a consistent way. Similarly, Begin() returns a Tx object that allows
-// reads and writes to happen without interference from other transactions.
-// Either type of transaction must be finished with the Close method.
+// To perform a read transaction, View accepts a callback function that it
+// will invoke with a ReadTx object that gives it a consistent view of the
+// state. Similarly, Update accepts a callback function that it will invoke with
+// a Tx object that allows reads and writes to happen without interference from
+// other transactions.
 //
 // This is an example of making an update to a Store:
 //
-//	tx, err := store.Begin()
+//	err := store.Update(func(tx state.Tx) {
+//		if err := tx.Nodes().Update(newNode); err != nil {
+//			reutrn err
+//		}
+//		return nil
+//	})
 //	if err != nil {
-//		return err
-//	}
-//	defer tx.Close()
-//	if err := tx.Nodes().Update(newNode); err != nil {
-//		reutrn err
+//		return fmt.Errorf("transaction failed: %v", err)
 //	}
 //
 // WatchableStore is a version of Store that exposes watch functionality.

--- a/state/memory_test.go
+++ b/state/memory_test.go
@@ -38,41 +38,44 @@ func TestStoreNode(t *testing.T) {
 	s := NewMemoryStore()
 	assert.NotNil(t, s)
 
-	readTx, err := s.BeginRead()
+	err := s.View(func(readTx ReadTx) error {
+		allNodes, err := readTx.Nodes().Find(All)
+		assert.NoError(t, err)
+		assert.Empty(t, allNodes)
+		return nil
+	})
 	assert.NoError(t, err)
-	allNodes, err := readTx.Nodes().Find(All)
-	assert.NoError(t, err)
-	assert.Empty(t, allNodes)
-	assert.NoError(t, readTx.Close())
 
-	tx, err := s.Begin()
-	assert.NoError(t, err)
-	for _, n := range nodeSet {
-		assert.NoError(t, tx.Nodes().Create(n))
-	}
-	allNodes, err = tx.Nodes().Find(All)
-	assert.NoError(t, err)
-	assert.Len(t, allNodes, len(nodeSet))
+	err = s.Update(func(tx Tx) error {
+		for _, n := range nodeSet {
+			assert.NoError(t, tx.Nodes().Create(n))
+		}
+		allNodes, err := tx.Nodes().Find(All)
+		assert.NoError(t, err)
+		assert.Len(t, allNodes, len(nodeSet))
 
-	assert.Error(t, tx.Nodes().Create(nodeSet[0]), "duplicate IDs must be rejected")
-	assert.NoError(t, tx.Close())
+		assert.Error(t, tx.Nodes().Create(nodeSet[0]), "duplicate IDs must be rejected")
+		return nil
+	})
+	assert.NoError(t, err)
 
-	readTx, err = s.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, nodeSet[0], readTx.Nodes().Get("id1"))
-	assert.Equal(t, nodeSet[1], readTx.Nodes().Get("id2"))
-	assert.Equal(t, nodeSet[2], readTx.Nodes().Get("id3"))
+	err = s.View(func(readTx ReadTx) error {
+		assert.Equal(t, nodeSet[0], readTx.Nodes().Get("id1"))
+		assert.Equal(t, nodeSet[1], readTx.Nodes().Get("id2"))
+		assert.Equal(t, nodeSet[2], readTx.Nodes().Get("id3"))
 
-	foundNodes, err := readTx.Nodes().Find(ByName("name1"))
+		foundNodes, err := readTx.Nodes().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+		foundNodes, err = readTx.Nodes().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 2)
+		foundNodes, err = readTx.Nodes().Find(ByName("invalid"))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 0)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Len(t, foundNodes, 1)
-	foundNodes, err = readTx.Nodes().Find(ByName("name2"))
-	assert.NoError(t, err)
-	assert.Len(t, foundNodes, 2)
-	foundNodes, err = readTx.Nodes().Find(ByName("invalid"))
-	assert.NoError(t, err)
-	assert.Len(t, foundNodes, 0)
-	assert.NoError(t, readTx.Close())
 
 	// Update.
 	update := &api.Node{
@@ -83,32 +86,32 @@ func TestStoreNode(t *testing.T) {
 			},
 		},
 	}
-	tx, err = s.Begin()
-	assert.NoError(t, err)
-	assert.NotEqual(t, update, tx.Nodes().Get("id3"))
-	assert.NoError(t, tx.Nodes().Update(update))
-	assert.Equal(t, update, tx.Nodes().Get("id3"))
+	err = s.Update(func(tx Tx) error {
+		assert.NotEqual(t, update, tx.Nodes().Get("id3"))
+		assert.NoError(t, tx.Nodes().Update(update))
+		assert.Equal(t, update, tx.Nodes().Get("id3"))
 
-	foundNodes, err = tx.Nodes().Find(ByName("name2"))
-	assert.NoError(t, err)
-	assert.Len(t, foundNodes, 1)
-	foundNodes, err = tx.Nodes().Find(ByName("name3"))
-	assert.NoError(t, err)
-	assert.Len(t, foundNodes, 1)
+		foundNodes, err := tx.Nodes().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+		foundNodes, err = tx.Nodes().Find(ByName("name3"))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
 
-	invalidUpdate := *nodeSet[0]
-	invalidUpdate.Spec.ID = "invalid"
-	assert.Error(t, tx.Nodes().Update(&invalidUpdate), "invalid IDs should be rejected")
+		invalidUpdate := *nodeSet[0]
+		invalidUpdate.Spec.ID = "invalid"
+		assert.Error(t, tx.Nodes().Update(&invalidUpdate), "invalid IDs should be rejected")
 
-	// Delete
-	assert.NotNil(t, tx.Nodes().Get("id1"))
-	assert.NoError(t, tx.Nodes().Delete("id1"))
-	assert.Nil(t, tx.Nodes().Get("id1"))
-	foundNodes, err = tx.Nodes().Find(ByName("name1"))
+		// Delete
+		assert.NotNil(t, tx.Nodes().Get("id1"))
+		assert.NoError(t, tx.Nodes().Delete("id1"))
+		assert.Nil(t, tx.Nodes().Get("id1"))
+		foundNodes, err = tx.Nodes().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Empty(t, foundNodes)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Empty(t, foundNodes)
-
-	assert.NoError(t, tx.Close())
 }
 
 func TestStoreJob(t *testing.T) {
@@ -143,33 +146,44 @@ func TestStoreJob(t *testing.T) {
 	s := NewMemoryStore()
 	assert.NotNil(t, s)
 
-	tx, err := s.Begin()
+	err := s.View(func(readTx ReadTx) error {
+		allJobs, err := readTx.Jobs().Find(All)
+		assert.NoError(t, err)
+		assert.Empty(t, allJobs)
+		return nil
+	})
 	assert.NoError(t, err)
-	allJobs, err := tx.Jobs().Find(All)
-	assert.NoError(t, err)
-	assert.Empty(t, allJobs)
-	for _, j := range jobSet {
-		assert.NoError(t, tx.Jobs().Create(j))
-	}
-	allJobs, err = tx.Jobs().Find(All)
-	assert.NoError(t, err)
-	assert.Len(t, allJobs, len(jobSet))
 
-	assert.Error(t, tx.Jobs().Create(jobSet[0]), "duplicate IDs must be rejected")
+	err = s.Update(func(tx Tx) error {
+		for _, j := range jobSet {
+			assert.NoError(t, tx.Jobs().Create(j))
+		}
+		allJobs, err := tx.Jobs().Find(All)
+		assert.NoError(t, err)
+		assert.Len(t, allJobs, len(jobSet))
 
-	assert.Equal(t, jobSet[0], tx.Jobs().Get("id1"))
-	assert.Equal(t, jobSet[1], tx.Jobs().Get("id2"))
-	assert.Equal(t, jobSet[2], tx.Jobs().Get("id3"))
+		assert.Error(t, tx.Jobs().Create(jobSet[0]), "duplicate IDs must be rejected")
+		return nil
+	})
+	assert.NoError(t, err)
 
-	foundJobs, err := tx.Jobs().Find(ByName("name1"))
+	err = s.View(func(readTx ReadTx) error {
+		assert.Equal(t, jobSet[0], readTx.Jobs().Get("id1"))
+		assert.Equal(t, jobSet[1], readTx.Jobs().Get("id2"))
+		assert.Equal(t, jobSet[2], readTx.Jobs().Get("id3"))
+
+		foundJobs, err := readTx.Jobs().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Len(t, foundJobs, 1)
+		foundJobs, err = readTx.Jobs().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundJobs, 2)
+		foundJobs, err = readTx.Jobs().Find(ByName("invalid"))
+		assert.NoError(t, err)
+		assert.Len(t, foundJobs, 0)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Len(t, foundJobs, 1)
-	foundJobs, err = tx.Jobs().Find(ByName("name2"))
-	assert.NoError(t, err)
-	assert.Len(t, foundJobs, 2)
-	foundJobs, err = tx.Jobs().Find(ByName("invalid"))
-	assert.NoError(t, err)
-	assert.Len(t, foundJobs, 0)
 
 	// Update.
 	update := &api.Job{
@@ -181,30 +195,32 @@ func TestStoreJob(t *testing.T) {
 			},
 		},
 	}
-	assert.NotEqual(t, update, tx.Jobs().Get("id3"))
-	assert.NoError(t, tx.Jobs().Update(update))
-	assert.Equal(t, update, tx.Jobs().Get("id3"))
+	err = s.Update(func(tx Tx) error {
+		assert.NotEqual(t, update, tx.Jobs().Get("id3"))
+		assert.NoError(t, tx.Jobs().Update(update))
+		assert.Equal(t, update, tx.Jobs().Get("id3"))
 
-	foundJobs, err = tx.Jobs().Find(ByName("name2"))
+		foundJobs, err := tx.Jobs().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundJobs, 1)
+		foundJobs, err = tx.Jobs().Find(ByName("name3"))
+		assert.NoError(t, err)
+		assert.Len(t, foundJobs, 1)
+
+		invalidUpdate := *jobSet[0]
+		invalidUpdate.ID = "invalid"
+		assert.Error(t, tx.Jobs().Update(&invalidUpdate), "invalid IDs should be rejected")
+
+		// Delete
+		assert.NotNil(t, tx.Jobs().Get("id1"))
+		assert.NoError(t, tx.Jobs().Delete("id1"))
+		assert.Nil(t, tx.Jobs().Get("id1"))
+		foundJobs, err = tx.Jobs().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Empty(t, foundJobs)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Len(t, foundJobs, 1)
-	foundJobs, err = tx.Jobs().Find(ByName("name3"))
-	assert.NoError(t, err)
-	assert.Len(t, foundJobs, 1)
-
-	invalidUpdate := *jobSet[0]
-	invalidUpdate.ID = "invalid"
-	assert.Error(t, tx.Jobs().Update(&invalidUpdate), "invalid IDs should be rejected")
-
-	// Delete
-	assert.NotNil(t, tx.Jobs().Get("id1"))
-	assert.NoError(t, tx.Jobs().Delete("id1"))
-	assert.Nil(t, tx.Jobs().Get("id1"))
-	foundJobs, err = tx.Jobs().Find(ByName("name1"))
-	assert.NoError(t, err)
-	assert.Empty(t, foundJobs)
-
-	assert.NoError(t, tx.Close())
 }
 
 func TestStoreTask(t *testing.T) {
@@ -256,55 +272,60 @@ func TestStoreTask(t *testing.T) {
 	s := NewMemoryStore()
 	assert.NotNil(t, s)
 
-	tx, err := s.Begin()
+	err := s.Update(func(tx Tx) error {
+		assert.NoError(t, tx.Nodes().Create(node))
+		assert.NoError(t, tx.Jobs().Create(job))
+
+		allTasks, err := tx.Tasks().Find(All)
+		assert.NoError(t, err)
+		assert.Empty(t, allTasks)
+
+		for _, task := range taskSet {
+			assert.NoError(t, tx.Tasks().Create(task))
+		}
+
+		allTasks, err = tx.Tasks().Find(All)
+		assert.NoError(t, err)
+		assert.Len(t, allTasks, len(taskSet))
+
+		assert.Error(t, tx.Tasks().Create(taskSet[0]), "duplicate IDs must be rejected")
+		return nil
+	})
 	assert.NoError(t, err)
 
-	assert.NoError(t, tx.Nodes().Create(node))
-	assert.NoError(t, tx.Jobs().Create(job))
+	err = s.View(func(readTx ReadTx) error {
+		assert.Equal(t, taskSet[0], readTx.Tasks().Get("id1"))
+		assert.Equal(t, taskSet[1], readTx.Tasks().Get("id2"))
+		assert.Equal(t, taskSet[2], readTx.Tasks().Get("id3"))
 
-	allTasks, err := tx.Tasks().Find(All)
-	assert.NoError(t, err)
-	assert.Empty(t, allTasks)
+		foundTasks, err := readTx.Tasks().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 1)
+		foundTasks, err = readTx.Tasks().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 2)
+		foundTasks, err = readTx.Tasks().Find(ByName("invalid"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 0)
 
-	for _, task := range taskSet {
-		assert.NoError(t, tx.Tasks().Create(task))
-	}
+		foundTasks, err = readTx.Tasks().Find(ByNodeID(node.Spec.ID))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 1)
+		assert.Equal(t, foundTasks[0], taskSet[0])
+		foundTasks, err = readTx.Tasks().Find(ByNodeID("invalid"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 0)
 
-	allTasks, err = tx.Tasks().Find(All)
+		foundTasks, err = readTx.Tasks().Find(ByJobID(job.ID))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 1)
+		assert.Equal(t, foundTasks[0], taskSet[1])
+		foundTasks, err = readTx.Tasks().Find(ByJobID("invalid"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 0)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Len(t, allTasks, len(taskSet))
-
-	assert.Error(t, tx.Tasks().Create(taskSet[0]), "duplicate IDs must be rejected")
-
-	assert.Equal(t, taskSet[0], tx.Tasks().Get("id1"))
-	assert.Equal(t, taskSet[1], tx.Tasks().Get("id2"))
-	assert.Equal(t, taskSet[2], tx.Tasks().Get("id3"))
-
-	foundTasks, err := tx.Tasks().Find(ByName("name1"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-	foundTasks, err = tx.Tasks().Find(ByName("name2"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 2)
-	foundTasks, err = tx.Tasks().Find(ByName("invalid"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 0)
-
-	foundTasks, err = tx.Tasks().Find(ByNodeID(node.Spec.ID))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-	assert.Equal(t, foundTasks[0], taskSet[0])
-	foundTasks, err = tx.Tasks().Find(ByNodeID("invalid"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 0)
-
-	foundTasks, err = tx.Tasks().Find(ByJobID(job.ID))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-	assert.Equal(t, foundTasks[0], taskSet[1])
-	foundTasks, err = tx.Tasks().Find(ByJobID("invalid"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 0)
 
 	// Update.
 	update := &api.Task{
@@ -319,30 +340,32 @@ func TestStoreTask(t *testing.T) {
 			},
 		},
 	}
-	assert.NotEqual(t, update, tx.Tasks().Get("id3"))
-	assert.NoError(t, tx.Tasks().Update(update))
-	assert.Equal(t, update, tx.Tasks().Get("id3"))
+	err = s.Update(func(tx Tx) error {
+		assert.NotEqual(t, update, tx.Tasks().Get("id3"))
+		assert.NoError(t, tx.Tasks().Update(update))
+		assert.Equal(t, update, tx.Tasks().Get("id3"))
 
-	foundTasks, err = tx.Tasks().Find(ByName("name2"))
+		foundTasks, err := tx.Tasks().Find(ByName("name2"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 1)
+		foundTasks, err = tx.Tasks().Find(ByName("name3"))
+		assert.NoError(t, err)
+		assert.Len(t, foundTasks, 1)
+
+		invalidUpdate := *taskSet[0]
+		invalidUpdate.ID = "invalid"
+		assert.Error(t, tx.Tasks().Update(&invalidUpdate), "invalid IDs should be rejected")
+
+		// Delete
+		assert.NotNil(t, tx.Tasks().Get("id1"))
+		assert.NoError(t, tx.Tasks().Delete("id1"))
+		assert.Nil(t, tx.Tasks().Get("id1"))
+		foundTasks, err = tx.Tasks().Find(ByName("name1"))
+		assert.NoError(t, err)
+		assert.Empty(t, foundTasks)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-	foundTasks, err = tx.Tasks().Find(ByName("name3"))
-	assert.NoError(t, err)
-	assert.Len(t, foundTasks, 1)
-
-	invalidUpdate := *taskSet[0]
-	invalidUpdate.ID = "invalid"
-	assert.Error(t, tx.Tasks().Update(&invalidUpdate), "invalid IDs should be rejected")
-
-	// Delete
-	assert.NotNil(t, tx.Tasks().Get("id1"))
-	assert.NoError(t, tx.Tasks().Delete("id1"))
-	assert.Nil(t, tx.Tasks().Get("id1"))
-	foundTasks, err = tx.Tasks().Find(ByName("name1"))
-	assert.NoError(t, err)
-	assert.Empty(t, foundTasks)
-
-	assert.NoError(t, tx.Close())
 }
 
 func TestStoreSnapshot(t *testing.T) {
@@ -432,25 +455,24 @@ func TestStoreSnapshot(t *testing.T) {
 	s1 := NewMemoryStore()
 	assert.NotNil(t, s1)
 
-	tx1, err := s1.Begin()
+	err := s1.Update(func(tx1 Tx) error {
+		// Prepoulate nodes
+		for _, n := range nodeSet {
+			assert.NoError(t, tx1.Nodes().Create(n))
+		}
+
+		// Prepopulate jobs
+		for _, j := range jobSet {
+			assert.NoError(t, tx1.Jobs().Create(j))
+		}
+
+		// Prepopulate tasks
+		for _, task := range taskSet {
+			assert.NoError(t, tx1.Tasks().Create(task))
+		}
+		return nil
+	})
 	assert.NoError(t, err)
-
-	// Prepoulate nodes
-	for _, n := range nodeSet {
-		assert.NoError(t, tx1.Nodes().Create(n))
-	}
-
-	// Prepopulate jobs
-	for _, j := range jobSet {
-		assert.NoError(t, tx1.Jobs().Create(j))
-	}
-
-	// Prepopulate tasks
-	for _, task := range taskSet {
-		assert.NoError(t, tx1.Tasks().Create(task))
-	}
-
-	assert.NoError(t, tx1.Close())
 
 	// Fork
 	s2 := NewMemoryStore()
@@ -459,155 +481,162 @@ func TestStoreSnapshot(t *testing.T) {
 	defer s1.WatchQueue().StopWatch(watcher)
 	assert.NoError(t, err)
 
-	tx1, err = s1.Begin()
-	assert.NoError(t, err)
+	err = s1.Update(func(tx1 Tx) error {
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, nodeSet[0], tx2.Nodes().Get("id1"))
+			assert.Equal(t, nodeSet[1], tx2.Nodes().Get("id2"))
+			assert.Equal(t, nodeSet[2], tx2.Nodes().Get("id3"))
 
-	tx2, err := s2.BeginRead()
-	assert.NoError(t, err)
+			assert.Equal(t, jobSet[0], tx2.Jobs().Get("id1"))
+			assert.Equal(t, jobSet[1], tx2.Jobs().Get("id2"))
+			assert.Equal(t, jobSet[2], tx2.Jobs().Get("id3"))
 
-	assert.Equal(t, nodeSet[0], tx2.Nodes().Get("id1"))
-	assert.Equal(t, nodeSet[1], tx2.Nodes().Get("id2"))
-	assert.Equal(t, nodeSet[2], tx2.Nodes().Get("id3"))
+			assert.Equal(t, taskSet[0], tx2.Tasks().Get("id1"))
+			assert.Equal(t, taskSet[1], tx2.Tasks().Get("id2"))
+			assert.Equal(t, taskSet[2], tx2.Tasks().Get("id3"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	assert.Equal(t, jobSet[0], tx2.Jobs().Get("id1"))
-	assert.Equal(t, jobSet[1], tx2.Jobs().Get("id2"))
-	assert.Equal(t, jobSet[2], tx2.Jobs().Get("id3"))
+		// Create node
+		createNode := &api.Node{
+			Spec: &api.NodeSpec{
+				ID: "id4",
+				Meta: &api.Meta{
+					Name: "name4",
+				},
+			},
+		}
+		assert.NoError(t, tx1.Nodes().Create(createNode))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	assert.Equal(t, taskSet[0], tx2.Tasks().Get("id1"))
-	assert.Equal(t, taskSet[1], tx2.Tasks().Get("id2"))
-	assert.Equal(t, taskSet[2], tx2.Tasks().Get("id3"))
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, createNode, tx2.Nodes().Get("id4"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	assert.NoError(t, tx2.Close())
+		// Update node
+		updateNode := &api.Node{
+			Spec: &api.NodeSpec{
+				ID: "id3",
+				Meta: &api.Meta{
+					Name: "name3",
+				},
+			},
+		}
+		assert.NoError(t, tx1.Nodes().Update(updateNode))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	// Create node
-	createNode := &api.Node{
-		Spec: &api.NodeSpec{
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, updateNode, tx2.Nodes().Get("id3"))
+			return nil
+		})
+		assert.NoError(t, err)
+
+		// Delete node
+		assert.NoError(t, tx1.Nodes().Delete("id1"))
+		assert.NoError(t, Apply(s2, <-watcher))
+
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Nil(t, tx2.Nodes().Get("id1"))
+			return nil
+		})
+		assert.NoError(t, err)
+
+		// Create job
+		createJob := &api.Job{
 			ID: "id4",
-			Meta: &api.Meta{
-				Name: "name4",
+			Spec: &api.JobSpec{
+				Meta: &api.Meta{
+					Name: "name4",
+				},
 			},
-		},
-	}
-	assert.NoError(t, tx1.Nodes().Create(createNode))
-	assert.NoError(t, Apply(s2, <-watcher))
+		}
+		assert.NoError(t, tx1.Jobs().Create(createJob))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, createNode, tx2.Nodes().Get("id4"))
-	assert.NoError(t, tx2.Close())
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, createJob, tx2.Jobs().Get("id4"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	// Update node
-	updateNode := &api.Node{
-		Spec: &api.NodeSpec{
+		// Update job
+		updateJob := &api.Job{
 			ID: "id3",
-			Meta: &api.Meta{
-				Name: "name3",
+			Spec: &api.JobSpec{
+				Meta: &api.Meta{
+					Name: "name3",
+				},
 			},
-		},
-	}
-	assert.NoError(t, tx1.Nodes().Update(updateNode))
-	assert.NoError(t, Apply(s2, <-watcher))
+		}
+		assert.NotEqual(t, updateJob, tx1.Jobs().Get("id3"))
+		assert.NoError(t, tx1.Jobs().Update(updateJob))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, updateNode, tx2.Nodes().Get("id3"))
-	assert.NoError(t, tx2.Close())
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, updateJob, tx2.Jobs().Get("id3"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	// Delete node
-	assert.NoError(t, tx1.Nodes().Delete("id1"))
-	assert.NoError(t, Apply(s2, <-watcher))
+		// Delete job
+		assert.NoError(t, tx1.Jobs().Delete("id1"))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Nil(t, tx2.Nodes().Get("id1"))
-	assert.NoError(t, tx2.Close())
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Nil(t, tx1.Jobs().Get("id1"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	// Create job
-	createJob := &api.Job{
-		ID: "id4",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name4",
+		// Create task
+		createTask := &api.Task{
+			ID: "id4",
+			Spec: &api.JobSpec{
+				Meta: &api.Meta{
+					Name: "name4",
+				},
 			},
-		},
-	}
-	assert.NoError(t, tx1.Jobs().Create(createJob))
-	assert.NoError(t, Apply(s2, <-watcher))
+		}
+		assert.NoError(t, tx1.Tasks().Create(createTask))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, createJob, tx2.Jobs().Get("id4"))
-	assert.NoError(t, tx2.Close())
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, createTask, tx2.Tasks().Get("id4"))
+			return nil
+		})
+		assert.NoError(t, err)
 
-	// Update job
-	updateJob := &api.Job{
-		ID: "id3",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name3",
+		// Update task
+		updateTask := &api.Task{
+			ID: "id3",
+			Spec: &api.JobSpec{
+				Meta: &api.Meta{
+					Name: "name3",
+				},
 			},
-		},
-	}
-	assert.NotEqual(t, updateJob, tx1.Jobs().Get("id3"))
-	assert.NoError(t, tx1.Jobs().Update(updateJob))
-	assert.NoError(t, Apply(s2, <-watcher))
+		}
+		assert.NoError(t, tx1.Tasks().Update(updateTask))
+		assert.NoError(t, Apply(s2, <-watcher))
 
-	tx2, err = s2.BeginRead()
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Equal(t, updateTask, tx2.Tasks().Get("id3"))
+			return nil
+		})
+		assert.NoError(t, err)
+
+		// Delete task
+		assert.NoError(t, tx1.Tasks().Delete("id1"))
+		assert.NoError(t, Apply(s2, <-watcher))
+
+		err = s2.View(func(tx2 ReadTx) error {
+			assert.Nil(t, tx2.Tasks().Get("id1"))
+			return nil
+		})
+		assert.NoError(t, err)
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, updateJob, tx2.Jobs().Get("id3"))
-	assert.NoError(t, tx2.Close())
-
-	// Delete job
-	assert.NoError(t, tx1.Jobs().Delete("id1"))
-	assert.NoError(t, Apply(s2, <-watcher))
-
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Nil(t, tx1.Jobs().Get("id1"))
-	assert.NoError(t, tx2.Close())
-
-	// Create task
-	createTask := &api.Task{
-		ID: "id4",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name4",
-			},
-		},
-	}
-	assert.NoError(t, tx1.Tasks().Create(createTask))
-	assert.NoError(t, Apply(s2, <-watcher))
-
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, createTask, tx2.Tasks().Get("id4"))
-	assert.NoError(t, tx2.Close())
-
-	// Update task
-	updateTask := &api.Task{
-		ID: "id3",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name3",
-			},
-		},
-	}
-	assert.NoError(t, tx1.Tasks().Update(updateTask))
-	assert.NoError(t, Apply(s2, <-watcher))
-
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Equal(t, updateTask, tx2.Tasks().Get("id3"))
-	assert.NoError(t, tx2.Close())
-
-	// Delete task
-	assert.NoError(t, tx1.Tasks().Delete("id1"))
-	assert.NoError(t, Apply(s2, <-watcher))
-
-	tx2, err = s2.BeginRead()
-	assert.NoError(t, err)
-	assert.Nil(t, tx2.Tasks().Get("id1"))
-	assert.NoError(t, tx2.Close())
-
-	assert.NoError(t, tx1.Close())
 }

--- a/state/store.go
+++ b/state/store.go
@@ -97,7 +97,6 @@ type ReadTx interface {
 	Nodes() NodeSetReader
 	Jobs() JobSetReader
 	Tasks() TaskSetReader
-	Close() error
 }
 
 // Tx is a read/write transaction. Note that transaction does not imply
@@ -108,7 +107,6 @@ type Tx interface {
 	Nodes() NodeSet
 	Jobs() JobSet
 	Tasks() TaskSet
-	Close() error
 }
 
 // A StoreCopier is capable of reading the full contents of a store from a
@@ -123,13 +121,16 @@ type StoreCopier interface {
 type Store interface {
 	StoreCopier
 
-	// Begin starts a full transaction that allows reads and writes. The
-	// transaction must be committed with Close.
-	Begin() (Tx, error)
+	// Update performs a full transaction that allows reads and writes.
+	// Within the callback function, changes can safely be made through the
+	// Tx interface. If the callback function returns nil, Update will
+	// attempt to commit the transaction.
+	Update(func(Tx) error) error
 
-	// BeginRead starts a transaction that reads only. The transaction must
-	// be finalized with Close.
-	BeginRead() (ReadTx, error)
+	// View performs a transaction that only includes reads. Within the
+	// callback function, a consistent view of the data is available through
+	// the ReadTx interface.
+	View(func(ReadTx) error) error
 }
 
 // WatchableStore is an extension of Store that publishes modifications to a


### PR DESCRIPTION
This makes the Store interface transactional and splits it up into
smaller interfaces.

The Store interface now has methods to begin read transactions and full
read/write transactions. These transactions have Nodes, Tasks, and Jobs
functions that provide either a readable or read/writable view of the
respective data type. Transactions are protected from interfering with
each other (using a lock, in the current memory store implementation).

Nodes, Tasks, and Jobs return separate interfaces to allow type safe
access. I also experimented with having them return a shared interface,
and found this was clunkier to work with - but it's another possible
model.

Fork has been renamed to Snapshot and now uses a StoreCopier interface
to split out the snapshotting functionality to the destination of the
data, by passing in a read transaction. This allows the destination of
the snapshot to implement a much simpler interface (it only needs a
CopyFrom method).

I'm in the process of updating the orchestrator and planner to take advantage
of the `Snapshot` functionality to track state more efficiently. But I'll open a
separate PR for that, since it's really a planner/orchestrator improvement rather
than part of this refactor.
