### PR TITLE
swarmctl: Include timestamps

### DIFF
--- a/cmd/swarmctl/common/print.go
+++ b/cmd/swarmctl/common/print.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	tspb "github.com/docker/swarm-v2/api/timestamp"
+	"github.com/docker/swarm-v2/protobuf/ptypes"
+	"github.com/dustin/go-humanize"
 )
 
 // PrintHeader prints a nice little header.
@@ -23,4 +27,16 @@ func FprintfIfNotEmpty(w io.Writer, format string, v interface{}) {
 	if v != nil && v != "" {
 		fmt.Fprintf(w, format, v)
 	}
+}
+
+// TimestampAgo returns a relatime time string from a timestamp (e.g. "12 seconds ago").
+func TimestampAgo(ts *tspb.Timestamp) string {
+	if ts == nil {
+		return ""
+	}
+	t, err := ptypes.Timestamp(ts)
+	if err != nil {
+		panic(err)
+	}
+	return humanize.Time(t)
 }

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -24,8 +24,8 @@ func printServiceSummary(service *api.Service) {
 	common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Meta.Name)
 	common.FprintfIfNotEmpty(w, "Instances\t: %d\n", service.Spec.Instances)
 	common.FprintfIfNotEmpty(w, "Strategy\t: %s\n", service.Spec.Strategy)
-	fmt.Fprintln(w, "Template:\t")
-	fmt.Fprintln(w, " Container:\t")
+	fmt.Fprintln(w, "Template\t")
+	fmt.Fprintln(w, " Container\t")
 	ctr := service.Spec.Template.GetContainer()
 	common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image.Reference)
 	common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
@@ -33,7 +33,7 @@ func printServiceSummary(service *api.Service) {
 	common.FprintfIfNotEmpty(w, "  Env\t: [%s]\n", strings.Join(ctr.Env, ", "))
 	if ctr.Resources != nil {
 		res := ctr.Resources
-		fmt.Fprintln(w, "  Resources:\t")
+		fmt.Fprintln(w, "  Resources\t")
 		printResources := func(w io.Writer, r *api.Resources) {
 			if r.NanoCPUs != 0 {
 				fmt.Fprintf(w, "      CPU\t: %g\n", float64(r.NanoCPUs)/1e9)
@@ -75,10 +75,11 @@ func printTasks(tasks []*api.Task, res *common.Resolver) {
 	common.PrintHeader(w, "Task ID", "Image", "Status", "Node")
 	for _, t := range tasks {
 		c := t.Spec.GetContainer()
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%s %s\t%s\n",
 			t.ID,
 			c.Image.Reference,
 			t.Status.State.String(),
+			common.TimestampAgo(t.Status.Timestamp),
 			res.Resolve(api.Node{}, t.NodeID),
 		)
 	}

--- a/cmd/swarmctl/task/list.go
+++ b/cmd/swarmctl/task/list.go
@@ -42,10 +42,11 @@ var (
 				}()
 				common.PrintHeader(w, "ID", "Service", "Status", "Node")
 				output = func(t *api.Task) {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%s %s\t%s\n",
 						t.ID,
 						res.Resolve(api.Service{}, t.ServiceID),
 						t.Status.State.String(),
+						common.TimestampAgo(t.Status.Timestamp),
 						res.Resolve(api.Node{}, t.NodeID),
 					)
 				}


### PR DESCRIPTION
```
$ swarmctl task ls
ID                         Service   Status                   Node
--                         -------   ------                   ----
050ghhdjiktejnlvc11k9pzbr  cadvisor  REJECTED 39 minutes ago  node-1
0eso7w9ri1jgmc4ule3vhk0bz  cadvisor  REJECTED 39 minutes ago  node-1
0vs2xdnsz8s6jt8dlq1b4sqre  cadvisor  REJECTED 39 minutes ago  node-2
3pp1z0yyrv3jjtpryyqztbgte  cadvisor  REJECTED 39 minutes ago  node-1
8l2bi7cvs0b92dtq7dznq9ow0  cadvisor  REJECTED 39 minutes ago  node-2
```

```
$ swarmctl service inspect cadvisor
ID                : eea7vq24m3zmj59j4j6082lm8
Name              : cadvisor
Instances         : 5
Strategy          : SERVICE_STRATEGY_SPREAD
Template
 Container
  Image           : google/cadvisor:v0.23.0

Task ID                      Image                      Status                     Node
-------                      -----                      ------                     ----
050ghhdjiktejnlvc11k9pzbr    google/cadvisor:v0.23.0    REJECTED 39 minutes ago    node-1
0eso7w9ri1jgmc4ule3vhk0bz    google/cadvisor:v0.23.0    REJECTED 39 minutes ago    node-1
0vs2xdnsz8s6jt8dlq1b4sqre    google/cadvisor:v0.23.0    REJECTED 39 minutes ago    node-2
3pp1z0yyrv3jjtpryyqztbgte    google/cadvisor:v0.23.0    REJECTED 39 minutes ago    node-1
8l2bi7cvs0b92dtq7dznq9ow0    google/cadvisor:v0.23.0    REJECTED 39 minutes ago    node-2
```

```
$ swarmctl task inspect 050ghhdjiktejnlvc11k9pzbr
ID                 : 050ghhdjiktejnlvc11k9pzbr
Service            : cadvisor
Status
  State            : REJECTED
  Timestamp        : 2016-04-20T22:14:03.795813148Z
  Message          : execution failed
  Error            : Tag v0.23.0 not found in repository docker.io/google/cadvisor
Node               : node-1
Spec
  Image            : google/cadvisor:v0.23.0
```
