### PR TITLE
swarmctl: Display service name alongside instance #.

### DIFF
--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -86,7 +86,7 @@ func (t tasksByInstance) Less(i, j int) bool {
 	return t[i].Instance < t[j].Instance
 }
 
-func printTasks(tasks []*api.Task, all bool, res *common.Resolver) {
+func printTasks(service *api.Service, tasks []*api.Task, all bool, res *common.Resolver) {
 	sort.Sort(tasksByInstance(tasks))
 
 	w := tabwriter.NewWriter(os.Stdout, 4, 4, 4, ' ', 0)
@@ -98,8 +98,9 @@ func printTasks(tasks []*api.Task, all bool, res *common.Resolver) {
 			continue
 		}
 		c := t.Spec.GetContainer()
-		fmt.Fprintf(w, "%s\t%d\t%s\t%s %s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s.%d\t%s\t%s %s\t%s\n",
 			t.ID,
+			service.Spec.Annotations.Name,
 			t.Instance,
 			c.Image.Reference,
 			t.Status.State.String(),
@@ -161,7 +162,7 @@ var (
 			printServiceSummary(service)
 			if len(tasks) > 0 {
 				fmt.Printf("\n")
-				printTasks(tasks, all || instance != 0, res)
+				printTasks(service, tasks, all || instance != 0, res)
 			}
 
 			return nil


### PR DESCRIPTION
@aaronlehmann I find this more pleasant. Thoughts?

```
Task ID                      Instance    Image                      Status                  Node
-------                      --------    -----                      ------                  ----
5c0v9qlwvns4rdhg6xsu1np8u    1           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
65x8oiob1drngexbvqk358q6k    2           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
4gn0pp64ezzbdqki7q7cumpxo    3           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
8d2d8sp23c1yocpftnob434yg    4           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
8p444k1zoatxwfvu9f38s2f35    5           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
a5ydiy0gr90hs5op5elznzxly    6           google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
```

```
Task ID                      Instance      Image                      Status                  Node
-------                      --------      -----                      ------                  ----
5mfy5dngvya2x82qu2zf9kn9a    cadvisor.1    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
1i514agf44c7gtcs8k2v7ady7    cadvisor.2    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
4tklpg6707qcqxo2dfj0k7gau    cadvisor.3    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
1cnv0dz8uikp9nz9gqf1lzko9    cadvisor.4    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
6i6v6rr38nrxv7oui1gm9olah    cadvisor.5    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
d8b65n5mqhvq12w2ib7046cig    cadvisor.6    google/cadvisor:v0.22.0    RUNNING 1 minute ago    node-1
```
