### PR TITLE
add -f on `job create` and `job update` and add `job diff`

### DIFF
--- a/cmd/swarmctl/job/cmd.go
+++ b/cmd/swarmctl/job/cmd.go
@@ -17,5 +17,7 @@ func init() {
 		createCmd,
 		updateCmd,
 		removeCmd,
+
+		diffCmd,
 	)
 }

--- a/cmd/swarmctl/job/common.go
+++ b/cmd/swarmctl/job/common.go
@@ -1,0 +1,27 @@
+package job
+
+import (
+	"os"
+
+	"github.com/docker/swarm-v2/spec"
+	flag "github.com/spf13/pflag"
+)
+
+func readServiceConfig(flags *flag.FlagSet) (*spec.ServiceConfig, error) {
+	path, err := flags.GetString("file")
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	service := &spec.ServiceConfig{}
+	if err := service.Parse(file); err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}

--- a/cmd/swarmctl/job/create.go
+++ b/cmd/swarmctl/job/create.go
@@ -14,47 +14,56 @@ var (
 		Use:   "create",
 		Short: "Create a job",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// TODO(aluzzardi): Check cobra best practices for flags handling.
 			flags := cmd.Flags()
-			if !flags.Changed("name") || !flags.Changed("image") {
-				return errors.New("--name and --image are mandatory")
-			}
-			name, err := flags.GetString("name")
-			if err != nil {
-				return err
-			}
-			image, err := flags.GetString("image")
-			if err != nil {
-				return err
-			}
-			instances, err := flags.GetInt64("instances")
-			if err != nil {
-				return err
+			var spec *api.JobSpec
+
+			if flags.Changed("file") {
+				service, err := readServiceConfig(flags)
+				if err != nil {
+					return err
+				}
+				spec = service.JobSpec()
+			} else { // TODO(vieux): support or error on both file.
+				if !flags.Changed("name") || !flags.Changed("image") {
+					return errors.New("--name and --image are mandatory")
+				}
+				name, err := flags.GetString("name")
+				if err != nil {
+					return err
+				}
+				image, err := flags.GetString("image")
+				if err != nil {
+					return err
+				}
+				instances, err := flags.GetInt64("instances")
+				if err != nil {
+					return err
+				}
+
+				spec = &api.JobSpec{
+					Meta: api.Meta{
+						Name: name,
+					},
+					Template: &api.TaskSpec{
+						Runtime: &api.TaskSpec_Container{
+							Container: &api.ContainerSpec{
+								Image: &api.ImageSpec{
+									Reference: image,
+								},
+							},
+						},
+					},
+					Orchestration: &api.JobSpec_Service{
+						Service: &api.JobSpec_ServiceJob{
+							Instances: instances,
+						},
+					},
+				}
 			}
 
 			c, err := common.Dial(cmd)
 			if err != nil {
 				return err
-			}
-
-			spec := &api.JobSpec{
-				Meta: api.Meta{
-					Name: name,
-				},
-				Template: &api.TaskSpec{
-					Runtime: &api.TaskSpec_Container{
-						Container: &api.ContainerSpec{
-							Image: &api.ImageSpec{
-								Reference: image,
-							},
-						},
-					},
-				},
-				Orchestration: &api.JobSpec_Service{
-					Service: &api.JobSpec_ServiceJob{
-						Instances: instances,
-					},
-				},
 			}
 			r, err := c.CreateJob(common.Context(cmd), &api.CreateJobRequest{Spec: spec})
 			if err != nil {
@@ -69,6 +78,7 @@ var (
 func init() {
 	createCmd.Flags().String("name", "", "Job name")
 	createCmd.Flags().String("image", "", "Image")
+	createCmd.Flags().StringP("file", "f", "", "Spec to use")
 	// TODO(aluzzardi): This should be called `service-instances` so that every
 	// orchestrator can have its own flag namespace.
 	createCmd.Flags().Int64("instances", 1, "Number of instances for the service Job")

--- a/cmd/swarmctl/job/diff.go
+++ b/cmd/swarmctl/job/diff.go
@@ -1,0 +1,57 @@
+package job
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/cmd/swarmctl/common"
+	"github.com/docker/swarm-v2/spec"
+	"github.com/spf13/cobra"
+)
+
+var (
+	diffCmd = &cobra.Command{
+		Use:   "diff <job ID>",
+		Short: "Diff a job",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("job ID missing")
+			}
+
+			flags := cmd.Flags()
+
+			if !flags.Changed("file") {
+				return errors.New("--file is mandatory")
+			}
+
+			c, err := common.Dial(cmd)
+			if err != nil {
+				return err
+			}
+
+			r, err := c.GetJob(common.Context(cmd), &api.GetJobRequest{JobID: args[0]})
+			if err != nil {
+				return err
+			}
+
+			localService, err := readServiceConfig(flags)
+			if err != nil {
+				return err
+			}
+
+			remoteService := &spec.ServiceConfig{}
+			remoteService.FromJobSpec(r.Job.Spec)
+			diff, err := localService.Diff(remoteService)
+			if err != nil {
+				return err
+			}
+			fmt.Print(diff)
+			return nil
+		},
+	}
+)
+
+func init() {
+	diffCmd.Flags().StringP("file", "f", "", "Spec to use")
+}

--- a/examples/job/create.yml
+++ b/examples/job/create.yml
@@ -1,0 +1,3 @@
+name: web
+image: nginx
+instances: 2

--- a/examples/job/update.yml
+++ b/examples/job/update.yml
@@ -1,0 +1,3 @@
+name: web
+image: nginx
+instances: 4

--- a/spec/service.go
+++ b/spec/service.go
@@ -1,0 +1,96 @@
+package spec
+
+import (
+	"fmt"
+	"io"
+
+	yaml "github.com/cloudfoundry-incubator/candiedyaml"
+	"github.com/docker/swarm-v2/api"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// ContainerConfig is a human representation of the ContainerSpec
+type ContainerConfig struct {
+	Image string `yaml:"image,omitempty"`
+}
+
+// ServiceConfig is a human representation of the ServiceJob
+type ServiceConfig struct {
+	ContainerConfig
+
+	Name      string `yaml:"name,omitempty"`
+	Instances int64  `yaml:"instances,omitempty"`
+}
+
+// Validate checks the validity of the ServiceConfig.
+func (s *ServiceConfig) Validate() error {
+	if s.Name == "" {
+		return fmt.Errorf("name is mandatory")
+	}
+	if s.Image == "" {
+		return fmt.Errorf("image is mandatory in %s", s.Name)
+	}
+	return nil
+}
+
+// Parse creates a ServiceConfig from a io.Reader.
+func (s *ServiceConfig) Parse(r io.Reader) error {
+	s.Instances = 1
+
+	if err := yaml.NewDecoder(r).Decode(s); err != nil {
+		return err
+	}
+
+	return s.Validate()
+}
+
+// JobSpec converts a ServiceConfig to a JobSpec.
+func (s *ServiceConfig) JobSpec() *api.JobSpec {
+	return &api.JobSpec{
+		Meta: api.Meta{
+			Name: s.Name,
+		},
+		Template: &api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{
+					Image: &api.ImageSpec{
+						Reference: s.Image,
+					},
+				},
+			},
+		},
+		Orchestration: &api.JobSpec_Service{
+			Service: &api.JobSpec_ServiceJob{
+				Instances: s.Instances,
+			},
+		},
+	}
+}
+
+// FromJobSpec converts a JobSpec to a ServiceConfig.
+func (s *ServiceConfig) FromJobSpec(jobSpec *api.JobSpec) {
+	s.Image = jobSpec.Template.GetContainer().Image.Reference
+	s.Name = jobSpec.Meta.Name
+	s.Instances = jobSpec.GetService().Instances
+}
+
+// Diff returns a diff between two ServiceConfigs.
+func (s *ServiceConfig) Diff(other *ServiceConfig) (string, error) {
+	local, err := yaml.Marshal(s)
+	if err != nil {
+		return "", err
+	}
+	remote, err := yaml.Marshal(other)
+	if err != nil {
+		return "", err
+	}
+
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(remote)),
+		B:        difflib.SplitLines(string(local)),
+		FromFile: "remote",
+		ToFile:   "local",
+	}
+
+	return difflib.GetUnifiedDiffString(diff)
+}

