### PR TITLE
api: move NodeID from NodeSpec to Node

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -152,8 +152,8 @@ func (a *Agent) register(ctx context.Context) (string, error) {
 	client := api.NewDispatcherClient(a.conn)
 
 	resp, err := client.Register(ctx, &api.RegisterRequest{
+		NodeID: a.config.ID,
 		Spec: &api.NodeSpec{
-			ID:   a.config.ID,
 			Meta: &api.Meta{Name: a.config.Name},
 		},
 	})

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -31,6 +31,10 @@ var _ = math.Inf
 
 type RegisterRequest struct {
 	Spec *NodeSpec `protobuf:"bytes,1,opt,name=spec" json:"spec,omitempty"`
+	// NodeID identifies the registering node.
+	//
+	// This contents of this field *must* be authenticated.
+	NodeID string `protobuf:"bytes,2,opt,name=node_id,proto3" json:"node_id,omitempty"`
 }
 
 func (m *RegisterRequest) Reset()      { *m = RegisterRequest{} }
@@ -178,11 +182,12 @@ func (this *RegisterRequest) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 5)
+	s := make([]string, 0, 6)
 	s = append(s, "&api.RegisterRequest{")
 	if this.Spec != nil {
 		s = append(s, "Spec: "+fmt.Sprintf("%#v", this.Spec)+",\n")
 	}
+	s = append(s, "NodeID: "+fmt.Sprintf("%#v", this.NodeID)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -599,6 +604,12 @@ func (m *RegisterRequest) MarshalTo(data []byte) (int, error) {
 		}
 		i += n1
 	}
+	if len(m.NodeID) > 0 {
+		data[i] = 0x12
+		i++
+		i = encodeVarintDispatcher(data, i, uint64(len(m.NodeID)))
+		i += copy(data[i:], m.NodeID)
+	}
 	return i, nil
 }
 
@@ -909,6 +920,10 @@ func (m *RegisterRequest) Size() (n int) {
 		l = m.Spec.Size()
 		n += 1 + l + sovDispatcher(uint64(l))
 	}
+	l = len(m.NodeID)
+	if l > 0 {
+		n += 1 + l + sovDispatcher(uint64(l))
+	}
 	return n
 }
 
