### PR TITLE
raft: use logrus instead of default Logger implementation

### DIFF
--- a/manager/state/raft.go
+++ b/manager/state/raft.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"math/rand"
 	"os"
@@ -21,6 +20,7 @@ import (
 	"github.com/coreos/etcd/wal"
 	"github.com/coreos/etcd/wal/walpb"
 	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/log"
 	"github.com/docker/swarm-v2/manager/state/leaderconn"
 	"github.com/docker/swarm-v2/manager/state/pb"
 	"github.com/gogo/protobuf/proto"
@@ -34,8 +34,6 @@ const (
 )
 
 var (
-	defaultLogger = &raft.DefaultLogger{Logger: log.New(os.Stderr, "raft", log.LstdFlags)}
-
 	// ErrConfChangeRefused is returned when there is an issue with the configuration change
 	ErrConfChangeRefused = errors.New("raft: propose configuration change refused")
 	// ErrApplyNotSpecified is returned during the creation of a raft node when no apply method was provided
@@ -274,7 +272,7 @@ func DefaultNodeConfig() *raft.Config {
 		ElectionTick:    3,
 		MaxSizePerMsg:   math.MaxUint16,
 		MaxInflightMsgs: 256,
-		Logger:          defaultLogger,
+		Logger:          log.G(context.Background()),
 	}
 }
 
@@ -938,7 +936,7 @@ func (n *Node) configure(ctx context.Context, cc raftpb.ConfChange) error {
 			return err
 		}
 		if x != nil {
-			log.Panic("return type should always be error")
+			log.G(ctx).Panic("raft: configuration change error, return type should always be error")
 		}
 		return nil
 	case <-ctx.Done():

--- a/manager/state/raft_test.go
+++ b/manager/state/raft_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/raft"
 	"github.com/docker/swarm-v2/api"
 	"github.com/pivotal-golang/clock/fakeclock"
@@ -24,12 +25,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	raftLogger = &raft.DefaultLogger{Logger: log.New(ioutil.Discard, "", 0)}
-)
-
 func init() {
 	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+	logrus.SetOutput(ioutil.Discard)
 }
 
 type testNode struct {
@@ -187,7 +185,6 @@ func newNode(t *testing.T, clockSource *fakeclock.FakeClock, opts ...NewNodeOpti
 	s := grpc.NewServer()
 
 	cfg := DefaultNodeConfig()
-	cfg.Logger = raftLogger
 
 	stateDir, err := ioutil.TempDir("", "test-raft")
 	require.NoError(t, err, "can't create temporary state directory")
@@ -257,7 +254,6 @@ func restartNode(t *testing.T, clockSource *fakeclock.FakeClock, oldNode *testNo
 	s := grpc.NewServer()
 
 	cfg := DefaultNodeConfig()
-	cfg.Logger = raftLogger
 
 	newNodeOpts := NewNodeOptions{
 		Addr:        oldNode.Address,


### PR DESCRIPTION
I would suggest to leave this always on or at least to put those logs somewhere in a file if we decide to disable it by default.

Fix #315 

/cc @aluzzardi @aaronlehmann 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