--- a/spec/service_test.go
+++ b/spec/service_test.go
@@ -1,0 +1,40 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServiceConfigValidate(t *testing.T) {
+	for _, bad := range []*ServiceConfig{
+		{Name: "", ContainerConfig: ContainerConfig{Image: ""}},
+		{Name: "name", ContainerConfig: ContainerConfig{Image: ""}},
+		{Name: "", ContainerConfig: ContainerConfig{Image: "image"}},
+	} {
+		assert.Error(t, bad.Validate())
+	}
+
+	for _, good := range []ServiceConfig{
+		{Name: "name", ContainerConfig: ContainerConfig{Image: "image"}},
+	} {
+
+		assert.NoError(t, good.Validate())
+	}
+}
+
+func TestDiffServiceConfigs(t *testing.T) {
+	service := &ServiceConfig{Name: "name", Instances: 1, ContainerConfig: ContainerConfig{Image: "nginx"}}
+
+	diff, err := service.Diff(
+		&ServiceConfig{Name: "name", Instances: 1, ContainerConfig: ContainerConfig{Image: "redis"}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "--- remote\n+++ local\n@@ -1 +1 @@\n-image: redis\n+image: nginx\n", diff)
+
+	diff, err = service.Diff(
+		&ServiceConfig{Name: "name", Instances: 2, ContainerConfig: ContainerConfig{Image: "nginx"}},
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, "--- remote\n+++ local\n@@ -3 +3 @@\n-instances: 2\n+instances: 1\n", diff)
+}

--- a/spec/spec.go
+++ b/spec/spec.go
@@ -1,24 +1,11 @@
 package spec
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/docker/swarm-v2/api"
 )
