### PR TITLE
Make subnet allocations sticky in new leader

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -422,8 +422,14 @@ func (na *NetworkAllocator) allocatePools(n *api.Network) (map[string]string, er
 	}
 
 	ipamConfigs := n.Spec.IPAM.Configurations
-	if n.Spec.IPAM.Configurations == nil {
-		ipamConfigs = append(ipamConfigs, &api.IPAMConfiguration{})
+	if ipamConfigs == nil {
+		if n.IPAM != nil {
+			ipamConfigs = n.IPAM.Configurations
+		}
+
+		if ipamConfigs == nil {
+			ipamConfigs = append(ipamConfigs, &api.IPAMConfiguration{})
+		}
 	}
 
 	// Update the runtime IPAM configurations with initial state


### PR DESCRIPTION
After leader failover we want the networks which did not have user
defined subnets to have the same subnets that were allocated in the
previous leader.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
