### PR TITLE
agent/exec/container: remove spurious parameter from integration test

### DIFF
--- a/agent/exec/container/runner_integration_test.go
+++ b/agent/exec/container/runner_integration_test.go
@@ -36,7 +36,7 @@ func TestRunnerFlowIntegration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	client, err := engineapi.NewClient(dockerTestAddr, "", nil, map[string]string{"Content-Type": "none"})
+	client, err := engineapi.NewClient(dockerTestAddr, "", nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 


### PR DESCRIPTION
Signed-off-by: Stephen J Day stephen.day@docker.com
