### PR TITLE
Add drainer

### DIFF
--- a/manager/drainer/drainer.go
+++ b/manager/drainer/drainer.go
@@ -1,0 +1,189 @@
+package drainer
+
+import (
+	"container/list"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/manager/state"
+)
+
+// Drainer removes tasks which are assigned to nodes that are no longer
+// responsive, or are selected for draining.
+type Drainer struct {
+	store       state.WatchableStore
+	deleteTasks *list.List
+
+	// stopChan signals to the state machine to stop running
+	stopChan chan struct{}
+	// doneChan is closed when the state machine terminates
+	doneChan chan struct{}
+}
+
+// New creates a new drainer.
+func New(store state.WatchableStore) *Drainer {
+	return &Drainer{
+		store:       store,
+		deleteTasks: list.New(),
+		stopChan:    make(chan struct{}),
+		doneChan:    make(chan struct{}),
+	}
+}
+
+func invalidNode(n *api.Node) bool {
+	return n == nil ||
+		n.Status.State != api.NodeStatus_READY ||
+		(n.Spec != nil && n.Spec.Availability == api.NodeAvailabilityDrain)
+}
+
+func (d *Drainer) initialPass(tx state.ReadTx) error {
+	tasks, err := tx.Tasks().Find(state.All)
+	if err != nil {
+		return err
+	}
+	for _, t := range tasks {
+		if t.NodeID != "" {
+			n := tx.Nodes().Get(t.NodeID)
+			if invalidNode(n) {
+				d.enqueue(t)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Run is the drainer event loop.
+func (d *Drainer) Run() error {
+	defer close(d.doneChan)
+
+	updates := state.Watch(d.store.WatchQueue(),
+		state.EventCreateTask{},
+		state.EventUpdateTask{},
+		state.EventCreateNode{},
+		state.EventUpdateNode{},
+		state.EventDeleteNode{},
+		state.EventCommit{})
+	defer d.store.WatchQueue().StopWatch(updates)
+
+	err := d.store.View(d.initialPass)
+	if err != nil {
+		log.Errorf("could not run initial drainer pass: %v", err)
+		return err
+	}
+
+	// Remove all tasks that have an invalid node assigned
+	d.tick()
+
+	pendingChanges := 0
+
+	// Watch for changes.
+	for {
+		select {
+		case event := <-updates:
+			switch v := event.Payload.(type) {
+			case state.EventCreateTask:
+				pendingChanges += d.taskChanged(v.Task)
+			case state.EventUpdateTask:
+				pendingChanges += d.taskChanged(v.Task)
+			case state.EventCreateNode:
+				pendingChanges += d.nodeChanged(v.Node)
+			case state.EventUpdateNode:
+				pendingChanges += d.nodeChanged(v.Node)
+			case state.EventDeleteNode:
+				pendingChanges += d.removeTasksByNodeID(v.Node.ID)
+			case state.EventCommit:
+				if pendingChanges > 0 {
+					d.tick()
+					pendingChanges = 0
+				}
+			}
+		case <-d.stopChan:
+			return nil
+		}
+	}
+}
+
+// Stop causes the drainer event loop to stop running.
+func (d *Drainer) Stop() {
+	close(d.stopChan)
+	<-d.doneChan
+}
+
+// enqueue queues a task for deletion.
+func (d *Drainer) enqueue(t *api.Task) {
+	d.deleteTasks.PushBack(t)
+}
+
+func (d *Drainer) taskChanged(t *api.Task) int {
+	if t.NodeID == "" {
+		return 0
+	}
+
+	var n *api.Node
+	err := d.store.View(func(tx state.ReadTx) error {
+		n = tx.Nodes().Get(t.NodeID)
+		return nil
+	})
+	if err != nil {
+		log.Errorf("error in drainer transaction: %v", err)
+		return 0
+	}
+	if invalidNode(n) {
+		d.enqueue(t)
+		return 1
+	}
+	return 0
+}
+
+func (d *Drainer) removeTasksByNodeID(nodeID string) int {
+	var tasks []*api.Task
+	err := d.store.View(func(tx state.ReadTx) error {
+		var err error
+		tasks, err = tx.Tasks().Find(state.ByNodeID(nodeID))
+		return err
+	})
+	if err != nil {
+		log.Errorf("error in drainer transaction: %v", err)
+		return 0
+	}
+
+	var pendingChanges int
+	for _, t := range tasks {
+		d.enqueue(t)
+		pendingChanges++
+	}
+	return pendingChanges
+}
+
+func (d *Drainer) nodeChanged(n *api.Node) int {
+	if !invalidNode(n) {
+		return 0
+	}
+
+	return d.removeTasksByNodeID(n.ID)
+}
+
+// tick deletes tasks that were selected for deletion.
+func (d *Drainer) tick() {
+	err := d.store.Update(func(tx state.Tx) error {
+		var next *list.Element
+		for e := d.deleteTasks.Front(); e != nil; e = next {
+			next = e.Next()
+			t := e.Value.(*api.Task)
+
+			// Ignore the error on deletion, because something else
+			// may have deleted the task before we got to it.
+			_ = tx.Tasks().Delete(t.ID)
+		}
+		return nil
+	})
+
+	if err != nil {
+		log.Errorf("Error in transaction: %v", err)
+
+		// leave deleteTasks list in place
+	} else {
+		d.deleteTasks = list.New()
+	}
+}

--- a/manager/drainer/drainer_test.go
+++ b/manager/drainer/drainer_test.go
@@ -1,0 +1,221 @@
+package drainer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/manager/state"
+	"github.com/docker/swarm-v2/manager/state/watch"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDrainer(t *testing.T) {
+	initialNodeSet := []*api.Node{
+		{
+			ID: "id1",
+			Spec: &api.NodeSpec{
+				Meta: api.Meta{
+					Name: "name1",
+				},
+				Availability: api.NodeAvailabilityActive,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_READY,
+			},
+		},
+		{
+			ID: "id2",
+			Spec: &api.NodeSpec{
+				Meta: api.Meta{
+					Name: "name2",
+				},
+				Availability: api.NodeAvailabilityActive,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_DOWN,
+			},
+		},
+		{
+			ID: "id3",
+			Spec: &api.NodeSpec{
+				Meta: api.Meta{
+					Name: "name3",
+				},
+				Availability: api.NodeAvailabilityActive,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_DISCONNECTED,
+			},
+		},
+		{
+			ID: "id4",
+			Spec: &api.NodeSpec{
+				Meta: api.Meta{
+					Name: "name4",
+				},
+				Availability: api.NodeAvailabilityPause,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_READY,
+			},
+		},
+		{
+			ID: "id5",
+			Spec: &api.NodeSpec{
+				Meta: api.Meta{
+					Name: "name5",
+				},
+				Availability: api.NodeAvailabilityDrain,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_READY,
+			},
+		},
+	}
+
+	initialTaskSet := []*api.Task{
+		// Task not assigned to any node
+		{
+			ID:   "id0",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name0",
+			},
+		},
+		// Tasks assigned to the nodes defined above
+		{
+			ID:   "id1",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name1",
+			},
+			NodeID: "id1",
+		},
+		{
+			ID:   "id2",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name2",
+			},
+			NodeID: "id2",
+		},
+		{
+			ID:   "id3",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name3",
+			},
+			NodeID: "id3",
+		},
+		{
+			ID:   "id4",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name4",
+			},
+			NodeID: "id4",
+		},
+		{
+			ID:   "id5",
+			Spec: &api.TaskSpec{},
+			Meta: api.Meta{
+				Name: "name5",
+			},
+			NodeID: "id5",
+		},
+	}
+
+	store := state.NewMemoryStore()
+	assert.NotNil(t, store)
+
+	err := store.Update(func(tx state.Tx) error {
+		// Prepoulate nodes
+		for _, n := range initialNodeSet {
+			assert.NoError(t, tx.Nodes().Create(n))
+		}
+
+		// Prepopulate tasks
+		for _, task := range initialTaskSet {
+			assert.NoError(t, tx.Tasks().Create(task))
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	drainer := New(store)
+
+	watch := state.Watch(store.WatchQueue(), state.EventDeleteTask{})
+	defer store.WatchQueue().StopWatch(watch)
+
+	go func() {
+		assert.NoError(t, drainer.Run())
+	}()
+
+	// id2, id3, and id5 should be deleted immediately
+	// NOTE: we can assume these will be emitted in lexical order because
+	// of the way indexing works in the store. If that ever changes, this
+	// part of the test might need to become more flexible.
+	deletion1 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion1.ID, "id2")
+	assert.Equal(t, deletion1.NodeID, "id2")
+	deletion2 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion2.ID, "id3")
+	assert.Equal(t, deletion2.NodeID, "id3")
+	deletion3 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion3.ID, "id5")
+	assert.Equal(t, deletion3.NodeID, "id5")
+
+	// Create a new task, assigned to node id2
+	err = store.Update(func(tx state.Tx) error {
+		task := initialTaskSet[2].Copy()
+		task.ID = "newtask"
+		task.NodeID = "id2"
+		assert.NoError(t, tx.Tasks().Create(task))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	deletion4 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion4.ID, "newtask")
+	assert.Equal(t, deletion4.NodeID, "id2")
+
+	// Set node id4 to the DRAINED state
+	err = store.Update(func(tx state.Tx) error {
+		n := initialNodeSet[3].Copy()
+		n.Spec.Availability = api.NodeAvailabilityDrain
+		assert.NoError(t, tx.Nodes().Update(n))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	deletion5 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion5.ID, "id4")
+	assert.Equal(t, deletion5.NodeID, "id4")
+
+	// Delete node id1
+	err = store.Update(func(tx state.Tx) error {
+		assert.NoError(t, tx.Nodes().Delete("id1"))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	deletion6 := watchDeleteTask(t, watch)
+	assert.Equal(t, deletion6.ID, "id1")
+	assert.Equal(t, deletion6.NodeID, "id1")
+
+	drainer.Stop()
+}
+
+func watchDeleteTask(t *testing.T, watch chan watch.Event) *api.Task {
+	for {
+		select {
+		case event := <-watch:
+			if task, ok := event.Payload.(state.EventDeleteTask); ok {
+				return task.Task
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("no task deletion")
+		}
+	}
+}

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -175,7 +175,7 @@ func (s *Scheduler) selectNodeForTask(tx state.Tx, nodes []*api.Node, t *api.Tas
 	targetTasks := 0
 
 	for _, n := range nodes {
-		if n.Status.State != api.NodeStatus_READY {
+		if n.Status.State != api.NodeStatus_READY || (n.Spec != nil && n.Spec.Availability != api.NodeAvailabilityActive) {
 			continue
 		}
 


### PR DESCRIPTION
This adds a drainer component that removes any tasks assigned to nodes
which either:
- Don't exist
- Aren't READY
- Are set to drained

Also, change the scheduler to avoid scheduling anything on non-active nodes.
