### PR TITLE
Raft ID stability

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -98,6 +98,8 @@ func TestManagerNodeCount(t *testing.T) {
 	go m.Run()
 	defer m.Stop()
 
+	assert.NoError(t, m.raftNode.Campaign(m.raftNode.Ctx))
+
 	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(10*time.Second),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout(l.Addr().Network(), addr, timeout)


### PR DESCRIPTION
Save raft node ID into WAL. When starting with an existing WAL, restore the node ID and rejoin the cluster under the same ID as before.

Change NewNode not to take an ID, since the ID is either loaded from disk or generated internally. This generation should be moved to the remote side eventually.

Add a test for rejoining the cluster based on stored logs. This also seems to work with the manager itself.
