### PR TITLE
Speed up "make coverage"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ clean: ## clean up binaries
 coverage: ## generate coverprofiles from the tests
 	@echo "🐳 $@"
 	@( for pkg in ${PACKAGES}; do \
+		go test -i -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=count $$pkg || exit; \
 		go test -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=count $$pkg || exit; \
 	done )
 


### PR DESCRIPTION
The current "coverage" target runs a separate "go test" on each
individual package, but does not save build artifacts between
invocations. Thus, each each package that "go test" gets called against
(including those with no tests) require rebuilding the whole set of
dependencies. This takes a long time.

Run "go test -i" to prebuild dependencies before running the actual
tests. This effectively warms a build cache that gets used by the
following "go test" invocation, as well as subsequent ones for packages
that overlap in dependencies.

Before:

```
real    2m22.252s
user    6m8.059s
sys     0m45.162s
```

After:

```
real    1m5.280s
user    1m23.572s
sys     0m11.932s
```
