### PR TITLE
Fix scheduler panic

### DIFF
--- a/manager/scheduler/indexed_node_heap.go
+++ b/manager/scheduler/indexed_node_heap.go
@@ -67,6 +67,9 @@ func (nh *nodeHeap) nodeInfo(nodeID string) NodeInfo {
 // addOrUpdateNode sets the number of tasks for a given node. It adds the node
 // to the heap if it wasn't already tracked.
 func (nh *nodeHeap) addOrUpdateNode(n NodeInfo) {
+	if n.Node == nil {
+		return
+	}
 	index, ok := nh.index[n.ID]
 	if ok {
 		nh.heap[index] = n
@@ -79,6 +82,9 @@ func (nh *nodeHeap) addOrUpdateNode(n NodeInfo) {
 // updateNode sets the number of tasks for a given node. It ignores the update
 // if the node isn't already tracked in the heap.
 func (nh *nodeHeap) updateNode(n NodeInfo) {
+	if n.Node == nil {
+		return
+	}
 	index, ok := nh.index[n.ID]
 	if ok {
 		nh.heap[index] = n


### PR DESCRIPTION
A common pattern in the scheduler is the following:

```
    nodeInfo := s.nodeHeap.nodeInfo(t.NodeID)
    nodeInfo.removeTask(t)
    s.nodeHeap.updateNode(nodeInfo)
```

We explicitly don't check if the node exists, to keep the code simple.
It's assumed that updateNode will drop the update if we're dealing with
a nonexistent node.

However, updateNode was missing a check for a nil nodeInfo.Node. Add
this to updateNode and addOrUpdateNode.
