### PR TITLE
Add IPAMOptions to network object

### DIFF
--- a/api/types.proto
+++ b/api/types.proto
@@ -21,7 +21,7 @@ message NodeSpec {
 	enum Availability {
 		option (gogoproto.goproto_enum_prefix) = false;
 
-		// Active nodes. 
+		// Active nodes.
 		ACTIVE = 0 [(gogoproto.enumvalue_customname) = "NodeAvailabilityActive"];
 
 		// Paused nodes won't be considered by the scheduler, preventing any
@@ -198,7 +198,7 @@ message TaskStatus {
 	//
 	// The following states should report a companion error:
 	//
-	// 	FAILED, REJECTED
+	//	FAILED, REJECTED
 	//
 	// TODO(stevvooe) Integrate this field with the error interface.
 	string err = 2;
@@ -261,21 +261,31 @@ message IPAMConfiguration {
 	// instances. For now, we will follow the conventions of libnetwork and
 	// specify this as part of the network specification.
 
+	// AddressFamily specifies the network address family that
+	// this IPAMConfiguration belongs to.
+	enum AddressFamily {
+		UNKNOWN = 0; // satisfy proto3
+		IPV4 = 4;
+		IPV6 = 6;
+	}
+
+	AddressFamily family = 1;
+
 	// Subnet defines a network as a CIDR address (ie network and mask
 	// 192.168.0.1/24).
-	string subnet = 1;
+	string subnet = 2;
 
 	// Range defines the portion of the subnet to allocate to tasks. This is
 	// defined as a subnet within the primary subnet.
-	string range = 2;
+	string range = 3;
 
 	// Gateway address within the subnet.
-	string gateway = 3;
+	string gateway = 4;
 
 	// Reserved is a list of address from the master pool that should *not* be
 	// allocated. These addresses may have already been allocated or may be
 	// reserved for another allocation manager.
-	map<string, string> reserved = 4;
+	map<string, string> reserved = 5;
 }
 
 
@@ -288,15 +298,14 @@ message Driver {
 	map <string, string> options = 2;
 }
 
+message IPAMOptions {
+	Driver driver = 1;
+	repeated IPAMConfiguration configurations = 3;
+}
+
 // NetworkSpec specifies user defined network parameters.
 message NetworkSpec {
 	Meta meta = 1 [(gogoproto.nullable) = false];
-
-	message IPAMOptions {
-		Driver driver = 1;
-		repeated IPAMConfiguration ipv4 = 3 [(gogoproto.customname) = "IPv4"];
-		repeated IPAMConfiguration ipv6 = 4 [(gogoproto.customname) = "IPv6"];
-	}
 
 	// Driver specific configuration consumed by the network driver.
 	Driver driver_configuration = 2;
@@ -317,6 +326,10 @@ message Network {
 
 	// Driver specific operational state provided by the network driver.
 	Driver driver_state = 3;
+
+	// Runtime state of IPAM options. This may not reflect the
+	// ipam options from NetworkSpec.
+	IPAMOptions ipam = 5 [(gogoproto.customname) = "IPAM"];
 }
 
 // WeightedPeer should be used anywhere where we are describing a remote peer

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -71,16 +71,15 @@ func TestAllocator(t *testing.T) {
 	// Now verify if we get network and tasks updated properly
 	n1, err := watchNetwork(t, netWatch)
 	assert.NoError(t, err)
-	assert.NotEqual(t, n1.Spec.IPAM.IPv4, nil)
-	assert.Equal(t, len(n1.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n1.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n1.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n1.Spec.IPAM.IPv4[0].Reserved), 0)
+	assert.NotEqual(t, n1.Spec.IPAM.Configurations, nil)
+	assert.Equal(t, len(n1.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n1.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n1.Spec.IPAM.Configurations[0].Reserved), 0)
 
-	_, subnet, err := net.ParseCIDR(n1.Spec.IPAM.IPv4[0].Subnet)
+	_, subnet, err := net.ParseCIDR(n1.Spec.IPAM.Configurations[0].Subnet)
 	assert.NoError(t, err)
 
-	ip := net.ParseIP(n1.Spec.IPAM.IPv4[0].Gateway)
+	ip := net.ParseIP(n1.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
 
 	t1, err := watchTask(t, taskWatch)
@@ -107,16 +106,15 @@ func TestAllocator(t *testing.T) {
 
 	n2, err := watchNetwork(t, netWatch)
 	assert.NoError(t, err)
-	assert.NotEqual(t, n2.Spec.IPAM.IPv4, nil)
-	assert.Equal(t, len(n2.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n2.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n2.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n2.Spec.IPAM.IPv4[0].Reserved), 0)
+	assert.NotEqual(t, n2.Spec.IPAM.Configurations, nil)
+	assert.Equal(t, len(n2.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n2.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n2.Spec.IPAM.Configurations[0].Reserved), 0)
 
-	_, subnet, err = net.ParseCIDR(n2.Spec.IPAM.IPv4[0].Subnet)
+	_, subnet, err = net.ParseCIDR(n2.Spec.IPAM.Configurations[0].Subnet)
 	assert.NoError(t, err)
 
-	ip = net.ParseIP(n2.Spec.IPAM.IPv4[0].Gateway)
+	ip = net.ParseIP(n2.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
 
 	assert.NoError(t, store.Update(func(tx state.Tx) error {
@@ -196,16 +194,15 @@ func TestAllocator(t *testing.T) {
 
 	n3, err := watchNetwork(t, netWatch)
 	assert.NoError(t, err)
-	assert.NotEqual(t, n3.Spec.IPAM.IPv4, nil)
-	assert.Equal(t, len(n3.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n3.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n3.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n3.Spec.IPAM.IPv4[0].Reserved), 0)
+	assert.NotEqual(t, n3.Spec.IPAM.Configurations, nil)
+	assert.Equal(t, len(n3.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n3.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n3.Spec.IPAM.Configurations[0].Reserved), 0)
 
-	_, subnet, err = net.ParseCIDR(n3.Spec.IPAM.IPv4[0].Subnet)
+	_, subnet, err = net.ParseCIDR(n3.Spec.IPAM.Configurations[0].Subnet)
 	assert.NoError(t, err)
 
-	ip = net.ParseIP(n3.Spec.IPAM.IPv4[0].Gateway)
+	ip = net.ParseIP(n3.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
 
 	t3, err := watchTask(t, taskWatch)

--- a/manager/allocator/networkallocator/networkallocator_test.go
+++ b/manager/allocator/networkallocator/networkallocator_test.go
@@ -28,7 +28,7 @@ func TestAllocateInvalidIPAM(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{
 					Name: "invalidipam,",
 				},
@@ -88,16 +88,15 @@ func TestAllocateEmptyConfig(t *testing.T) {
 
 	err := na.Allocate(n)
 	assert.NoError(t, err)
-	assert.NotEqual(t, n.Spec.IPAM.IPv4, nil)
-	assert.Equal(t, len(n.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n.Spec.IPAM.IPv4[0].Reserved), 0)
+	assert.NotEqual(t, n.Spec.IPAM.Configurations, nil)
+	assert.Equal(t, len(n.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations[0].Reserved), 0)
 
-	_, _, err = net.ParseCIDR(n.Spec.IPAM.IPv4[0].Subnet)
+	_, _, err = net.ParseCIDR(n.Spec.IPAM.Configurations[0].Subnet)
 	assert.NoError(t, err)
 
-	ip := net.ParseIP(n.Spec.IPAM.IPv4[0].Gateway)
+	ip := net.ParseIP(n.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
 }
 
@@ -110,9 +109,9 @@ func TestAllocateWithOneSubnet(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet: "192.168.1.0/24",
 					},
@@ -123,13 +122,12 @@ func TestAllocateWithOneSubnet(t *testing.T) {
 
 	err := na.Allocate(n)
 	assert.NoError(t, err)
-	assert.Equal(t, len(n.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n.Spec.IPAM.IPv4[0].Reserved), 0)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Subnet, "192.168.1.0/24")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations[0].Reserved), 0)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Subnet, "192.168.1.0/24")
 
-	ip := net.ParseIP(n.Spec.IPAM.IPv4[0].Gateway)
+	ip := net.ParseIP(n.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
 }
 
@@ -142,9 +140,9 @@ func TestAllocateWithOneSubnetGateway(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet:  "192.168.1.0/24",
 						Gateway: "192.168.1.1",
@@ -156,12 +154,11 @@ func TestAllocateWithOneSubnetGateway(t *testing.T) {
 
 	err := na.Allocate(n)
 	assert.NoError(t, err)
-	assert.Equal(t, len(n.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n.Spec.IPAM.IPv4), 1)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n.Spec.IPAM.IPv4[0].Reserved), 0)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Subnet, "192.168.1.0/24")
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Gateway, "192.168.1.1")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations), 1)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations[0].Reserved), 0)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Subnet, "192.168.1.0/24")
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Gateway, "192.168.1.1")
 }
 
 func TestAllocateWithOneSubnetInvalidGateway(t *testing.T) {
@@ -173,9 +170,9 @@ func TestAllocateWithOneSubnetInvalidGateway(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet:  "192.168.1.0/24",
 						Gateway: "192.168.2.1",
@@ -198,9 +195,9 @@ func TestAllocateWithInvalidSubnet(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet: "1.1.1.1/32",
 					},
@@ -222,9 +219,9 @@ func TestAllocateWithTwoSubnetsNoGateway(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet: "192.168.1.0/24",
 					},
@@ -238,18 +235,17 @@ func TestAllocateWithTwoSubnetsNoGateway(t *testing.T) {
 
 	err := na.Allocate(n)
 	assert.NoError(t, err)
-	assert.Equal(t, len(n.Spec.IPAM.IPv6), 0)
-	assert.Equal(t, len(n.Spec.IPAM.IPv4), 2)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Range, "")
-	assert.Equal(t, len(n.Spec.IPAM.IPv4[0].Reserved), 0)
-	assert.Equal(t, n.Spec.IPAM.IPv4[0].Subnet, "192.168.1.0/24")
-	assert.Equal(t, n.Spec.IPAM.IPv4[1].Range, "")
-	assert.Equal(t, len(n.Spec.IPAM.IPv4[1].Reserved), 0)
-	assert.Equal(t, n.Spec.IPAM.IPv4[1].Subnet, "192.168.2.0/24")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations), 2)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Range, "")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations[0].Reserved), 0)
+	assert.Equal(t, n.Spec.IPAM.Configurations[0].Subnet, "192.168.1.0/24")
+	assert.Equal(t, n.Spec.IPAM.Configurations[1].Range, "")
+	assert.Equal(t, len(n.Spec.IPAM.Configurations[1].Reserved), 0)
+	assert.Equal(t, n.Spec.IPAM.Configurations[1].Subnet, "192.168.2.0/24")
 
