### PR TITLE
Enable race detector in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,8 +107,8 @@ uninstall:
 coverage: ## generate coverprofiles from the tests
 	@echo "🐳 $@"
 	@( for pkg in ${PACKAGES}; do \
-		go test -i -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=count $$pkg || exit; \
-		go test -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=count $$pkg || exit; \
+		go test -i -race -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=atomic $$pkg || exit; \
+		go test -race -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=atomic $$pkg || exit; \
 	done )
 
 help: ## this help


### PR DESCRIPTION
This adds race detection to the coverage target.

This is an experiment. If CI passes and coverage information is still accurate, let's merge it.