-
-// ServiceConfig is a human representation of the ServiceJob
-type ServiceConfig struct {
-	ContainerConfig
-
-	Instances int64 `yaml:"instances,omitempty"`
-}
-
-// ContainerConfig is a human representation of the ContainerSpec
-type ContainerConfig struct {
-	Image string `yaml:"image,omitempty"`
-}
 
 // Spec is a human representation of the API spec.
 type Spec struct {
@@ -44,8 +31,9 @@ func ReadFrom(path string) (*Spec, error) {
 
 func (s *Spec) validate() error {
 	for name, service := range s.Services {
-		if service.Image == "" {
-			return fmt.Errorf("image is mandatory in %s", name)
+		service.Name = name
+		if err := service.Validate(); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -54,30 +42,8 @@ func (s *Spec) validate() error {
 // JobSpecs returns all the JobSpecs in the Spec.
 func (s *Spec) JobSpecs() []*api.JobSpec {
 	jobSpecs := []*api.JobSpec{}
-	for name, service := range s.Services {
-		// TODO(vieux): what if we want to pass 0 in the file?
-		if service.Instances == 0 {
-			service.Instances = 1
-		}
-		jobSpecs = append(jobSpecs, &api.JobSpec{
-			Meta: api.Meta{
-				Name: name,
-			},
-			Template: &api.TaskSpec{
-				Runtime: &api.TaskSpec_Container{
-					Container: &api.ContainerSpec{
-						Image: &api.ImageSpec{
-							Reference: service.Image,
-						},
-					},
-				},
-			},
-			Orchestration: &api.JobSpec_Service{
-				Service: &api.JobSpec_ServiceJob{
-					Instances: service.Instances,
-				},
-			},
-		})
+	for _, service := range s.Services {
+		jobSpecs = append(jobSpecs, service.JobSpec())
 	}
 	return jobSpecs
 }


### PR DESCRIPTION
The code is probably a bit rough, but it's demoable.

---

job create -f:

```
$./bin/swarmctl job create -f examples/job/create.yml
45zkpek6qcgqlvly7fiqvtbsh
$ ./bin/swarmctl job ls
ID                         Name  Image  Instances
45zkpek6qcgqlvly7fiqvtbsh  web   nginx  2
```

job diff 

```
$ ./bin/swarmctl job diff 45zkpek6qcgqlvly7fiqvtbsh -f examples/job/update.yml
--- store
+++ local
@@ -3 +3 @@
-instances: 2
+instances: 4
```

job update -f

```
$ ./bin/swarmctl job update 45zkpek6qcgqlvly7fiqvtbsh -f examples/job/update.yml
45zkpek6qcgqlvly7fiqvtbsh
$ ./bin/swarmctl job ls
ID                         Name  Image  Instances
45zkpek6qcgqlvly7fiqvtbsh  web   nginx  4
```
