### PR TITLE
Simplify orchestrator event loop

### DIFF
--- a/scheduler/orchestrator/orchestrator.go
+++ b/scheduler/orchestrator/orchestrator.go
@@ -52,10 +52,7 @@ func (o *Orchestrator) Run() {
 
 	for {
 		select {
-		case event, ok := <-watcher:
-			if !ok {
-				return
-			}
+		case event := <-watcher:
 			switch v := event.Payload.(type) {
 			case state.EventDeleteJob:
 				o.deleteJob(v.Job)
@@ -68,7 +65,7 @@ func (o *Orchestrator) Run() {
 			}
 		case <-o.stopChan:
 			queue.StopWatch(watcher)
-			o.stopChan = nil
+			return
 		}
 	}
 }


### PR DESCRIPTION
It's not necessary to drain the watch channel after stopping it. The
watch code uses a select statement to make sure its writing goroutine
doesn't block past a close.