@@ -1049,6 +1064,7 @@ func (this *RegisterRequest) String() string {
 	}
 	s := strings.Join([]string{`&RegisterRequest{`,
 		`Spec:` + strings.Replace(fmt.Sprintf("%v", this.Spec), "NodeSpec", "NodeSpec", 1) + `,`,
+		`NodeID:` + fmt.Sprintf("%v", this.NodeID) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1218,6 +1234,35 @@ func (m *RegisterRequest) Unmarshal(data []byte) error {
 			if err := m.Spec.Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowDispatcher
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthDispatcher
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NodeID = string(data[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/dispatcher.proto
+++ b/api/dispatcher.proto
@@ -38,6 +38,11 @@ service Dispatcher { // maybe dispatch, al likes this
 
 message RegisterRequest {
 	NodeSpec spec = 1;
+
+	// NodeID identifies the registering node.
+	//
+	// This contents of this field *must* be authenticated.
+	string node_id = 2 [(gogoproto.customname) = "NodeID"];
 }
 
 message RegisterResponse {

--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -183,16 +183,8 @@ func (*Meta) ProtoMessage() {}
 
 type NodeSpec struct {
 	Meta *Meta `protobuf:"bytes,1,opt,name=meta" json:"meta,omitempty"`
-	// ID specifies the identity of the node.
-	// TODO(stevvooe): Currently, node identity responsibility is up in the
-	// air. It really depends on the security model. Placed here, we are saying
-	// that a node is responsible for its own identity. If we decide that this
-	// is the masters responsibility, this goes elsewhere.
-	//
-	// In all liklihood, this field will be removed, in favor of the Node.ID
-	// field and node identity will be conferred through another channel.
-	ID   string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
-	Addr string `protobuf:"bytes,3,opt,name=addr,proto3" json:"addr,omitempty"`
+	// Addr provides an address for the node, accessible via the manager set.
+	Addr string `protobuf:"bytes,2,opt,name=addr,proto3" json:"addr,omitempty"`
 	// Status is the state of the node as seen by the creator the
 	// specification. When reported by an agent, this will almost always be
 	// READY or empty. When communicating through the Cluster API, this can be
@@ -204,6 +196,8 @@ func (m *NodeSpec) Reset()      { *m = NodeSpec{} }
 func (*NodeSpec) ProtoMessage() {}
 
 type Node struct {
+	// ID specifies the identity of the node.
+	ID   string    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	Spec *NodeSpec `protobuf:"bytes,2,opt,name=spec" json:"spec,omitempty"`
 	// Status provides the current status of the node, as seen by the manager.
 	// This may differ from the state in the nodespec.
@@ -781,12 +775,11 @@ func (this *NodeSpec) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 8)
+	s := make([]string, 0, 7)
 	s = append(s, "&api.NodeSpec{")
 	if this.Meta != nil {
 		s = append(s, "Meta: "+fmt.Sprintf("%#v", this.Meta)+",\n")
 	}
-	s = append(s, "ID: "+fmt.Sprintf("%#v", this.ID)+",\n")
 	s = append(s, "Addr: "+fmt.Sprintf("%#v", this.Addr)+",\n")
 	if this.Status != nil {
 		s = append(s, "Status: "+fmt.Sprintf("%#v", this.Status)+",\n")
@@ -798,8 +791,9 @@ func (this *Node) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 6)
+	s := make([]string, 0, 7)
 	s = append(s, "&api.Node{")
+	s = append(s, "ID: "+fmt.Sprintf("%#v", this.ID)+",\n")
 	if this.Spec != nil {
 		s = append(s, "Spec: "+fmt.Sprintf("%#v", this.Spec)+",\n")
 	}
@@ -1245,14 +1239,8 @@ func (m *NodeSpec) MarshalTo(data []byte) (int, error) {
 		}
 		i += n1
 	}
-	if len(m.ID) > 0 {
-		data[i] = 0x12
-		i++
-		i = encodeVarintTypes(data, i, uint64(len(m.ID)))
-		i += copy(data[i:], m.ID)
-	}
 	if len(m.Addr) > 0 {
-		data[i] = 0x1a
+		data[i] = 0x12
 		i++
 		i = encodeVarintTypes(data, i, uint64(len(m.Addr)))
 		i += copy(data[i:], m.Addr)
@@ -1285,6 +1273,12 @@ func (m *Node) MarshalTo(data []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	if len(m.ID) > 0 {
+		data[i] = 0xa
+		i++
+		i = encodeVarintTypes(data, i, uint64(len(m.ID)))
+		i += copy(data[i:], m.ID)
+	}
 	if m.Spec != nil {
 		data[i] = 0x12
 		i++
@@ -2190,10 +2184,6 @@ func (m *NodeSpec) Size() (n int) {
 		l = m.Meta.Size()
 		n += 1 + l + sovTypes(uint64(l))
 	}
-	l = len(m.ID)
-	if l > 0 {
-		n += 1 + l + sovTypes(uint64(l))
-	}
 	l = len(m.Addr)
 	if l > 0 {
 		n += 1 + l + sovTypes(uint64(l))
@@ -2208,6 +2198,10 @@ func (m *NodeSpec) Size() (n int) {
 func (m *Node) Size() (n int) {
 	var l int
 	_ = l
+	l = len(m.ID)
+	if l > 0 {
+		n += 1 + l + sovTypes(uint64(l))
+	}
 	if m.Spec != nil {
 		l = m.Spec.Size()
 		n += 1 + l + sovTypes(uint64(l))
@@ -2623,7 +2617,6 @@ func (this *NodeSpec) String() string {
 	}
 	s := strings.Join([]string{`&NodeSpec{`,
 		`Meta:` + strings.Replace(fmt.Sprintf("%v", this.Meta), "Meta", "Meta", 1) + `,`,
-		`ID:` + fmt.Sprintf("%v", this.ID) + `,`,
 		`Addr:` + fmt.Sprintf("%v", this.Addr) + `,`,
 		`Status:` + strings.Replace(fmt.Sprintf("%v", this.Status), "NodeStatus", "NodeStatus", 1) + `,`,
 		`}`,
@@ -2635,6 +2628,7 @@ func (this *Node) String() string {
 		return "nil"
 	}
 	s := strings.Join([]string{`&Node{`,
+		`ID:` + fmt.Sprintf("%v", this.ID) + `,`,
 		`Spec:` + strings.Replace(fmt.Sprintf("%v", this.Spec), "NodeSpec", "NodeSpec", 1) + `,`,
 		`Status:` + strings.Replace(strings.Replace(this.Status.String(), "NodeStatus", "NodeStatus", 1), `&`, ``, 1) + `,`,
 		`}`,
@@ -3218,35 +3212,6 @@ func (m *NodeSpec) Unmarshal(data []byte) error {
 			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowTypes
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := data[iNdEx]
-				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthTypes
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.ID = string(data[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Addr", wireType)
 			}
 			var stringLen uint64
@@ -3357,6 +3322,35 @@ func (m *Node) Unmarshal(data []byte) error {
 			return fmt.Errorf("proto: Node: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowTypes
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthTypes
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Spec", wireType)

--- a/api/types.proto
+++ b/api/types.proto
@@ -17,17 +17,8 @@ message Meta {
 message NodeSpec {
 	Meta meta = 1;
 
-	// ID specifies the identity of the node.
-	// TODO(stevvooe): Currently, node identity responsibility is up in the
-	// air. It really depends on the security model. Placed here, we are saying
-	// that a node is responsible for its own identity. If we decide that this
-	// is the masters responsibility, this goes elsewhere.
-	//
-	// In all liklihood, this field will be removed, in favor of the Node.ID
-	// field and node identity will be conferred through another channel.
-	string id = 2 [(gogoproto.customname) = "ID"];
-
-	string addr = 3;
+	// Addr provides an address for the node, accessible via the manager set.
+	string addr = 2;
 
 	// Status is the state of the node as seen by the creator the
 	// specification. When reported by an agent, this will almost always be
@@ -41,8 +32,7 @@ message NodeSpec {
 
 message Node {
 	// ID specifies the identity of the node.
-	// TODO(stevvooe): Please see the comment on NodeSpec. Leaving this out for now.
-	// string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1 [(gogoproto.customname) = "ID"];
 
 	NodeSpec spec = 2;
 

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -63,17 +63,17 @@ func TestRegisterTwice(t *testing.T) {
 	assert.NoError(t, err)
 	defer gd.Close()
 
-	testNode := &api.NodeSpec{ID: "test"}
+	testNode := &api.Node{ID: "test"}
 	var expectedSessionID string
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.NotEmpty(t, resp.SessionID)
 		expectedSessionID = resp.SessionID
 	}
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.Equal(t, resp.SessionID, expectedSessionID)
@@ -88,10 +88,10 @@ func TestHeartbeat(t *testing.T) {
 	assert.NoError(t, err)
 	defer gd.Close()
 
-	testNode := &api.NodeSpec{ID: "test"}
+	testNode := &api.Node{ID: "test"}
 	var expectedSessionID string
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.NotEmpty(t, resp.SessionID)
@@ -129,10 +129,10 @@ func TestHeartbeatTimeout(t *testing.T) {
 	assert.NoError(t, err)
 	defer gd.Close()
 
-	testNode := &api.NodeSpec{ID: "test"}
+	testNode := &api.Node{ID: "test"}
 	var expectedSessionID string
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.NotEmpty(t, resp.SessionID)
@@ -170,10 +170,10 @@ func TestTasks(t *testing.T) {
 	gd, err := startDispatcher(DefaultConfig())
 	assert.NoError(t, err)
 	defer gd.Close()
-	testNode := &api.NodeSpec{ID: "test"}
+	testNode := &api.Node{ID: "test"}
 	var expectedSessionID string
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.NotEmpty(t, resp.SessionID)
@@ -264,10 +264,10 @@ func TestTaskUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	defer gd.Close()
 
-	testNode := &api.NodeSpec{ID: "test"}
+	testNode := &api.Node{ID: "test"}
 	var expectedSessionID string
 	{
-		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{Spec: testNode})
+		resp, err := gd.Client.Register(context.Background(), &api.RegisterRequest{NodeID: testNode.ID, Spec: testNode.Spec})
 		assert.NoError(t, err)
 		assert.Equal(t, resp.NodeID, testNode.ID)
 		assert.NotEmpty(t, resp.SessionID)

--- a/scheduler/planner/planner.go
+++ b/scheduler/planner/planner.go
@@ -137,8 +137,8 @@ func (p *Planner) scheduleTask(t *api.Task) bool {
 			return err
 		}
 
-		log.Infof("Assigning task %s to node %s", t.ID, node.Spec.ID)
-		t.NodeID = node.Spec.ID
+		log.Infof("Assigning task %s to node %s", t.ID, node.ID)
+		t.NodeID = node.ID
 		t.Status.State = api.TaskStatus_ASSIGNED
 		if err := tx.Tasks().Update(t); err != nil {
 			log.Error(err)
@@ -166,7 +166,7 @@ func (p *Planner) selectNodeForTask(t *api.Task, tx state.Tx) *api.Node {
 
 	for _, n := range nodes {
 		if n.Status.State == api.NodeStatus_READY /*&& !n.Drained*/ {
-			tasks, err := tx.Tasks().Find(state.ByNodeID(n.Spec.ID))
+			tasks, err := tx.Tasks().Find(state.ByNodeID(n.ID))
 			if err != nil {
 				log.Errorf("Error selecting tasks by node: %v", err)
 				continue

--- a/state/apply.go
+++ b/state/apply.go
@@ -35,7 +35,7 @@ func Apply(store Store, item watch.Event) (err error) {
 		case EventUpdateNode:
 			return tx.Nodes().Update(v.Node)
 		case EventDeleteNode:
-			return tx.Nodes().Delete(v.Node.Spec.ID)
+			return tx.Nodes().Delete(v.Node.ID)
 		}
 		return errors.New("unrecognized event type")
 	})

--- a/state/memory.go
+++ b/state/memory.go
@@ -94,11 +94,11 @@ type nodes struct {
 // Create adds a new node to the store.
 // Returns ErrExist if the ID is already taken.
 func (nodes nodes) Create(n *api.Node) error {
-	if _, ok := nodes.s.nodes[n.Spec.ID]; ok {
+	if _, ok := nodes.s.nodes[n.ID]; ok {
 		return ErrExist
 	}
 
-	nodes.s.nodes[n.Spec.ID] = n
+	nodes.s.nodes[n.ID] = n
 	Publish(nodes.s.queue, EventCreateNode{Node: n})
 	return nil
 }
@@ -106,11 +106,11 @@ func (nodes nodes) Create(n *api.Node) error {
 // Update updates an existing node in the store.
 // Returns ErrNotExist if the node doesn't exist.
 func (nodes nodes) Update(n *api.Node) error {
-	if _, ok := nodes.s.nodes[n.Spec.ID]; !ok {
+	if _, ok := nodes.s.nodes[n.ID]; !ok {
 		return ErrNotExist
 	}
 
-	nodes.s.nodes[n.Spec.ID] = n
+	nodes.s.nodes[n.ID] = n
 	Publish(nodes.s.queue, EventUpdateNode{Node: n})
 	return nil
 }
@@ -447,7 +447,7 @@ func (s *MemoryStore) CopyFrom(tx ReadTx) error {
 		return err
 	}
 	for _, n := range nodes {
-		s.nodes[n.Spec.ID] = n
+		s.nodes[n.ID] = n
 	}
 
 	tasks, err := tx.Tasks().Find(All)

--- a/state/memory_test.go
+++ b/state/memory_test.go
@@ -10,24 +10,24 @@ import (
 func TestStoreNode(t *testing.T) {
 	nodeSet := []*api.Node{
 		{
+			ID: "id1",
 			Spec: &api.NodeSpec{
-				ID: "id1",
 				Meta: &api.Meta{
 					Name: "name1",
 				},
 			},
 		},
 		{
+			ID: "id2",
 			Spec: &api.NodeSpec{
-				ID: "id2",
 				Meta: &api.Meta{
 					Name: "name2",
 				},
 			},
 		},
 		{
+			ID: "id3",
 			Spec: &api.NodeSpec{
-				ID: "id3",
 				Meta: &api.Meta{
 					Name: "name2",
 				},
@@ -79,8 +79,8 @@ func TestStoreNode(t *testing.T) {
 
 	// Update.
 	update := &api.Node{
+		ID: "id3",
 		Spec: &api.NodeSpec{
-			ID: "id3",
 			Meta: &api.Meta{
 				Name: "name3",
 			},
@@ -99,7 +99,7 @@ func TestStoreNode(t *testing.T) {
 		assert.Len(t, foundNodes, 1)
 
 		invalidUpdate := *nodeSet[0]
-		invalidUpdate.Spec.ID = "invalid"
+		invalidUpdate.ID = "invalid"
 		assert.Error(t, tx.Nodes().Update(&invalidUpdate), "invalid IDs should be rejected")
 
 		// Delete
@@ -297,8 +297,8 @@ func TestStoreNetwork(t *testing.T) {
 
 func TestStoreTask(t *testing.T) {
 	node := &api.Node{
+		ID: "node1",
 		Spec: &api.NodeSpec{
-			ID: "node1",
 			Meta: &api.Meta{
 				Name: "node-name1",
 			},
@@ -320,7 +320,7 @@ func TestStoreTask(t *testing.T) {
 					Name: "name1",
 				},
 			},
-			NodeID: node.Spec.ID,
+			NodeID: node.ID,
 		},
 		{
 			ID: "id2",
@@ -380,7 +380,7 @@ func TestStoreTask(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 0)
 
-		foundTasks, err = readTx.Tasks().Find(ByNodeID(node.Spec.ID))
+		foundTasks, err = readTx.Tasks().Find(ByNodeID(node.ID))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 1)
 		assert.Equal(t, foundTasks[0], taskSet[0])
@@ -443,24 +443,24 @@ func TestStoreTask(t *testing.T) {
 func TestStoreSnapshot(t *testing.T) {
 	nodeSet := []*api.Node{
 		{
+			ID: "id1",
 			Spec: &api.NodeSpec{
-				ID: "id1",
 				Meta: &api.Meta{
 					Name: "name1",
 				},
 			},
 		},
 		{
+			ID: "id2",
 			Spec: &api.NodeSpec{
-				ID: "id2",
 				Meta: &api.Meta{
 					Name: "name2",
 				},
 			},
 		},
 		{
+			ID: "id3",
 			Spec: &api.NodeSpec{
-				ID: "id3",
 				Meta: &api.Meta{
 					Name: "name2",
 				},
@@ -503,7 +503,7 @@ func TestStoreSnapshot(t *testing.T) {
 					Name: "name1",
 				},
 			},
-			NodeID: nodeSet[0].Spec.ID,
+			NodeID: nodeSet[0].ID,
 		},
 		{
 			ID: "id2",
@@ -572,8 +572,8 @@ func TestStoreSnapshot(t *testing.T) {
 
 		// Create node
 		createNode := &api.Node{
+			ID: "id4",
 			Spec: &api.NodeSpec{
-				ID: "id4",
 				Meta: &api.Meta{
 					Name: "name4",
 				},
@@ -590,8 +590,8 @@ func TestStoreSnapshot(t *testing.T) {
 
 		// Update node
 		updateNode := &api.Node{
+			ID: "id3",
 			Spec: &api.NodeSpec{
-				ID: "id3",
 				Meta: &api.Meta{
 					Name: "name3",
 				},

--- a/state/watch.go
+++ b/state/watch.go
@@ -243,7 +243,7 @@ type NodeCheckFunc func(n1, n2 *api.Node) bool
 
 // NodeCheckID is a NodeCheckFunc for matching node IDs.
 func NodeCheckID(n1, n2 *api.Node) bool {
-	return n1.Spec.ID == n2.Spec.ID
+	return n1.ID == n2.ID
 }
 
 // NodeCheckStatus is a NodeCheckFunc for matching node status.


### PR DESCRIPTION
We have no plans to allow nodes to declare their own identifiers as part
of the node specification. In all cases, NodeID will be authenticated or
assigned to the node via the manager. Before this becomes a problem, we
are moving NodeID to Node, where it belongs. Nodes still state their
NodeID, as they may see, as part of a `RegisterRequest`, but dispatchers
must authenticate it.

Closes #78 

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @diogomonica @al
