### PR TITLE
Fix removal of tasks in agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -329,11 +329,6 @@ func (a *Agent) handleTaskAssignment(ctx context.Context, tasks []*api.Task) err
 			continue
 		}
 
-		// don't remove the task if the manager doesn't want us to.
-		if task.DesiredState < api.TaskStateDead {
-			continue
-		}
-
 		// TODO(stevvooe): Modify this to take the task through a graceful
 		// shutdown. This just outright removes it.
 		if err := a.removeTask(ctx, task); err != nil {


### PR DESCRIPTION
We were checking if the desired state of the task was DEAD before
removing it, but this check was done against the original version of the
task assigned to the agent, not the updated assignment set.

Since this check is only useful for stopping a task without removing the
container, which isn't supported yet, just remove it for now.

Fixes #408

cc @stevvooe 
