### PR TITLE
Add Raft log replication backend

### DIFF
--- a/api/manager.proto
+++ b/api/manager.proto
@@ -59,5 +59,5 @@ message RaftNode {
 // TODO(abronan): remove when the integration with store is completed
 message Pair {
 	string key = 1;
-	string value = 2;
+	bytes value = 2;
 }

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	// TODO(abronan): remove these blank imports after
-	// including the raft backend
-	_ "github.com/coreos/etcd/raft"
-	_ "github.com/coreos/etcd/raft/raftpb"
 	"github.com/docker/swarm-v2/version"
 	"github.com/spf13/cobra"
 )

--- a/state/cluster.go
+++ b/state/cluster.go
@@ -1,0 +1,61 @@
+package state
+
+import (
+	"sync"
+
+	"github.com/docker/swarm-v2/api"
+)
+
+// Cluster represents a set of active
+// raft members
+type Cluster struct {
+	lock  sync.RWMutex
+	peers map[uint64]*Peer
+}
+
+// Peer represents a raft cluster peer
+type Peer struct {
+	*api.RaftNode
+
+	Client *Raft
+}
+
+// NewCluster creates a new cluster neighbors
+// list for a raft member
+func NewCluster() *Cluster {
+	return &Cluster{
+		peers: make(map[uint64]*Peer),
+	}
+}
+
+// Peers returns the list of peers in the cluster
+func (c *Cluster) Peers() map[uint64]*Peer {
+	peers := make(map[uint64]*Peer)
+	c.lock.RLock()
+	for k, v := range c.peers {
+		peers[k] = v
+	}
+	c.lock.RUnlock()
+	return peers
+}
+
+// GetPeer returns informations on a given peer
+func (c *Cluster) GetPeer(id uint64) *Peer {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.peers[id]
+}
+
+// AddPeer adds a node to our neighbors
+func (c *Cluster) AddPeer(peer *Peer) {
+	c.lock.Lock()
+	c.peers[peer.ID] = peer
+	c.lock.Unlock()
+}
+
+// RemovePeer removes a node from our neighbors
+func (c *Cluster) RemovePeer(id uint64) {
+	c.lock.Lock()
+	delete(c.peers, id)
+	c.lock.Unlock()
+}

