### PR TITLE
Fix spinning/hanging in orchestrator test

### DIFF
--- a/scheduler/orchestrator/orchestrator.go
+++ b/scheduler/orchestrator/orchestrator.go
@@ -68,6 +68,7 @@ func (o *Orchestrator) Run() {
 			}
 		case <-o.stopChan:
 			queue.StopWatch(watcher)
+			o.stopChan = nil
 		}
 	}
 }

--- a/watch/pubsub.go
+++ b/watch/pubsub.go
@@ -126,6 +126,7 @@ func (p *publisher) sendEvents(ch chan<- Event, sub *subscriber) {
 				select {
 				case ch <- nextEvent:
 				case <-sub.closed:
+					close(ch)
 					return
 				}
 			}


### PR DESCRIPTION
Set o.stopChan to nil after it is closed. Otherwise, the orchestrator
event loop can trigger that case forever.

Also, fix watch/pubsub.go to close the subscription channel when the
watcher is stopped while processing an event. This fix originally
appeared in #53, which hasn't been merged yet.
