### PR TITLE
UI integration for instance numbers

### DIFF
--- a/cmd/swarmctl/task/inspect.go
+++ b/cmd/swarmctl/task/inspect.go
@@ -54,6 +54,7 @@ var (
 				_ = w.Flush()
 			}()
 			fmt.Fprintf(w, "ID\t: %s\n", r.Task.ID)
+			fmt.Fprintf(w, "Instance\t: %d\n", r.Task.Instance)
 			fmt.Fprintf(w, "Service\t: %s\n", res.Resolve(api.Service{}, r.Task.ServiceID))
 			printTaskStatus(w, r.Task.Status)
 			fmt.Fprintf(w, "Node\t: %s\n", res.Resolve(api.Node{}, r.Task.NodeID))

--- a/cmd/swarmctl/task/list.go
+++ b/cmd/swarmctl/task/list.go
@@ -45,11 +45,12 @@ var (
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				common.PrintHeader(w, "ID", "Service", "Status", "Node")
+				common.PrintHeader(w, "ID", "Service", "Instance", "Status", "Node")
 				output = func(t *api.Task) {
-					fmt.Fprintf(w, "%s\t%s\t%s %s\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%d\t%s %s\t%s\n",
 						t.ID,
 						res.Resolve(api.Service{}, t.ServiceID),
+						t.Instance,
 						t.Status.State.String(),
 						common.TimestampAgo(t.Status.Timestamp),
 						res.Resolve(api.Node{}, t.NodeID),


### PR DESCRIPTION
This adds instance numbers to the output of task ls, task inspect, and
service inspect. It also adds a --instance option to inspect, which
will show the tasks for a specific instance (including dead tasks).

Tasks are sorted by instance number in service inspect.

cc @aluzzardi