--- a/state/raft.go
+++ b/state/raft.go
@@ -1,0 +1,462 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/docker/swarm-v2/api"
+	"github.com/gogo/protobuf/proto"
+)
+
+var (
+	defaultLogger = &raft.DefaultLogger{Logger: log.New(os.Stderr, "raft", log.LstdFlags)}
+
+	// ErrConnectionRefused is thrown when a connection is refused to a node member in the raft
+	ErrConnectionRefused = errors.New("connection refused to the node")
+	// ErrConfChangeRefused is thrown when there is an issue with the configuration change
+	ErrConfChangeRefused = errors.New("propose configuration change refused")
+	// ErrApplyNotSpecified is thrown during the creation of a raft node when no apply method was provided
+	ErrApplyNotSpecified = errors.New("apply method was not specified")
+	// ErrPeerNotFound is thrown when we try an operation on a peer that does not exist in the cluster list
+	ErrPeerNotFound = errors.New("peer not found in cluster list")
+)
+
+// ApplyCommand function can be used and triggered
+// every time there is an append entry event
+type ApplyCommand func(interface{})
+
+// Node represents the Raft Node useful
+// configuration.
+type Node struct {
+	raft.Node
+
+	Client   *Raft
+	Cluster  *Cluster
+	Server   *grpc.Server
+	Listener net.Listener
+	Ctx      context.Context
+
+	ID      uint64
+	Address string
+	Port    int
+	Error   error
+
+	storeLock sync.RWMutex
+	PStore    map[string]string
+	Store     *raft.MemoryStorage
+	Cfg       *raft.Config
+
+	ticker *time.Ticker
+	stopCh chan struct{}
+	errCh  chan error
+
+	// ApplyCommand is called when a log entry
+	// is committed to the logs, behind can
+	// lie any kind of logic processing the
+	// message
+	apply ApplyCommand
+}
+
+// NewNode generates a new Raft node based on an unique
+// ID, an address and optionally: a handler and receive
+// only channel to send event when an entry is committed
+// to the logs
+func NewNode(ctx context.Context, id uint64, addr string, cfg *raft.Config, apply ApplyCommand) (*Node, error) {
+	if cfg == nil {
+		cfg = DefaultNodeConfig()
+	}
+
+	store := raft.NewMemoryStorage()
+	peers := []raft.Peer{{ID: id}}
+
+	n := &Node{
+		ID:      id,
+		Ctx:     ctx,
+		Cluster: NewCluster(),
+		Store:   store,
+		Address: addr,
+		Cfg: &raft.Config{
+			ID:              id,
+			ElectionTick:    cfg.ElectionTick,
+			HeartbeatTick:   cfg.HeartbeatTick,
+			Storage:         store,
+			MaxSizePerMsg:   cfg.MaxSizePerMsg,
+			MaxInflightMsgs: cfg.MaxInflightMsgs,
+			Logger:          cfg.Logger,
+		},
+		PStore: make(map[string]string),
+		ticker: time.NewTicker(time.Second),
+		stopCh: make(chan struct{}),
+		apply:  apply,
+	}
+
+	n.Cluster.AddPeer(
+		&Peer{
+			RaftNode: &api.RaftNode{
+				ID:   id,
+				Addr: addr,
+			},
+		},
+	)
+
+	n.Node = raft.StartNode(n.Cfg, peers)
+	return n, nil
+}
+
+// DefaultNodeConfig returns the default config for a
+// raft node that can be modified and customized
+func DefaultNodeConfig() *raft.Config {
+	return &raft.Config{
+		HeartbeatTick:   1,
+		ElectionTick:    3,
+		MaxSizePerMsg:   math.MaxUint16,
+		MaxInflightMsgs: 256,
+		Logger:          defaultLogger,
+	}
+}
+
+// Start is the main loop for a Raft node, it
+// goes along the state machine, acting on the
+// messages received from other Raft nodes in
+// the cluster
+func (n *Node) Start() (errCh <-chan error) {
+	n.errCh = make(chan error)
+	go func() {
+		for {
+			select {
+			case <-n.ticker.C:
+				n.Tick()
+
+			case rd := <-n.Ready():
+				n.saveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
+				n.send(rd.Messages)
+				if !raft.IsEmptySnap(rd.Snapshot) {
+					n.processSnapshot(rd.Snapshot)
+				}
+				for _, entry := range rd.CommittedEntries {
+					err := n.process(entry)
+					if err != nil {
+						n.errCh <- err
+					}
+					if entry.Type == raftpb.EntryConfChange {
+						var cc raftpb.ConfChange
+						err := cc.Unmarshal(entry.Data)
+						if err != nil {
+							n.errCh <- err
+						}
+						switch cc.Type {
+						case raftpb.ConfChangeAddNode:
+							n.applyAddNode(cc)
+						case raftpb.ConfChangeRemoveNode:
+							n.applyRemoveNode(cc)
+						}
+						n.ApplyConfChange(cc)
+					}
+				}
+				n.Advance()
+
+			case <-n.stopCh:
+				n.Stop()
+				n.Node = nil
+				close(n.stopCh)
+				return
+			}
+		}
+	}()
+	return n.errCh
+}
+
+// Shutdown stops the raft node processing loop.
+// Calling Shutdown on an already stopped node
+// will result in a deadlock
+func (n *Node) Shutdown() {
+	n.stopCh <- struct{}{}
+}
+
+// IsLeader checks if we are the leader or not
+func (n *Node) IsLeader() bool {
+	if n.Node.Status().Lead == n.ID {
+		return true
+	}
+	return false
+}
+
+// Leader returns the id of the leader
+func (n *Node) Leader() uint64 {
+	return n.Node.Status().Lead
+}
+
+// Join asks to a member of the raft to propose
+// a configuration change and add us as a member thus
+// beginning the log replication process. This method
+// is called from an aspiring member to an existing member
+func (n *Node) Join(ctx context.Context, req *api.JoinRequest) (*api.JoinResponse, error) {
+	meta, err := proto.Marshal(req.Node)
+	if err != nil {
+		return nil, err
+	}
+
+	confChange := raftpb.ConfChange{
+		ID:      req.Node.ID,
+		Type:    raftpb.ConfChangeAddNode,
+		NodeID:  req.Node.ID,
+		Context: meta,
+	}
+
+	err = n.ProposeConfChange(n.Ctx, confChange)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []*api.RaftNode
+	for _, node := range n.Cluster.Peers() {
+		nodes = append(nodes, &api.RaftNode{
+			ID:   node.ID,
+			Addr: node.Addr,
+		})
+	}
+
+	// TODO (abronan): instead of sending back
+	// the list of nodes and let the new member
+	// add them itself to its local list: grpc
+	// call add from the node sending the conf
+	// change
+	return &api.JoinResponse{Members: nodes}, nil
+}
+
+// Leave asks to a member of the raft to remove
+// us from the raft cluster. This method is called
+// from a member who is willing to leave its raft
+// membership to an active member of the raft
+func (n *Node) Leave(ctx context.Context, req *api.LeaveRequest) (*api.LeaveResponse, error) {
+	confChange := raftpb.ConfChange{
+		ID:      req.Node.ID,
+		Type:    raftpb.ConfChangeRemoveNode,
+		NodeID:  req.Node.ID,
+		Context: []byte(""),
+	}
+
+	err := n.ProposeConfChange(n.Ctx, confChange)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.LeaveResponse{}, nil
+}
+
+// ProcessRaftMessage calls 'Step' which advances the
+// raft state machine with the provided message on the
+// receiving node
+func (n *Node) ProcessRaftMessage(ctx context.Context, msg *api.ProcessRaftMessageRequest) (*api.ProcessRaftMessageResponse, error) {
+	err := n.Step(n.Ctx, *msg.Msg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.ProcessRaftMessageResponse{}, nil
+}
+
+// RemoveNode removes a node from the raft cluster
+func (n *Node) RemoveNode(node *Peer) error {
+	confChange := raftpb.ConfChange{
+		ID:      node.ID,
+		Type:    raftpb.ConfChangeRemoveNode,
+		NodeID:  node.ID,
+		Context: []byte(""),
+	}
+
+	err := n.ProposeConfChange(n.Ctx, confChange)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// RegisterNode registers a new node on the cluster
+func (n *Node) RegisterNode(node *api.RaftNode) error {
+	var (
+		client *Raft
+		err    error
+	)
+
+	for i := 1; i <= MaxRetries; i++ {
+		client, err = GetRaftClient(node.Addr, 2*time.Second)
+		if err != nil {
+			if i == MaxRetries {
+				return ErrConnectionRefused
+			}
+		}
+	}
+
+	n.Cluster.AddPeer(&Peer{RaftNode: node, Client: client})
+	return nil
+}
+
+// RegisterNodes registers a set of nodes in the cluster
+func (n *Node) RegisterNodes(nodes []*api.RaftNode) (err error) {
+	for _, node := range nodes {
+		err = n.RegisterNode(node)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// UnregisterNode unregisters a node that has died or
+// has gracefully left the raft subsystem
+func (n *Node) UnregisterNode(id uint64) error {
+	// Do not unregister yourself
+	if n.ID == id {
+		return nil
+	}
+
+	peer := n.Cluster.GetPeer(id)
+	if peer == nil {
+		return ErrPeerNotFound
+	}
+
+	err := peer.Client.Conn.Close()
+	if err != nil {
+		return err
+	}
+
+	n.Cluster.RemovePeer(id)
+	return nil
+}
+
+// Get returns a value from the PStore
+func (n *Node) Get(key string) string {
+	n.storeLock.RLock()
+	defer n.storeLock.RUnlock()
+	return n.PStore[key]
+}
+
+// Put puts a value in the raft store
+func (n *Node) Put(key string, value string) {
+	n.storeLock.Lock()
+	defer n.storeLock.Unlock()
+	n.PStore[key] = value
+}
+
+// StoreLength returns the length of the store
+func (n *Node) StoreLength() int {
+	n.storeLock.Lock()
+	defer n.storeLock.Unlock()
+	return len(n.PStore)
+}
+
+// applyAddNode is called when we receive a ConfChange
+// from a member in the raft cluster, this adds a new
+// node to the existing raft cluster
+func (n *Node) applyAddNode(conf raftpb.ConfChange) error {
+	peer := &api.RaftNode{}
+	err := proto.Unmarshal(conf.Context, peer)
+	if err != nil {
+		return err
+	}
+	if n.ID != peer.ID {
+		n.RegisterNode(peer)
+	}
+	return nil
+}
+
+// applyRemoveNode is called when we receive a ConfChange
+// from a member in the raft cluster, this removes a node
+// from the existing raft cluster
+func (n *Node) applyRemoveNode(conf raftpb.ConfChange) {
+	// The leader steps down
+	if n.ID == n.Leader() && n.ID == conf.NodeID {
+		n.Stop()
+		return
+	}
+
+	// If the node from where the remove is issued is
+	// a follower and the leader steps down, Campaign
+	// to be the leader
+	if conf.NodeID == n.Leader() {
+		n.Campaign(n.Ctx)
+	}
+
+	// Unregister the node, if we can't remove
+	// the node for some reasons because it has
+	// already been removed, let it be
+	n.UnregisterNode(conf.NodeID)
+}
+
+// Saves a log entry to our Store
+func (n *Node) saveToStorage(hardState raftpb.HardState, entries []raftpb.Entry, snapshot raftpb.Snapshot) {
+	n.Store.Append(entries)
+
+	if !raft.IsEmptyHardState(hardState) {
+		n.Store.SetHardState(hardState)
+	}
+
+	if !raft.IsEmptySnap(snapshot) {
+		n.Store.ApplySnapshot(snapshot)
+	}
+}
+
+// Sends a series of messages to members in the raft
+func (n *Node) send(messages []raftpb.Message) {
+	peers := n.Cluster.Peers()
+
+	for _, m := range messages {
+		// Process locally
+		if m.To == n.ID {
+			n.Step(n.Ctx, m)
+			continue
+		}
+
+		// If node is an active raft member send the message
+		if peer, ok := peers[m.To]; ok {
+			_, err := peer.Client.ProcessRaftMessage(n.Ctx, &api.ProcessRaftMessageRequest{&m})
+			if err != nil {
+				n.ReportUnreachable(peer.ID)
+			}
+		}
+	}
+}
+
+// Process a data entry and optionnally triggers an event
+// or a function handler after the entry is processed
+func (n *Node) process(entry raftpb.Entry) error {
+	if entry.Type == raftpb.EntryNormal && entry.Data != nil {
+		// TODO (abronan, al, mrjana): replace KV pair
+		// by internal store interface
+		pair := &api.Pair{}
+		err := proto.Unmarshal(entry.Data, pair)
+		if err != nil {
+			return err
+		}
+
+		// Apply the command
+		if n.apply != nil {
+			n.apply(entry.Data)
+		}
+
+		// Put the value into the store
+		n.Put(pair.Key, string(pair.Value))
+	}
+	return nil
+}
+
+// Process snapshot is not yet implemented but applies
+// a snapshot to handle node failures and restart
+func (n *Node) processSnapshot(snapshot raftpb.Snapshot) {
+	// TODO(abronan): implement snapshot
+	panic(fmt.Sprintf("Applying snapshot on node %v is not implemented", n.ID))
+}

--- a/state/raft_test.go
+++ b/state/raft_test.go
@@ -1,0 +1,411 @@
+package state
+
+import (
+	"io/ioutil"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/docker/swarm-v2/api"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	raftLogger = &raft.DefaultLogger{Logger: log.New(ioutil.Discard, "", 0)}
+)
+
+// Main Raft test method, we execute the
+// tests sequentially to avoid any issue
+// on bootstrap and raft cluster lifecycle
+func TestRaft(t *testing.T) {
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+
+	testBootstrap(t)
+	testLeader(t)
+	testLeaderDown(t)
+	testFollowerDown(t)
+	testLogReplication(t)
+	testLogReplicationWithoutLeader(t)
+	testQuorumFailure(t)
+	testLeaderLeave(t)
+	testFollowerLeave(t)
+
+	// TODO
+	testSnapshot(t)
+	testRecoverSnapshot(t)
+}
+
+func newInitNode(t *testing.T, id uint64) *Node {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err, "can't bind to raft service port")
+	s := grpc.NewServer()
+
+	cfg := DefaultNodeConfig()
+	cfg.Logger = raftLogger
+
+	n, err := NewNode(context.Background(), id, l.Addr().String(), cfg, nil)
+	assert.NoError(t, err, "can't create raft node")
+	n.Listener = l
+	n.Server = s
+
+	n.Campaign(n.Ctx)
+	n.Start()
+
+	Register(s, n)
+	go s.Serve(l)
+
+	time.Sleep(1 * time.Second)
+	return n
+}
+
+func newJoinNode(t *testing.T, id uint64, join string) *Node {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err, "can't bind to raft service port")
+	s := grpc.NewServer()
+
+	cfg := DefaultNodeConfig()
+	cfg.Logger = raftLogger
+
+	n, err := NewNode(context.Background(), id, l.Addr().String(), cfg, nil)
+	assert.NoError(t, err, "can't create raft node")
+	n.Listener = l
+	n.Server = s
+
+	n.Start()
+
+	c, err := GetRaftClient(join, 100*time.Millisecond)
+	assert.NoError(t, err, "can't initiate connection with existing raft")
+
+	resp, err := c.Join(n.Ctx, &api.JoinRequest{
+		&api.RaftNode{ID: id, Addr: l.Addr().String()},
+	})
+	assert.NoError(t, err, "can't join existing Raft")
+
+	err = n.RegisterNodes(resp.Members)
+	assert.NoError(t, err, "can't add nodes to the local cluster list")
+
+	Register(s, n)
+	go s.Serve(l)
+
+	time.Sleep(1 * time.Second)
+	return n
+}
+
+func newRaftCluster(t *testing.T) map[int]*Node {
+	nodes := make(map[int]*Node, 0)
+
+	nodes[1] = newInitNode(t, 1)
+	nodes[2] = newJoinNode(t, 2, nodes[1].Listener.Addr().String())
+	nodes[3] = newJoinNode(t, 3, nodes[1].Listener.Addr().String())
+
+	return nodes
+}
+
+func addRaftNode(t *testing.T, nodes map[int]*Node) {
+	n := len(nodes) + 1
+	nodes[n] = newJoinNode(t, uint64(n), nodes[1].Listener.Addr().String())
+}
+
+func teardownCluster(t *testing.T, nodes map[int]*Node) {
+	for _, node := range nodes {
+		shutdownNode(node)
+	}
+	nodes = nil
+
+	// FIXME We have to wait a little bit for the
+	// connections to be cleaned up properly
+	time.Sleep(2 * time.Second)
+}
+
+func removeNode(nodes map[string]*Node, node string) {
+	shutdownNode(nodes[node])
+	delete(nodes, node)
+}
+
+func shutdownNode(node *Node) {
+	node.Server.Stop()
+	node.Server.TestingCloseConns()
+	node.Listener.Close()
+	node.Listener = nil
+	node.Shutdown()
+}
+
+func testBootstrap(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	assert.Equal(t, len(nodes[1].Cluster.Peers()), 3)
+	assert.Equal(t, len(nodes[2].Cluster.Peers()), 3)
+	assert.Equal(t, len(nodes[3].Cluster.Peers()), 3)
+}
+
+func testLeader(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	assert.True(t, nodes[1].IsLeader(), "error: node 1 is not the Leader")
+
+	// nodes should all have the same leader
+	assert.Equal(t, nodes[1].Leader(), nodes[1].ID)
+	assert.Equal(t, nodes[2].Leader(), nodes[1].ID)
+	assert.Equal(t, nodes[3].Leader(), nodes[1].ID)
+}
+
+func testLeaderDown(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// Stop node 1
+	nodes[1].Stop()
+
+	// Wait for the re-election to occur
+	time.Sleep(4 * time.Second)
+
+	// Leader should not be 1
+	assert.NotEqual(t, nodes[2].Leader(), nodes[1].ID)
+
+	// Ensure that node 2 and node 3 have the same leader
+	assert.Equal(t, nodes[3].Leader(), nodes[2].Leader())
+
+	// Propose a value
+	nodes[2].Propose(nodes[2].Ctx, pair)
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// The value should be replicated on all remaining nodes
+	assert.Equal(t, nodes[2].StoreLength(), 1)
+	assert.Equal(t, nodes[2].Get(key), string(value))
+	assert.Equal(t, len(nodes[2].Cluster.Peers()), 3)
+
+	assert.Equal(t, nodes[3].StoreLength(), 1)
+	assert.Equal(t, nodes[3].Get(key), string(value))
+	assert.Equal(t, len(nodes[3].Cluster.Peers()), 3)
+}
+
+func testFollowerDown(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// Stop node 3
+	nodes[3].Stop()
+
+	// Wait election tick
+	time.Sleep(4 * time.Second)
+
+	// Leader should still be 1
+	assert.True(t, nodes[1].IsLeader(), "node 1 is not a leader anymore")
+	assert.Equal(t, nodes[2].Leader(), nodes[1].ID)
+
+	// Propose a value
+	nodes[2].Propose(nodes[2].Ctx, pair)
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// The value should be replicated on all remaining nodes
+	assert.Equal(t, nodes[1].StoreLength(), 1)
+	assert.Equal(t, nodes[1].Get(key), string(value))
+	assert.Equal(t, len(nodes[1].Cluster.Peers()), 3)
+
+	assert.Equal(t, nodes[2].StoreLength(), 1)
+	assert.Equal(t, nodes[2].Get(key), string(value))
+	assert.Equal(t, len(nodes[2].Cluster.Peers()), 3)
+}
+
+func testLogReplication(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// Propose a value
+	err = nodes[1].Propose(nodes[1].Ctx, pair)
+	assert.NoError(t, err, "can't propose new value")
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// All nodes should have the value in the physical store
+	assert.Equal(t, nodes[1].StoreLength(), 1)
+	assert.Equal(t, nodes[1].Get(key), string(value))
+
+	assert.Equal(t, nodes[2].StoreLength(), 1)
+	assert.Equal(t, nodes[2].Get(key), string(value))
+
+	assert.Equal(t, nodes[3].StoreLength(), 1)
+	assert.Equal(t, nodes[3].Get(key), string(value))
+}
+
+func testLogReplicationWithoutLeader(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// Stop the leader
+	nodes[1].Stop()
+
+	// Propose a value
+	err = nodes[2].Propose(nodes[2].Ctx, pair)
+	assert.NoError(t, err, "can't propose new value")
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// No value should be replicated in the store in the absence of the leader
+	assert.Equal(t, nodes[2].StoreLength(), 0)
+	assert.Equal(t, nodes[2].Get(key), "")
+
+	assert.Equal(t, nodes[3].StoreLength(), 0)
+	assert.Equal(t, nodes[3].Get(key), "")
+}
+
+func testQuorumFailure(t *testing.T) {
+	// Bring up a 5 nodes cluster
+	nodes := newRaftCluster(t)
+	addRaftNode(t, nodes)
+	addRaftNode(t, nodes)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// Lose a majority
+	nodes[3].Stop()
+	nodes[4].Stop()
+	nodes[5].Stop()
+
+	// Propose a value
+	nodes[1].Propose(nodes[1].Ctx, pair)
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// The value should not be replicated, we have no majority
+	assert.Equal(t, nodes[1].StoreLength(), 0)
+	assert.Equal(t, nodes[1].Get(key), "")
+
+	assert.Equal(t, nodes[2].StoreLength(), 0)
+	assert.Equal(t, nodes[2].Get(key), "")
+}
+
+func testFollowerLeave(t *testing.T) {
+	// Bring up a 5 nodes cluster
+	nodes := newRaftCluster(t)
+	addRaftNode(t, nodes)
+	addRaftNode(t, nodes)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	resp, err := nodes[5].Leave(nodes[5].Ctx, &api.LeaveRequest{&api.RaftNode{ID: nodes[5].ID}})
+	assert.NoError(t, err, "error sending message to leave the raft")
+	assert.NotNil(t, resp, "leave response message is nil")
+
+	// Propose a value
+	nodes[1].Propose(nodes[1].Ctx, pair)
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// Value should be replicated on every node
+	assert.Equal(t, nodes[1].StoreLength(), 1)
+	assert.Equal(t, nodes[1].Get(key), string(value))
+	assert.Equal(t, len(nodes[1].Cluster.Peers()), 4)
+
+	assert.Equal(t, nodes[2].StoreLength(), 1)
+	assert.Equal(t, nodes[2].Get(key), string(value))
+	assert.Equal(t, len(nodes[2].Cluster.Peers()), 4)
+
+	assert.Equal(t, nodes[3].StoreLength(), 1)
+	assert.Equal(t, nodes[3].Get(key), string(value))
+	assert.Equal(t, len(nodes[3].Cluster.Peers()), 4)
+
+	assert.Equal(t, nodes[4].StoreLength(), 1)
+	assert.Equal(t, nodes[4].Get(key), string(value))
+	assert.Equal(t, len(nodes[4].Cluster.Peers()), 4)
+}
+
+func testLeaderLeave(t *testing.T) {
+	nodes := newRaftCluster(t)
+	defer teardownCluster(t, nodes)
+
+	key := "foo"
+	value := []byte("bar")
+
+	pair, err := EncodePair(key, value)
+	assert.NoError(t, err, "can't encode key/value pair")
+
+	// node 1 is the leader
+	assert.Equal(t, nodes[1].Leader(), nodes[1].ID)
+
+	// Try to leave the raft
+	resp, err := nodes[1].Leave(nodes[1].Ctx, &api.LeaveRequest{&api.RaftNode{ID: nodes[1].ID}})
+	assert.NoError(t, err, "error sending message to leave the raft")
+	assert.NotNil(t, resp, "leave response message is nil")
+
+	// Wait for election tick
+	time.Sleep(4 * time.Second)
+
+	// Leader should not be 1
+	assert.NotEqual(t, nodes[2].Leader(), nodes[1].ID)
+	assert.Equal(t, nodes[2].Leader(), nodes[3].Leader())
+
+	// Propose a value
+	nodes[2].Propose(nodes[2].Ctx, pair)
+
+	// Wait heartbeat tick
+	time.Sleep(1 * time.Second)
+
+	// The value should be replicated on all remaining nodes
+	assert.Equal(t, nodes[2].StoreLength(), 1)
+	assert.Equal(t, nodes[2].Get(key), string(value))
+	assert.Equal(t, len(nodes[2].Cluster.Peers()), 2)
+
+	assert.Equal(t, nodes[3].StoreLength(), 1)
+	assert.Equal(t, nodes[3].Get(key), string(value))
+	assert.Equal(t, len(nodes[3].Cluster.Peers()), 2)
+}
+
+func testSnapshot(t *testing.T) {
+	t.Skip()
+}
+
+func testRecoverSnapshot(t *testing.T) {
+	t.Skip()
+}

--- a/state/util.go
+++ b/state/util.go
@@ -1,0 +1,66 @@
+package state
+
+import (
+	"errors"
+	"time"
+
+	"github.com/docker/swarm-v2/api"
+	"github.com/gogo/protobuf/proto"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	// MaxRetries is the maximum number of retries allowed to
+	// initiate a grpc connection to a remote raft member
+	MaxRetries = 3
+)
+
+// Raft represents a connection to a raft member
+type Raft struct {
+	api.ManagerClient
+	Conn *grpc.ClientConn
+}
+
+// GetRaftClient returns a raft client object to communicate
+// with other raft members
+func GetRaftClient(addr string, timeout time.Duration) (*Raft, error) {
+	conn, err := dial(addr, "tcp", timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Raft{
+		ManagerClient: api.NewManagerClient(conn),
+		Conn:          conn,
+	}, nil
+}
+
+// dial returns a grpc client connection
+func dial(addr string, protocol string, timeout time.Duration) (*grpc.ClientConn, error) {
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(timeout))
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// EncodePair returns a protobuf encoded key/value pair to be sent through raft
+func EncodePair(key string, value []byte) ([]byte, error) {
+	k := proto.String(key)
+	pair := &api.Pair{
+		Key:   *k,
+		Value: value,
+	}
+	data, err := proto.Marshal(pair)
+	if err != nil {
+		return nil, errors.New("Can't encode key/value using protobuf")
+	}
+	return data, nil
+}
+
+// Register registers the node raft server
+func Register(server *grpc.Server, node *Node) {
+	api.RegisterManagerServer(server, node)
+}


### PR DESCRIPTION
Replaces #14 

This takes the existing code in #14 using the API defined in #50 

I will improve from the current state after review and merge. Next step should weave the raft store to the memory store and add tests for the integration.

/cc @aluzzardi @aaronlehmann @vieux 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
