### PR TITLE
add -l, --log-level to both swarmd and swarmctl

### DIFF
--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/cmd/swarmctl/job"
 	"github.com/docker/swarm-v2/cmd/swarmctl/node"
 	"github.com/docker/swarm-v2/cmd/swarmctl/task"
@@ -14,8 +14,7 @@ import (
 
 func main() {
 	if err := mainCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(1)
+		logrus.Fatal(err)
 	}
 }
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"net"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/manager/clusterapi"
 	"github.com/docker/swarm-v2/manager/dispatcher"
@@ -51,6 +52,8 @@ func (m *Manager) ListenAndServe() error {
 	if err != nil {
 		return err
 	}
+	logrus.WithFields(logrus.Fields{"proto": m.config.ListenProto, "addr": m.config.ListenAddr}).Info("Listening for connections")
+
 	return m.server.Serve(lis)
 }
 


### PR DESCRIPTION
1st PR, feel free to comment if I didn't follow the code conventions.

introduced a `common` package in `cmd` used to share code between swarmd and swarmctl

If you think cmd should only contains actual commands, please tell me where to put this pkg.
