### PR TITLE
Let go handle build deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,10 @@ test: ## run test
 	@echo "🐳 $@"
 	@go test -parallel 8 -race -tags "${DOCKER_BUILDTAGS}" ${PACKAGES}
 
+FORCE:
+
 # Build a binary from a cmd.
-bin/%: cmd/% version/version.go $(shell find . -type f -name '*.go') ## build binary
+bin/%: cmd/% FORCE
 	@echo "🐳 $@"
 	@go build -i -tags "${DOCKER_BUILDTAGS}" -o $@ ${GO_LDFLAGS}  ${GO_GCFLAGS} ./$<
 


### PR DESCRIPTION
We shouldn't try to figure out go build dependencies in Make, because
we won't be able to do it as accurately as go. Force the binaries targets
to run without regard to dependencies. Then let go figure out for itself
whether anything needs to be rebuilt.
