### PR TITLE
Include cluster member list and removed nodes in snapshots

### DIFF
--- a/manager/state/cluster.go
+++ b/manager/state/cluster.go
@@ -6,63 +6,40 @@ import (
 	"github.com/docker/swarm-v2/api"
 )
 
-// Cluster represents a raft cluster
-type Cluster interface {
-	// ID returns the cluster ID
-	ID() uint64
-	// Members returns a map of members identified by their raft ID
-	Members() map[uint64]*Member
-	// AddMember adds a member to the cluster memberlist
-	AddMember(*Member) error
-	// RemoveMember removes a member from the memberlist and add
-	// it to the remove set
-	RemoveMember(uint64) error
-	// Member retrieves a particular member based on ID, or nil if the
-	// member does not exist in the cluster
-	GetMember(id uint64) *Member
-	// IsIDRemoved checks whether the given ID has been removed from this
-	// cluster at some point in the past
-	IsIDRemoved(id uint64) bool
-}
-
 // cluster represents a set of active
 // raft members
 type cluster struct {
 	id uint64
 
 	mu      sync.RWMutex
-	members map[uint64]*Member
+	members map[uint64]*member
 
 	// removed contains the list of removed members,
 	// those ids cannot be reused
 	removed map[uint64]bool
 }
 
-// Member represents a raft cluster member
-type Member struct {
+// member represents a raft cluster member
+type member struct {
 	*api.RaftNode
 
 	Client *Raft
 }
 
-// NewCluster creates a new cluster neighbors
+// newCluster creates a new cluster neighbors
 // list for a raft member
-func NewCluster() Cluster {
+func newCluster() *cluster {
 	// TODO generate cluster ID
 
 	return &cluster{
-		members: make(map[uint64]*Member),
+		members: make(map[uint64]*member),
 		removed: make(map[uint64]bool),
 	}
 }
 
-func (c *cluster) ID() uint64 {
-	return c.id
-}
-
-// Members returns the list of raft members in the cluster
-func (c *cluster) Members() map[uint64]*Member {
-	members := make(map[uint64]*Member)
+// listMembers returns the list of raft members in the cluster.
+func (c *cluster) listMembers() map[uint64]*member {
+	members := make(map[uint64]*member)
 	c.mu.RLock()
 	for k, v := range c.members {
 		members[k] = v
@@ -71,34 +48,56 @@ func (c *cluster) Members() map[uint64]*Member {
 	return members
 }
 
-// GetMember returns informations on a given member
-func (c *cluster) GetMember(id uint64) *Member {
+// listRemoved returns the list of raft members removed from the cluster.
+func (c *cluster) listRemoved() []uint64 {
+	c.mu.RLock()
+	removed := make([]uint64, 0, len(c.removed))
+	for k := range c.removed {
+		removed = append(removed, k)
+	}
+	c.mu.RUnlock()
+	return removed
+}
+
+// getMember returns informations on a given member.
+func (c *cluster) getMember(id uint64) *member {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.members[id]
 }
 
-// AddMember adds a node to the cluster memberlist
-func (c *cluster) AddMember(member *Member) error {
+// addMember adds a node to the cluster memberlist.
+func (c *cluster) addMember(member *member) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.members[member.ID] = member
 	return nil
 }
 
-// RemoveMember removes a node from the cluster memberlist
-func (c *cluster) RemoveMember(id uint64) error {
+// removeMember removes a node from the cluster memberlist.
+func (c *cluster) removeMember(id uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.members[id].Client.Conn.Close()
+	conn := c.members[id].Client.Conn
+	if conn != nil {
+		conn.Close()
+	}
 	c.removed[id] = true
 	delete(c.members, id)
 	return nil
 }
 
-// IsIDRemoved checks if a member is in the remove set
-func (c *cluster) IsIDRemoved(id uint64) bool {
+// isIDRemoved checks if a member is in the remove set.
+func (c *cluster) isIDRemoved(id uint64) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.removed[id]
+}
+
+// clear resets the list of active members and removed members.
+func (c *cluster) clear() {
+	c.mu.Lock()
+	c.members = make(map[uint64]*member)
+	c.removed = make(map[uint64]bool)
+	c.mu.Unlock()
 }

--- a/manager/state/pb/store.proto
+++ b/manager/state/pb/store.proto
@@ -5,8 +5,37 @@ package pb;
 import "github.com/gogo/protobuf/gogoproto/gogo.proto";
 import "github.com/docker/swarm-v2/api/types.proto";
 
+// RaftNode represents a raft node to be added or removed from
+// an existing raft cluster.
+// FIXME(aaronl): This is copied from the api package because it's not
+// posssible to import manager.go.
+message RaftNode {
+	uint64 id = 1 [(gogoproto.customname) = "ID"];
+	string addr = 2;
+}
+
 // StoreSnapshot is used to store snapshots of the store.
 message StoreSnapshot {
+	// TODO(aaronl): The current method of assembling a StoreSnapshot
+	// structure and marshalling it is not optimal. It may be better to
+	// write out nodes, networks, tasks, etc. one at a time to an io.Writer
+	// using gogo-protobuf's io.DelimitedWriter. A new value of the version
+	// field could support this approach.
+
+	repeated api.Node nodes = 1;
+	repeated api.Job jobs = 2;
+	repeated api.Network networks = 3;
+	repeated api.Task tasks = 4;
+	repeated api.Volume volumes = 5;
+}
+
+// ClusterSnapshot stores cluster membership information in snapshots.
+message ClusterSnapshot {
+	repeated RaftNode members = 1;
+	repeated uint64 removed = 2;
+}
+
+message Snapshot {
 	enum Version {
 		// V0 is the initial version of the StoreSnapshot message.
 		V0 = 0;
@@ -14,15 +43,6 @@ message StoreSnapshot {
 
 	Version version = 1;
 
-	// TODO(aaronl): The current method of assembling a StoreSnapshot
-	// structure and marshalling it is not optimal. It may be better to
-	// write out nodes, networks, tasks, etc. one at a time to an io.Writer
-	// using gogo-protobuf's io.DelimitedWriter. A new value of the version
-	// field could support this approach.
-
-	repeated api.Node nodes = 2;
-	repeated api.Job jobs = 3;
-	repeated api.Network networks = 4;
-	repeated api.Task tasks = 5;
-	repeated api.Volume volumes = 6;
+	ClusterSnapshot membership = 2 [(gogoproto.nullable) = false];
+	StoreSnapshot store = 3 [(gogoproto.nullable) = false];
 }

--- a/manager/state/store.go
+++ b/manager/state/store.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/manager/state/pb"
 	"github.com/docker/swarm-v2/manager/state/watch"
 )
 
@@ -192,11 +193,11 @@ type Store interface {
 	View(func(ReadTx) error) error
 
 	// Save serializes the data in the store.
-	Save() ([]byte, error)
+	Save() (*pb.StoreSnapshot, error)
 
 	// Restore sets the contents of the store to the serialized data in the
 	// argument.
-	Restore([]byte) error
+	Restore(*pb.StoreSnapshot) error
 }
 
 // WatchableStore is an extension of Store that publishes modifications to a


### PR DESCRIPTION
Normally, the member list is built from configuration changes in the
raft log. When restarting a node, it will replay the raft log and build
the member list. However, if a snapshot has been taken and the log was
compacted, configuration change entries may no longer be present in the
log. This means that the snapshot needs to contain the member list (and
list of removed nodes) at the time the snapshot was taken.
