### PR TITLE
swarmctl: Misc usability improvements.

### DIFF
--- a/cmd/swarmctl/common/print.go
+++ b/cmd/swarmctl/common/print.go
@@ -3,7 +3,18 @@ package common
 import (
 	"fmt"
 	"io"
+	"strings"
 )
+
+// PrintHeader prints a nice little header.
+func PrintHeader(w io.Writer, columns ...string) {
+	underline := make([]string, len(columns))
+	for i := range underline {
+		underline[i] = strings.Repeat("-", len(columns[i]))
+	}
+	fmt.Fprintf(w, "%s\n", strings.Join(columns, "\t"))
+	fmt.Fprintf(w, "%s\n", strings.Join(underline, "\t"))
+}
 
 // FprintfIfNotEmpty prints only if `s` is not empty.
 //

--- a/cmd/swarmctl/network/list.go
+++ b/cmd/swarmctl/network/list.go
@@ -39,7 +39,7 @@ var (
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				fmt.Fprintln(w, "ID\tName\tDriver")
+				common.PrintHeader(w, "ID", "Name", "Driver")
 				output = func(n *api.Network) {
 					spec := n.Spec
 					fmt.Fprintf(w, "%s\t%s\t%s\n",

--- a/cmd/swarmctl/node/list.go
+++ b/cmd/swarmctl/node/list.go
@@ -39,7 +39,7 @@ var (
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				fmt.Fprintln(w, "ID\tName\tStatus\tAvailability")
+				common.PrintHeader(w, "ID", "Name", "Status", "Availability")
 				output = func(n *api.Node) {
 					spec := n.Spec
 					if spec == nil {

--- a/cmd/swarmctl/service/cmd.go
+++ b/cmd/swarmctl/service/cmd.go
@@ -5,8 +5,9 @@ import "github.com/spf13/cobra"
 var (
 	// Cmd exposes the top-level service command.
 	Cmd = &cobra.Command{
-		Use:   "service",
-		Short: "Service management",
+		Use:     "service",
+		Aliases: []string{"svc"},
+		Short:   "Service management",
 	}
 )
 

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -14,6 +14,67 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func printServiceSummary(service *api.Service) {
+	w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
+	defer func() {
+		// Ignore flushing errors - there's nothing we can do.
+		_ = w.Flush()
+	}()
+	common.FprintfIfNotEmpty(w, "ID\t: %s\n", service.ID)
+	common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Meta.Name)
+	common.FprintfIfNotEmpty(w, "Instances\t: %d\n", service.Spec.Instances)
+	common.FprintfIfNotEmpty(w, "Strategy\t: %s\n", service.Spec.Strategy)
+	fmt.Fprintln(w, "Template:\t")
+	fmt.Fprintln(w, " Container:\t")
+	ctr := service.Spec.Template.GetContainer()
+	common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image.Reference)
+	common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
+	common.FprintfIfNotEmpty(w, "  Args\t: [%s]\n", strings.Join(ctr.Args, ", "))
+	common.FprintfIfNotEmpty(w, "  Env\t: [%s]\n", strings.Join(ctr.Env, ", "))
+	if ctr.Resources != nil {
+		res := ctr.Resources
+		fmt.Fprintln(w, "  Resources:\t")
+		printResources := func(w io.Writer, r *api.Resources) {
+			if r.NanoCPUs != 0 {
+				fmt.Fprintf(w, "      CPU\t: %g\n", float64(r.NanoCPUs)/1e9)
+			}
+			if r.MemoryBytes != 0 {
+				fmt.Fprintf(w, "      Memory\t: %s\n", humanize.IBytes(uint64(r.MemoryBytes)))
+			}
+		}
+		if res.Reservations != nil {
+			fmt.Fprintln(w, "    Reservations:\t")
+			printResources(w, res.Reservations)
+		}
+		if res.Limits != nil {
+			fmt.Fprintln(w, "    Limits:\t")
+			printResources(w, res.Limits)
+		}
+	}
+	if len(ctr.Networks) > 0 {
+		fmt.Fprintln(w, "  Networks:\t")
+		for _, n := range ctr.Networks {
+			fmt.Fprintf(w, " %s\n", n.GetName())
+		}
+	}
+}
+
+func printTasks(tasks []*api.Task, res *common.Resolver) {
+	w := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
+	defer w.Flush()
+
+	common.PrintHeader(w, "Task ID", "Image", "Status", "Node")
+	for _, t := range tasks {
+		c := t.Spec.GetContainer()
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			t.ID,
+			c.Image.Reference,
+			t.Status.State.String(),
+			res.Resolve(api.Node{}, t.NodeID),
+		)
+	}
+}
+
 var (
 	inspectCmd = &cobra.Command{
 		Use:   "inspect <service ID>",
@@ -27,51 +88,29 @@ var (
 				return err
 			}
 
+			res := common.NewResolver(cmd, c)
+
 			service, err := getService(common.Context(cmd), c, args[0])
 			if err != nil {
 				return err
 			}
-			w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
-			defer func() {
-				// Ignore flushing errors - there's nothing we can do.
-				_ = w.Flush()
-			}()
-			common.FprintfIfNotEmpty(w, "ID\t: %s\n", service.ID)
-			common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Meta.Name)
-			common.FprintfIfNotEmpty(w, "Instances\t: %s\n", service.Spec.Instances)
-			common.FprintfIfNotEmpty(w, "Strategy\t: %s\n", service.Spec.Strategy)
-			fmt.Fprintln(w, "Template:\t")
-			fmt.Fprintln(w, " Container:\t")
-			ctr := service.Spec.Template.GetContainer()
-			common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image.Reference)
-			common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
-			common.FprintfIfNotEmpty(w, "  Args\t: [%s]\n", strings.Join(ctr.Args, ", "))
-			common.FprintfIfNotEmpty(w, "  Env\t: [%s]\n", strings.Join(ctr.Env, ", "))
-			if ctr.Resources != nil {
-				res := ctr.Resources
-				fmt.Fprintln(w, "  Resources:\t")
-				printResources := func(w io.Writer, r *api.Resources) {
-					if r.NanoCPUs != 0 {
-						fmt.Fprintf(w, "      CPU\t: %g\n", float64(r.NanoCPUs)/1e9)
-					}
-					if r.MemoryBytes != 0 {
-						fmt.Fprintf(w, "      Memory\t: %s\n", humanize.IBytes(uint64(r.MemoryBytes)))
-					}
-				}
-				if res.Reservations != nil {
-					fmt.Fprintln(w, "    Reservations:\t")
-					printResources(w, res.Reservations)
-				}
-				if res.Limits != nil {
-					fmt.Fprintln(w, "    Limits:\t")
-					printResources(w, res.Limits)
+
+			// TODO(aluzzardi): This should be implemented as a ListOptions filter.
+			r, err := c.ListTasks(common.Context(cmd), &api.ListTasksRequest{})
+			if err != nil {
+				return err
+			}
+			tasks := []*api.Task{}
+			for _, t := range r.Tasks {
+				if t.ServiceID == service.ID {
+					tasks = append(tasks, t)
 				}
 			}
-			if len(ctr.Networks) > 0 {
-				fmt.Fprintln(w, "  Networks:\t")
-				for _, n := range ctr.Networks {
-					fmt.Fprintf(w, " %s\n", n.GetName())
-				}
+
+			printServiceSummary(service)
+			if len(tasks) > 0 {
+				fmt.Printf("\n")
+				printTasks(tasks, res)
 			}
 
 			return nil

--- a/cmd/swarmctl/service/list.go
+++ b/cmd/swarmctl/service/list.go
@@ -39,7 +39,7 @@ var (
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				fmt.Fprintln(w, "ID\tName\tImage\tInstances")
+				common.PrintHeader(w, "ID", "Name", "Image", "Instances")
 				output = func(s *api.Service) {
 					spec := s.Spec
 					var reference string

--- a/cmd/swarmctl/task/inspect.go
+++ b/cmd/swarmctl/task/inspect.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/docker/swarm-v2/api"
@@ -44,6 +45,14 @@ var (
 				fmt.Fprintf(w, "Status:\t%s\n", r.Task.Status.State.String())
 			}
 			fmt.Fprintf(w, "Node:\t%s\n", res.Resolve(api.Node{}, r.Task.NodeID))
+
+			fmt.Fprintln(w, "Spec:\t")
+			ctr := r.Task.Spec.GetContainer()
+			common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image.Reference)
+			common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
+			common.FprintfIfNotEmpty(w, "  Args\t: [%s]\n", strings.Join(ctr.Args, ", "))
+			common.FprintfIfNotEmpty(w, "  Env\t: [%s]\n", strings.Join(ctr.Env, ", "))
+
 			return nil
 		},
 	}

--- a/cmd/swarmctl/task/list.go
+++ b/cmd/swarmctl/task/list.go
@@ -40,7 +40,7 @@ var (
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				fmt.Fprintln(w, "ID\tService\tStatus\tNode")
+				common.PrintHeader(w, "ID", "Service", "Status", "Node")
 				output = func(t *api.Task) {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 						t.ID,

--- a/cmd/swarmctl/volume/list.go
+++ b/cmd/swarmctl/volume/list.go
@@ -31,7 +31,7 @@ var (
 				// Ignore flushing errors - there's nothing we can do.
 				_ = w.Flush()
 			}()
-			fmt.Fprintln(w, "ID\tName\tDriver\tOptions")
+			common.PrintHeader(w, "ID", "Name", "Driver", "Options")
 			for _, v := range r.Volumes {
 				spec := v.Spec
 				if spec == nil {


### PR DESCRIPTION
- Cleaner column separation
- `service inspect` displays task list
- `task inspect` displays container information
- alias `service` to `svc`

```
$ swarmctl svc inspect web
ID                 : cvb5eyaer4fab5b5uyg3bibjy
Name               : web
Instances          : 10
Strategy           : SERIVCE_SCHEDULING_STRATEGY_SPREAD
Template:
 Container:
  Image            : google/cadvisor:v0.22.0

TASK ID                      IMAGE                      STATUS     NODE
-------                      -----                      ------     ----
03k5qfcko2ak44tq6r228ipcn    google/cadvisor:v0.22.0    RUNNING    node-2
07kuswexjmq9trjin0stcz4hp    google/cadvisor:v0.22.0    RUNNING    node-1
0u9892zpyw024bjav0qv9u9ms    google/cadvisor:v0.22.0    RUNNING    node-1
2vdir76gkukkepzvzsyjoos6y    google/cadvisor:v0.22.0    RUNNING    node-2
3n8l0qitx6sxzj2omy37gtdz3    google/cadvisor:v0.22.0    RUNNING    node-1
4i6fe51eoqxbbi6bnmrvxufpg    google/cadvisor:v0.22.0    RUNNING    node-2
5bli2bszrwcb3wjia0bgb6x0m    google/cadvisor:v0.22.0    RUNNING    node-2
9nqs1l9rso32ihaogijr2coi0    google/cadvisor:v0.22.0    RUNNING    node-1
aloqjnvc55i4kxm6orsjtcyp6    google/cadvisor:v0.22.0    RUNNING    node-2
b8n0zzfatihn7l20qsx1zv3ok    google/cadvisor:v0.22.0    RUNNING    node-1
```
