### PR TITLE
Add Batch store method

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -33,10 +33,6 @@ import (
 	"github.com/pivotal-golang/clock"
 )
 
-const (
-	maxRequestBytes = 1.5 * 1024 * 1024
-)
-
 var (
 	// ErrConfChangeRefused is returned when there is an issue with the configuration change
 	ErrConfChangeRefused = errors.New("raft: propose configuration change refused")
@@ -927,7 +923,7 @@ func (n *Node) processInternalRaftRequest(ctx context.Context, r *api.InternalRa
 		return nil, err
 	}
 
-	if len(data) > maxRequestBytes {
+	if len(data) > state.MaxTransactionBytes {
 		n.wait.cancel(r.ID)
 		return nil, ErrRequestTooLarge
 	}


### PR DESCRIPTION
There are several cases where a component needs to perform a batch of
actions on the store. For example, the orchestrator, seeing that the
number of instances set for a service has changed from 1 to 10000 will
try to create 9999 tasks. Another example is the scheduler seeing these
9999 tasks being created, and batching assignments for them in a single
transaction.

Batching is good because it amortizes the latency of a raft write over
many changes. But we need to keep the batch size limited to avoid
exceeding the limit on the size of a raft write, or tying up the store
lock for too long.

One approach is to have every store user that makes multiple changes in
an Update apply its own batch limiting. The problem with this is that it
leads to much more complex code. All of these call sites must split
their activities across multiple Update calls, and do proper error
handling at each transaction boundary. If we forget to do this at a
certain call site, things can break once the data volume gets big enough
to be too large for a single raft write.

Instead, introduce a new method on the store that calls a callback with
a Batch object. The callback can call Update multiple times on the Batch
object, and the changes made in Update will be applied over one or more
transactions. Batch should only be used in cases where the caller
doesn't need all the changes to be applied atomically (this is usually
the case). In case an error is encountered, Batch returns the number of
updates that were committed.

Convert scheduler, orchestrator, drainer, and allocator to use Batch for
batch transactions.

Fixes #169
