### PR TITLE
Add support for volumes in the manager

### DIFF
--- a/api/cluster.pb.go
+++ b/api/cluster.pb.go
@@ -260,6 +260,60 @@ type ListNetworksResponse struct {
 func (m *ListNetworksResponse) Reset()      { *m = ListNetworksResponse{} }
 func (*ListNetworksResponse) ProtoMessage() {}
 
+type CreateVolumeRequest struct {
+	Spec *VolumeSpec `protobuf:"bytes,1,opt,name=spec" json:"spec,omitempty"`
+}
+
+func (m *CreateVolumeRequest) Reset()      { *m = CreateVolumeRequest{} }
+func (*CreateVolumeRequest) ProtoMessage() {}
+
+type CreateVolumeResponse struct {
+	Volume *Volume `protobuf:"bytes,1,opt,name=volume" json:"volume,omitempty"`
+}
+
+func (m *CreateVolumeResponse) Reset()      { *m = CreateVolumeResponse{} }
+func (*CreateVolumeResponse) ProtoMessage() {}
+
+type GetVolumeRequest struct {
+	VolumeID string `protobuf:"bytes,1,opt,name=volume_id,proto3" json:"volume_id,omitempty"`
+}
+
+func (m *GetVolumeRequest) Reset()      { *m = GetVolumeRequest{} }
+func (*GetVolumeRequest) ProtoMessage() {}
+
+type GetVolumeResponse struct {
+	Volume *Volume `protobuf:"bytes,1,opt,name=volume" json:"volume,omitempty"`
+}
+
+func (m *GetVolumeResponse) Reset()      { *m = GetVolumeResponse{} }
+func (*GetVolumeResponse) ProtoMessage() {}
+
+type RemoveVolumeRequest struct {
+	VolumeID string `protobuf:"bytes,1,opt,name=volume_id,proto3" json:"volume_id,omitempty"`
+}
+
+func (m *RemoveVolumeRequest) Reset()      { *m = RemoveVolumeRequest{} }
+func (*RemoveVolumeRequest) ProtoMessage() {}
+
+type RemoveVolumeResponse struct {
+}
+
+func (m *RemoveVolumeResponse) Reset()      { *m = RemoveVolumeResponse{} }
+func (*RemoveVolumeResponse) ProtoMessage() {}
+
+type ListVolumesRequest struct {
+}
+
+func (m *ListVolumesRequest) Reset()      { *m = ListVolumesRequest{} }
+func (*ListVolumesRequest) ProtoMessage() {}
+
+type ListVolumesResponse struct {
+	Volumes []*Volume `protobuf:"bytes,1,rep,name=volumes" json:"volumes,omitempty"`
+}
+
+func (m *ListVolumesResponse) Reset()      { *m = ListVolumesResponse{} }
+func (*ListVolumesResponse) ProtoMessage() {}
+
 func init() {
 	proto.RegisterType((*ListOptions)(nil), "api.ListOptions")
 	proto.RegisterType((*GetNodeRequest)(nil), "api.GetNodeRequest")
@@ -294,6 +348,14 @@ func init() {
 	proto.RegisterType((*RemoveNetworkResponse)(nil), "api.RemoveNetworkResponse")
 	proto.RegisterType((*ListNetworksRequest)(nil), "api.ListNetworksRequest")
 	proto.RegisterType((*ListNetworksResponse)(nil), "api.ListNetworksResponse")
+	proto.RegisterType((*CreateVolumeRequest)(nil), "api.CreateVolumeRequest")
+	proto.RegisterType((*CreateVolumeResponse)(nil), "api.CreateVolumeResponse")
+	proto.RegisterType((*GetVolumeRequest)(nil), "api.GetVolumeRequest")
+	proto.RegisterType((*GetVolumeResponse)(nil), "api.GetVolumeResponse")
+	proto.RegisterType((*RemoveVolumeRequest)(nil), "api.RemoveVolumeRequest")
+	proto.RegisterType((*RemoveVolumeResponse)(nil), "api.RemoveVolumeResponse")
+	proto.RegisterType((*ListVolumesRequest)(nil), "api.ListVolumesRequest")
+	proto.RegisterType((*ListVolumesResponse)(nil), "api.ListVolumesResponse")
 }
 
 func (m *ListOptions) Copy() *ListOptions {
@@ -706,6 +768,103 @@ func (m *ListNetworksResponse) Copy() *ListNetworksResponse {
 	return o
 }
 
+func (m *CreateVolumeRequest) Copy() *CreateVolumeRequest {
+	if m == nil {
+		return nil
+	}
+
+	o := &CreateVolumeRequest{
+		Spec: m.Spec.Copy(),
+	}
+
+	return o
+}
+
+func (m *CreateVolumeResponse) Copy() *CreateVolumeResponse {
+	if m == nil {
+		return nil
+	}
+
+	o := &CreateVolumeResponse{
+		Volume: m.Volume.Copy(),
+	}
+
+	return o
+}
+
+func (m *GetVolumeRequest) Copy() *GetVolumeRequest {
+	if m == nil {
+		return nil
+	}
+
+	o := &GetVolumeRequest{
+		VolumeID: m.VolumeID,
+	}
+
+	return o
+}
+
+func (m *GetVolumeResponse) Copy() *GetVolumeResponse {
+	if m == nil {
+		return nil
+	}
+
+	o := &GetVolumeResponse{
+		Volume: m.Volume.Copy(),
+	}
+
+	return o
+}
+
+func (m *RemoveVolumeRequest) Copy() *RemoveVolumeRequest {
+	if m == nil {
+		return nil
+	}
+
+	o := &RemoveVolumeRequest{
+		VolumeID: m.VolumeID,
+	}
+
+	return o
+}
+
+func (m *RemoveVolumeResponse) Copy() *RemoveVolumeResponse {
+	if m == nil {
+		return nil
+	}
+
+	o := &RemoveVolumeResponse{}
+
+	return o
+}
+
+func (m *ListVolumesRequest) Copy() *ListVolumesRequest {
+	if m == nil {
+		return nil
+	}
+
+	o := &ListVolumesRequest{}
+
+	return o
+}
+
+func (m *ListVolumesResponse) Copy() *ListVolumesResponse {
+	if m == nil {
+		return nil
+	}
+
+	o := &ListVolumesResponse{}
+
+	if m.Volumes != nil {
+		o.Volumes = make([]*Volume, 0, len(m.Volumes))
+		for _, v := range m.Volumes {
+			o.Volumes = append(o.Volumes, v.Copy())
+		}
+	}
+
+	return o
+}
+
 func (this *ListOptions) GoString() string {
 	if this == nil {
 		return "nil"
@@ -1075,6 +1234,92 @@ func (this *ListNetworksResponse) GoString() string {
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
+func (this *CreateVolumeRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.CreateVolumeRequest{")
+	if this.Spec != nil {
+		s = append(s, "Spec: "+fmt.Sprintf("%#v", this.Spec)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *CreateVolumeResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.CreateVolumeResponse{")
+	if this.Volume != nil {
+		s = append(s, "Volume: "+fmt.Sprintf("%#v", this.Volume)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *GetVolumeRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.GetVolumeRequest{")
+	s = append(s, "VolumeID: "+fmt.Sprintf("%#v", this.VolumeID)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *GetVolumeResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.GetVolumeResponse{")
+	if this.Volume != nil {
+		s = append(s, "Volume: "+fmt.Sprintf("%#v", this.Volume)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *RemoveVolumeRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.RemoveVolumeRequest{")
+	s = append(s, "VolumeID: "+fmt.Sprintf("%#v", this.VolumeID)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *RemoveVolumeResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 4)
+	s = append(s, "&api.RemoveVolumeResponse{")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *ListVolumesRequest) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 4)
+	s = append(s, "&api.ListVolumesRequest{")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *ListVolumesResponse) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 5)
+	s = append(s, "&api.ListVolumesResponse{")
+	if this.Volumes != nil {
+		s = append(s, "Volumes: "+fmt.Sprintf("%#v", this.Volumes)+",\n")
+	}
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
 func valueToGoStringCluster(v interface{}, typ string) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -1124,6 +1369,10 @@ type ClusterClient interface {
 	ListNetworks(ctx context.Context, in *ListNetworksRequest, opts ...grpc.CallOption) (*ListNetworksResponse, error)
 	CreateNetwork(ctx context.Context, in *CreateNetworkRequest, opts ...grpc.CallOption) (*CreateNetworkResponse, error)
 	RemoveNetwork(ctx context.Context, in *RemoveNetworkRequest, opts ...grpc.CallOption) (*RemoveNetworkResponse, error)
+	GetVolume(ctx context.Context, in *GetVolumeRequest, opts ...grpc.CallOption) (*GetVolumeResponse, error)
+	ListVolumes(ctx context.Context, in *ListVolumesRequest, opts ...grpc.CallOption) (*ListVolumesResponse, error)
+	CreateVolume(ctx context.Context, in *CreateVolumeRequest, opts ...grpc.CallOption) (*CreateVolumeResponse, error)
+	RemoveVolume(ctx context.Context, in *RemoveVolumeRequest, opts ...grpc.CallOption) (*RemoveVolumeResponse, error)
 }
 
 type clusterClient struct {
@@ -1278,6 +1527,42 @@ func (c *clusterClient) RemoveNetwork(ctx context.Context, in *RemoveNetworkRequ
 	return out, nil
 }
 
+func (c *clusterClient) GetVolume(ctx context.Context, in *GetVolumeRequest, opts ...grpc.CallOption) (*GetVolumeResponse, error) {
+	out := new(GetVolumeResponse)
+	err := grpc.Invoke(ctx, "/api.Cluster/GetVolume", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clusterClient) ListVolumes(ctx context.Context, in *ListVolumesRequest, opts ...grpc.CallOption) (*ListVolumesResponse, error) {
+	out := new(ListVolumesResponse)
+	err := grpc.Invoke(ctx, "/api.Cluster/ListVolumes", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clusterClient) CreateVolume(ctx context.Context, in *CreateVolumeRequest, opts ...grpc.CallOption) (*CreateVolumeResponse, error) {
+	out := new(CreateVolumeResponse)
+	err := grpc.Invoke(ctx, "/api.Cluster/CreateVolume", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *clusterClient) RemoveVolume(ctx context.Context, in *RemoveVolumeRequest, opts ...grpc.CallOption) (*RemoveVolumeResponse, error) {
+	out := new(RemoveVolumeResponse)
+	err := grpc.Invoke(ctx, "/api.Cluster/RemoveVolume", in, out, c.cc, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Server API for Cluster service
 
 type ClusterServer interface {
@@ -1297,6 +1582,10 @@ type ClusterServer interface {
 	ListNetworks(context.Context, *ListNetworksRequest) (*ListNetworksResponse, error)
 	CreateNetwork(context.Context, *CreateNetworkRequest) (*CreateNetworkResponse, error)
 	RemoveNetwork(context.Context, *RemoveNetworkRequest) (*RemoveNetworkResponse, error)
+	GetVolume(context.Context, *GetVolumeRequest) (*GetVolumeResponse, error)
+	ListVolumes(context.Context, *ListVolumesRequest) (*ListVolumesResponse, error)
+	CreateVolume(context.Context, *CreateVolumeRequest) (*CreateVolumeResponse, error)
+	RemoveVolume(context.Context, *RemoveVolumeRequest) (*RemoveVolumeResponse, error)
 }
 
 func RegisterClusterServer(s *grpc.Server, srv ClusterServer) {
@@ -1495,6 +1784,54 @@ func _Cluster_RemoveNetwork_Handler(srv interface{}, ctx context.Context, dec fu
 	return out, nil
 }
 
+func _Cluster_GetVolume_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(GetVolumeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ClusterServer).GetVolume(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Cluster_ListVolumes_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(ListVolumesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ClusterServer).ListVolumes(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Cluster_CreateVolume_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(CreateVolumeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ClusterServer).CreateVolume(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func _Cluster_RemoveVolume_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error) (interface{}, error) {
+	in := new(RemoveVolumeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	out, err := srv.(ClusterServer).RemoveVolume(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 var _Cluster_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "api.Cluster",
 	HandlerType: (*ClusterServer)(nil),
@@ -1562,6 +1899,22 @@ var _Cluster_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "RemoveNetwork",
 			Handler:    _Cluster_RemoveNetwork_Handler,
+		},
+		{
+			MethodName: "GetVolume",
+			Handler:    _Cluster_GetVolume_Handler,
+		},
+		{
+			MethodName: "ListVolumes",
+			Handler:    _Cluster_ListVolumes_Handler,
+		},
+		{
+			MethodName: "CreateVolume",
+			Handler:    _Cluster_CreateVolume_Handler,
+		},
+		{
+			MethodName: "RemoveVolume",
+			Handler:    _Cluster_RemoveVolume_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{},
@@ -2441,6 +2794,204 @@ func (m *ListNetworksResponse) MarshalTo(data []byte) (int, error) {
 	return i, nil
 }
 
+func (m *CreateVolumeRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CreateVolumeRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Spec != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintCluster(data, i, uint64(m.Spec.Size()))
+		n17, err := m.Spec.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n17
+	}
+	return i, nil
+}
+
+func (m *CreateVolumeResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *CreateVolumeResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Volume != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintCluster(data, i, uint64(m.Volume.Size()))
+		n18, err := m.Volume.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n18
+	}
+	return i, nil
+}
+
+func (m *GetVolumeRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *GetVolumeRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.VolumeID) > 0 {
+		data[i] = 0xa
+		i++
+		i = encodeVarintCluster(data, i, uint64(len(m.VolumeID)))
+		i += copy(data[i:], m.VolumeID)
+	}
+	return i, nil
+}
+
+func (m *GetVolumeResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *GetVolumeResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Volume != nil {
+		data[i] = 0xa
+		i++
+		i = encodeVarintCluster(data, i, uint64(m.Volume.Size()))
+		n19, err := m.Volume.MarshalTo(data[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n19
+	}
+	return i, nil
+}
+
+func (m *RemoveVolumeRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RemoveVolumeRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.VolumeID) > 0 {
+		data[i] = 0xa
+		i++
+		i = encodeVarintCluster(data, i, uint64(len(m.VolumeID)))
+		i += copy(data[i:], m.VolumeID)
+	}
+	return i, nil
+}
+
+func (m *RemoveVolumeResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *RemoveVolumeResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *ListVolumesRequest) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ListVolumesRequest) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	return i, nil
+}
+
+func (m *ListVolumesResponse) Marshal() (data []byte, err error) {
+	size := m.Size()
+	data = make([]byte, size)
+	n, err := m.MarshalTo(data)
+	if err != nil {
+		return nil, err
+	}
+	return data[:n], nil
+}
+
+func (m *ListVolumesResponse) MarshalTo(data []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Volumes) > 0 {
+		for _, msg := range m.Volumes {
+			data[i] = 0xa
+			i++
+			i = encodeVarintCluster(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
 func encodeFixed64Cluster(data []byte, offset int, v uint64) int {
 	data[offset] = uint8(v)
 	data[offset+1] = uint8(v >> 8)
@@ -2802,6 +3353,80 @@ func (m *ListNetworksResponse) Size() (n int) {
 	return n
 }
 
+func (m *CreateVolumeRequest) Size() (n int) {
+	var l int
+	_ = l
+	if m.Spec != nil {
+		l = m.Spec.Size()
+		n += 1 + l + sovCluster(uint64(l))
+	}
+	return n
+}
+
+func (m *CreateVolumeResponse) Size() (n int) {
+	var l int
+	_ = l
+	if m.Volume != nil {
+		l = m.Volume.Size()
+		n += 1 + l + sovCluster(uint64(l))
+	}
+	return n
+}
+
+func (m *GetVolumeRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.VolumeID)
+	if l > 0 {
+		n += 1 + l + sovCluster(uint64(l))
+	}
+	return n
+}
+
+func (m *GetVolumeResponse) Size() (n int) {
+	var l int
+	_ = l
+	if m.Volume != nil {
+		l = m.Volume.Size()
+		n += 1 + l + sovCluster(uint64(l))
+	}
+	return n
+}
+
+func (m *RemoveVolumeRequest) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.VolumeID)
+	if l > 0 {
+		n += 1 + l + sovCluster(uint64(l))
+	}
+	return n
+}
+
+func (m *RemoveVolumeResponse) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ListVolumesRequest) Size() (n int) {
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ListVolumesResponse) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Volumes) > 0 {
+		for _, e := range m.Volumes {
+			l = e.Size()
+			n += 1 + l + sovCluster(uint64(l))
+		}
+	}
+	return n
+}
+
 func sovCluster(x uint64) (n int) {
 	for {
 		n++
@@ -3140,6 +3765,84 @@ func (this *ListNetworksResponse) String() string {
 	}
 	s := strings.Join([]string{`&ListNetworksResponse{`,
 		`Networks:` + strings.Replace(fmt.Sprintf("%v", this.Networks), "Network", "Network", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CreateVolumeRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CreateVolumeRequest{`,
+		`Spec:` + strings.Replace(fmt.Sprintf("%v", this.Spec), "VolumeSpec", "VolumeSpec", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *CreateVolumeResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&CreateVolumeResponse{`,
+		`Volume:` + strings.Replace(fmt.Sprintf("%v", this.Volume), "Volume", "Volume", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetVolumeRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetVolumeRequest{`,
+		`VolumeID:` + fmt.Sprintf("%v", this.VolumeID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *GetVolumeResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&GetVolumeResponse{`,
+		`Volume:` + strings.Replace(fmt.Sprintf("%v", this.Volume), "Volume", "Volume", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RemoveVolumeRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RemoveVolumeRequest{`,
+		`VolumeID:` + fmt.Sprintf("%v", this.VolumeID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RemoveVolumeResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RemoveVolumeResponse{`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListVolumesRequest) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListVolumesRequest{`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *ListVolumesResponse) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&ListVolumesResponse{`,
+		`Volumes:` + strings.Replace(fmt.Sprintf("%v", this.Volumes), "Volume", "Volume", 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -5778,6 +6481,594 @@ func (m *ListNetworksResponse) Unmarshal(data []byte) error {
 			}
 			m.Networks = append(m.Networks, &Network{})
 			if err := m.Networks[len(m.Networks)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateVolumeRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateVolumeRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateVolumeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Spec", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Spec == nil {
+				m.Spec = &VolumeSpec{}
+			}
+			if err := m.Spec.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateVolumeResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateVolumeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateVolumeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volume", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Volume == nil {
+				m.Volume = &Volume{}
+			}
+			if err := m.Volume.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetVolumeRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetVolumeRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetVolumeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VolumeID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.VolumeID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetVolumeResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetVolumeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetVolumeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volume", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Volume == nil {
+				m.Volume = &Volume{}
+			}
+			if err := m.Volume.Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RemoveVolumeRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RemoveVolumeRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RemoveVolumeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field VolumeID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.VolumeID = string(data[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RemoveVolumeResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RemoveVolumeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RemoveVolumeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListVolumesRequest) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListVolumesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListVolumesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipCluster(data[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthCluster
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ListVolumesResponse) Unmarshal(data []byte) error {
+	l := len(data)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowCluster
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := data[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ListVolumesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ListVolumesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volumes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowCluster
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthCluster
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Volumes = append(m.Volumes, &Volume{})
+			if err := m.Volumes[len(m.Volumes)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/api/cluster.proto
+++ b/api/cluster.proto
@@ -34,6 +34,11 @@ service Cluster {
 	rpc ListNetworks(ListNetworksRequest) returns (ListNetworksResponse) {};
 	rpc CreateNetwork(CreateNetworkRequest) returns (CreateNetworkResponse) {};
 	rpc RemoveNetwork(RemoveNetworkRequest) returns (RemoveNetworkResponse) {};
+
+	rpc GetVolume(GetVolumeRequest) returns (GetVolumeResponse) {};
+	rpc ListVolumes(ListVolumesRequest) returns (ListVolumesResponse) {};
+	rpc CreateVolume(CreateVolumeRequest) returns (CreateVolumeResponse) {};
+	rpc RemoveVolume(RemoveVolumeRequest) returns (RemoveVolumeResponse) {};
 }
 
 message ListOptions {
@@ -166,4 +171,32 @@ message ListNetworksRequest {}
 
 message ListNetworksResponse {
 	repeated Network networks = 1;
+}
+
+message CreateVolumeRequest {
+	VolumeSpec spec = 1;
+}
+
+message CreateVolumeResponse {
+	Volume volume = 1;
+}
+
+message GetVolumeRequest {
+	string volume_id = 1 [(gogoproto.customname) = "VolumeID"];
+}
+
+message GetVolumeResponse {
+	Volume volume = 1;
+}
+
+message RemoveVolumeRequest {
+	string volume_id = 1 [(gogoproto.customname) = "VolumeID"];
+}
+
+message RemoveVolumeResponse {}
+
+message ListVolumesRequest {}
+
+message ListVolumesResponse {
+	repeated Volume volumes = 1;
 }

--- a/api/types.proto
+++ b/api/types.proto
@@ -348,6 +348,22 @@ message Network {
 	IPAMOptions ipam = 5 [(gogoproto.customname) = "IPAM"];
 }
 
+// VolumeSpec defines the properties of a Volume.
+message VolumeSpec {
+	Meta meta = 1 [(gogoproto.nullable) = false];
+
+	// Driver specific configuration consumed by the Volume driver.
+	Driver driver_configuration = 2;
+}
+
+message Volume {
+	string id = 1 [(gogoproto.customname) = "ID"];
+	VolumeSpec spec = 2;
+
+	// Driver specific operational state provided by the Volume driver.
+	Driver driver_state = 3;
+}
+
 // WeightedPeer should be used anywhere where we are describing a remote peer
 // with a weight.
 message WeightedPeer {
@@ -384,5 +400,9 @@ message StoreAction {
 		Network create_network = 10;
 		Network update_network = 11;
 		string remove_network = 12;
+
+		Volume create_volume = 13;
+		Volume update_volume = 14;
+		string remove_volume = 15;
 	}
 }

--- a/cmd/swarmctl/volume/create.go
+++ b/cmd/swarmctl/volume/create.go
@@ -3,7 +3,10 @@ package volume
 import (
 	"errors"
 	"fmt"
+	"strings"
 
+	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/cmd/swarmctl/common"
 	"github.com/spf13/cobra"
 )
 
@@ -20,18 +23,43 @@ var (
 			if err != nil {
 				return err
 			}
-			driver, err := flags.GetString("driver")
-			if err != nil {
-				return err
-			}
-			opts, err := flags.GetString("opts")
+			driverName, err := flags.GetString("driver")
 			if err != nil {
 				return err
 			}
 
-			fmt.Printf("Volume Name = %s, driver = %s, options = %s\n", name, driver, opts)
-			// TODO: Send it to the Manager thru grpc
+			driver := new(api.Driver)
+			driver.Name = driverName
+			opts, err := cmd.Flags().GetStringSlice("opts")
+			if err != nil {
+				return err
+			}
 
+			driver.Options = map[string]string{}
+			for _, opt := range opts {
+				optPair := strings.Split(opt, "=")
+				if len(optPair) != 2 {
+					return fmt.Errorf("Malformed opts: %s", opt)
+				}
+				driver.Options[optPair[0]] = optPair[1]
+			}
+
+			spec := &api.VolumeSpec{
+				Meta: api.Meta{
+					Name: name,
+				},
+				DriverConfiguration: driver,
+			}
+
+			c, err := common.Dial(cmd)
+			if err != nil {
+				return err
+			}
+			r, err := c.CreateVolume(common.Context(cmd), &api.CreateVolumeRequest{Spec: spec})
+			if err != nil {
+				return err
+			}
+			fmt.Println(r.Volume.ID)
 			return nil
 		},
 	}
@@ -40,5 +68,5 @@ var (
 func init() {
 	createCmd.Flags().String("name", "", "Volume name")
 	createCmd.Flags().String("driver", "", "Volume driver")
-	createCmd.Flags().String("opts", "", "Volume driver options")
+	createCmd.Flags().StringSlice("opts", []string{}, "Volume driver options")
 }

--- a/cmd/swarmctl/volume/inspect.go
+++ b/cmd/swarmctl/volume/inspect.go
@@ -9,26 +9,18 @@ import (
 
 var (
 	inspectCmd = &cobra.Command{
-		Use:   "inspect",
+		Use:   "inspect <volume ID>",
 		Short: "Inspect a volume",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			flags := cmd.Flags()
-			if !flags.Changed("name") {
-				return errors.New("--name is required")
-			}
-			name, err := flags.GetString("name")
-			if err != nil {
-				return err
+			if len(args) == 0 {
+				return errors.New("volume ID missing")
 			}
 
-			fmt.Printf("Volume Name = %s\n", name)
-			// TODO: Send it to the Manager thru grpc
+			fmt.Printf("Volume ID = %s\n", args[0])
+
+			// TODO(amitshukla): Send it to the Manager thru grpc
 
 			return nil
 		},
 	}
 )
-
-func init() {
-	inspectCmd.Flags().String("name", "", "Volume name")
-}

--- a/cmd/swarmctl/volume/rm.go
+++ b/cmd/swarmctl/volume/rm.go
@@ -1,5 +1,7 @@
 package volume
 
+// TODO(amitshukla): rename this file to remove.go and ls.Cmd to removeCmd - will do this change in a separate PR
+
 import (
 	"errors"
 	"fmt"
@@ -9,28 +11,19 @@ import (
 
 var (
 	rmCmd = &cobra.Command{
-		Use:     "remove <Volume name>",
+		Use:     "remove <volume ID>",
 		Short:   "Remove a volume",
 		Aliases: []string{"rm"},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			flags := cmd.Flags()
-			if !flags.Changed("name") {
-				return errors.New("--name is required")
-			}
-			name, err := flags.GetString("name")
-			if err != nil {
-				return err
+			if len(args) == 0 {
+				return errors.New("volume ID is missing")
 			}
 
-			fmt.Printf("Volume Name = %s\n", name)
+			fmt.Printf("Volume ID = %s\n", args[0])
 
-			// TODO: Send it to the Manager thru grpc
+			// TODO(amitshukla): Send it to the Manager thru grpc
 
 			return nil
 		},
 	}
 )
-
-func init() {
-	rmCmd.Flags().String("name", "", "Volume name")
-}

--- a/manager/clusterapi/common.go
+++ b/manager/clusterapi/common.go
@@ -12,3 +12,17 @@ func validateMeta(m api.Meta) error {
 	}
 	return nil
 }
+
+func validateDriver(driver *api.Driver) error {
+	if driver == nil {
+		// It is ok to not specify the driver. We will choose
+		// a default driver.
+		return nil
+	}
+
+	if driver.Name == "" {
+		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
+	}
+
+	return nil
+}

--- a/manager/clusterapi/network.go
+++ b/manager/clusterapi/network.go
@@ -11,20 +11,6 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-func validateDriver(driver *api.Driver) error {
-	if driver == nil {
-		// It is ok to not specify the driver. We will choose
-		// a default driver.
-		return nil
-	}
-
-	if driver.Name == "" {
-		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
-	}
-
-	return nil
-}
-
 func validateIPAMConfiguration(ipamConf *api.IPAMConfiguration) error {
 	if ipamConf == nil {
 		return grpc.Errorf(codes.InvalidArgument, "ipam configuration: cannot be empty")

--- a/manager/clusterapi/volume.go
+++ b/manager/clusterapi/volume.go
@@ -1,0 +1,114 @@
+package clusterapi
+
+import (
+	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/identity"
+	"github.com/docker/swarm-v2/manager/state"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func validateVolumeSpec(spec *api.VolumeSpec) error {
+	if spec == nil {
+		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+	}
+
+	if err := validateDriver(spec.DriverConfiguration); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CreateVolume creates and return a Volume based on the provided VolumeSpec.
+// - Returns `InvalidArgument` if the VolumeSpec is malformed.
+// - Returns `Unimplemented` if the VolumeSpec references unimplemented features.
+// - Returns `AlreadyExists` if the VolumeID conflicts.
+// - Returns an error if the creation fails.
+func (s *Server) CreateVolume(ctx context.Context, request *api.CreateVolumeRequest) (*api.CreateVolumeResponse, error) {
+	if err := validateVolumeSpec(request.Spec); err != nil {
+		return nil, err
+	}
+	// TODO(amitshukla): validate driver_configuration
+
+	// TODO(amitshukla): Consider using `Name` as a primary key to handle
+	// duplicate creations. See #65
+	volume := &api.Volume{
+		ID:   identity.NewID(),
+		Spec: request.Spec,
+	}
+
+	err := s.store.Update(func(tx state.Tx) error {
+		return tx.Volumes().Create(volume)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.CreateVolumeResponse{
+		Volume: volume,
+	}, nil
+}
+
+// GetVolume returns a Volume given a VolumeID.
+// - Returns `InvalidArgument` if VolumeID is not provided.
+// - Returns `NotFound` if the Volume is not found.
+func (s *Server) GetVolume(ctx context.Context, request *api.GetVolumeRequest) (*api.GetVolumeResponse, error) {
+	if request.VolumeID == "" {
+		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+	}
+
+	var volume *api.Volume
+	err := s.store.View(func(tx state.ReadTx) error {
+		volume = tx.Volumes().Get(request.VolumeID)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if volume == nil {
+		return nil, grpc.Errorf(codes.NotFound, "volume %s not found", request.VolumeID)
+	}
+	return &api.GetVolumeResponse{
+		Volume: volume,
+	}, nil
+}
+
+// RemoveVolume removes a Volume referenced by VolumeID.
+// - Returns `InvalidArgument` if VolumeID is not provided.
+// - Returns `NotFound` if the Volume is not found.
+// - Returns an error if the deletion fails.
+func (s *Server) RemoveVolume(ctx context.Context, request *api.RemoveVolumeRequest) (*api.RemoveVolumeResponse, error) {
+	if request.VolumeID == "" {
+		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+	}
+
+	err := s.store.Update(func(tx state.Tx) error {
+		return tx.Volumes().Delete(request.VolumeID)
+	})
+	if err != nil {
+		if err == state.ErrNotExist {
+			return nil, grpc.Errorf(codes.NotFound, "volume %s not found", request.VolumeID)
+		}
+		return nil, err
+	}
+	return &api.RemoveVolumeResponse{}, nil
+}
+
+// ListVolumes returns a list of all volumes.
+func (s *Server) ListVolumes(ctx context.Context, request *api.ListVolumesRequest) (*api.ListVolumesResponse, error) {
+	var volumes []*api.Volume
+	err := s.store.View(func(tx state.ReadTx) error {
+		var err error
+
+		volumes, err = tx.Volumes().Find(state.All)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &api.ListVolumesResponse{
+		Volumes: volumes,
+	}, nil
+}

--- a/manager/clusterapi/volume_test.go
+++ b/manager/clusterapi/volume_test.go
@@ -1,0 +1,90 @@
+package clusterapi
+
+import (
+	"testing"
+
+	"github.com/docker/swarm-v2/api"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+)
+
+func createVolumeSpec(name string) *api.VolumeSpec {
+	return &api.VolumeSpec{
+		Meta: api.Meta{
+			Name: name,
+		},
+	}
+}
+
+func createVolume(t *testing.T, ts *testServer, name string) *api.Volume {
+	spec := createVolumeSpec(name)
+	r, err := ts.Client.CreateVolume(context.Background(), &api.CreateVolumeRequest{Spec: spec})
+	assert.NoError(t, err)
+	return r.Volume
+}
+
+func TestValidateVolumeSpec(t *testing.T) {
+	err := validateVolumeSpec(nil)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+}
+
+func TestCreateVolume(t *testing.T) {
+	ts := newTestServer(t)
+	_, err := ts.Client.CreateVolume(context.Background(), &api.CreateVolumeRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	spec := createVolumeSpec("name")
+	r, err := ts.Client.CreateVolume(context.Background(), &api.CreateVolumeRequest{Spec: spec})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, r.Volume.ID)
+}
+
+func TestGetVolume(t *testing.T) {
+	ts := newTestServer(t)
+	_, err := ts.Client.GetVolume(context.Background(), &api.GetVolumeRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	_, err = ts.Client.GetVolume(context.Background(), &api.GetVolumeRequest{VolumeID: "invalid"})
+	assert.Error(t, err)
+	assert.Equal(t, codes.NotFound, grpc.Code(err))
+
+	volume := createVolume(t, ts, "name")
+	r, err := ts.Client.GetVolume(context.Background(), &api.GetVolumeRequest{VolumeID: volume.ID})
+	assert.NoError(t, err)
+	assert.Equal(t, volume, r.Volume)
+}
+
+func TestRemoveVolume(t *testing.T) {
+	ts := newTestServer(t)
+	_, err := ts.Client.RemoveVolume(context.Background(), &api.RemoveVolumeRequest{})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	volume := createVolume(t, ts, "name")
+	r, err := ts.Client.RemoveVolume(context.Background(), &api.RemoveVolumeRequest{VolumeID: volume.ID})
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+}
+
+func TestListVolumes(t *testing.T) {
+	ts := newTestServer(t)
+	r, err := ts.Client.ListVolumes(context.Background(), &api.ListVolumesRequest{})
+	assert.NoError(t, err)
+	assert.Empty(t, r.Volumes)
+
+	createVolume(t, ts, "name1")
+	r, err = ts.Client.ListVolumes(context.Background(), &api.ListVolumesRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(r.Volumes))
+
+	createVolume(t, ts, "name2")
+	createVolume(t, ts, "name3")
+	r, err = ts.Client.ListVolumes(context.Background(), &api.ListVolumesRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(r.Volumes))
+}

--- a/manager/state/apply.go
+++ b/manager/state/apply.go
@@ -38,6 +38,13 @@ func Apply(store Store, item watch.Event) (err error) {
 			return tx.Nodes().Update(v.Node)
 		case EventDeleteNode:
 			return tx.Nodes().Delete(v.Node.ID)
+
+		case EventCreateVolume:
+			return tx.Volumes().Create(v.Volume)
+		case EventUpdateVolume:
+			return tx.Volumes().Update(v.Volume)
+		case EventDeleteVolume:
+			return tx.Volumes().Delete(v.Volume.ID)
 		case EventCommit:
 			return nil
 		}

--- a/manager/state/memory.go
+++ b/manager/state/memory.go
@@ -22,6 +22,7 @@ const (
 	tableTask    = "task"
 	tableJob     = "job"
 	tableNetwork = "network"
+	tableVolume  = "volume"
 
 	prefix = "_prefix"
 )
@@ -114,6 +115,21 @@ func NewMemoryStore(proposer Proposer) *MemoryStore {
 					},
 				},
 			},
+			tableVolume: {
+				Name: tableVolume,
+				Indexes: map[string]*memdb.IndexSchema{
+					indexID: {
+						Name:    indexID,
+						Unique:  true,
+						Indexer: volumeIndexerByID{},
+					},
+					indexName: {
+						Name:    indexName,
+						Unique:  true,
+						Indexer: volumeIndexerByName{},
+					},
+				},
+			},
 		},
 	}
 
@@ -162,6 +178,7 @@ type readTx struct {
 	jobs     jobs
 	tasks    tasks
 	networks networks
+	volumes  volumes
 }
 
 // View executes a read transaction.
@@ -179,6 +196,9 @@ func (s *MemoryStore) View(cb func(ReadTx) error) error {
 			memDBTx: memDBTx,
 		},
 		networks: networks{
+			memDBTx: memDBTx,
+		},
+		volumes: volumes{
 			memDBTx: memDBTx,
 		},
 	}
@@ -203,11 +223,16 @@ func (t readTx) Tasks() TaskSetReader {
 	return t.tasks
 }
 
+func (t readTx) Volumes() VolumeSetReader {
+	return t.volumes
+}
+
 type tx struct {
 	nodes      nodes
 	jobs       jobs
 	tasks      tasks
 	networks   networks
+	volumes    volumes
 	changelist []Event
 }
 
@@ -221,11 +246,13 @@ func (s *MemoryStore) applyStoreActions(actions []*api.StoreAction) error {
 		jobs:     jobs{memDBTx: memDBTx},
 		tasks:    tasks{memDBTx: memDBTx},
 		networks: networks{memDBTx: memDBTx},
+		volumes:  volumes{memDBTx: memDBTx},
 	}
 	tx.nodes.tx = &tx
 	tx.jobs.tx = &tx
 	tx.tasks.tx = &tx
 	tx.networks.tx = &tx
+	tx.volumes.tx = &tx
 
 	for _, sa := range actions {
 		if err := applyStoreAction(tx, sa); err != nil {
@@ -277,6 +304,13 @@ func applyStoreAction(tx tx, sa *api.StoreAction) error {
 		return tx.Nodes().Update(v.UpdateNode)
 	case *api.StoreAction_RemoveNode:
 		return tx.Nodes().Delete(v.RemoveNode)
+
+	case *api.StoreAction_CreateVolume:
+		return tx.Volumes().Create(v.CreateVolume)
+	case *api.StoreAction_UpdateVolume:
+		return tx.Volumes().Update(v.UpdateVolume)
+	case *api.StoreAction_RemoveVolume:
+		return tx.Volumes().Delete(v.RemoveVolume)
 	}
 	return errors.New("unrecognized action type")
 }
@@ -291,11 +325,13 @@ func (s *MemoryStore) Update(cb func(Tx) error) error {
 		jobs:     jobs{memDBTx: memDBTx},
 		tasks:    tasks{memDBTx: memDBTx},
 		networks: networks{memDBTx: memDBTx},
+		volumes:  volumes{memDBTx: memDBTx},
 	}
 	tx.nodes.tx = &tx
 	tx.jobs.tx = &tx
 	tx.tasks.tx = &tx
 	tx.networks.tx = &tx
+	tx.volumes.tx = &tx
 
 	err := cb(tx)
 
@@ -383,6 +419,20 @@ func (tx tx) newStoreAction() ([]*api.StoreAction, error) {
 			sa.Action = &api.StoreAction_RemoveNode{
 				RemoveNode: v.Node.ID,
 			}
+
+		case EventCreateVolume:
+			sa.Action = &api.StoreAction_CreateVolume{
+				CreateVolume: v.Volume,
+			}
+		case EventUpdateVolume:
+			sa.Action = &api.StoreAction_UpdateVolume{
+				UpdateVolume: v.Volume,
+			}
+		case EventDeleteVolume:
+			sa.Action = &api.StoreAction_RemoveVolume{
+				RemoveVolume: v.Volume.ID,
+			}
+
 		default:
 			return nil, errors.New("unrecognized event type")
 		}
@@ -406,6 +456,10 @@ func (tx tx) Jobs() JobSet {
 
 func (tx tx) Tasks() TaskSet {
 	return tx.tasks
+}
+
+func (tx tx) Volumes() VolumeSet {
+	return tx.volumes
 }
 
 type nodes struct {
@@ -1093,6 +1147,163 @@ func (ni networkIndexerByName) FromObject(obj interface{}) (bool, []byte, error)
 	return true, []byte(n.Spec.Meta.Name + "\x00"), nil
 }
 
+type volumes struct {
+	tx      *tx
+	memDBTx *memdb.Txn
+}
+
+func (volumes volumes) table() string {
+	return tableVolume
+}
+
+// lookup is an internal typed wrapper around memdb.
+func (volumes volumes) lookup(index, id string) *api.Volume {
+	v, err := volumes.memDBTx.First(volumes.table(), index, id)
+	if err != nil {
+		return nil
+	}
+	if v != nil {
+		return v.(*api.Volume)
+	}
+	return nil
+}
+
+// Create adds a new volume to the store.
+// Returns ErrExist if the ID is already taken.
+func (volumes volumes) Create(v *api.Volume) error {
+	if volumes.lookup(indexID, v.ID) != nil {
+		return ErrExist
+	}
+
+	// Ensure the name is not already in use.
+	if v.Spec != nil && volumes.lookup(indexName, v.Spec.Meta.Name) != nil {
+		return ErrNameConflict
+	}
+
+	err := volumes.memDBTx.Insert(volumes.table(), v.Copy())
+	if err == nil {
+		volumes.tx.changelist = append(volumes.tx.changelist, EventCreateVolume{Volume: v})
+	}
+	return err
+}
+
+// Update updates an existing volume in the store.
+// Returns ErrNotExist if the volume doesn't exist.
+func (volumes volumes) Update(v *api.Volume) error {
+	if volumes.lookup(indexID, v.ID) == nil {
+		return ErrNotExist
+	}
+
+	// Ensure the name is either not in use or already used by this same Volume.
+	if existing := volumes.lookup(indexName, v.Spec.Meta.Name); existing != nil {
+		if existing.ID != v.ID {
+			return ErrNameConflict
+		}
+	}
+
+	err := volumes.memDBTx.Insert(volumes.table(), v.Copy())
+	if err == nil {
+		volumes.tx.changelist = append(volumes.tx.changelist, EventUpdateVolume{Volume: v})
+	}
+	return err
+}
+
+// Delete removes a volume from the store.
+// Returns ErrNotExist if the volume doesn't exist.
+func (volumes volumes) Delete(id string) error {
+	v := volumes.lookup(indexID, id)
+	if v == nil {
+		return ErrNotExist
+	}
+
+	err := volumes.memDBTx.Delete(volumes.table(), v)
+	if err == nil {
+		volumes.tx.changelist = append(volumes.tx.changelist, EventDeleteVolume{Volume: v})
+	}
+	return err
+}
+
+// Get looks up a volume by ID.
+// Returns nil if the volume doesn't exist.
+func (volumes volumes) Get(id string) *api.Volume {
+	if v := volumes.lookup(indexID, id); v != nil {
+		return v.Copy()
+	}
+	return nil
+}
+
+// Find selects a set of volumes and returns them. If by is nil,
+// returns all volumes.
+func (volumes volumes) Find(by By) ([]*api.Volume, error) {
+	fromResultIterator := func(it memdb.ResultIterator) []*api.Volume {
+		volumes := []*api.Volume{}
+		for {
+			obj := it.Next()
+			if obj == nil {
+				break
+			}
+			if v, ok := obj.(*api.Volume); ok {
+				volumes = append(volumes, v.Copy())
+			}
+		}
+		return volumes
+	}
+	switch c := by.(type) {
+	case all:
+		it, err := volumes.memDBTx.Get(volumes.table(), indexID)
+		if err != nil {
+			return nil, err
+		}
+		return fromResultIterator(it), nil
+	case byName:
+		it, err := volumes.memDBTx.Get(volumes.table(), indexName, string(c))
+		if err != nil {
+			return nil, err
+		}
+		return fromResultIterator(it), nil
+	default:
+		return nil, ErrInvalidFindBy
+	}
+
+}
+
+type volumeIndexerByID struct{}
+
+func (vi volumeIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {
+	return fromArgs(args...)
+}
+
+func (vi volumeIndexerByID) FromObject(obj interface{}) (bool, []byte, error) {
+	v, ok := obj.(*api.Volume)
+	if !ok {
+		panic("unexpected type passed to FromObject")
+	}
+
+	// Add the null character as a terminator
+	val := v.ID + "\x00"
+	return true, []byte(val), nil
+}
+
+type volumeIndexerByName struct{}
+
+func (vi volumeIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+	return fromArgs(args...)
+}
+
+func (vi volumeIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+	v, ok := obj.(*api.Volume)
+	if !ok {
+		panic("unexpected type passed to FromObject")
+	}
+
+	// Add the null character as a terminator
+	if v.Spec == nil {
+		return false, nil, nil
+	}
+	// Add the null character as a terminator
+	return true, []byte(v.Spec.Meta.Name + "\x00"), nil
+}
+
 // CopyFrom causes this store to hold a copy of the provided data set.
 func (s *MemoryStore) CopyFrom(readTx ReadTx) error {
 	return s.Update(func(tx Tx) error {
@@ -1137,6 +1348,16 @@ func (s *MemoryStore) CopyFrom(readTx ReadTx) error {
 		}
 		for _, n := range networks {
 			if err := tx.Networks().Create(n); err != nil {
+				return err
+			}
+		}
+
+		volumes, err := readTx.Volumes().Find(All)
+		if err != nil {
+			return err
+		}
+		for _, v := range volumes {
+			if err := tx.Volumes().Create(v); err != nil {
 				return err
 			}
 		}

--- a/manager/state/pb/store.pb.go
+++ b/manager/state/pb/store.pb.go
@@ -57,6 +57,7 @@ type StoreSnapshot struct {
 	Jobs     []*api.Job            `protobuf:"bytes,3,rep,name=jobs" json:"jobs,omitempty"`
 	Networks []*api.Network        `protobuf:"bytes,4,rep,name=networks" json:"networks,omitempty"`
 	Tasks    []*api.Task           `protobuf:"bytes,5,rep,name=tasks" json:"tasks,omitempty"`
+	Volumes  []*api.Volume         `protobuf:"bytes,6,rep,name=volumes" json:"volumes,omitempty"`
 }
 
 func (m *StoreSnapshot) Reset()      { *m = StoreSnapshot{} }
@@ -70,7 +71,7 @@ func (this *StoreSnapshot) GoString() string {
 	if this == nil {
 		return "nil"
 	}
-	s := make([]string, 0, 9)
+	s := make([]string, 0, 10)
 	s = append(s, "&pb.StoreSnapshot{")
 	s = append(s, "Version: "+fmt.Sprintf("%#v", this.Version)+",\n")
 	if this.Nodes != nil {
@@ -84,6 +85,9 @@ func (this *StoreSnapshot) GoString() string {
 	}
 	if this.Tasks != nil {
 		s = append(s, "Tasks: "+fmt.Sprintf("%#v", this.Tasks)+",\n")
+	}
+	if this.Volumes != nil {
+		s = append(s, "Volumes: "+fmt.Sprintf("%#v", this.Volumes)+",\n")
 	}
 	s = append(s, "}")
 	return strings.Join(s, "")
@@ -181,6 +185,18 @@ func (m *StoreSnapshot) MarshalTo(data []byte) (int, error) {
 			i += n
 		}
 	}
+	if len(m.Volumes) > 0 {
+		for _, msg := range m.Volumes {
+			data[i] = 0x32
+			i++
+			i = encodeVarintStore(data, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(data[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
 	return i, nil
 }
 
@@ -241,6 +257,12 @@ func (m *StoreSnapshot) Size() (n int) {
 			n += 1 + l + sovStore(uint64(l))
 		}
 	}
+	if len(m.Volumes) > 0 {
+		for _, e := range m.Volumes {
+			l = e.Size()
+			n += 1 + l + sovStore(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -267,6 +289,7 @@ func (this *StoreSnapshot) String() string {
 		`Jobs:` + strings.Replace(fmt.Sprintf("%v", this.Jobs), "Job", "api.Job", 1) + `,`,
 		`Networks:` + strings.Replace(fmt.Sprintf("%v", this.Networks), "Network", "api.Network", 1) + `,`,
 		`Tasks:` + strings.Replace(fmt.Sprintf("%v", this.Tasks), "Task", "api.Task", 1) + `,`,
+		`Volumes:` + strings.Replace(fmt.Sprintf("%v", this.Volumes), "Volume", "api.Volume", 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -448,6 +471,37 @@ func (m *StoreSnapshot) Unmarshal(data []byte) error {
 			}
 			m.Tasks = append(m.Tasks, &api.Task{})
 			if err := m.Tasks[len(m.Tasks)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Volumes", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStore
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := data[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStore
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Volumes = append(m.Volumes, &api.Volume{})
+			if err := m.Volumes[len(m.Volumes)-1].Unmarshal(data[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/manager/state/pb/store.proto
+++ b/manager/state/pb/store.proto
@@ -24,4 +24,5 @@ message StoreSnapshot {
 	repeated api.Job jobs = 3;
 	repeated api.Network networks = 4;
 	repeated api.Task tasks = 5;
+	repeated api.Volume volumes = 6;
 }

--- a/manager/state/watch.go
+++ b/manager/state/watch.go
@@ -355,6 +355,87 @@ func (e EventDeleteNode) matches(watchEvent watch.Event) bool {
 	return true
 }
 
+// VolumeCheckFunc is the type of function used to perform filtering checks on
+// api.Volume structures.
+type VolumeCheckFunc func(v1, v2 *api.Volume) bool
+
+// VolumeCheckID is a VolumeCheckFunc for matching volume IDs.
+func VolumeCheckID(v1, v2 *api.Volume) bool {
+	return v1.ID == v2.ID
+}
+
+// EventCreateVolume is the type used to put CreateVolume events on the
+// publish/subscribe queue and filter these events in calls to Watch.
+type EventCreateVolume struct {
+	Volume *api.Volume
+	// Checks is a list of functions to call to filter events for a watch
+	// stream. They are applied with AND logic. They are only applicable for
+	// calls to Watch.
+	Checks []VolumeCheckFunc
+}
+
+func (e EventCreateVolume) matches(watchEvent watch.Event) bool {
+	typedEvent, ok := watchEvent.Payload.(EventCreateVolume)
+	if !ok {
+		return false
+	}
+
+	for _, check := range e.Checks {
+		if !check(e.Volume, typedEvent.Volume) {
+			return false
+		}
+	}
+	return true
+}
+
+// EventUpdateVolume is the type used to put UpdateVolume events on the
+// publish/subscribe queue and filter these events in calls to Watch.
+type EventUpdateVolume struct {
+	Volume *api.Volume
+	// Checks is a list of functions to call to filter events for a watch
+	// stream. They are applied with AND logic. They are only applicable for
+	// calls to Watch.
+	Checks []VolumeCheckFunc
+}
+
+func (e EventUpdateVolume) matches(watchEvent watch.Event) bool {
+	typedEvent, ok := watchEvent.Payload.(EventUpdateVolume)
+	if !ok {
+		return false
+	}
+
+	for _, check := range e.Checks {
+		if !check(e.Volume, typedEvent.Volume) {
+			return false
+		}
+	}
+	return true
+}
+
+// EventDeleteVolume is the type used to put DeleteVolume events on the
+// publish/subscribe queue and filter these events in calls to Watch.
+type EventDeleteVolume struct {
+	Volume *api.Volume
+	// Checks is a list of functions to call to filter events for a watch
+	// stream. They are applied with AND logic. They are only applicable for
+	// calls to Watch.
+	Checks []VolumeCheckFunc
+}
+
+func (e EventDeleteVolume) matches(watchEvent watch.Event) bool {
+	typedEvent, ok := watchEvent.Payload.(EventDeleteVolume)
+	if !ok {
+		return false
+	}
+
+	for _, check := range e.Checks {
+		if !check(e.Volume, typedEvent.Volume) {
+			return false
+		}
+	}
+	return true
+}
+
 // Watch takes a variable number of events to match against. The subscriber
 // will receive events that match any of the arguments passed to Watch.
 //


### PR DESCRIPTION
Added Manager support for `volume create` and `volume ls`
The changes are fairly boiler plate and send client commands over to the manager. Create stores the volume created into the memory store, while ls lists the all volumes that have been created.

Fixed some comments from previous PR: https://github.com/docker/swarm-v2/pull/191

Postponed to a future PR
1. Some renaming ls -> list; rm -> remove (noted as TODOs)
2. Implementation of `volume inspect` and `volume remove`

Signed-off-by: amitshukla amit.shukla@gmail.com
