### PR TITLE
api: define TaskSpec to control execution

### DIFF
--- a/api/types.proto
+++ b/api/types.proto
@@ -8,8 +8,6 @@ import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 
 // Meta is common to all API objects types.
 message Meta {
-	// TODO(stevvooe): Consider an ID here. Probably not.
-
 	string name = 1;
 	map<string, string> labels = 2;
 }
@@ -65,11 +63,38 @@ message ImageSpec {
 	// reference is a docker image reference. This can include a rpository, tag
 	// or be fully qualified witha digest. The format is specified in the
 	// distribution/reference package.
-	string reference = 1; // TODO(stevvooe): Field type should be reference.Field.
+	string reference = 1;
 }
 
-// Spec defines the properties of a Job. As tasks are created, they gain the
-// Job specification.
+message ContainerSpec {
+	ImageSpec image = 1;
+
+	// Command to run the the container. The first element is a path to the
+	// executable and the following elements are treated as arguments.
+	//
+	// If command is empty, execution will fall back to the entrypoint.
+	repeated string command = 2;
+
+	// Args specifies arguments provided to the entrypoint of the container.
+	// Ignored if command is specified.
+	repeated string args = 3;
+
+	// Env specifies the environment variables for the container in NAME=VALUE
+	// format. These must be compliant with  [IEEE Std
+	// 1003.1-2001](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html).
+	repeated string env = 4;
+}
+
+// TaskSpec defines properties required by the agent for execution.
+message TaskSpec {
+	oneof runtime {
+		ContainerSpec container = 1;
+	}
+}
+
+// JobSpec defines the properties of a Job. As tasks are created, they gain the
+// encapsulated template and any emergent properties from the job
+// configuration.
 //
 // There are two key components to a spec. The first is a "source". A source
 // defines runnable content. For the swarm use case, this is a container but we
@@ -80,6 +105,8 @@ message JobSpec {
 	Meta meta = 1;
 
 	message ServiceJob {
+		// Instances specifies the number of instances of the service job that
+		// should be running.
 		int64 instances = 1;
 	}
 
@@ -103,21 +130,19 @@ message JobSpec {
 		}
 	}
 
