### PR TITLE
Add Network methods to store

### DIFF
--- a/state/apply.go
+++ b/state/apply.go
@@ -25,6 +25,11 @@ func Apply(store Store, item watch.Event) (err error) {
 		case EventDeleteJob:
 			return tx.Jobs().Delete(v.Job.ID)
 
+		case EventCreateNetwork:
+			return tx.Networks().Create(v.Network)
+		case EventDeleteNetwork:
+			return tx.Networks().Delete(v.Network.ID)
+
 		case EventCreateNode:
 			return tx.Nodes().Create(v.Node)
 		case EventUpdateNode:

--- a/state/store.go
+++ b/state/store.go
@@ -66,6 +66,28 @@ type JobSet interface {
 	JobSetWriter
 }
 
+// NetworkSetWriter is the write half of a network dataset.
+type NetworkSetWriter interface {
+	Create(j *api.Network) error
+	Delete(id string) error
+}
+
+// NetworkSetReader is the read half of a network dataset.
+type NetworkSetReader interface {
+	// Get returns the network with this ID, or nil if none exists with the
+	// specified ID.
+	Get(id string) *api.Network
+	// Find selects a set of networks and returns them. If by is nil,
+	// returns all jobs.
+	Find(by By) ([]*api.Network, error)
+}
+
+// NetworkSet is a readable and writable consistent view of networks.
+type NetworkSet interface {
+	NetworkSetReader
+	NetworkSetWriter
+}
+
 // TaskSetWriter is the write half of a task dataset.
 type TaskSetWriter interface {
 	Create(t *api.Task) error
@@ -96,6 +118,7 @@ type TaskSet interface {
 type ReadTx interface {
 	Nodes() NodeSetReader
 	Jobs() JobSetReader
+	Networks() NetworkSetReader
 	Tasks() TaskSetReader
 }
 
@@ -106,6 +129,7 @@ type ReadTx interface {
 type Tx interface {
 	Nodes() NodeSet
 	Jobs() JobSet
+	Networks() NetworkSet
 	Tasks() TaskSet
 }
 

--- a/state/watch.go
+++ b/state/watch.go
@@ -180,6 +180,63 @@ func (e EventDeleteJob) matches(watchEvent watch.Event) bool {
 	return true
 }
 
+// NetworkCheckFunc is the type of function used to perform filtering checks on
+// api.Job structures.
+type NetworkCheckFunc func(n1, n2 *api.Network) bool
+
+// NetworkCheckID is a NetworkCheckFunc for matching network IDs.
+func NetworkCheckID(n1, n2 *api.Network) bool {
+	return n1.ID == n2.ID
+}
+
+// EventCreateNetwork is the type used to put CreateNetwork events on the
+// publish/subscribe queue and filter these events in calls to Watch.
+type EventCreateNetwork struct {
+	Network *api.Network
+	// Checks is a list of functions to call to filter events for a watch
+	// stream. They are applied with AND logic. They are only applicable for
+	// calls to Watch.
+	Checks []NetworkCheckFunc
+}
+
+func (e EventCreateNetwork) matches(watchEvent watch.Event) bool {
+	typedEvent, ok := watchEvent.Payload.(EventCreateNetwork)
+	if !ok {
+		return false
+	}
+
+	for _, check := range e.Checks {
+		if !check(e.Network, typedEvent.Network) {
+			return false
+		}
+	}
+	return true
+}
+
+// EventDeleteNetwork is the type used to put DeleteNetwork events on the
+// publish/subscribe queue and filter these events in calls to Watch.
+type EventDeleteNetwork struct {
+	Network *api.Network
+	// Checks is a list of functions to call to filter events for a watch
+	// stream. They are applied with AND logic. They are only applicable for
+	// calls to Watch.
+	Checks []NetworkCheckFunc
+}
+
+func (e EventDeleteNetwork) matches(watchEvent watch.Event) bool {
+	typedEvent, ok := watchEvent.Payload.(EventDeleteNetwork)
+	if !ok {
+		return false
+	}
+
+	for _, check := range e.Checks {
+		if !check(e.Network, typedEvent.Network) {
+			return false
+		}
+	}
+	return true
+}
+
 // NodeCheckFunc is the type of function used to perform filtering checks on
 // api.Job structures.
 type NodeCheckFunc func(n1, n2 *api.Node) bool


### PR DESCRIPTION
Added network object accessor methods to store interface
and the associated watcher interfaces for it.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
