### PR TITLE
Only run unit tests once in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,14 @@ PACKAGES=$(shell go list ./... | grep -v /vendor/)
 
 GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
-.PHONY: clean all fmt vet lint errcheck complexity build binaries test setup checkprotos coverage
+.PHONY: clean all fmt vet lint errcheck complexity build binaries test setup checkprotos coverage ci check
 .DEFAULT: default
-all: fmt vet lint errcheck complexity build binaries test
+
+check: fmt vet lint errcheck complexity
+
+all: check build binaries test
+
+ci: check build binaries checkprotos coverage
 
 AUTHORS: .mailmap .git/HEAD
 	git log --format='%aN <%aE>' | sort -fu > $@

--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,7 @@ test:
         # - `checkprotos`: Build and check the proto files *only* once all
         #                  tests pass with checked-in generated code.
         # - `coverage`: Generate coverage reports.
-        - cd "$WORKDIR" && make all checkprotos coverage
+        - cd "$WORKDIR" && make ci
 
     post:
         # Report to codecov.io


### PR DESCRIPTION
The unit tests were first being run as part of the "all" makefile
target, and then a second time for "coverage". We only need to run
"coverage".

Introduce a "ci" target in the makefile that builds the appropriate set
of targets (equavelent to "all",  minus "test", plus "checkprotos" and
"coverage").
