### PR TITLE
raft_test: Revert 100 ms timeouts

### DIFF
--- a/manager/state/raft_test.go
+++ b/manager/state/raft_test.go
@@ -162,7 +162,7 @@ func newJoinNode(t *testing.T, id uint64, join string) *Node {
 
 	n.Start()
 
-	c, err := GetRaftClient(join, 100*time.Millisecond)
+	c, err := GetRaftClient(join, 500*time.Millisecond)
 	assert.NoError(t, err, "can't initiate connection with existing raft")
 
 	resp, err := c.Join(n.Ctx, &api.JoinRequest{
@@ -328,7 +328,7 @@ func TestRaftLeaderDown(t *testing.T) {
 	checkValue(t, nodes[2], value)
 	assert.Equal(t, len(nodes[2].Cluster.Peers()), 3)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkValue(t, nodes[3], value)
 	assert.Equal(t, len(nodes[3].Cluster.Peers()), 3)
@@ -355,7 +355,7 @@ func TestRaftFollowerDown(t *testing.T) {
 	checkValue(t, nodes[1], value)
 	assert.Equal(t, len(nodes[1].Cluster.Peers()), 3)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkValue(t, nodes[2], value)
 	assert.Equal(t, len(nodes[2].Cluster.Peers()), 3)
@@ -374,7 +374,7 @@ func TestRaftLogReplication(t *testing.T) {
 	// All nodes should have the value in the physical store
 	checkValue(t, nodes[1], value)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkValue(t, nodes[2], value)
 	checkValue(t, nodes[3], value)
@@ -395,7 +395,7 @@ func TestRaftLogReplicationWithoutLeader(t *testing.T) {
 	// No value should be replicated in the store in the absence of the leader
 	checkNoValue(t, nodes[2])
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkNoValue(t, nodes[3])
 }
@@ -421,7 +421,7 @@ func TestRaftQuorumFailure(t *testing.T) {
 	// The value should not be replicated, we have no majority
 	checkNoValue(t, nodes[2])
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkNoValue(t, nodes[1])
 }
@@ -451,7 +451,7 @@ func TestRaftFollowerLeave(t *testing.T) {
 	// Value should be replicated on every node
 	checkValue(t, nodes[1], value)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkValue(t, nodes[2], value)
 
@@ -499,7 +499,7 @@ func TestRaftLeaderLeave(t *testing.T) {
 	checkValue(t, nodes[leader], value)
 	assert.Equal(t, len(nodes[leader].Cluster.Peers()), 2)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	checkValue(t, nodes[follower], value)
 	assert.Equal(t, len(nodes[follower].Cluster.Peers()), 2)
@@ -519,7 +519,7 @@ func TestRaftNewNodeGetsData(t *testing.T) {
 	// Add a new node
 	addRaftNode(t, nodes)
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	// Value should be replicated on every node
 	for _, node := range nodes {


### PR DESCRIPTION
These seem so low enough to make it very likely that they will
occasionally be insufficient on loaded CI VMs. Go back to 500 ms. Since
the tests are run in parallel, an extra 400 ms of test execution time
shouldn't be a big deal.
