### PR TITLE
swarmctl: Partially fix `swarmctl diff`

### DIFF
--- a/spec/service.go
+++ b/spec/service.go
@@ -234,6 +234,23 @@ func (s *ServiceConfig) FromProto(serviceSpec *api.ServiceSpec) {
 		s.Mounts.FromProto(apiMounts)
 	}
 
+	if serviceSpec.Endpoint != nil {
+		for _, port := range serviceSpec.Endpoint.Ports {
+			s.Ports = append(s.Ports, PortConfig{
+				Name:     port.Name,
+				Protocol: strings.ToLower(port.Protocol.String()),
+				Port:     port.Port,
+				NodePort: port.NodePort,
+			})
+		}
+	}
+
+	if serviceSpec.Template.GetContainer().Networks != nil {
+		for _, net := range serviceSpec.Template.GetContainer().Networks {
+			s.Networks = append(s.Networks, net.GetNetworkID())
+		}
+	}
+
 	switch serviceSpec.Mode {
 	case api.ServiceModeRunning:
 		s.Mode = "running"


### PR DESCRIPTION
There's a bunch of diffs between remote/local because we don't serialize/deserialize in the same way:

```
--- remote
+++ local
@@ -8,23 +8,17 @@
     - OPTION_A=Cats
     - OPTION_B=Dogs
     networks:
-    - 4gyihcxico6x3nd2tlkcoa0f7
+    - mynetwork
     name: frontend
     instances: 1
-    mode: running
-    restart: always
-    restartdelay: "0"
     ports:
     - name: front
-      protocol: TCP
+      protocol: tcp
       port: 80
   redis:
     image: redis
     networks:
-    - 4gyihcxico6x3nd2tlkcoa0f7
+    - mynetwork
     name: redis
     instances: 1
-    mode: running
-    restart: always
-    restartdelay: "0"
```

This PR fixes ports but there's still a lot.
