### PR TITLE
Only start node with a non-empty list of peers when initializing a new cluster

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -98,8 +98,6 @@ func TestManagerNodeCount(t *testing.T) {
 	go m.Run()
 	defer m.Stop()
 
-	assert.NoError(t, m.raftNode.Campaign(m.raftNode.Ctx))
-
 	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(10*time.Second),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout(l.Addr().Network(), addr, timeout)


### PR DESCRIPTION
Split Start into Start and StartByJoining functions. The first uses the
cluster info in the durable state, or initializes a new cluster if there
is no state. StartByJoining joins an existing cluster.

This solves a problem where nodes would have different config changes in
index 1 of their logs, meaning the logs were inconsistent between nodes,
and nodes had different views of the cluster.
