### PR TITLE
Additions and improvements to raft testsuite

### DIFF
--- a/manager/state/raft.go
+++ b/manager/state/raft.go
@@ -816,6 +816,9 @@ func (n *Node) processInternalRaftRequest(ctx context.Context, r *api.InternalRa
 	case <-n.stopCh:
 		n.wait.cancel(r.ID)
 		return nil, ErrStopped
+	case <-ctx.Done():
+		n.wait.cancel(r.ID)
+		return nil, ctx.Err()
 	}
 }
 


### PR DESCRIPTION
- Add TestRaftRestartClusterSimultaneously and
  TestRaftRestartClusterStaggered. These stop all nodes in the cluster
  and then bring them back up, either all at the same time or with
  delays in between their startups.
- Add TestRaftQuorumRecovery, which loses the quorum, and then recovers
  the quorum. The start of this test is similar to
  TestRaftQuorumFailure, except to mix things up, the leader is one of the
  failed nodes in this test.
- Fix TestRaftQuorumFailure to actually verify that a proposed value
  doesn't propagate. Previously, it was proposing the value to a
  non-leader node, so the proposal would have failed regardless of the
  quorum state.
- Add TestRaftJoinFollower, which adds a new node and points it to one
  of the followers instead of a leader.

cc @abronan
