### PR TITLE
[WIP] namespaces: experiment with resolution

### DIFF
--- a/namespaces/context.go
+++ b/namespaces/context.go
@@ -1,0 +1,78 @@
+package namespaces
+
+// Context represents a referential position for a given namespace. We use the
+// namespace and a search space to generate the candidate space.
+type Context struct {
+	// Namespace is the root name for the context. It is effectively the
+	// default name for the context.
+	//
+	// It can also be thought of as the level of reference required to
+	// disambiguate references from those generated from the search space.
+	Namespace Name
+
+	// Search provides a list of namespaces to combine with unresolved
+	// references to build out qualified references to other objects.
+	Search []Name
+}
+
+var (
+	DefaultContext = Context{
+		Namespace: "default",
+	}
+)
+
+// ResolutionOptions controls the behavior of Context.Resolve.
+type ResolutionOptions struct {
+	// Match will be used to filter the candidates during resolution.
+	Match func(name Name) bool
+
+	// Qualify ensures that all references returned by resolve are qualifiable
+	// outside the context.
+	Qualify bool
+}
+
+// Resolve returns the most valid reference for the provided name based on the
+// match function.  The least specific reference required should be returned.
+func (ctx *Context) Resolve(name Name, opts ResolutionOptions) (Name, error) {
+	candidates, err := ctx.Candidates(name)
+	if err != nil {
+		return "", err
+	}
+
+	for i, candidate := range candidates {
+		if opts.Match != nil && !opts.Match(candidate) {
+			continue
+		}
+
+		if !opts.Qualify && i == 0 {
+			// if we hit the first candidate, we have encountered the local
+			// version of the name, so we only return the partial form.
+			return name, nil
+		} else {
+			return candidate, nil
+		}
+	}
+
+	return "", ErrNameUnresolved
+}
+
+// Candidates expands the name in the search space into a set of candidates.
+// The provided list of candidates may be referenceable from the context.
+//
+// The first returned entry is always the local reference.
+func (ctx *Context) Candidates(name Name) ([]Name, error) {
+	roots := append([]Name{ctx.Namespace}, ctx.Search...)
+
+	var candidates []Name
+	for _, root := range roots {
+		candidate, err := name.Join(root)
+		if err != nil {
+			// maybe just return these?
+			return nil, err
+		}
+
+		candidates = append(candidates, candidate)
+	}
+
+	return candidates, nil
+}