-	ip := net.ParseIP(n.Spec.IPAM.IPv4[0].Gateway)
+	ip := net.ParseIP(n.Spec.IPAM.Configurations[0].Gateway)
 	assert.NotEqual(t, ip, nil)
-	ip = net.ParseIP(n.Spec.IPAM.IPv4[1].Gateway)
+	ip = net.ParseIP(n.Spec.IPAM.Configurations[1].Gateway)
 	assert.NotEqual(t, ip, nil)
 }
 
@@ -262,9 +258,9 @@ func TestFree(t *testing.T) {
 				Name: "test",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet:  "192.168.1.0/24",
 						Gateway: "192.168.1.1",
@@ -294,9 +290,9 @@ func TestAllocateTaskFree(t *testing.T) {
 				Name: "test1",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet:  "192.168.1.0/24",
 						Gateway: "192.168.1.1",
@@ -313,9 +309,9 @@ func TestAllocateTaskFree(t *testing.T) {
 				Name: "test2",
 			},
 			DriverConfiguration: &api.Driver{},
-			IPAM: &api.NetworkSpec_IPAMOptions{
+			IPAM: &api.IPAMOptions{
 				Driver: &api.Driver{},
-				IPv4: []*api.IPAMConfiguration{
+				Configurations: []*api.IPAMConfiguration{
 					{
 						Subnet:  "192.168.2.0/24",
 						Gateway: "192.168.2.1",

--- a/manager/clusterapi/network.go
+++ b/manager/clusterapi/network.go
@@ -60,7 +60,7 @@ func validateIPAMConfiguration(ipamConf *api.IPAMConfiguration) error {
 	return nil
 }
 
-func validateIPAM(ipam *api.NetworkSpec_IPAMOptions) error {
+func validateIPAM(ipam *api.IPAMOptions) error {
 	if ipam == nil {
 		// It is ok to not specify any IPAM configurations. We
 		// will choose good defaults.
@@ -71,14 +71,8 @@ func validateIPAM(ipam *api.NetworkSpec_IPAMOptions) error {
 		return err
 	}
 
-	for _, ipv4Conf := range ipam.IPv4 {
-		if err := validateIPAMConfiguration(ipv4Conf); err != nil {
-			return err
-		}
-	}
-
-	for _, ipv6Conf := range ipam.IPv6 {
-		if err := validateIPAMConfiguration(ipv6Conf); err != nil {
+	for _, ipamConf := range ipam.Configurations {
+		if err := validateIPAMConfiguration(ipamConf); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This is in addition to IPAMOptions found in NetworkSpec. We
need this because the IPAMOptions could be auto generated
if the user did not provide any options in the NetworkSpec.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
