### PR TITLE
Avoid holding store Update lock while making scheduling decisions

### DIFF
--- a/manager/state/store.go
+++ b/manager/state/store.go
@@ -216,6 +216,10 @@ func ViewAndWatch(store WatchableStore, cb func(ReadTx) error) (watch chan watch
 		watch = store.WatchQueue().Watch()
 		return nil
 	})
+	if watch != nil && err != nil {
+		store.WatchQueue().StopWatch(watch)
+		watch = nil
+	}
 	return
 }
 


### PR DESCRIPTION
Maintain a local copy of the master store. Make scheduling decisions
inside an Update on that local store. After doing a batch of scheduling
decisions, apply the changes to the master store.

@aluzzardi
