### PR TITLE
[WIP] Clustered managers

### DIFF
--- a/cmd/swarmd/manager.go
+++ b/cmd/swarmd/manager.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/docker/swarm-v2/manager"
-	"github.com/docker/swarm-v2/manager/state"
 	"github.com/spf13/cobra"
 )
 
@@ -15,17 +14,31 @@ var managerCmd = &cobra.Command{
 			return err
 		}
 
-		store := state.NewMemoryStore(nil)
+		joinRaft, err := cmd.Flags().GetString("join-cluster")
+		if err != nil {
+			return err
+		}
 
-		m := manager.New(&manager.Config{
-			Store:       store,
+		stateDir, err := cmd.Flags().GetString("state-dir")
+		if err != nil {
+			return err
+		}
+
+		m, err := manager.New(&manager.Config{
 			ListenProto: "tcp",
 			ListenAddr:  addr,
+			JoinRaft:    joinRaft,
+			StateDir:    stateDir,
 		})
+		if err != nil {
+			return err
+		}
 		return m.Run()
 	},
 }
 
 func init() {
 	managerCmd.Flags().String("listen-addr", "0.0.0.0:4242", "Listen address")
+	managerCmd.Flags().String("join-cluster", "", "Join cluster with a node at this address")
+	managerCmd.Flags().String("state-dir", "/var/lib/docker/cluster", "State directory")
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,9 +1,13 @@
 package manager
 
 import (
+	"fmt"
+	"math/rand"
 	"net"
-
-	"golang.org/x/net/context"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
@@ -13,6 +17,7 @@ import (
 	"github.com/docker/swarm-v2/manager/orchestrator"
 	"github.com/docker/swarm-v2/manager/scheduler"
 	"github.com/docker/swarm-v2/manager/state"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 
@@ -20,13 +25,18 @@ var _ api.ManagerServer = &Manager{}
 
 // Config is used to tune the Manager.
 type Config struct {
-	Store state.WatchableStore
-
 	ListenProto string
 	ListenAddr  string
 	// Listener will be used for grpc serving if it's not nil, ListenProto and
 	// ListenAddr fields will be used otherwise.
 	Listener net.Listener
+
+	// JoinRaft is an optional address of a node in an existing raft
+	// cluster to join.
+	JoinRaft string
+
+	// Top-level state directory
+	StateDir string
 }
 
 // Manager is the cluster manager for Swarm.
@@ -41,10 +51,16 @@ type Manager struct {
 	drainer      *drainer.Drainer
 	scheduler    *scheduler.Scheduler
 	server       *grpc.Server
+	raftNode     *state.Node
+
+	leadershipCh chan state.LeadershipState
+	leaderLock   sync.Mutex
+
+	managerDone chan struct{}
 }
 
 // New creates a Manager which has not started to accept requests yet.
-func New(config *Config) *Manager {
+func New(config *Config) (*Manager, error) {
 	dispatcherConfig := dispatcher.DefaultConfig()
 
 	// TODO(stevvooe): Reported address of manager is plumbed to listen addr
@@ -53,21 +69,98 @@ func New(config *Config) *Manager {
 	// through which agent nodes access the manager.
 	dispatcherConfig.Addr = config.ListenAddr
 
+	err := os.MkdirAll(config.StateDir, 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state directory: %v", err)
+	}
+
+	raftStateDir := filepath.Join(config.StateDir, "raft")
+	err = os.MkdirAll(raftStateDir, 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create raft state directory: %v", err)
+	}
+
+	raftCfg := state.DefaultNodeConfig()
+
+	rand.Seed(time.Now().UnixNano())
+
+	leadershipCh := make(chan state.LeadershipState)
+
+	newNodeOpts := state.NewNodeOptions{
+		ID:       uint64(rand.Int63()), // FIXME(aaronl)
+		Addr:     config.ListenAddr,
+		Config:   raftCfg,
+		StateDir: raftStateDir,
+	}
+	raftNode, err := state.NewNode(context.Background(), newNodeOpts, leadershipCh)
+	if err != nil {
+		return nil, fmt.Errorf("can't create raft node: %v", err)
+	}
+
+	store := raftNode.MemoryStore()
+
 	m := &Manager{
 		config:       config,
-		apiserver:    clusterapi.NewServer(config.Store),
-		dispatcher:   dispatcher.New(config.Store, dispatcherConfig),
-		orchestrator: orchestrator.New(config.Store),
-		scheduler:    scheduler.New(config.Store),
-		drainer:      drainer.New(config.Store),
+		apiserver:    clusterapi.NewServer(store),
+		dispatcher:   dispatcher.New(store, dispatcherConfig),
 		server:       grpc.NewServer(),
+		raftNode:     raftNode,
+		leadershipCh: leadershipCh,
 	}
 
 	api.RegisterManagerServer(m.server, m)
 	api.RegisterClusterServer(m.server, m.apiserver)
 	api.RegisterDispatcherServer(m.server, m.dispatcher)
 
-	return m
+	return m, nil
+}
+
+func (m *Manager) startRaftNode() {
+	errCh := m.raftNode.Start()
+	go func() {
+		for {
+			select {
+			case err := <-errCh:
+				log.Error(err)
+			case <-m.managerDone:
+				return
+			}
+		}
+	}()
+}
+
+func (m *Manager) initRaft() error {
+	err := m.raftNode.Campaign(m.raftNode.Ctx)
+	if err != nil {
+		return fmt.Errorf("couldn't campaign to be the leader: %v", err)
+	}
+
+	m.startRaftNode()
+
+	return nil
+}
+
+func (m *Manager) joinRaft(lis net.Listener) error {
+	m.startRaftNode()
+
+	c, err := state.GetRaftClient(m.config.JoinRaft, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("can't join raft cluster: %v", err)
+	}
+
+	resp, err := c.Join(m.raftNode.Ctx, &api.JoinRequest{
+		Node: &api.RaftNode{ID: m.raftNode.ID, Addr: m.config.ListenAddr},
+	})
+	if err != nil {
+		return fmt.Errorf("can't join raft cluster: %v", err)
+	}
+
+	err = m.raftNode.RegisterNodes(resp.Members)
+	if err != nil {
+		return fmt.Errorf("can't add members to the local cluster list: %v", err)
+	}
+
+	return nil
 }
 
 // Run starts all manager sub-systems and the gRPC server at the configured
@@ -83,26 +176,76 @@ func (m *Manager) Run() error {
 		lis = l
 	}
 
-	// Start all sub-components in separate goroutines.
-	// TODO(aluzzardi): This should have some kind of error handling so that
-	// any component that goes down would bring the entire manager down.
+	m.raftNode.Listener = lis
+	m.raftNode.Server = m.server
+
+	m.managerDone = make(chan struct{})
+	defer close(m.managerDone)
+
 	go func() {
-		if err := m.scheduler.Run(); err != nil {
-			log.Error(err)
-		}
-	}()
-	go func() {
-		if err := m.orchestrator.Run(); err != nil {
-			log.Error(err)
-		}
-	}()
-	go func() {
-		if err := m.drainer.Run(); err != nil {
-			log.Error(err)
+		for {
+			select {
+			case newState := <-m.leadershipCh:
+				if newState == state.IsLeader {
+					store := m.raftNode.MemoryStore()
+
+					m.leaderLock.Lock()
+					m.orchestrator = orchestrator.New(store)
+					m.scheduler = scheduler.New(store)
+					m.drainer = drainer.New(store)
+					m.leaderLock.Unlock()
+
+					// Start all sub-components in separate goroutines.
+					// TODO(aluzzardi): This should have some kind of error handling so that
+					// any component that goes down would bring the entire manager down.
+					go func() {
+						if err := m.scheduler.Run(); err != nil {
+							log.Error(err)
+						}
+					}()
+					go func() {
+						if err := m.orchestrator.Run(); err != nil {
+							log.Error(err)
+						}
+					}()
+					go func() {
+						if err := m.drainer.Run(); err != nil {
+							log.Error(err)
+						}
+					}()
+				} else if newState == state.IsFollower {
+					m.leaderLock.Lock()
+					m.drainer.Stop()
+					m.orchestrator.Stop()
+					m.scheduler.Stop()
+
+					m.drainer = nil
+					m.orchestrator = nil
+					m.scheduler = nil
+					m.leaderLock.Unlock()
+				}
+			case <-m.managerDone:
+				return
+			}
 		}
 	}()
 
 	log.WithFields(log.Fields{"proto": lis.Addr().Network(), "addr": lis.Addr().String()}).Info("Listening for connections")
+	var err error
+	if m.config.JoinRaft != "" {
+		err = m.joinRaft(lis)
+	} else {
+		err = m.initRaft()
+	}
+	if err != nil {
+		return err
+	}
+
+	state.Register(m.server, m.raftNode)
+
+	// Wait for raft to become available.
+	// FIXME(aaronl): This should not be handled by sleeping.
+	time.Sleep(time.Second)
 
 	return m.server.Serve(lis)
 }
@@ -110,10 +253,20 @@ func (m *Manager) Run() error {
 // Stop stops the manager. It immediately closes all open connections and
 // active RPCs as well as stopping the scheduler.
 func (m *Manager) Stop() {
+	m.leaderLock.Lock()
+	if m.drainer != nil {
+		m.drainer.Stop()
+	}
+	if m.orchestrator != nil {
+		m.orchestrator.Stop()
+	}
+	if m.scheduler != nil {
+		m.scheduler.Stop()
+	}
+	m.leaderLock.Unlock()
+
+	m.raftNode.Shutdown()
 	m.server.Stop()
-	m.drainer.Stop()
-	m.orchestrator.Stop()
-	m.scheduler.Stop()
 }
 
 // GRPC Methods

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -41,11 +41,16 @@ func TestManager(t *testing.T) {
 	assert.NoError(t, temp.Close())
 	assert.NoError(t, os.Remove(temp.Name()))
 
-	m := New(&Config{
-		Store:       store,
+	stateDir, err := ioutil.TempDir("", "test-raft")
+	assert.NoError(t, err)
+	defer os.RemoveAll(stateDir)
+
+	m, err := New(&Config{
 		ListenProto: "unix",
 		ListenAddr:  temp.Name(),
+		StateDir:    stateDir,
 	})
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 
 	done := make(chan error)
@@ -80,10 +85,15 @@ func TestManagerNodeCount(t *testing.T) {
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 
-	m := New(&Config{
-		Store:    store,
+	stateDir, err := ioutil.TempDir("", "test-raft")
+	assert.NoError(t, err)
+	defer os.RemoveAll(stateDir)
+
+	m, err := New(&Config{
 		Listener: l,
+		StateDir: stateDir,
 	})
+	assert.NoError(t, err)
 	assert.NotNil(t, m)
 	go m.Run()
 	defer m.Stop()
@@ -125,7 +135,7 @@ func TestManagerNodeCount(t *testing.T) {
 		a2.Stop(ctx)
 	}()
 
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 
 	resp, err := mClient.NodeCount(context.Background(), &api.NodeCountRequest{})
 	assert.NoError(t, err)

--- a/manager/state/memory.go
+++ b/manager/state/memory.go
@@ -287,7 +287,7 @@ func (s *MemoryStore) Update(cb func(Tx) error) error {
 		var sa []*api.StoreAction
 		sa, err = tx.newStoreAction()
 
-		if err == nil {
+		if err == nil && sa != nil {
 			err = s.proposer.ProposeValue(context.Background(), sa)
 		}
 	}

--- a/manager/state/raft_test.go
+++ b/manager/state/raft_test.go
@@ -118,7 +118,7 @@ func newInitNode(t *testing.T, id uint64) *Node {
 		StateDir:     stateDir,
 		TickInterval: testTick,
 	}
-	n, err := NewNode(context.Background(), newNodeOpts)
+	n, err := NewNode(context.Background(), newNodeOpts, nil)
 	require.NoError(t, err, "can't create raft node")
 	n.Listener = l
 	n.Server = s
@@ -160,7 +160,7 @@ func newJoinNode(t *testing.T, id uint64, join string) *Node {
 		TickInterval: testTick,
 	}
 
-	n, err := NewNode(context.Background(), newNodeOpts)
+	n, err := NewNode(context.Background(), newNodeOpts, nil)
 	require.NoError(t, err, "can't create raft node")
 	n.Listener = l
 	n.Server = s


### PR DESCRIPTION
Allow managers to join a raft cluster. Data is replicated through the cluster, so API commands can be sent to any manager.

This is still very much a work in progress. Opening to get early feedback. Managers can join a cluster and see updates as other managers make them, but rejoining a cluster after a restart or network partition doesn't work yet, and managers don't yet receive a snapshot of the store state when they join the cluster.

Non-exhaustive list of TODO items:
- [ ] ID stability after a restart
- [ ] Fix rejoining a cluster (use RestartNode when joining an existing cluster?)
- [x] Generate snapshots, and use them to populate newly joining managers (done in #209)
- [ ] Automated tests
