### PR TITLE
raftpicker, manager: check for leader on Pick

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -116,9 +116,6 @@ func TestManagerNodeCount(t *testing.T) {
 
 	opts := []grpc.DialOption{grpc.WithTimeout(10 * time.Second)}
 	opts = append(opts, grpc.WithTransportCredentials(managerSecurityConfig.ClientTLSCreds))
-	opts = append(opts, grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-		return net.DialTimeout(l.Addr().Network(), addr, timeout)
-	}))
 
 	conn, err := grpc.Dial(l.Addr().String(), opts...)
 	assert.NoError(t, err)

--- a/manager/raftpicker/raftpicker.go
+++ b/manager/raftpicker/raftpicker.go
@@ -1,6 +1,8 @@
 package raftpicker
 
 import (
+	"sync"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/transport"
@@ -8,36 +10,71 @@ import (
 
 // Picker always picks address of cluster leader.
 type Picker struct {
+	mu   sync.Mutex
+	addr string
 	raft AddrSelector
 	conn *grpc.Conn
+	cc   *grpc.ClientConn
 }
 
 // New returns new Picker with AddrSelector interface which it'll use for
-// picking.
-func New(raft AddrSelector) grpc.Picker {
-	return &Picker{raft: raft}
+// picking. initAddr should be same as for Dial, because there is no way to get
+// target from ClientConn.
+func New(raft AddrSelector, initAddr string) grpc.Picker {
+	return &Picker{raft: raft, addr: initAddr}
 }
 
 // Init does initial processing for the Picker, e.g., initiate some connections.
 func (p *Picker) Init(cc *grpc.ClientConn) error {
-	c, err := grpc.NewConn(cc)
-	if err != nil {
-		return err
+	p.cc = cc
+	return nil
+}
+
+func (p *Picker) initConn() error {
+	if p.conn == nil {
+		conn, err := grpc.NewConn(p.cc)
+		if err != nil {
+			return err
+		}
+		p.conn = conn
 	}
-	p.conn = c
 	return nil
 }
 
 // Pick blocks until either a transport.ClientTransport is ready for the upcoming RPC
 // or some error happens.
 func (p *Picker) Pick(ctx context.Context) (transport.ClientTransport, error) {
+	p.mu.Lock()
+	if err := p.initConn(); err != nil {
+		p.mu.Unlock()
+		return nil, err
+	}
+	p.mu.Unlock()
+
+	addr, err := p.raft.LeaderAddr()
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	if p.addr != addr {
+		p.addr = addr
+		p.conn.NotifyReset()
+	}
+	p.mu.Unlock()
 	return p.conn.Wait(ctx)
 }
 
 // PickAddr picks a peer address for connecting. This will be called repeated for
 // connecting/reconnecting.
 func (p *Picker) PickAddr() (string, error) {
-	return p.raft.LeaderAddr()
+	addr, err := p.raft.LeaderAddr()
+	if err != nil {
+		return "", err
+	}
+	p.mu.Lock()
+	p.addr = addr
+	p.mu.Unlock()
+	return addr, nil
 }
 
 // State returns the connectivity state of the underlying connections.
@@ -60,4 +97,16 @@ func (p *Picker) Reset() error {
 // Close closes all the Conn's owned by this Picker.
 func (p *Picker) Close() error {
 	return p.conn.Close()
+}
+
+// Dial returns *grpc.ClientConn with picker set to raftpicker with initial
+// address of cluster leader.
+func Dial(selector AddrSelector, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	addr, err := selector.LeaderAddr()
+	if err != nil {
+		return nil, err
+	}
+	picker := New(selector, addr)
+	opts = append(opts, grpc.WithPicker(picker))
+	return grpc.Dial(addr, opts...)
 }

--- a/protobuf/plugin/raftproxy/test/raftproxy_test.go
+++ b/protobuf/plugin/raftproxy/test/raftproxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/swarm-v2/manager/raftpicker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -47,12 +48,16 @@ func (m *mockCluster) IsLeader() bool {
 func TestSimpleRedirect(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	addr := l.Addr().String()
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 	require.NoError(t, err)
 	defer conn.Close()
 
-	api, err := NewRaftProxyRouteGuideServer(testRouteGuide{}, &mockCluster{addr: l.Addr().String()})
+	cluster := &mockCluster{addr: addr}
+	cConn, err := raftpicker.Dial(cluster, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 	require.NoError(t, err)
+
+	api := NewRaftProxyRouteGuideServer(testRouteGuide{}, cConn, cluster)
 	srv := grpc.NewServer()
 	RegisterRouteGuideServer(srv, api)
 	go srv.Serve(l)
@@ -67,11 +72,16 @@ func TestSimpleRedirect(t *testing.T) {
 func TestServerStreamRedirect(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	addr := l.Addr().String()
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cluster := &mockCluster{addr: addr}
+	cConn, err := raftpicker.Dial(cluster, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 	require.NoError(t, err)
 
-	api, err := NewRaftProxyRouteGuideServer(testRouteGuide{}, &mockCluster{addr: l.Addr().String()})
-	require.NoError(t, err)
+	api := NewRaftProxyRouteGuideServer(testRouteGuide{}, cConn, cluster)
 	srv := grpc.NewServer()
 	RegisterRouteGuideServer(srv, api)
 	go srv.Serve(l)
@@ -89,11 +99,16 @@ func TestServerStreamRedirect(t *testing.T) {
 func TestClientStreamRedirect(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	addr := l.Addr().String()
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cluster := &mockCluster{addr: addr}
+	cConn, err := raftpicker.Dial(cluster, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 	require.NoError(t, err)
 
-	api, err := NewRaftProxyRouteGuideServer(testRouteGuide{}, &mockCluster{addr: l.Addr().String()})
-	require.NoError(t, err)
+	api := NewRaftProxyRouteGuideServer(testRouteGuide{}, cConn, cluster)
 	srv := grpc.NewServer()
 	RegisterRouteGuideServer(srv, api)
 	go srv.Serve(l)
@@ -113,11 +128,16 @@ func TestClientStreamRedirect(t *testing.T) {
 func TestClientServerStreamRedirect(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	conn, err := grpc.Dial(l.Addr().String(), grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	addr := l.Addr().String()
+	conn, err := grpc.Dial(addr, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cluster := &mockCluster{addr: addr}
+	cConn, err := raftpicker.Dial(cluster, grpc.WithInsecure(), grpc.WithTimeout(5*time.Second))
 	require.NoError(t, err)
 
-	api, err := NewRaftProxyRouteGuideServer(testRouteGuide{}, &mockCluster{addr: l.Addr().String()})
-	require.NoError(t, err)
+	api := NewRaftProxyRouteGuideServer(testRouteGuide{}, cConn, cluster)
 	srv := grpc.NewServer()
 	RegisterRouteGuideServer(srv, api)
 	go srv.Serve(l)


### PR DESCRIPTION
also I slightly changed order of things in manager.Run. Now raft cluster
starts first and only then services are registered on grpc server. I
tried to do lazy Dial, but it's pretty hard with current grpc interface
and looks much uglier.
Let me know if you have ideas how to do it better.
