### PR TITLE
log: standardize on local logging package

### DIFF
--- a/cmd/swarm-bench/collector.go
+++ b/cmd/swarm-bench/collector.go
@@ -7,8 +7,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/docker/swarm-v2/log"
 	"github.com/rcrowley/go-metrics"
+	"golang.org/x/net/context"
 )
 
 // Collector waits for tasks to phone home while collecting statistics.
@@ -34,7 +35,7 @@ func (c *Collector) Collect(count int64) {
 	for i := int64(0); i < count; i++ {
 		conn, err := c.ln.Accept()
 		if err != nil {
-			logrus.Error(err)
+			log.G(context.Background()).WithError(err).Error("failure accepting connection")
 			continue
 		}
 		c.t.UpdateSince(start)

--- a/cmd/swarmctl/volume/list.go
+++ b/cmd/swarmctl/volume/list.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"text/tabwriter"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/cmd/swarmctl/common"
+	"github.com/docker/swarm-v2/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -17,6 +18,7 @@ var (
 		Short:   "List volumes",
 		Aliases: []string{"ls"},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			c, err := common.Dial(cmd)
 			if err != nil {
 				return err
@@ -43,7 +45,7 @@ var (
 				// and don't have any proper error handling whatsover.
 				// Instead of aborting, we should display what we can of the Volume.
 				if name == "" || v.ID == "" {
-					log.Fatalf("Malformed volume: %v", v)
+					log.G(ctx).Fatalf("Malformed volume: %v", v)
 				}
 
 				driverName := ""

--- a/cmd/swarmd/agent.go
+++ b/cmd/swarmd/agent.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
 	engineapi "github.com/docker/engine-api/client"
 	"github.com/docker/swarm-v2/agent"
 	"github.com/docker/swarm-v2/agent/exec/container"
 	"github.com/docker/swarm-v2/identity"
+	"github.com/docker/swarm-v2/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 )
@@ -18,6 +18,7 @@ var (
 empty path, the agent will allocate an identity and startup. If data is
 already present, the agent will recover and startup.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			hostname, err := cmd.Flags().GetString("hostname")
 			if err != nil {
 				return err
@@ -29,7 +30,7 @@ already present, the agent will recover and startup.`,
 			}
 
 			if id == "" {
-				log.Debugf("agent: generated random identifier")
+				log.G(ctx).Debugf("agent: generated random identifier")
 				id = identity.NewID()
 			}
 
@@ -43,7 +44,7 @@ already present, the agent will recover and startup.`,
 				return err
 			}
 
-			log.Debugf("managers: %v", managerAddrs)
+			log.G(ctx).Debugf("managers: %v", managerAddrs)
 			managers := agent.NewManagers(managerAddrs...)
 
 			client, err := engineapi.NewClient(engineAddr, "", nil, nil)
@@ -60,10 +61,10 @@ already present, the agent will recover and startup.`,
 				Executor: executor,
 			})
 			if err != nil {
-				log.Fatalln(err)
+				log.G(ctx).Fatalln(err)
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			if err := ag.Start(ctx); err != nil {

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -4,13 +4,14 @@ import (
 	"os"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/swarm-v2/log"
 	"github.com/docker/swarm-v2/version"
 	"github.com/spf13/cobra"
 )
 
 func main() {
 	if err := mainCmd.Execute(); err != nil {
-		logrus.Fatal(err)
+		log.L.Fatal(err)
 	}
 }
 
@@ -22,11 +23,11 @@ var (
 			logrus.SetOutput(os.Stderr)
 			flag, err := cmd.Flags().GetString("log-level")
 			if err != nil {
-				logrus.Fatal(err)
+				log.L.Fatal(err)
 			}
 			level, err := logrus.ParseLevel(flag)
 			if err != nil {
-				logrus.Fatal(err)
+				log.L.Fatal(err)
 			}
 			logrus.SetLevel(level)
 		},

--- a/cmd/swarmd/manager.go
+++ b/cmd/swarmd/manager.go
@@ -3,12 +3,14 @@ package main
 import (
 	"github.com/docker/swarm-v2/manager"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 var managerCmd = &cobra.Command{
 	Use:   "manager",
 	Short: "Run the swarm manager",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
 		addr, err := cmd.Flags().GetString("listen-addr")
 		if err != nil {
 			return err
@@ -33,7 +35,7 @@ var managerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return m.Run()
+		return m.Run(ctx)
 	},
 }
 

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -64,7 +64,7 @@ type allocActor struct {
 
 	// Init routine which is called during the initialization of
 	// the allocator.
-	init func() error
+	init func(ctx context.Context) error
 }
 
 // New returns a new instance of Allocator for use during allocation
@@ -116,7 +116,7 @@ func (a *Allocator) Start(ctx context.Context) error {
 			// init might return an allocator specific context
 			// which is a child of the passed in context to hold
 			// allocator specific state
-			if err := aaCopy.init(); err != nil {
+			if err := aaCopy.init(ctx); err != nil {
 				// Stop the watches for this allocator
 				// if we are failing in the init of
 				// this allocator.

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -6,8 +6,8 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
+	"github.com/docker/swarm-v2/log"
 	"github.com/docker/swarm-v2/manager/state"
 	"github.com/docker/swarm-v2/manager/state/watch"
 	"golang.org/x/net/context"
@@ -80,7 +80,7 @@ func New(store state.WatchableStore, c *Config) *Dispatcher {
 
 // Register is used for registration of node with particular dispatcher.
 func (d *Dispatcher) Register(ctx context.Context, r *api.RegisterRequest) (*api.RegisterResponse, error) {
-	log.WithField("request", r).Debugf("(*Dispatcher).Register")
+	log.G(ctx).WithField("request", r).Debugf("(*Dispatcher).Register")
 	// TODO: here goes auth
 
 	// create or update node in store
@@ -113,9 +113,9 @@ func (d *Dispatcher) Register(ctx context.Context, r *api.RegisterRequest) (*api
 
 	expireFunc := func() {
 		nodeStatus := api.NodeStatus{State: api.NodeStatus_DOWN, Message: "heartbeat failure"}
-		log.WithField("node.id", nid).Debugf("heartbeat expiration")
+		log.G(ctx).WithField("node.id", nid).Debugf("heartbeat expiration")
 		if err := d.nodeRemove(nid, nodeStatus); err != nil {
-			log.Errorf("error deregistering node %s after heartbeat expiration: %v", nid, err)
+			log.G(ctx).WithError(err).Errorf("failed deregistering node %s after heartbeat expiration", nid)
 		}
 	}
 
@@ -136,14 +136,14 @@ func (d *Dispatcher) Register(ctx context.Context, r *api.RegisterRequest) (*api
 // UpdateTaskStatus updates status of task. Node should send such updates
 // on every status change of its tasks.
 func (d *Dispatcher) UpdateTaskStatus(ctx context.Context, r *api.UpdateTaskStatusRequest) (*api.UpdateTaskStatusResponse, error) {
-	log.WithField("request", r).Debugf("(*Dispatcher).UpdateTaskStatus")
+	log.G(ctx).WithField("request", r).Debugf("(*Dispatcher).UpdateTaskStatus")
 
 	if _, err := d.nodes.GetWithSession(r.NodeID, r.SessionID); err != nil {
 		return nil, err
 	}
 	err := d.store.Update(func(tx state.Tx) error {
 		for _, u := range r.Updates {
-			logger := log.WithField("task.id", u.TaskID)
+			logger := log.G(ctx).WithField("task.id", u.TaskID)
 			if u.Status == nil {
 				logger.Warnf("task report has nil status")
 				continue
@@ -180,7 +180,7 @@ func (d *Dispatcher) UpdateTaskStatus(ctx context.Context, r *api.UpdateTaskStat
 // of tasks which should be run on node, if task is not present in that list,
 // it should be terminated.
 func (d *Dispatcher) Tasks(r *api.TasksRequest, stream api.Dispatcher_TasksServer) error {
-	log.WithField("request", r).Debugf("(*Dispatcher).Tasks")
+	log.G(stream.Context()).WithField("request", r).Debugf("(*Dispatcher).Tasks")
 
 	if _, err := d.nodes.GetWithSession(r.NodeID, r.SessionID); err != nil {
 		return err
@@ -265,7 +265,7 @@ func (d *Dispatcher) nodeRemove(id string, status api.NodeStatus) error {
 // Node should send new heartbeat earlier than now + TTL, otherwise it will
 // be deregistered from dispatcher and its status will be updated to NodeStatus_DOWN
 func (d *Dispatcher) Heartbeat(ctx context.Context, r *api.HeartbeatRequest) (*api.HeartbeatResponse, error) {
-	log.WithField("request", r).Debugf("(*Dispatcher).Heartbeat")
+	log.G(ctx).WithField("request", r).Debugf("(*Dispatcher).Heartbeat")
 
 	period, err := d.nodes.Heartbeat(r.NodeID, r.SessionID)
 	return &api.HeartbeatResponse{Period: period}, err
@@ -302,7 +302,8 @@ func (d *Dispatcher) getManagers() []*api.WeightedPeer {
 // special boolean field Disconnect which if true indicates that node should
 // reconnect to another Manager immediately.
 func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_SessionServer) error {
-	log.WithField("request", r).Debugf("(*Dispatcher).Session")
+	ctx := stream.Context()
+	log.G(ctx).WithField("request", r).Debugf("(*Dispatcher).Session")
 	if _, err := d.nodes.GetWithSession(r.NodeID, r.SessionID); err != nil {
 		return err
 	}
@@ -343,7 +344,7 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 		if disconnect {
 			nodeStatus := api.NodeStatus{State: api.NodeStatus_DISCONNECTED, Message: "node is currently trying to find new manager"}
 			if err := d.nodeRemove(r.NodeID, nodeStatus); err != nil {
-				log.Error(err)
+				log.G(ctx).WithError(err).Error("failed to remove node")
 			}
 		}
 

--- a/manager/drainer/drainer_test.go
+++ b/manager/drainer/drainer_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/manager/state"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestDrainer(t *testing.T) {
+	ctx := context.Background()
 	initialNodeSet := []*api.Node{
 		{
 			ID: "id1",
@@ -149,7 +151,7 @@ func TestDrainer(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		assert.NoError(t, drainer.Run())
+		assert.NoError(t, drainer.Run(ctx))
 	}()
 
 	// id2, id3, and id5 should be deleted immediately

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -33,6 +33,7 @@ func (e *NoopExecutor) Runner(t *api.Task) (exec.Runner, error) {
 }
 
 func TestManager(t *testing.T) {
+	ctx := context.TODO()
 	store := state.NewMemoryStore(nil)
 	assert.NotNil(t, store)
 
@@ -56,7 +57,7 @@ func TestManager(t *testing.T) {
 	done := make(chan error)
 	defer close(done)
 	go func() {
-		done <- m.Run()
+		done <- m.Run(ctx)
 	}()
 
 	conn, err := grpc.Dial(temp.Name(), grpc.WithInsecure(), grpc.WithTimeout(10*time.Second),
@@ -80,6 +81,7 @@ func TestManager(t *testing.T) {
 }
 
 func TestManagerNodeCount(t *testing.T) {
+	ctx := context.TODO()
 	store := state.NewMemoryStore(nil)
 	assert.NotNil(t, store)
 
@@ -95,7 +97,7 @@ func TestManagerNodeCount(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotNil(t, m)
-	go m.Run()
+	go m.Run(ctx)
 	defer m.Stop()
 
 	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(10*time.Second),

--- a/manager/orchestrator/orchestrator.go
+++ b/manager/orchestrator/orchestrator.go
@@ -3,10 +3,11 @@ package orchestrator
 import (
 	"reflect"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/identity"
+	"github.com/docker/swarm-v2/log"
 	"github.com/docker/swarm-v2/manager/state"
+	"golang.org/x/net/context"
 )
 
 // An Orchestrator runs a reconciliation loop to create and destroy
@@ -30,7 +31,7 @@ func New(store state.WatchableStore) *Orchestrator {
 }
 
 // Run contains the orchestrator event loop. It runs until Stop is called.
-func (o *Orchestrator) Run() error {
+func (o *Orchestrator) Run(ctx context.Context) error {
 	defer close(o.doneChan)
 
 	// Watch changes to services and tasks
@@ -50,21 +51,22 @@ func (o *Orchestrator) Run() error {
 	}
 
 	for _, j := range existingServices {
-		o.reconcile(j)
+		o.reconcile(ctx, j)
 	}
 
 	for {
 		select {
 		case event := <-watcher:
+			// TODO(stevvooe): Use ctx to limit running time of operation.
 			switch v := event.(type) {
 			case state.EventDeleteService:
-				o.deleteService(v.Service)
+				o.deleteService(ctx, v.Service)
 			case state.EventCreateService:
-				o.reconcile(v.Service)
+				o.reconcile(ctx, v.Service)
 			case state.EventUpdateService:
-				o.reconcile(v.Service)
+				o.reconcile(ctx, v.Service)
 			case state.EventDeleteTask:
-				o.deleteTask(v.Task)
+				o.deleteTask(ctx, v.Task)
 			}
 		case <-o.stopChan:
 			return nil
@@ -78,12 +80,12 @@ func (o *Orchestrator) Stop() {
 	<-o.doneChan
 }
 
-func (o *Orchestrator) deleteService(service *api.Service) {
-	log.Debugf("Service %s was deleted", service.ID)
+func (o *Orchestrator) deleteService(ctx context.Context, service *api.Service) {
+	log.G(ctx).Debugf("Service %s was deleted", service.ID)
 	err := o.store.Update(func(tx state.Tx) error {
 		tasks, err := tx.Tasks().Find(state.ByServiceID(service.ID))
 		if err != nil {
-			log.Errorf("Error finding tasks for service: %v", err)
+			log.G(ctx).WithError(err).Errorf("failed finding tasks for service")
 			return err
 		}
 		for _, t := range tasks {
@@ -94,11 +96,11 @@ func (o *Orchestrator) deleteService(service *api.Service) {
 		return nil
 	})
 	if err != nil {
-		log.Errorf("Error in transaction: %v", err)
+		log.G(ctx).WithError(err).Errorf("deleteService transaction failed")
 	}
 }
 
-func (o *Orchestrator) deleteTask(task *api.Task) {
+func (o *Orchestrator) deleteTask(ctx context.Context, task *api.Task) {
 	if task.ServiceID != "" {
 		var service *api.Service
 		err := o.store.View(func(tx state.ReadTx) error {
@@ -106,19 +108,19 @@ func (o *Orchestrator) deleteTask(task *api.Task) {
 			return nil
 		})
 		if err != nil {
-			log.Errorf("Error in transaction: %v", err)
+			log.G(ctx).WithError(err).Errorf("deleteTask transaction failed")
 		}
 		if service != nil {
-			o.reconcile(service)
+			o.reconcile(ctx, service)
 		}
 	}
 }
 
-func (o *Orchestrator) reconcile(service *api.Service) {
+func (o *Orchestrator) reconcile(ctx context.Context, service *api.Service) {
 	err := o.store.Update(func(tx state.Tx) error {
 		tasks, err := tx.Tasks().Find(state.ByServiceID(service.ID))
 		if err != nil {
-			log.Errorf("Error finding tasks for service: %v", err)
+			log.G(ctx).WithError(err).Errorf("reconcile failed finding tasks")
 			return nil
 		}
 		numTasks := int64(len(tasks))
@@ -126,45 +128,45 @@ func (o *Orchestrator) reconcile(service *api.Service) {
 
 		switch {
 		case specifiedInstances > numTasks:
-			log.Debugf("Service %s was scaled up from %d to %d instances", service.ID, numTasks, specifiedInstances)
+			log.G(ctx).Debugf("Service %s was scaled up from %d to %d instances", service.ID, numTasks, specifiedInstances)
 			// Update all current tasks then add missing tasks
-			o.updateTasks(tx, service, tasks)
-			o.addTasks(tx, service, specifiedInstances-numTasks)
+			o.updateTasks(ctx, tx, service, tasks)
+			o.addTasks(ctx, tx, service, specifiedInstances-numTasks)
 
 		case specifiedInstances < numTasks:
 			// TODO(aaronl): Scaling down needs to involve the
 			// planner. The orchestrator should not be deleting
 			// tasks directly.
-			log.Debugf("Service %s was scaled down from %d to %d instances", service.ID, numTasks, specifiedInstances)
+			log.G(ctx).Debugf("Service %s was scaled down from %d to %d instances", service.ID, numTasks, specifiedInstances)
 			// Update up to N tasks then remove the extra
-			o.updateTasks(tx, service, tasks[0:specifiedInstances])
-			o.removeTasks(tx, service, tasks[specifiedInstances:numTasks])
+			o.updateTasks(ctx, tx, service, tasks[0:specifiedInstances])
+			o.removeTasks(ctx, tx, service, tasks[specifiedInstances:numTasks])
 
 		case specifiedInstances == numTasks:
 			// Simple update, no scaling - update all tasks.
-			o.updateTasks(tx, service, tasks)
+			o.updateTasks(ctx, tx, service, tasks)
 		}
 
 		return nil
 	})
 	if err != nil {
-		log.Errorf("Error in transaction: %v", err)
+		log.G(ctx).WithError(err).Errorf("reconcile transaction failed")
 	}
 }
 
-func (o *Orchestrator) updateTasks(tx state.Tx, service *api.Service, tasks []*api.Task) {
+func (o *Orchestrator) updateTasks(ctx context.Context, tx state.Tx, service *api.Service, tasks []*api.Task) {
 	for _, t := range tasks {
 		if reflect.DeepEqual(service.Spec.Template, t.Spec) {
 			continue
 		}
-		o.addTasks(tx, service, 1)
+		o.addTasks(ctx, tx, service, 1)
 		if err := tx.Tasks().Delete(t.ID); err != nil {
-			log.Errorf("Failed to remove %s: %v", t.ID, err)
+			log.G(ctx).Errorf("Failed to remove %s: %v", t.ID, err)
 		}
 	}
 }
 
-func (o *Orchestrator) addTasks(tx state.Tx, service *api.Service, count int64) {
+func (o *Orchestrator) addTasks(ctx context.Context, tx state.Tx, service *api.Service, count int64) {
 	spec := *service.Spec.Template
 	meta := service.Spec.Meta // TODO(stevvooe): Copy metadata with nice name.
 
@@ -179,17 +181,17 @@ func (o *Orchestrator) addTasks(tx state.Tx, service *api.Service, count int64) 
 			},
 		}
 		if err := tx.Tasks().Create(task); err != nil {
-			log.Errorf("Failed to create task: %v", err)
+			log.G(ctx).Errorf("Failed to create task: %v", err)
 		}
 	}
 }
 
-func (o *Orchestrator) removeTasks(tx state.Tx, service *api.Service, tasks []*api.Task) {
+func (o *Orchestrator) removeTasks(ctx context.Context, tx state.Tx, service *api.Service, tasks []*api.Task) {
 	for _, t := range tasks {
 		// TODO(aluzzardi): Find a better way to deal with errors.
 		// If `Delete` fails, it probably means the task was already deleted which is fine.
 		if err := tx.Tasks().Delete(t.ID); err != nil {
-			log.Errorf("Failed to remove task %s: %v", t.ID, err)
+			log.G(ctx).WithError(err).Errorf("removing task %s failed", t.ID)
 		}
 	}
 }

--- a/manager/orchestrator/orchestrator_test.go
+++ b/manager/orchestrator/orchestrator_test.go
@@ -8,9 +8,11 @@ import (
 	"github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/manager/state"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestOrchestrator(t *testing.T) {
+	ctx := context.Background()
 	store := state.NewMemoryStore(nil)
 	assert.NotNil(t, store)
 
@@ -40,7 +42,7 @@ func TestOrchestrator(t *testing.T) {
 
 	// Start the orchestrator.
 	go func() {
-		assert.NoError(t, orchestrator.Run())
+		assert.NoError(t, orchestrator.Run(ctx))
 	}()
 
 	observedTask1 := watchTaskCreate(t, watch)

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/docker/swarm-v2/identity"
 	"github.com/docker/swarm-v2/manager/state"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
 )
 
 func TestScheduler(t *testing.T) {
+	ctx := context.Background()
 	initialNodeSet := []*api.Node{
 		{
 			ID: "id1",
@@ -108,7 +110,7 @@ func TestScheduler(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		assert.NoError(t, scheduler.Run())
+		assert.NoError(t, scheduler.Run(ctx))
 	}()
 
 	assignment1 := watchAssignment(t, watch)
@@ -352,6 +354,7 @@ func TestScheduler(t *testing.T) {
 }
 
 func TestSchedulerNoReadyNodes(t *testing.T) {
+	ctx := context.Background()
 	initialTask := &api.Task{
 		ID:   "id1",
 		Spec: &api.TaskSpec{},
@@ -379,7 +382,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		assert.NoError(t, scheduler.Run())
+		assert.NoError(t, scheduler.Run(ctx))
 	}()
 
 	err = store.Update(func(tx state.Tx) error {
@@ -408,6 +411,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 }
 
 func TestSchedulerResourceConstraint(t *testing.T) {
+	ctx := context.Background()
 	// Create a ready node without enough memory to run the task.
 	underprovisionedNode := &api.Node{
 		ID: "underprovisioned",
@@ -465,7 +469,7 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		assert.NoError(t, scheduler.Run())
+		assert.NoError(t, scheduler.Run(ctx))
 	}()
 
 	err = store.Update(func(tx state.Tx) error {
@@ -555,6 +559,7 @@ func BenchmarkSchedulerWorstCase100kNodes1MTasks(b *testing.B) {
 }
 
 func benchScheduler(b *testing.B, nodes, tasks int, worstCase bool) {
+	ctx := context.Background()
 	for iters := 0; iters < b.N; iters++ {
 		b.StopTimer()
 		s := state.NewMemoryStore(nil)
@@ -564,7 +569,7 @@ func benchScheduler(b *testing.B, nodes, tasks int, worstCase bool) {
 		watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
 
 		go func() {
-			_ = scheduler.Run()
+			_ = scheduler.Run(ctx)
 		}()
 
 		// Let the scheduler get started


### PR DESCRIPTION
This commit removes direct references to logrus throughout the code
base. We also ensure that the logger is grabbed from a local context,
where available.

The context has been plumbed where missing but full functionality has
not been added because certain cases require further analysis. The is
especially true in raft where context cancellation could be a critical
behavioral tool.

Closes #316

Signed-off-by: Stephen J Day stephen.day@docker.com