-	oneof source {
-		ImageSpec image = 2;
+	oneof orchestration {
+		ServiceJob service = 2;
+		BatchJob batch = 3;
+		GlobalJob global = 4;
+		CronJob cron = 5;
 	}
 
-	oneof orchestration { // TODO(stevvooe): Consider calling this strategy.
-		ServiceJob service = 3;
-		BatchJob batch = 4;
-		GlobalJob global = 5;
-		CronJob cron = 6;
-	}
+	// Environment specifies key=value style environment variables that will be
+	// set on all tasks implementing the job.
+	repeated NetworkAttachmentSpec networks = 6;
 
-	repeated NetworkAttachmentSpec networks = 7;
-
-	// TODO(stevvooe): Specify the components that make up the container
-	// configuration. This should have fields similar to container.Config.
+	// Template defines the base configuration for tasks created for this job.
+	TaskSpec template = 7;
 }
 
 message TaskStatus {
@@ -157,22 +182,18 @@ message Task {
 
 	// NodeID indicates the node to which the task is assigned. If this field
 	// is empty or not set, the task is unassigned.
-	string node_id = 4 [(gogoproto.customname) = "NodeID"];
+	string node_id = 3 [(gogoproto.customname) = "NodeID"];
 
-	// NOTE(stevvooe): Spec, status or both may be set, depending on the role
-	// of this message.
+	// Meta inherits labels from the JobSpec.Meta associated with this task. It
+	// may include other labels added by the manager. The name will be a human
+	// readable name, calculated based on the JobSpec.Meta.Name field.
+	Meta meta = 4;
 
-	JobSpec spec = 5;
+	// Spec declares the runtime parameters for the task. This is copied out of
+	// the job's template field.
+	TaskSpec spec = 5;
 
 	TaskStatus status = 6;
-
-	// Resolved is the source resolved by the swarm cluster. This may be
-	// identical, depending on the name provided in the JobSpec. For example,
-	// the name field may be "redis", whereas this field would specify the
-	// exact hash, "redis@sha256:...".
-	oneof resolved {
-		ImageSpec image = 7;
-	}
 
 	message NetworkAttachment {
 		// Network state as a whole becomes part of Task so
@@ -185,7 +206,7 @@ message Task {
 		repeated string addresses = 2;
 	}
 
-	repeated NetworkAttachment networks = 3;
+	repeated NetworkAttachment networks = 7;
 }
 
 message Job {

--- a/cmd/swarmctl/job/create.go
+++ b/cmd/swarmctl/job/create.go
@@ -44,9 +44,13 @@ var (
 				Meta: &api.Meta{
 					Name: name,
 				},
-				Source: &api.JobSpec_Image{
-					Image: &api.ImageSpec{
-						Reference: image,
+				Template: &api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{
+							Image: &api.ImageSpec{
+								Reference: image,
+							},
+						},
 					},
 				},
 				Orchestration: &api.JobSpec_Service{

--- a/cmd/swarmctl/job/ls.go
+++ b/cmd/swarmctl/job/ls.go
@@ -34,7 +34,7 @@ var (
 			for _, j := range r.Jobs {
 				spec := j.Spec
 				service := spec.GetService()
-				image := spec.GetImage()
+				image := spec.Template.GetContainer().Image
 
 				// TODO(aluzzardi): Right now we only implement the happy path
 				// and don't have any proper error handling whatsover.

--- a/manager/clusterapi/job.go
+++ b/manager/clusterapi/job.go
@@ -20,16 +20,22 @@ func validateJobSpecMeta(m *api.Meta) error {
 	return nil
 }
 
-func validateJobSpecImageSpec(spec *api.JobSpec) error {
-	if spec.GetSource() == nil {
-		return grpc.Errorf(codes.InvalidArgument, "source: required in job spec")
+func validateJobSpecTemplate(spec *api.JobSpec) error {
+	if spec.Template.GetRuntime() == nil {
+		return grpc.Errorf(codes.InvalidArgument, "template: runtime container spec required in job spec task template")
 	}
-	image := spec.GetImage()
+
+	container := spec.Template.GetContainer()
+	if container == nil {
+		return grpc.Errorf(codes.Unimplemented, "template: unimplemented runtime in job spec task template")
+	}
+
+	image := container.Image
 	if image == nil {
-		return grpc.Errorf(codes.Unimplemented, "source: invalid source type. only image is supposed")
+		return grpc.Errorf(codes.Unimplemented, "template: container image not specified")
 	}
 	if image.Reference == "" {
-		return grpc.Errorf(codes.InvalidArgument, "source: image reference must be provided")
+		return grpc.Errorf(codes.InvalidArgument, "template: image reference must be provided")
 	}
 	return nil
 }
@@ -61,7 +67,7 @@ func validateJobSpec(spec *api.JobSpec) error {
 	if err := validateJobSpecMeta(spec.Meta); err != nil {
 		return err
 	}
-	if err := validateJobSpecImageSpec(spec); err != nil {
+	if err := validateJobSpecTemplate(spec); err != nil {
 		return err
 	}
 	if err := validateJobSpecOrchestration(spec); err != nil {

--- a/scheduler/orchestrator/orchestrator.go
+++ b/scheduler/orchestrator/orchestrator.go
@@ -138,10 +138,13 @@ func (o *Orchestrator) balance(job *api.Job) {
 			// Scale up
 			log.Debugf("Job %s was scaled up from %d to %d instances", job.ID, numTasks, specifiedInstances)
 			diff := specifiedInstances - numTasks
+			spec := *job.Spec.Template
+			meta := *job.Spec.Meta // TODO(stevvooe): Copy metadata with nice name.
+
 			for i := int64(0); i < diff; i++ {
-				spec := *job.Spec
 				task := &api.Task{
 					ID:    identity.NewID(),
+					Meta:  &meta,
 					Spec:  &spec,
 					JobID: job.ID,
 					Status: &api.TaskStatus{

--- a/scheduler/orchestrator/orchestrator_test.go
+++ b/scheduler/orchestrator/orchestrator_test.go
@@ -29,6 +29,7 @@ func TestOrchestrator(t *testing.T) {
 				Meta: &api.Meta{
 					Name: "name1",
 				},
+				Template: &api.TaskSpec{},
 				Orchestration: &api.JobSpec_Service{
 					Service: &api.JobSpec_ServiceJob{
 						Instances: 2,
@@ -46,11 +47,11 @@ func TestOrchestrator(t *testing.T) {
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask1.Spec.Meta.Name, "name1")
+	assert.Equal(t, observedTask1.Meta.Name, "name1")
 
 	observedTask2 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask2.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask2.Spec.Meta.Name, "name1")
+	assert.Equal(t, observedTask2.Meta.Name, "name1")
 
 	// Create a second job.
 	err = store.Update(func(tx state.Tx) error {
@@ -60,6 +61,7 @@ func TestOrchestrator(t *testing.T) {
 				Meta: &api.Meta{
 					Name: "name2",
 				},
+				Template: &api.TaskSpec{},
 				Orchestration: &api.JobSpec_Service{
 					Service: &api.JobSpec_ServiceJob{
 						Instances: 1,
@@ -74,7 +76,7 @@ func TestOrchestrator(t *testing.T) {
 
 	observedTask3 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask3.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask3.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedTask3.Meta.Name, "name2")
 
 	// Update a job to scale it out to 3 instances
 	err = store.Update(func(tx state.Tx) error {
@@ -84,6 +86,7 @@ func TestOrchestrator(t *testing.T) {
 				Meta: &api.Meta{
 					Name: "name2",
 				},
+				Template: &api.TaskSpec{},
 				Orchestration: &api.JobSpec_Service{
 					Service: &api.JobSpec_ServiceJob{
 						Instances: 3,
@@ -98,11 +101,11 @@ func TestOrchestrator(t *testing.T) {
 
 	observedTask4 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask4.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask4.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedTask4.Meta.Name, "name2")
 
 	observedTask5 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask5.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask5.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedTask5.Meta.Name, "name2")
 
 	// Now scale it back down to 1 instance
 	err = store.Update(func(tx state.Tx) error {
@@ -112,6 +115,7 @@ func TestOrchestrator(t *testing.T) {
 				Meta: &api.Meta{
 					Name: "name2",
 				},
+				Template: &api.TaskSpec{},
 				Orchestration: &api.JobSpec_Service{
 					Service: &api.JobSpec_ServiceJob{
 						Instances: 1,
@@ -126,11 +130,11 @@ func TestOrchestrator(t *testing.T) {
 
 	observedDeletion1 := watchTaskDelete(t, watch)
 	assert.Equal(t, observedDeletion1.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedDeletion1.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedDeletion1.Meta.Name, "name2")
 
 	observedDeletion2 := watchTaskDelete(t, watch)
 	assert.Equal(t, observedDeletion2.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedDeletion2.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedDeletion2.Meta.Name, "name2")
 
 	// There should be one remaining task attached to job id2/name2.
 	var tasks []*api.Task
@@ -155,7 +159,7 @@ func TestOrchestrator(t *testing.T) {
 
 	observedTask6 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask6.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedTask6.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedTask6.Meta.Name, "name2")
 
 	// Delete the job. Its remaining task should go away.
 	err = store.Update(func(tx state.Tx) error {
@@ -166,7 +170,7 @@ func TestOrchestrator(t *testing.T) {
 
 	observedDeletion3 := watchTaskDelete(t, watch)
 	assert.Equal(t, observedDeletion3.Status.State, api.TaskStatus_NEW)
-	assert.Equal(t, observedDeletion3.Spec.Meta.Name, "name2")
+	assert.Equal(t, observedDeletion3.Meta.Name, "name2")
 
 	orchestrator.Stop()
 }

--- a/state/memory.go
+++ b/state/memory.go
@@ -518,12 +518,11 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 		panic("unexpected type passed to FromObject")
 	}
 
-	if t.Spec == nil || t.Spec.Meta == nil {
+	if t.Spec == nil || t.Meta == nil {
 		return false, nil, nil
 	}
 	// Add the null character as a terminator
-	return true, []byte(t.Spec.Meta.Name + "\x00"), nil
-
+	return true, []byte(t.Meta.Name + "\x00"), nil
 }
 
 type taskIndexerByJobID struct{}

--- a/state/memory_test.go
+++ b/state/memory_test.go
@@ -338,29 +338,26 @@ func TestStoreTask(t *testing.T) {
 	taskSet := []*api.Task{
 		{
 			ID: "id1",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name1",
-				},
+			Meta: &api.Meta{
+				Name: "name1",
 			},
+			Spec:   &api.TaskSpec{},
 			NodeID: node.ID,
 		},
 		{
 			ID: "id2",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name2",
-				},
+			Meta: &api.Meta{
+				Name: "name2",
 			},
+			Spec:  &api.TaskSpec{},
 			JobID: job.ID,
 		},
 		{
 			ID: "id3",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name2",
-				},
+			Meta: &api.Meta{
+				Name: "name2",
 			},
+			Spec: &api.TaskSpec{},
 		},
 	}
 
@@ -425,15 +422,10 @@ func TestStoreTask(t *testing.T) {
 	// Update.
 	update := &api.Task{
 		ID: "id3",
-
-		// NOTE(stevvooe): It doesn't entirely make sense to updating task to
-		// have a different name on the job spec. We are mostly doing this to
-		// test that the store works.
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name3",
-			},
+		Meta: &api.Meta{
+			Name: "name3",
 		},
+		Spec: &api.TaskSpec{},
 	}
 	err = s.Update(func(tx Tx) error {
 		assert.NotEqual(t, update, tx.Tasks().Get("id3"))
@@ -523,29 +515,26 @@ func TestStoreSnapshot(t *testing.T) {
 	taskSet := []*api.Task{
 		{
 			ID: "id1",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name1",
-				},
+			Meta: &api.Meta{
+				Name: "name1",
 			},
+			Spec:   &api.TaskSpec{},
 			NodeID: nodeSet[0].ID,
 		},
 		{
 			ID: "id2",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name2",
-				},
+			Meta: &api.Meta{
+				Name: "name2",
 			},
+			Spec:  &api.TaskSpec{},
 			JobID: jobSet[0].ID,
 		},
 		{
 			ID: "id3",
-			Spec: &api.JobSpec{
-				Meta: &api.Meta{
-					Name: "name2",
-				},
+			Meta: &api.Meta{
+				Name: "name2",
 			},
+			Spec: &api.TaskSpec{},
 		},
 	}
 
@@ -724,11 +713,10 @@ func TestStoreSnapshot(t *testing.T) {
 	// Create task
 	createTask := &api.Task{
 		ID: "id4",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name4",
-			},
+		Meta: &api.Meta{
+			Name: "name4",
 		},
+		Spec: &api.TaskSpec{},
 	}
 
 	err = s1.Update(func(tx1 Tx) error {
@@ -748,11 +736,10 @@ func TestStoreSnapshot(t *testing.T) {
 	// Update task
 	updateTask := &api.Task{
 		ID: "id3",
-		Spec: &api.JobSpec{
-			Meta: &api.Meta{
-				Name: "name3",
-			},
+		Meta: &api.Meta{
+			Name: "name3",
 		},
+		Spec: &api.TaskSpec{},
 	}
 
 	err = s1.Update(func(tx1 Tx) error {


### PR DESCRIPTION
Up until this point, discussion on JobSpec and TaskSpec has been
academic. The goal was to have some set of common fields that would flow
from Job to Task. After implementing a partial agent, it was found that
isolating the cluster-level definitions from the agent-level definitions
is the correct approach. We accomplish this by adding a template to
JobSpec which defines the core task configuration. This field is copied
directly into child tasks of a job.

TaskSpec only contains a single union field at this time. The intent is
to have several different "runtimes" that can be defined on task,
allowing the dispatch and execution of different targets, depending on
requirements. The only available runtime at this point is docker,
defined by ContainerSpec. With this, we omit the concept of a source and
bind the runtime context to the runtime, meaning that each runtime must
have the ability to fetch their own context.

Signed-off-by: Stephen J Day stephen.day@docker.com
