### PR TITLE
raft: fix a potential race on wait initialization and usage for configuration changes

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -227,6 +227,7 @@ func NewNode(ctx context.Context, opts NewNodeOptions, leadershipCh chan Leaders
 	n.appliedIndex = snapshot.Metadata.Index
 	n.snapshotIndex = snapshot.Metadata.Index
 	n.reqIDGen = idutil.NewGenerator(uint16(n.Config.ID), time.Now())
+	n.wait = newWait()
 
 	if n.startNodePeers != nil {
 		if n.joinAddr != "" {
@@ -421,7 +422,6 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot) (err erro
 // Before running the main loop, it first starts the raft node based on saved
 // cluster state. If no saved state exists, it starts a single-node cluster.
 func (n *Node) Run(ctx context.Context) {
-	n.wait = newWait()
 	for {
 		select {
 		case <-n.ticker.C():


### PR DESCRIPTION
Fixes a race on tests for `wait` usage, it was initialized on the `Run` function of raft while a node could call `Join` while `wait` was initialized calling `Run`. So instead we initialize `wait` on `NewNode`.

_The error seen on local tests before the fix_:

```
==================
WARNING: DATA RACE
Read by goroutine 94:
  github.com/docker/swarm-v2/manager/state/raft.(*Node).configure()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:979 +0xa6
  github.com/docker/swarm-v2/manager/state/raft.(*Node).Join()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:571 +0x5d2
  github.com/docker/swarm-v2/api._Raft_Join_Handler()
      /home/abronan/go/src/github.com/docker/swarm-v2/api/manager.pb.go:365 +0x150
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:497 +0x11c0
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).handleStream()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:646 +0x1418
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:323 +0xad
Previous write by goroutine 78:
  github.com/docker/swarm-v2/manager/state/raft.(*Node).Run()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:424 +0x10e
Goroutine 94 (running) created at:
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:324 +0xa7
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport/http2_server.go:213 +0x19c8
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport/http2_server.go:272 +0xf56
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:325 +0x1dc
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveNewHTTP2Transport()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:312 +0x54d
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).handleRawConn()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:289 +0x5b1
Goroutine 78 (running) created at:
  github.com/docker/swarm-v2/manager/state/raft/testutils.NewInitNode()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/testutils/testutils.go:226 +0x357
  github.com/docker/swarm-v2/manager/state/raft/testutils.NewRaftCluster()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/testutils/testutils.go:294 +0xa6
  github.com/docker/swarm-v2/manager/state/raft_test.TestRaftFollowerDown()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft_test.go:120 +0x81
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc
==================
==================
WARNING: DATA RACE
Write by goroutine 94:
  sync/atomic.CompareAndSwapInt32()
      /usr/lib/go/src/runtime/race_amd64.s:279 +0xb
  sync.(*Mutex).Lock()
      /usr/lib/go/src/sync/mutex.go:44 +0x4d
  github.com/docker/swarm-v2/manager/state/raft.(*wait).register()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/wait.go:25 +0x57
  github.com/docker/swarm-v2/manager/state/raft.(*Node).configure()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:979 +0xd4
  github.com/docker/swarm-v2/manager/state/raft.(*Node).Join()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:571 +0x5d2
  github.com/docker/swarm-v2/api._Raft_Join_Handler()
      /home/abronan/go/src/github.com/docker/swarm-v2/api/manager.pb.go:365 +0x150
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).processUnaryRPC()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:497 +0x11c0
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).handleStream()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:646 +0x1418
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:323 +0xad
Previous write by goroutine 78:
  github.com/docker/swarm-v2/manager/state/raft.(*Node).Run()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft.go:424 +0x99
Goroutine 94 (running) created at:
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams.func1()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:324 +0xa7
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport.(*http2Server).operateHeaders()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport/http2_server.go:213 +0x19c8
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport.(*http2Server).HandleStreams()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/transport/http2_server.go:272 +0xf56
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveStreams()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:325 +0x1dc
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).serveNewHTTP2Transport()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:312 +0x54d
  github.com/docker/swarm-v2/vendor/google.golang.org/grpc.(*Server).handleRawConn()
      /home/abronan/go/src/github.com/docker/swarm-v2/vendor/google.golang.org/grpc/server.go:289 +0x5b1
Goroutine 78 (running) created at:
  github.com/docker/swarm-v2/manager/state/raft/testutils.NewInitNode()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/testutils/testutils.go:226 +0x357
  github.com/docker/swarm-v2/manager/state/raft/testutils.NewRaftCluster()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/testutils/testutils.go:294 +0xa6
  github.com/docker/swarm-v2/manager/state/raft_test.TestRaftFollowerDown()
      /home/abronan/go/src/github.com/docker/swarm-v2/manager/state/raft/raft_test.go:120 +0x81
  testing.tRunner()
      /usr/lib/go/src/testing/testing.go:473 +0xdc
==================
```

/cc @aaronlehmann 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
