### PR TITLE
store: Don't check version number when applying an update from raft

### DIFF
--- a/manager/state/memory.go
+++ b/manager/state/memory.go
@@ -547,12 +547,12 @@ func (nodes nodes) Update(n *api.Node) error {
 	if oldN == nil {
 		return ErrNotExist
 	}
-	if oldN.Version != n.Version {
-		return ErrSequenceConflict
-	}
 
 	copy := n.Copy()
 	if nodes.curVersion != nil {
+		if oldN.Version != n.Version {
+			return ErrSequenceConflict
+		}
 		copy.Version = *nodes.curVersion
 	}
 
@@ -737,12 +737,11 @@ func (tasks tasks) Update(t *api.Task) error {
 	if oldT == nil {
 		return ErrNotExist
 	}
-	if oldT.Version != t.Version {
-		return ErrSequenceConflict
-	}
-
 	copy := t.Copy()
 	if tasks.curVersion != nil {
+		if oldT.Version != t.Version {
+			return ErrSequenceConflict
+		}
 		copy.Version = *tasks.curVersion
 	}
 
@@ -943,9 +942,6 @@ func (jobs jobs) Update(j *api.Job) error {
 	if oldJ == nil {
 		return ErrNotExist
 	}
-	if oldJ.Version != j.Version {
-		return ErrSequenceConflict
-	}
 
 	// Ensure the name is either not in use or already used by this same Job.
 	if existing := jobs.lookup(indexName, j.Spec.Meta.Name); existing != nil {
@@ -956,6 +952,9 @@ func (jobs jobs) Update(j *api.Job) error {
 
 	copy := j.Copy()
 	if jobs.curVersion != nil {
+		if oldJ.Version != j.Version {
+			return ErrSequenceConflict
+		}
 		copy.Version = *jobs.curVersion
 	}
 
@@ -1142,12 +1141,12 @@ func (networks networks) Update(n *api.Network) error {
 	if oldN == nil {
 		return ErrNotExist
 	}
-	if oldN.Version != n.Version {
-		return ErrSequenceConflict
-	}
 
 	copy := n.Copy()
 	if networks.curVersion != nil {
+		if oldN.Version != n.Version {
+			return ErrSequenceConflict
+		}
 		copy.Version = *networks.curVersion
 	}
 


### PR DESCRIPTION
When Update is called directly, the Version field contains the old
version, and we update it as part of the update process. But when we are
applying an update from the raft log, the version number has already
been changed to contain the new version, and comparing it against the
old version will fail. When we're operating in a passive mode (as a
follower, or as a leader replaying the log), don't do the version check,
and just apply the Version field as is. This makes sense because then
the sequencer is something that should only run on the leader.

cc @aluzzardi
