### PR TITLE
Compile fix for drainer test

### DIFF
--- a/manager/drainer/drainer_test.go
+++ b/manager/drainer/drainer_test.go
@@ -126,7 +126,7 @@ func TestDrainer(t *testing.T) {
 		},
 	}
 
-	store := state.NewMemoryStore()
+	store := state.NewMemoryStore(nil)
 	assert.NotNil(t, store)
 
 	err := store.Update(func(tx state.Tx) error {


### PR DESCRIPTION
This was merged after unrelated changed made it into master that broke
compilation of the test.
