### PR TITLE
scheduler: Fix panic when resourced are defined but reservations aren't.

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -39,7 +39,11 @@ func (f *ResourceFilter) Enabled(t *api.Task) bool {
 	if c == nil {
 		return false
 	}
-	if r := c.Resources; r == nil || (r.Reservations.NanoCPUs == 0 && r.Reservations.MemoryBytes == 0) {
+	r := c.Resources
+	if r == nil || r.Reservations == nil {
+		return false
+	}
+	if r.Reservations.NanoCPUs == 0 && r.Reservations.MemoryBytes == 0 {
 		return false
 	}
 	return true


### PR DESCRIPTION
Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
