### PR TITLE
identity: panic rather than returning an error.

### DIFF
--- a/identity/randomid.go
+++ b/identity/randomid.go
@@ -37,20 +37,14 @@ const (
 // 128 bits of entropy encoded with base36. Leading padding is added if the
 // string is less 25 bytes. We do not intend to maintain this interface, so
 // identifiers should be treated opaquely.
-//
-// The only errors returned by NewID are related to reading the random source.
-// These should be rare, but please make sure to check the error because the
-// result of degraded or absent randomness can be disasterous. In the future,
-// errors may be less rare if another identifier generation scheme is
-// leveraged.
-func NewID() (string, error) {
+func NewID() string {
 	var p [randomIDEntropyBytes]byte
 
 	if _, err := io.ReadFull(idReader, p[:]); err != nil {
-		return "", err
+		panic(fmt.Errorf("failed to read random bytes: %v", err))
 	}
 
 	var nn big.Int
 	nn.SetBytes(p[:])
-	return fmt.Sprintf("%0[1]*s", maxRandomIDLength, nn.Text(randomIDBase)), nil
+	return fmt.Sprintf("%0[1]*s", maxRandomIDLength, nn.Text(randomIDBase))
 }

--- a/identity/randomid_test.go
+++ b/identity/randomid_test.go
@@ -10,10 +10,7 @@ func TestGenerateGUID(t *testing.T) {
 	idReader = rand.New(rand.NewSource(0))
 
 	for i := 0; i < 1000; i++ {
-		guid, err := NewID()
-		if err != nil {
-			t.Fatal(err)
-		}
+		guid := NewID()
 
 		var i big.Int
 		_, ok := i.SetString(guid, randomIDBase)

--- a/manager/clusterapi/job.go
+++ b/manager/clusterapi/job.go
@@ -22,16 +22,12 @@ func (s *Server) CreateJob(ctx context.Context, request *api.CreateJobRequest) (
 
 	// TODO(aluzzardi): Consider using `Name` as a primary key to handle
 	// duplicate creations. See #65
-	id, err := identity.NewID()
-	if err != nil {
-		return nil, err
-	}
 	job := &api.Job{
-		ID:   id,
+		ID:   identity.NewID(),
 		Spec: request.Spec,
 	}
 
-	err = s.store.Update(func(tx state.Tx) error {
+	err := s.store.Update(func(tx state.Tx) error {
 		return tx.Jobs().Create(job)
 	})
 	if err != nil {

--- a/scheduler/orchestrator/orchestrator.go
+++ b/scheduler/orchestrator/orchestrator.go
@@ -115,17 +115,14 @@ func (o *Orchestrator) balance(job *api.Job) {
 			for i := int64(0); i < diff; i++ {
 				spec := *job.Spec
 				task := &api.Task{
+					ID:    identity.NewID(),
 					Spec:  &spec,
 					JobID: job.ID,
 					Status: &api.TaskStatus{
 						State: api.TaskStatus_NEW,
 					},
 				}
-				var err error
-				task.ID, err = identity.NewID()
-				if err != nil {
-					log.Error(err)
-				} else if err := tx.Tasks().Create(task); err != nil {
+				if err := tx.Tasks().Create(task); err != nil {
 					log.Error(err)
 				}
 			}


### PR DESCRIPTION
Returning an error makes its usage much less nicer (see updated code).
Also, the caller wouldn't even really know how to deal with that.

If it becomes a problem, we should fallback to another source of ID
generation rather than returning an error.

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
