### PR TITLE
Do not try to move task to ALLOCATED again

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -237,7 +237,7 @@ func TestAllocator(t *testing.T) {
 			},
 			Spec: &api.TaskSpec{
 				Runtime: &api.TaskSpec_Container{
-					Container: &api.ContainerSpec{},
+					Container: &api.Container{},
 				},
 			},
 		}

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -154,7 +154,7 @@ func (a *Allocator) doTaskAlloc(nc *networkContext, ev events.Event) {
 	if len(t.Spec.GetContainer().Networks) == 0 {
 		// If we are already in allocated state, there is
 		// absolutely nothing else to do.
-		if t.Status.State == api.TaskStateAllocated {
+		if t.Status.State >= api.TaskStateAllocated {
 			return
 		}
 


### PR DESCRIPTION
When trying to move tasks with no network
attachment, check if task state is greater than
or equal to ALLOCATED and if so do nothing. Only
try to move it to ALLOCATED only when it is less
than ALLOCATED.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
