### PR TITLE
swarmctl: Show only running tasks unless -a is provided.

### DIFF
--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -13,7 +13,7 @@ import (
 // Dial establishes a connection and creates a client.
 // It infers connection parameters from CLI options.
 func Dial(cmd *cobra.Command) (api.ClusterClient, error) {
-	addr, err := cmd.Flags().GetString("addr")
+	addr, err := cmd.Flags().GetString("host")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	mainCmd.PersistentFlags().StringP("addr", "a", "127.0.0.1:4242", "Address of the Swarm manager")
+	mainCmd.PersistentFlags().StringP("host", "H", "127.0.0.1:4242", "Specify the address of the manager to connect to")
 	mainCmd.PersistentFlags().BoolP("no-resolve", "n", false, "Do not try to map IDs to Names when displaying them")
 
 	mainCmd.AddCommand(root.Cmds...)

--- a/cmd/swarmctl/task/list.go
+++ b/cmd/swarmctl/task/list.go
@@ -17,6 +17,11 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()
 
+			all, err := flags.GetBool("all")
+			if err != nil {
+				return err
+			}
+
 			quiet, err := flags.GetBool("quiet")
 			if err != nil {
 				return err
@@ -55,7 +60,9 @@ var (
 			}
 
 			for _, t := range r.Tasks {
-				output(t)
+				if all || t.Status.State <= api.TaskStateRunning {
+					output(t)
+				}
 			}
 			return nil
 		},
@@ -63,5 +70,6 @@ var (
 )
 
 func init() {
+	listCmd.Flags().BoolP("all", "a", false, "Show all tasks (default shows just running)")
 	listCmd.Flags().BoolP("quiet", "q", false, "Only display IDs")
 }


### PR DESCRIPTION
This affects both task ls and service inspect.

`-a` was previously used to provide the manager address globally and has
been replaced by `-H` to be consistent with docker.

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