--- a/namespaces/context_test.go
+++ b/namespaces/context_test.go
@@ -1,0 +1,305 @@
+package namespaces
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestContextExpansion(t *testing.T) {
+	for _, testcase := range []struct {
+		ctx      *Context
+		inputs   []Name
+		expected [][]Name
+	}{
+		{
+			ctx:    &DefaultContext,
+			inputs: []Name{"redis", "postgres", "frontend"},
+			expected: [][]Name{
+				[]Name{
+					"redis.default",
+				},
+				[]Name{
+					"postgres.default",
+				},
+				[]Name{
+					"frontend.default",
+				},
+			},
+		},
+		{
+			ctx: &Context{
+				Namespace: "myapp",
+				Search: []Name{
+					"default",
+					"development",
+				},
+			},
+			inputs: []Name{"redis", "postgres", "frontend"},
+			expected: [][]Name{
+				[]Name{
+					"redis.myapp",
+					"redis.default",
+					"redis.development",
+				},
+				[]Name{
+					"postgres.myapp",
+					"postgres.default",
+					"postgres.development",
+				},
+				[]Name{
+					"frontend.myapp",
+					"frontend.default",
+					"frontend.development",
+				},
+			},
+		},
+	} {
+
+		fatalf := func(format string, args ...interface{}) {
+			args = append([]interface{}{testcase.ctx, testcase.inputs}, args...)
+			t.Fatalf("context=%v, inputs=%v: "+format, args...)
+		}
+		for i, input := range testcase.inputs {
+			candidates, err := testcase.ctx.Candidates(input)
+			if err != nil {
+				fatalf("unexpected error getting candidates: %v", err)
+			}
+
+			if !reflect.DeepEqual(candidates, testcase.expected[i]) {
+				fatalf("%v != %v", candidates, testcase.expected[i])
+			}
+
+			// test local resolution
+			resolved, err := testcase.ctx.Resolve(input, ResolutionOptions{})
+			if err != nil {
+				fatalf("unexpected error resolving local reference: %v", err)
+			}
+
+			if resolved != input {
+				fatalf("local reference not resolved: %v != %v", resolved, input)
+			}
+
+			// Make every resolution qualified
+			resolved, err = testcase.ctx.Resolve(input, ResolutionOptions{Qualify: true})
+			if err != nil {
+				fatalf("unexpected error resolving local reference: %v", err)
+			}
+
+			expectedQualified, err := input.Join(testcase.ctx.Namespace)
+			if err != nil {
+				fatalf("unexpected error calculating expected qualified name: %v", err)
+			}
+
+			if resolved != expectedQualified {
+				fatalf("unexpected qualified reference: ", resolved, expectedQualified)
+			}
+
+			// filter local references, simulating missing resources in namespace.
+			resolved, err = testcase.ctx.Resolve(input, ResolutionOptions{
+				Qualify: true,
+				Match: func(name Name) bool {
+					return !(name == input || name == expectedQualified)
+				},
+			})
+
+			// if the search space is empty, we expect a resolution error
+			if len(testcase.ctx.Search) == 0 {
+				if err != ErrNameUnresolved {
+					fatalf("unexpected error resolving external name in namespace without searchspace: %v != %v", err, ErrNameUnresolved)
+				}
+			} else {
+				if err != nil {
+					fatalf("unexpected error filtering resolution: %v", err)
+				}
+
+				// the first match should be the first expected
+				if resolved != testcase.expected[i][1] {
+					fatalf("resolved external reference incorrect: %v != %v", resolved, testcase.expected[i][1])
+				}
+			}
+		}
+	}
+}
+
+// TestContextApplication demonstrates a few use cases of context.
+func TestContextApplication(t *testing.T) {
+	ns1 := namespace{
+		name:   "ns1",
+		search: []Name{"ns2", "ns3"},
+		resources: []resource{
+			{
+				name: "www",
+				references: []Name{
+					"frontend",
+					"backend",
+				},
+			},
+			{
+				name: "redis",
+				references: []Name{
+					"backend",
+					"redis-data",
+				},
+			},
+		},
+	}
+
+	// run the same app, but declare volume redis-data
+	ns2 := namespace{
+		name:   "ns2",
+		search: []Name{"ns3"},
+		resources: []resource{
+			{
+				name: "www",
+				references: []Name{
+					"frontend",
+					"backend",
+				},
+			},
+			{
+				name: "redis",
+				references: []Name{
+					"backend",
+					"redis-data",
+				},
+			},
+			{
+				name: "redis-data",
+			},
+		},
+	}
+
+	// define the networks separately
+	ns3 := namespace{
+		name: "ns3",
+		resources: []resource{
+			{
+				name: "frontend",
+			},
+			{
+				name: "backend",
+			},
+		},
+	}
+
+	cluster := cluster{
+		namespaces: []namespace{ns1, ns2, ns3},
+	}
+
+	// loop through the namespaces, resolving references against the cluster.
+	for _, ns := range []namespace{ns1, ns2, ns3} {
+		fmt.Println("namespace", ns.name)
+		var indent string
+		printlni := func(args ...interface{}) {
+			fmt.Println(append([]interface{}{indent}, args...)...)
+		}
+
+		indent = "\t"
+		for _, r := range ns.resources {
+			printlni(r.name, "==", r.qualify(ns.context()))
+
+			indent = "\t\t"
+
+			for _, r := range r.references {
+				name, err := cluster.resolve(ns.context(), r)
+				if err != nil {
+					if err != ErrNameUnresolved {
+						panic(err)
+					}
+
+					printlni(r)
+				} else {
+					printlni(r, "==", name)
+				}
+			}
+
+			indent = "\t"
+
+		}
+		indent = ""
+	}
+
+	t.Fail()
+}
+
+// resource is a named resource within a namespace that references other
+// resources, which may or may not be a part of the current namespace.
+type resource struct {
+	name       Name
+	references []Name
+}
+
+func (r *resource) qualify(ctx *Context) Name {
+	q, err := r.name.Join(ctx.Namespace)
+	if err != nil {
+		panic(err)
+	}
+
+	return q
+}
+
+// namespace simulates an application namespace and all associated
+// resources.
+type namespace struct {
+	name      Name
+	resources []resource
+	search    []Name
+}
+
+func (ns namespace) context() *Context {
+	return &Context{Namespace: ns.name, Search: ns.search}
+}
+
+// defined returns a set of names that are defined in the namespace.
+func (ns namespace) defined() []Name {
+	var names []Name
+	for _, resource := range ns.resources {
+		names = append(names, resource.name)
+	}
+
+	return names
+}
+
+func (ns namespace) qualified() []Name {
+	names := ns.defined()
+	for i := range names {
+		var err error
+		names[i], err = names[i].Join(ns.name)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	return names
+}
+
+func (ns namespace) references() []Name {
+	var references []Name
+	for _, resource := range ns.resources {
+		references = append(references, resource.references...)
+	}
+	return references
+}
+
+// cluster simlulates the cluster
+type cluster struct {
+	namespaces []namespace
+}
+
+// exists returns true if the qualified name exists in the cluster.
+func (c *cluster) exists(name Name) bool {
+	for _, ns := range c.namespaces {
+		for _, q := range ns.qualified() {
+			if q == name {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (c *cluster) resolve(ctx *Context, name Name) (Name, error) {
+	return ctx.Resolve(name, ResolutionOptions{Qualify: true, Match: c.exists})
+}

--- a/namespaces/errors.go
+++ b/namespaces/errors.go
@@ -1,0 +1,8 @@
+package namespaces
+
+import "errors"
+
+var (
+	ErrNameInvalid    = errors.New("namespaces: invalid name")
+	ErrNameUnresolved = errors.New("namespaces: unresolvable name")
+)

--- a/namespaces/name.go
+++ b/namespaces/name.go
@@ -1,0 +1,86 @@
+package namespaces
+
+import "strings"
+
+// Name represents a name within a namespace. It may be any valid DNS
+// subdomain.
+type Name string
+
+// ParseName parse the name, returning an error if it is not valid.
+func ParseName(s string) (Name, error) {
+	n := Name(s)
+	if err := n.Validate(); err != nil {
+		return "", err
+	}
+
+	return n, nil
+}
+
+// Validate the name, returning an error if not valid.
+func (n Name) Validate() error {
+	if !isDomainName(n) {
+		return ErrNameInvalid
+	}
+
+	return nil
+}
+
+// Join appends the base to the name, returning an error if the resulting name
+// is no longer valid.
+func (n Name) Join(base Name) (Name, error) {
+	joined := Name(strings.Join([]string{string(n), string(base)}, "."))
+	if err := joined.Validate(); err != nil {
+		return "", err
+	}
+
+	return joined, nil
+}
+
+// isDomainName from net/dnsclient.go
+func isDomainName(s Name) bool {
+	// See RFC 1035, RFC 3696.
+	if len(s) == 0 {
+		return false
+	}
+	if len(s) > 255 {
+		return false
+	}
+
+	last := byte('.')
+	ok := false // Ok once we've seen a letter.
+	partlen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_':
+			ok = true
+			partlen++
+		case '0' <= c && c <= '9':
+			// fine
+			partlen++
+		case c == '-':
+			// Byte before dash cannot be dot.
+			if last == '.' {
+				return false
+			}
+			partlen++
+		case c == '.':
+			// Byte before dot cannot be dot, dash.
+			if last == '.' || last == '-' {
+				return false
+			}
+			if partlen > 63 || partlen == 0 {
+				return false
+			}
+			partlen = 0
+		}
+		last = c
+	}
+	if last == '-' || partlen > 63 {
+		return false
+	}
+
+	return ok
+}


### PR DESCRIPTION
The enclosed changeset includes a namespace context implementation with
search spaces and configurable resolution. We unit test this at a
production-ready level.

Also included is a simulation of namespace resolution in an environment
with namespaces and search resolution. Unresolved references are left to
the cluster for resolution against namespaces.

Notice that with very few lines of code, we get extremely interesting
behavior. The following is the output of the experiment:

```
namespace ns1
    www == www.ns1
        frontend == frontend.ns3
        backend == backend.ns3
    redis == redis.ns1
        backend == backend.ns3
        redis-data == redis-data.ns2
namespace ns2
    www == www.ns2
        frontend == frontend.ns3
        backend == backend.ns3
    redis == redis.ns2
        backend == backend.ns3
        redis-data == redis-data.ns2
    redis-data == redis-data.ns2
namespace ns3
    frontend == frontend.ns3
    backend == backend.ns3
```

Above, we show an isolated ns1 using resources from ns2 and ns3 to
actually run. ns1 and ns2 are sharing the networks declared in ns3.

Please check out the simulation code for details but all references are
actually calculated from the perspective of the namespace. We can
actually make it such that changes to the namespace can allow one to
update entire applications with small changes to the namespace.

Signed-off-by: Stephen J Day stephen.day@docker.com
