### PR TITLE
Move Fill service tasks thru allocator and scheduler

### DIFF
--- a/examples/cadvisor.yml
+++ b/examples/cadvisor.yml
@@ -4,7 +4,7 @@ namespace: monitoring
 services:
     cadvisor:
         image: google/cadvisor:v0.22.0
-        instances: 2
+        mode: fill
         update:
             parallelism: 1
             delay: 10s

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -221,7 +221,10 @@ func (d *Dispatcher) Tasks(r *api.TasksRequest, stream api.Dispatcher_TasksServe
 
 		var tasks []*api.Task
 		for _, t := range tasksMap {
-			tasks = append(tasks, t)
+			// dispatcher only sends tasks that have been assigned to a node
+			if t != nil && t.Status.State >= api.TaskStateAssigned {
+				tasks = append(tasks, t)
+			}
 		}
 
 		if err := stream.Send(&api.TasksMessage{Tasks: tasks}); err != nil {

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -206,10 +206,12 @@ func TestTasks(t *testing.T) {
 	testTask1 := &api.Task{
 		NodeID: nodeID,
 		ID:     "testTask1",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
 	}
 	testTask2 := &api.Task{
 		NodeID: nodeID,
 		ID:     "testTask2",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
 	}
 
 	{

--- a/manager/orchestrator/fill.go
+++ b/manager/orchestrator/fill.go
@@ -217,6 +217,8 @@ func (f *FillOrchestrator) reconcileOneService(ctx context.Context, service *api
 			}
 			// this node needs to run 1 copy of the task
 			if len(ntasks) == 0 {
+				// TODO(dongluochen): restart delay should
+				// take effect if this is a restart
 				f.addTask(ctx, batch, service, nodeID)
 			} else {
 				updateTasks = append(updateTasks, ntasks[0])
@@ -304,6 +306,8 @@ func (f *FillOrchestrator) reconcileServiceOneNode(ctx context.Context, serviceI
 		}
 		// this node needs to run 1 copy of the task
 		if len(tasks) == 0 {
+			// TODO(dongluochen): restart delay should
+			// take effect if this is a restart
 			f.addTask(ctx, batch, service, nodeID)
 		} else {
 			f.removeTasks(ctx, batch, service, tasks[1:])

--- a/manager/orchestrator/fill_test.go
+++ b/manager/orchestrator/fill_test.go
@@ -30,9 +30,8 @@ var (
 			Annotations: api.Annotations{
 				Name: "name1",
 			},
-			Template:  &api.TaskSpec{},
-			Instances: 1,
-			Mode:      api.ServiceModeFill,
+			Template: &api.TaskSpec{},
+			Mode:     api.ServiceModeFill,
 		},
 	}
 
@@ -42,9 +41,8 @@ var (
 			Annotations: api.Annotations{
 				Name: "name2",
 			},
-			Template:  &api.TaskSpec{},
-			Instances: 1,
-			Mode:      api.ServiceModeFill,
+			Template: &api.TaskSpec{},
+			Mode:     api.ServiceModeFill,
 		},
 	}
 )


### PR DESCRIPTION
This change makes Fill service tasks go thru allocator, scheduler before dispatcher pushes them to node. Scheduler checks and updates resources for the target node. 

cc @aluzzardi @aaronlehmann @mrjana. 

Signed-off-by: Dong Chen dongluo.chen@docker.com
