### PR TITLE
api: task "Accepted" state and Go idiomatic enum

### DIFF
--- a/api/types.proto
+++ b/api/types.proto
@@ -145,25 +145,42 @@ message JobSpec {
 	TaskSpec template = 7;
 }
 
-message TaskStatus {
-	enum State {
-		NEW = 0;
-		ALLOCATED = 1; // successfull allocation of resources that the task needs
-		ASSIGNED = 2;
-		PREPARING = 3;
-		READY = 4;
-		STARTING = 5;
-		RUNNING = 6;
-		SHUTDOWN = 7;
-		COMPLETE = 8; // successful completion of task (not error code, just ran)
-		FAILED = 9; // task execution failed with error
-		REJECTED = 10; // task could not be executed here.
-		FINALIZE = 11; // when task is deallocated from node, waiting on cleanup
-		DEAD = 12; // completely finished, unallocated task.
-	}
+// TaskState enumerates the states that a task progresses through within an
+// agent. States are designed to be monotonically increasing, such that if two
+// states are seen by a task, the greater of the new represents the true state.
+enum TaskState {
+	option (gogoproto.goproto_enum_prefix) = false;
+	option (gogoproto.enum_customname) = "TaskState";
+	NEW = 0 [(gogoproto.enumvalue_customname)="TaskStateNew"];
+	ALLOCATED = 1 [(gogoproto.enumvalue_customname)="TaskStateAllocated"]; // successful allocation of resources that the task needs
+	ASSIGNED = 2 [(gogoproto.enumvalue_customname)="TaskStateAssigned"];
+	ACCEPTED = 3 [(gogoproto.enumvalue_customname)="TaskStateAccepted"]; // task has been accepted by an agent.
+	PREPARING = 4 [(gogoproto.enumvalue_customname)="TaskStatePreparing"];
+	READY = 5 [(gogoproto.enumvalue_customname)="TaskStateReady"];
+	STARTING = 6 [(gogoproto.enumvalue_customname)="TaskStateStarting"];
+	RUNNING = 7 [(gogoproto.enumvalue_customname)="TaskStateRunning"];
+	SHUTDOWN = 8 [(gogoproto.enumvalue_customname)="TaskStateShutdown"];
+	COMPLETE = 9 [(gogoproto.enumvalue_customname)="TaskStateCompleted"]; // successful completion of task (not error code, just ran)
+	FAILED = 10 [(gogoproto.enumvalue_customname)="TaskStateFailed"]; // task execution failed with error
+	REJECTED = 11 [(gogoproto.enumvalue_customname)="TaskStateRejected"]; // task could not be executed here.
+	FINALIZE = 12 [(gogoproto.enumvalue_customname)="TaskStateFinalize"]; // when task is deallocated from node, waiting on cleanup
+	DEAD = 13 [(gogoproto.enumvalue_customname)="TaskStateDead"]; // completely finished, unallocated task.
+}
 
-	State state = 2;
-	string message = 3;
+message TaskStatus {
+	// State expresses the current state of the task.
+	TaskState state = 1;
+
+	// Err is set if the task is in an error state.
+	//
+	// The following states should report a companion error:
+	//
+	// 	FAILED, REJECTED
+	//
+	// TODO(stevvooe) Integrate this field with the error interface.
+	string err = 2;
+
+	// TODO(stevvooe): Report on runtime statistics.
 }
 
 // Task specifies the parameters for implementing a Spec. A task is effectively

--- a/cmd/swarmctl/task/inspect.go
+++ b/cmd/swarmctl/task/inspect.go
@@ -35,8 +35,8 @@ var (
 			}()
 			fmt.Fprintf(w, "ID:\t%s\n", r.Task.ID)
 			fmt.Fprintf(w, "JobID:\t%s\n", r.Task.JobID)
-			if r.Task.Status.Message != "" {
-				fmt.Fprintf(w, "Status:\t%s (%s)\n", r.Task.Status.State.String(), r.Task.Status.Message)
+			if r.Task.Status.Err != "" {
+				fmt.Fprintf(w, "Status:\t%s (%s)\n", r.Task.Status.State.String(), r.Task.Status.Err)
 			} else {
 				fmt.Fprintf(w, "Status:\t%s\n", r.Task.Status.State.String())
 			}

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -216,7 +216,7 @@ func TestTasks(t *testing.T) {
 		assert.NoError(t, tx.Tasks().Update(&api.Task{
 			ID:     testTask1.ID,
 			NodeID: testNode.ID,
-			Status: &api.TaskStatus{Message: "1234"},
+			Status: &api.TaskStatus{State: api.TaskStateFailed, Err: "1234"},
 		}))
 		return nil
 	})
@@ -247,7 +247,8 @@ func TestTasks(t *testing.T) {
 	assert.Equal(t, len(resp.Tasks), 2)
 	for _, task := range resp.Tasks {
 		if task.ID == "testTask1" {
-			assert.Equal(t, task.Status.Message, "1234")
+			assert.Equal(t, task.Status.State, api.TaskStateFailed)
+			assert.Equal(t, task.Status.Err, "1234")
 		}
 	}
 
@@ -289,8 +290,8 @@ func TestTaskUpdate(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	testTask1.Status = &api.TaskStatus{State: api.TaskStatus_ASSIGNED}
-	testTask2.Status = &api.TaskStatus{State: api.TaskStatus_ASSIGNED}
+	testTask1.Status = &api.TaskStatus{State: api.TaskStateAssigned}
+	testTask2.Status = &api.TaskStatus{State: api.TaskStateAssigned}
 	updReq := &api.UpdateTaskStatusRequest{
 		NodeID: testNode.ID,
 		Tasks:  []*api.Task{testTask1, testTask2},
@@ -312,8 +313,8 @@ func TestTaskUpdate(t *testing.T) {
 		assert.NotNil(t, storeTask1)
 		storeTask2 := readTx.Tasks().Get(testTask2.ID)
 		assert.NotNil(t, storeTask2)
-		assert.Equal(t, storeTask1.Status.State, api.TaskStatus_ASSIGNED)
-		assert.Equal(t, storeTask2.Status.State, api.TaskStatus_ASSIGNED)
+		assert.Equal(t, storeTask1.Status.State, api.TaskStateAssigned)
+		assert.Equal(t, storeTask2.Status.State, api.TaskStateAssigned)
 		return nil
 	})
 	assert.NoError(t, err)

--- a/manager/orchestrator/orchestrator.go
+++ b/manager/orchestrator/orchestrator.go
@@ -145,7 +145,7 @@ func (o *Orchestrator) balance(job *api.Job) {
 					Spec:  &spec,
 					JobID: job.ID,
 					Status: &api.TaskStatus{
-						State: api.TaskStatus_NEW,
+						State: api.TaskStateNew,
 					},
 				}
 				if err := tx.Tasks().Create(task); err != nil {

--- a/manager/orchestrator/orchestrator_test.go
+++ b/manager/orchestrator/orchestrator_test.go
@@ -48,11 +48,11 @@ func TestOrchestrator(t *testing.T) {
 	}()
 
 	observedTask1 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask1.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask1.Meta.Name, "name1")
 
 	observedTask2 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask2.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask2.Meta.Name, "name1")
 
 	// Create a second job.
@@ -77,7 +77,7 @@ func TestOrchestrator(t *testing.T) {
 	assert.NoError(t, err)
 
 	observedTask3 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask3.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.Meta.Name, "name2")
 
 	// Update a job to scale it out to 3 instances
@@ -102,11 +102,11 @@ func TestOrchestrator(t *testing.T) {
 	assert.NoError(t, err)
 
 	observedTask4 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask4.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask4.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask4.Meta.Name, "name2")
 
 	observedTask5 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask5.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask5.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask5.Meta.Name, "name2")
 
 	// Now scale it back down to 1 instance
@@ -131,11 +131,11 @@ func TestOrchestrator(t *testing.T) {
 	assert.NoError(t, err)
 
 	observedDeletion1 := watchTaskDelete(t, watch)
-	assert.Equal(t, observedDeletion1.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedDeletion1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion1.Meta.Name, "name2")
 
 	observedDeletion2 := watchTaskDelete(t, watch)
-	assert.Equal(t, observedDeletion2.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedDeletion2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion2.Meta.Name, "name2")
 
 	// There should be one remaining task attached to job id2/name2.
@@ -160,7 +160,7 @@ func TestOrchestrator(t *testing.T) {
 	watchTaskDelete(t, watch)
 
 	observedTask6 := watchTaskCreate(t, watch)
-	assert.Equal(t, observedTask6.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedTask6.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask6.Meta.Name, "name2")
 
 	// Delete the job. Its remaining task should go away.
@@ -171,7 +171,7 @@ func TestOrchestrator(t *testing.T) {
 	assert.NoError(t, err)
 
 	observedDeletion3 := watchTaskDelete(t, watch)
-	assert.Equal(t, observedDeletion3.Status.State, api.TaskStatus_NEW)
+	assert.Equal(t, observedDeletion3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion3.Meta.Name, "name2")
 
 	orchestrator.Stop()

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -160,7 +160,7 @@ func (s *Scheduler) scheduleTask(tx state.Tx, nodes []*api.Node, t api.Task) *ap
 
 	log.Infof("Assigning task %s to node %s", t.ID, node.ID)
 	t.NodeID = node.ID
-	t.Status = &api.TaskStatus{State: api.TaskStatus_ASSIGNED}
+	t.Status = &api.TaskStatus{State: api.TaskStateAssigned}
 	if err := tx.Tasks().Update(&t); err != nil {
 		log.Error(err)
 		return nil


### PR DESCRIPTION
To ensure we can detect service time between a node receiving a task and
preparing of the runtime environment, an ACCEPTED state has been added.
Once a node has registered the task locally, the ACCEPTED state is
reported to the manager. The main benefit to measure the time between
ACCEPTED and PREPARING to detect overloaded nodes.

The TaskStatus.Message field is now called Err. We may want to provide
more structure there, but this is to clarify that it is not a general
message field. Ideally, this field could serialize arbitrary errors, but
we'd need to do some code generation tricks to acheive this.

We also now generate idiomatic enum definitions.

Signed-off-by: Stephen J Day stephen.day@docker.com
