### PR TITLE
prevent infinite reco in `swarmctl` by adding a timeout

### DIFF
--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"time"
+
 	"github.com/docker/swarm-v2/api"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -15,7 +17,7 @@ func Dial(cmd *cobra.Command) (api.ClusterClient, error) {
 		return nil, err
 	}
 
-	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	conn, err := grpc.Dial(addr, grpc.WithBlock(), grpc.WithInsecure(), grpc.WithTimeout(time.Second))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/docker/swarm-v2/cmd/swarmctl/job"
 	"github.com/docker/swarm-v2/cmd/swarmctl/node"
@@ -16,7 +17,7 @@ func main() {
 	if c, err := mainCmd.ExecuteC(); err != nil {
 		c.Println("Error:", grpc.ErrorDesc(err))
 		// if it's not a grpc, we assume it's a user error and we display the usage.
-		if grpc.Code(err) == codes.Unknown {
+		if !strings.HasPrefix(grpc.ErrorDesc(err), "grpc:") && grpc.Code(err) == codes.Unknown {
 			c.Println(c.UsageString())
 		}
 


### PR DESCRIPTION
Signed-off-by: Victor Vieux vieux@docker.com
