### PR TITLE
Remove complexity check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,12 @@ PACKAGES=$(shell go list ./... | grep -v /vendor/)
 
 GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
-.PHONY: clean all fmt vet lint errcheck complexity build binaries test setup checkprotos coverage ci check
+.PHONY: clean all fmt vet lint errcheck build binaries test setup checkprotos coverage ci check
 .DEFAULT: default
 
 all: check build binaries test
 
-check: fmt vet lint errcheck complexity
+check: fmt vet lint errcheck
 
 ci: check build binaries checkprotos coverage
 
@@ -45,7 +45,6 @@ setup:
 	@echo "🐳 $@"
 	# TODO(stevvooe): Install these from the vendor directory
 	@go get -u github.com/golang/lint/golint
-	@go get -u github.com/fzipp/gocyclo
 	@go get -u github.com/kisielk/errcheck
 	@go get -u github.com/golang/mock/mockgen
 
@@ -83,10 +82,6 @@ lint:
 errcheck:
 	@echo "🐳 $@"
 	@test -z "$$(golint ./... | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
-
-complexity:
-	@echo "🐳 $@"
-	@test -z "$$(gocyclo -over 15 . | grep -v vendor/ | grep -v "pb_test.go:" | grep -v ".pb.go:" | tee /dev/stderr)"
 
 build:
 	@echo "🐳 $@"


### PR DESCRIPTION
I propose removing this check because it often causes CI to fail for no good reason. We then have to invest time into figuring out what the tool doesn't like and pleasing it, rather than doing productive work or applying our own best practices about code quality.

The idea of limiting function size seems reasonable, but there are two big problems with these checks that make me think we should remove them. The first is that every case statement in a switch is counted as a unit of complexity. This means any switch statement with more than a few cases is effectively banned. I don't think this is a reasonable rule, and if we optimize our code to fit this rule we'll be optimizing for the wrong thing. Excluding files manually will become a mess to manage.

The second problem is that the hard cutoff on cyclomatic complexity can force refactoring at awkward times. For example, an urgent bug fix PR that adds a simple `if` statement to a function might not pass CI because it pushes that function over the threshold. Then the developer has to refactor the function, which makes the bug fix much harder to confidently review. I don't think the hard cutoff is a reasonable constraint. I think if we use this tool at all, we should manually review its output as _suggestions_ for possible refactoring.
