### PR TITLE
CLI commands for volumes

### DIFF
--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/swarm-v2/cmd/swarmctl/node"
 	"github.com/docker/swarm-v2/cmd/swarmctl/root"
 	"github.com/docker/swarm-v2/cmd/swarmctl/task"
+	"github.com/docker/swarm-v2/cmd/swarmctl/volume"
 	"github.com/docker/swarm-v2/version"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -44,6 +45,7 @@ func init() {
 		node.Cmd,
 		job.Cmd,
 		task.Cmd,
+		volume.Cmd,
 		version.Cmd,
 	)
 }

--- a/cmd/swarmctl/volume/cmd.go
+++ b/cmd/swarmctl/volume/cmd.go
@@ -1,0 +1,20 @@
+package volume
+
+import "github.com/spf13/cobra"
+
+var (
+	// Cmd exposes the top-level volume command
+	Cmd = &cobra.Command{
+		Use:   "volume",
+		Short: "Volume management",
+	}
+)
+
+func init() {
+	Cmd.AddCommand(
+		inspectCmd,
+		lsCmd,
+		createCmd,
+		rmCmd,
+	)
+}

--- a/cmd/swarmctl/volume/create.go
+++ b/cmd/swarmctl/volume/create.go
@@ -1,0 +1,44 @@
+package volume
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	createCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a volume",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			if !flags.Changed("name") || !flags.Changed("driver") {
+				return errors.New("--name and --driver are mandatory")
+			}
+			name, err := flags.GetString("name")
+			if err != nil {
+				return err
+			}
+			driver, err := flags.GetString("driver")
+			if err != nil {
+				return err
+			}
+			opts, err := flags.GetString("opts")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Volume Name = %s, driver = %s, options = %s\n", name, driver, opts)
+			// TODO: Send it to the Manager thru grpc
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	createCmd.Flags().String("name", "", "Volume name")
+	createCmd.Flags().String("driver", "", "Volume driver")
+	createCmd.Flags().String("opts", "", "Volume driver options")
+}

--- a/cmd/swarmctl/volume/inspect.go
+++ b/cmd/swarmctl/volume/inspect.go
@@ -1,0 +1,34 @@
+package volume
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	inspectCmd = &cobra.Command{
+		Use:   "inspect",
+		Short: "Inspect a volume",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			if !flags.Changed("name") {
+				return errors.New("--name is required")
+			}
+			name, err := flags.GetString("name")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Volume Name = %s\n", name)
+			// TODO: Send it to the Manager thru grpc
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	inspectCmd.Flags().String("name", "", "Volume name")
+}

--- a/cmd/swarmctl/volume/ls.go
+++ b/cmd/swarmctl/volume/ls.go
@@ -1,0 +1,16 @@
+package volume
+
+import "github.com/spf13/cobra"
+
+var (
+	lsCmd = &cobra.Command{
+		Use:     "list",
+		Short:   "List volumes",
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// TODO: Send it to the Manager thru grpc
+
+			return nil
+		},
+	}
+)

--- a/cmd/swarmctl/volume/rm.go
+++ b/cmd/swarmctl/volume/rm.go
@@ -1,0 +1,36 @@
+package volume
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	rmCmd = &cobra.Command{
+		Use:     "remove <Volume name>",
+		Short:   "Remove a volume",
+		Aliases: []string{"rm"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			if !flags.Changed("name") {
+				return errors.New("--name is required")
+			}
+			name, err := flags.GetString("name")
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Volume Name = %s\n", name)
+
+			// TODO: Send it to the Manager thru grpc
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	rmCmd.Flags().String("name", "", "Volume name")
+}


### PR DESCRIPTION
Add CLI for volume commands:
- `swarmctl volume create`
  - Create a new volume at the cluster wide volume
  - Options
    - Name - unique in the cluster [required]
    - Volume driver [required]
    - Driver options [optional]
- `swarmctl volume remove`
  - Remove a cluster level volume
  - Options
    - Name [required]
- `swarmctl volume list`
  - List volumes defined at the cluster level
- `swarmctl volume inspect`
  - Get information about a particular volume
  - Input: Name or ID [required]

Further details in: https://github.com/docker/swarm-v2/issues/187

Signed-off-by: amitshukla amit.shukla@gmail.com
