### PR TITLE
raft: Make test send timeouts looser

### DIFF
--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -194,7 +194,7 @@ func NewNode(t *testing.T, clockSource *fakeclock.FakeClock, securityConfig *ca.
 		Config:         cfg,
 		StateDir:       stateDir,
 		ClockSource:    clockSource,
-		SendTimeout:    100 * time.Millisecond,
+		SendTimeout:    10 * time.Second,
 		TLSCredentials: securityConfig.ClientTLSCreds,
 	}
 
@@ -267,7 +267,7 @@ func RestartNode(t *testing.T, clockSource *fakeclock.FakeClock, oldNode *TestNo
 		Config:         cfg,
 		StateDir:       oldNode.StateDir,
 		ClockSource:    clockSource,
-		SendTimeout:    100 * time.Millisecond,
+		SendTimeout:    10 * time.Second,
 		TLSCredentials: securityConfig.ClientTLSCreds,
 	}
 


### PR DESCRIPTION
The tests were using 100 ms timeouts for sends to other cluster members,
which could potentially lead to flaky behavior in an oversubscribed
virtualized environment. Boost the timeouts to 10 seconds. To prevent
this from adding to the time it takes to tear down the cluster after
each test, cancel the raft node's parent context when it shuts down, so
sends are also cancelled.

cc @abronan
