### PR TITLE
Honor task desired state in allocator

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -178,7 +178,8 @@ func TestAllocator(t *testing.T) {
 			Status: &api.TaskStatus{
 				State: api.TaskStateNew,
 			},
-			ServiceID: "testServiceID2",
+			ServiceID:    "testServiceID2",
+			DesiredState: api.TaskStateRunning,
 			Spec: &api.TaskSpec{
 				Runtime: &api.TaskSpec_Container{
 					Container: &api.Container{
@@ -214,6 +215,7 @@ func TestAllocator(t *testing.T) {
 			Status: &api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			DesiredState: api.TaskStateRunning,
 			Spec: &api.TaskSpec{
 				Runtime: &api.TaskSpec_Container{
 					Container: &api.Container{
@@ -284,7 +286,8 @@ func TestAllocator(t *testing.T) {
 			Status: &api.TaskStatus{
 				State: api.TaskStateNew,
 			},
-			ServiceID: "testServiceID2",
+			DesiredState: api.TaskStateRunning,
+			ServiceID:    "testServiceID2",
 			Spec: &api.TaskSpec{
 				Runtime: &api.TaskSpec_Container{
 					Container: &api.Container{},
@@ -320,6 +323,7 @@ func TestAllocator(t *testing.T) {
 			Status: &api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			DesiredState: api.TaskStateRunning,
 			Spec: &api.TaskSpec{
 				Runtime: &api.TaskSpec_Container{
 					Container: &api.Container{},


### PR DESCRIPTION
With the task lifecycle changes and the introduction of DesiredState in
task object, allocator needs to the honor that and make
allocation/deallocation decisions based on that to properly work in sync
with the other stages of the manager pipeline. Made changes to make
allocation/deallocation decisions based on a combination of task
DesiredState and the current state.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
