### PR TITLE
store: View doesn't need to return an error

### DIFF
--- a/manager/clusterapi/network.go
+++ b/manager/clusterapi/network.go
@@ -122,13 +122,9 @@ func (s *Server) GetNetwork(ctx context.Context, request *api.GetNetworkRequest)
 	}
 
 	var n *api.Network
-	err := s.store.View(func(tx state.ReadTx) error {
+	s.store.View(func(tx state.ReadTx) {
 		n = tx.Networks().Get(request.NetworkID)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 	if n == nil {
 		return nil, grpc.Errorf(codes.NotFound, "network %s not found", request.NetworkID)
 	}
@@ -160,16 +156,17 @@ func (s *Server) RemoveNetwork(ctx context.Context, request *api.RemoveNetworkRe
 
 // ListNetworks returns a list of all networks.
 func (s *Server) ListNetworks(ctx context.Context, request *api.ListNetworksRequest) (*api.ListNetworksResponse, error) {
-	var networks []*api.Network
-	err := s.store.View(func(tx state.ReadTx) error {
-		var err error
+	var (
+		networks []*api.Network
+		err      error
+	)
 
+	s.store.View(func(tx state.ReadTx) {
 		if request.Options == nil || request.Options.Query == "" {
 			networks, err = tx.Networks().Find(state.All)
 		} else {
 			networks, err = tx.Networks().Find(state.ByQuery(request.Options.Query))
 		}
-		return err
 	})
 	if err != nil {
 		return nil, err

--- a/manager/clusterapi/node.go
+++ b/manager/clusterapi/node.go
@@ -24,13 +24,9 @@ func (s *Server) GetNode(ctx context.Context, request *api.GetNodeRequest) (*api
 	}
 
 	var node *api.Node
-	err := s.store.View(func(tx state.ReadTx) error {
+	s.store.View(func(tx state.ReadTx) {
 		node = tx.Nodes().Get(request.NodeID)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 	if node == nil {
 		return nil, grpc.Errorf(codes.NotFound, "node %s not found", request.NodeID)
 	}
@@ -41,15 +37,16 @@ func (s *Server) GetNode(ctx context.Context, request *api.GetNodeRequest) (*api
 
 // ListNodes returns a list of all nodes.
 func (s *Server) ListNodes(ctx context.Context, request *api.ListNodesRequest) (*api.ListNodesResponse, error) {
-	var nodes []*api.Node
-	err := s.store.View(func(tx state.ReadTx) error {
-		var err error
+	var (
+		nodes []*api.Node
+		err   error
+	)
+	s.store.View(func(tx state.ReadTx) {
 		if request.Options == nil || request.Options.Query == "" {
 			nodes, err = tx.Nodes().Find(state.All)
 		} else {
 			nodes, err = tx.Nodes().Find(state.ByQuery(request.Options.Query))
 		}
-		return err
 	})
 	if err != nil {
 		return nil, err

--- a/manager/clusterapi/service.go
+++ b/manager/clusterapi/service.go
@@ -118,13 +118,9 @@ func (s *Server) GetService(ctx context.Context, request *api.GetServiceRequest)
 	}
 
 	var service *api.Service
-	err := s.store.View(func(tx state.ReadTx) error {
+	s.store.View(func(tx state.ReadTx) {
 		service = tx.Services().Get(request.ServiceID)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 	if service == nil {
 		return nil, grpc.Errorf(codes.NotFound, "service %s not found", request.ServiceID)
 	}
@@ -192,15 +188,16 @@ func (s *Server) RemoveService(ctx context.Context, request *api.RemoveServiceRe
 
 // ListServices returns a list of all services.
 func (s *Server) ListServices(ctx context.Context, request *api.ListServicesRequest) (*api.ListServicesResponse, error) {
-	var services []*api.Service
-	err := s.store.View(func(tx state.ReadTx) error {
-		var err error
+	var (
+		services []*api.Service
+		err      error
+	)
+	s.store.View(func(tx state.ReadTx) {
 		if request.Options == nil || request.Options.Query == "" {
 			services, err = tx.Services().Find(state.All)
 		} else {
 			services, err = tx.Services().Find(state.ByQuery(request.Options.Query))
 		}
-		return err
 	})
 	if err != nil {
 		return nil, err

--- a/manager/clusterapi/task.go
+++ b/manager/clusterapi/task.go
@@ -17,13 +17,9 @@ func (s *Server) GetTask(ctx context.Context, request *api.GetTaskRequest) (*api
 	}
 
 	var task *api.Task
-	err := s.store.View(func(tx state.ReadTx) error {
+	s.store.View(func(tx state.ReadTx) {
 		task = tx.Tasks().Get(request.TaskID)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 	if task == nil {
 		return nil, grpc.Errorf(codes.NotFound, "task %s not found", request.TaskID)
 	}
@@ -55,12 +51,12 @@ func (s *Server) RemoveTask(ctx context.Context, request *api.RemoveTaskRequest)
 
 // ListTasks returns a list of all tasks.
 func (s *Server) ListTasks(ctx context.Context, request *api.ListTasksRequest) (*api.ListTasksResponse, error) {
-	var tasks []*api.Task
-	err := s.store.View(func(tx state.ReadTx) error {
-		var err error
-
+	var (
+		tasks []*api.Task
+		err   error
+	)
+	s.store.View(func(tx state.ReadTx) {
 		tasks, err = tx.Tasks().Find(state.All)
-		return err
 	})
 	if err != nil {
 		return nil, err

--- a/manager/clusterapi/volume.go
+++ b/manager/clusterapi/volume.go
@@ -60,13 +60,9 @@ func (s *Server) GetVolume(ctx context.Context, request *api.GetVolumeRequest) (
 	}
 
 	var volume *api.Volume
-	err := s.store.View(func(tx state.ReadTx) error {
+	s.store.View(func(tx state.ReadTx) {
 		volume = tx.Volumes().Get(request.VolumeID)
-		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
 	if volume == nil {
 		return nil, grpc.Errorf(codes.NotFound, "volume %s not found", request.VolumeID)
 	}
@@ -98,12 +94,12 @@ func (s *Server) RemoveVolume(ctx context.Context, request *api.RemoveVolumeRequ
 
 // ListVolumes returns a list of all volumes.
 func (s *Server) ListVolumes(ctx context.Context, request *api.ListVolumesRequest) (*api.ListVolumesResponse, error) {
-	var volumes []*api.Volume
-	err := s.store.View(func(tx state.ReadTx) error {
-		var err error
-
+	var (
+		volumes []*api.Volume
+		err     error
+	)
+	s.store.View(func(tx state.ReadTx) {
 		volumes, err = tx.Volumes().Find(state.All)
-		return err
 	})
 	if err != nil {
 		return nil, err

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -204,19 +204,15 @@ func (d *Dispatcher) Tasks(r *api.TasksRequest, stream api.Dispatcher_TasksServe
 	defer cancel()
 
 	tasksMap := make(map[string]*api.Task)
-	err = d.store.View(func(readTx state.ReadTx) error {
+	d.store.View(func(readTx state.ReadTx) {
 		tasks, err := readTx.Tasks().Find(state.ByNodeID(agentID))
 		if err != nil {
-			return nil
+			return
 		}
 		for _, t := range tasks {
 			tasksMap[t.ID] = t
 		}
-		return nil
 	})
-	if err != nil {
-		return err
-	}
 
 	for {
 		if _, err := d.nodes.GetWithSession(agentID, r.SessionID); err != nil {

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -138,14 +138,12 @@ func TestHeartbeat(t *testing.T) {
 	assert.NotZero(t, resp.Period)
 	time.Sleep(300 * time.Millisecond)
 
-	err = gd.Store.View(func(readTx state.ReadTx) error {
+	gd.Store.View(func(readTx state.ReadTx) {
 		storeNodes, err := readTx.Nodes().Find(state.All)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, storeNodes)
 		assert.Equal(t, storeNodes[0].Status.State, api.NodeStatus_READY)
-		return nil
 	})
-	assert.NoError(t, err)
 }
 
 func TestHeartbeatTimeout(t *testing.T) {
@@ -166,14 +164,12 @@ func TestHeartbeatTimeout(t *testing.T) {
 	}
 	time.Sleep(500 * time.Millisecond)
 
-	err = gd.Store.View(func(readTx state.ReadTx) error {
+	gd.Store.View(func(readTx state.ReadTx) {
 		storeNodes, err := readTx.Nodes().Find(state.All)
 		assert.NoError(t, err)
 		assert.NotEmpty(t, storeNodes)
 		assert.Equal(t, api.NodeStatus_DOWN, storeNodes[0].Status.State)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// check that node is deregistered
 	resp, err := gd.Clients[0].Heartbeat(context.Background(), &api.HeartbeatRequest{SessionID: expectedSessionID})
@@ -338,7 +334,7 @@ func TestTaskUpdate(t *testing.T) {
 	updReq.SessionID = expectedSessionID
 	_, err = gd.Clients[0].UpdateTaskStatus(context.Background(), updReq)
 	assert.NoError(t, err)
-	err = gd.Store.View(func(readTx state.ReadTx) error {
+	gd.Store.View(func(readTx state.ReadTx) {
 		storeTask1 := readTx.Tasks().Get(testTask1.ID)
 		assert.NotNil(t, storeTask1)
 		assert.NotNil(t, storeTask1.Status)
@@ -347,9 +343,7 @@ func TestTaskUpdate(t *testing.T) {
 		assert.NotNil(t, storeTask2.Status)
 		assert.Equal(t, storeTask1.Status.State, api.TaskStateAssigned)
 		assert.Equal(t, storeTask2.Status.State, api.TaskStateAssigned)
-		return nil
 	})
-	assert.NoError(t, err)
 }
 
 func TestSession(t *testing.T) {

--- a/manager/orchestrator/orchestrator_test.go
+++ b/manager/orchestrator/orchestrator_test.go
@@ -131,14 +131,14 @@ func TestOrchestrator(t *testing.T) {
 
 	// There should be one remaining task attached to service id2/name2.
 	var liveTasks []*api.Task
-	err = store.View(func(readTx state.ReadTx) error {
-		tasks, err := readTx.Tasks().Find(state.ByServiceID("id2"))
+	store.View(func(readTx state.ReadTx) {
+		var tasks []*api.Task
+		tasks, err = readTx.Tasks().Find(state.ByServiceID("id2"))
 		for _, t := range tasks {
 			if t.DesiredState == api.TaskStateRunning {
 				liveTasks = append(liveTasks, t)
 			}
 		}
-		return err
 	})
 	assert.NoError(t, err)
 	assert.Len(t, liveTasks, 1)

--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -17,9 +17,8 @@ func getRunnableServiceTasks(t *testing.T, store state.WatchableStore, s *api.Se
 		tasks []*api.Task
 	)
 
-	err = store.View(func(tx state.ReadTx) error {
+	store.View(func(tx state.ReadTx) {
 		tasks, err = tx.Tasks().Find(state.ByServiceID(s.ID))
-		return err
 	})
 	assert.NoError(t, err)
 

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/etcd/wal"
 	"github.com/coreos/etcd/wal/walpb"
 	"github.com/docker/swarm-v2/api"
+	pb "github.com/docker/swarm-v2/api"
 	"github.com/docker/swarm-v2/ca"
 	"github.com/docker/swarm-v2/log"
 	"github.com/docker/swarm-v2/manager/state"
@@ -826,12 +827,13 @@ func (n *Node) doSnapshot() {
 			n.snapshotInProgress <- snapshotIndex
 		}()
 
-		err := n.memoryStore.View(func(tx state.ReadTx) error {
+		var err error
+		n.memoryStore.View(func(tx state.ReadTx) {
 			close(viewStarted)
 
-			storeSnapshot, err := n.memoryStore.Save(tx)
+			var storeSnapshot *pb.StoreSnapshot
+			storeSnapshot, err = n.memoryStore.Save(tx)
 			snapshot.Store = *storeSnapshot
-			return err
 		})
 		if err != nil {
 			n.Config.Logger.Error(err)

--- a/manager/state/store.go
+++ b/manager/state/store.go
@@ -224,7 +224,7 @@ type Store interface {
 	// View performs a transaction that only includes reads. Within the
 	// callback function, a consistent view of the data is available through
 	// the ReadTx interface.
-	View(func(ReadTx) error) error
+	View(func(ReadTx))
 
 	// Save serializes the data in the store.
 	Save(ReadTx) (*pb.StoreSnapshot, error)

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -107,7 +107,7 @@ type readTx struct {
 }
 
 // View executes a read transaction.
-func (s *MemoryStore) View(cb func(state.ReadTx) error) error {
+func (s *MemoryStore) View(cb func(state.ReadTx)) {
 	memDBTx := s.memDB.Txn(false)
 
 	readTx := readTx{
@@ -127,9 +127,8 @@ func (s *MemoryStore) View(cb func(state.ReadTx) error) error {
 			memDBTx: memDBTx,
 		},
 	}
-	err := cb(readTx)
+	cb(readTx)
 	memDBTx.Commit()
-	return err
 }
 
 func (t readTx) Nodes() state.NodeSetReader {

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -175,17 +175,15 @@ func TestStoreNode(t *testing.T) {
 	s := NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	err := s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		allNodes, err := readTx.Nodes().Find(state.All)
 		assert.NoError(t, err)
 		assert.Empty(t, allNodes)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	setupTestStore(t, s)
 
-	err = s.Update(func(tx state.Tx) error {
+	err := s.Update(func(tx state.Tx) error {
 		allNodes, err := tx.Nodes().Find(state.All)
 		assert.NoError(t, err)
 		assert.Len(t, allNodes, len(nodeSet))
@@ -195,7 +193,7 @@ func TestStoreNode(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		assert.Equal(t, nodeSet[0], readTx.Nodes().Get("id1"))
 		assert.Equal(t, nodeSet[1], readTx.Nodes().Get("id2"))
 		assert.Equal(t, nodeSet[2], readTx.Nodes().Get("id3"))
@@ -219,10 +217,7 @@ func TestStoreNode(t *testing.T) {
 		foundNodes, err = readTx.Nodes().Find(state.ByQuery("id"))
 		assert.NoError(t, err)
 		assert.Len(t, foundNodes, 3)
-
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update.
 	update := &api.Node{
@@ -265,17 +260,15 @@ func TestStoreService(t *testing.T) {
 	s := NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	err := s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		allServices, err := readTx.Services().Find(state.All)
 		assert.NoError(t, err)
 		assert.Empty(t, allServices)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	setupTestStore(t, s)
 
-	err = s.Update(func(tx state.Tx) error {
+	err := s.Update(func(tx state.Tx) error {
 		assert.Equal(t,
 			tx.Services().Create(&api.Service{
 				ID: "id1",
@@ -299,7 +292,7 @@ func TestStoreService(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		assert.Equal(t, serviceSet[0], readTx.Services().Get("id1"))
 		assert.Equal(t, serviceSet[1], readTx.Services().Get("id2"))
 		assert.Equal(t, serviceSet[2], readTx.Services().Get("id3"))
@@ -327,9 +320,7 @@ func TestStoreService(t *testing.T) {
 		foundServices, err = readTx.Services().Find(state.ByServiceMode(api.ServiceModeBatch))
 		assert.NoError(t, err)
 		assert.Len(t, foundServices, 0)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update.
 	err = s.Update(func(tx state.Tx) error {
@@ -394,17 +385,15 @@ func TestStoreNetwork(t *testing.T) {
 	s := NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	err := s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		allNetworks, err := readTx.Networks().Find(state.All)
 		assert.NoError(t, err)
 		assert.Empty(t, allNetworks)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	setupTestStore(t, s)
 
-	err = s.Update(func(tx state.Tx) error {
+	err := s.Update(func(tx state.Tx) error {
 		allNetworks, err := tx.Networks().Find(state.All)
 		assert.NoError(t, err)
 		assert.Len(t, allNetworks, len(networkSet))
@@ -414,7 +403,7 @@ func TestStoreNetwork(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		assert.Equal(t, networkSet[0], readTx.Networks().Get("id1"))
 		assert.Equal(t, networkSet[1], readTx.Networks().Get("id2"))
 		assert.Equal(t, networkSet[2], readTx.Networks().Get("id3"))
@@ -428,9 +417,7 @@ func TestStoreNetwork(t *testing.T) {
 		foundNetworks, err = readTx.Networks().Find(state.ByName("invalid"))
 		assert.NoError(t, err)
 		assert.Len(t, foundNetworks, 0)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	err = s.Update(func(tx state.Tx) error {
 		// Delete
@@ -452,17 +439,15 @@ func TestStoreTask(t *testing.T) {
 	s := NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	err := s.View(func(tx state.ReadTx) error {
+	s.View(func(tx state.ReadTx) {
 		allTasks, err := tx.Tasks().Find(state.All)
 		assert.NoError(t, err)
 		assert.Empty(t, allTasks)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	setupTestStore(t, s)
 
-	err = s.Update(func(tx state.Tx) error {
+	err := s.Update(func(tx state.Tx) error {
 		allTasks, err := tx.Tasks().Find(state.All)
 		assert.NoError(t, err)
 		assert.Len(t, allTasks, len(taskSet))
@@ -472,7 +457,7 @@ func TestStoreTask(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		assert.Equal(t, taskSet[0], readTx.Tasks().Get("id1"))
 		assert.Equal(t, taskSet[1], readTx.Tasks().Get("id2"))
 		assert.Equal(t, taskSet[2], readTx.Tasks().Get("id3"))
@@ -502,9 +487,7 @@ func TestStoreTask(t *testing.T) {
 		foundTasks, err = readTx.Tasks().Find(state.ByServiceID("invalid"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 0)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update.
 	update := &api.Task{
@@ -547,17 +530,15 @@ func TestStoreVolume(t *testing.T) {
 	s := NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	err := s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		allVolumes, err := readTx.Volumes().Find(state.All)
 		assert.NoError(t, err)
 		assert.Empty(t, allVolumes)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	setupTestStore(t, s)
 
-	err = s.Update(func(tx state.Tx) error {
+	err := s.Update(func(tx state.Tx) error {
 		assert.Equal(t,
 			tx.Volumes().Create(&api.Volume{
 				ID: "id1",
@@ -581,7 +562,7 @@ func TestStoreVolume(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = s.View(func(readTx state.ReadTx) error {
+	s.View(func(readTx state.ReadTx) {
 		assert.Equal(t, volumeSet[0], readTx.Volumes().Get("id1"))
 		assert.Equal(t, volumeSet[1], readTx.Volumes().Get("id2"))
 		assert.Equal(t, volumeSet[2], readTx.Volumes().Get("id3"))
@@ -592,9 +573,7 @@ func TestStoreVolume(t *testing.T) {
 		foundVolumes, err = readTx.Volumes().Find(state.ByName("invalid"))
 		assert.NoError(t, err)
 		assert.Len(t, foundVolumes, 0)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update.
 	err = s.Update(func(tx state.Tx) error {
@@ -726,7 +705,7 @@ func TestStoreSnapshot(t *testing.T) {
 	defer cancel()
 	assert.NoError(t, err)
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, nodeSet[0], tx2.Nodes().Get("id1"))
 		assert.Equal(t, nodeSet[1], tx2.Nodes().Get("id2"))
 		assert.Equal(t, nodeSet[2], tx2.Nodes().Get("id3"))
@@ -738,9 +717,7 @@ func TestStoreSnapshot(t *testing.T) {
 		assert.Equal(t, taskSet[0], tx2.Tasks().Get("id1"))
 		assert.Equal(t, taskSet[1], tx2.Tasks().Get("id2"))
 		assert.Equal(t, taskSet[2], tx2.Tasks().Get("id3"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Create node
 	createNode := &api.Node{
@@ -761,11 +738,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, createNode, tx2.Nodes().Get("id4"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update node
 	updateNode := &api.Node{
@@ -786,11 +761,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, updateNode, tx2.Nodes().Get("id3"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	err = s1.Update(func(tx1 state.Tx) error {
 		// Delete node
@@ -802,11 +775,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Nil(t, tx2.Nodes().Get("id1"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Create service
 	createService := &api.Service{
@@ -827,11 +798,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, createService, tx2.Services().Get("id4"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update service
 	updateService := serviceSet[2].Copy()
@@ -846,11 +815,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, updateService, tx2.Services().Get("id3"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	err = s1.Update(func(tx1 state.Tx) error {
 		// Delete service
@@ -862,11 +829,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Nil(t, tx2.Services().Get("id1"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Create task
 	createTask := &api.Task{
@@ -885,11 +850,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, createTask, tx2.Tasks().Get("id4"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	// Update task
 	updateTask := &api.Task{
@@ -907,11 +870,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Equal(t, updateTask, tx2.Tasks().Get("id3"))
-		return nil
 	})
-	assert.NoError(t, err)
 
 	err = s1.Update(func(tx1 state.Tx) error {
 		// Delete task
@@ -922,11 +883,9 @@ func TestStoreSnapshot(t *testing.T) {
 	assert.NoError(t, state.Apply(s2, <-watcher))
 	<-watcher // consume commit event
 
-	err = s2.View(func(tx2 state.ReadTx) error {
+	s2.View(func(tx2 state.ReadTx) {
 		assert.Nil(t, tx2.Tasks().Get("id1"))
-		return nil
 	})
-	assert.NoError(t, err)
 }
 
 func TestFailedTransaction(t *testing.T) {
@@ -961,7 +920,7 @@ func TestFailedTransaction(t *testing.T) {
 	})
 	assert.Error(t, err)
 
-	err = s.View(func(tx state.ReadTx) error {
+	s.View(func(tx state.ReadTx) {
 		foundNodes, err := tx.Nodes().Find(state.All)
 		assert.NoError(t, err)
 		assert.Len(t, foundNodes, 1)
@@ -971,9 +930,7 @@ func TestFailedTransaction(t *testing.T) {
 		foundNodes, err = tx.Nodes().Find(state.ByName("name2"))
 		assert.NoError(t, err)
 		assert.Len(t, foundNodes, 0)
-		return nil
 	})
-	assert.NoError(t, err)
 }
 
 type mockProposer struct {
@@ -1175,21 +1132,19 @@ func TestStoreSaveRestore(t *testing.T) {
 	setupTestStore(t, s1)
 
 	var snapshot *api.StoreSnapshot
-	err := s1.View(func(tx state.ReadTx) error {
+	s1.View(func(tx state.ReadTx) {
 		var err error
 		snapshot, err = s1.Save(tx)
 		assert.NoError(t, err)
-		return nil
 	})
-	assert.NoError(t, err)
 
 	s2 := NewMemoryStore(nil)
 	assert.NotNil(t, s2)
 
-	err = s2.Restore(snapshot)
+	err := s2.Restore(snapshot)
 	assert.NoError(t, err)
 
-	err = s2.View(func(tx state.ReadTx) error {
+	s2.View(func(tx state.ReadTx) {
 		allTasks, err := tx.Tasks().Find(state.All)
 		assert.NoError(t, err)
 		assert.Len(t, allTasks, len(taskSet))
@@ -1217,10 +1172,7 @@ func TestStoreSaveRestore(t *testing.T) {
 		for i := range allServices {
 			assert.Equal(t, allServices[i], serviceSet[i])
 		}
-
-		return nil
 	})
-	assert.NoError(t, err)
 }
 
 const benchmarkNumNodes = 10000
@@ -1309,44 +1261,40 @@ func BenchmarkDeleteNodeTransaction(b *testing.B) {
 func BenchmarkGetNode(b *testing.B) {
 	s, nodeIDs := setupNodes(b, benchmarkNumNodes)
 	b.ResetTimer()
-	_ = s.View(func(tx1 state.ReadTx) error {
+	s.View(func(tx1 state.ReadTx) {
 		for i := 0; i < b.N; i++ {
 			_ = tx1.Nodes().Get(nodeIDs[i%benchmarkNumNodes])
 		}
-		return nil
 	})
 }
 
 func BenchmarkFindAllNodes(b *testing.B) {
 	s, _ := setupNodes(b, benchmarkNumNodes)
 	b.ResetTimer()
-	_ = s.View(func(tx1 state.ReadTx) error {
+	s.View(func(tx1 state.ReadTx) {
 		for i := 0; i < b.N; i++ {
 			_, _ = tx1.Nodes().Find(state.All)
 		}
-		return nil
 	})
 }
 
 func BenchmarkFindNodeByName(b *testing.B) {
 	s, _ := setupNodes(b, benchmarkNumNodes)
 	b.ResetTimer()
-	_ = s.View(func(tx1 state.ReadTx) error {
+	s.View(func(tx1 state.ReadTx) {
 		for i := 0; i < b.N; i++ {
 			_, _ = tx1.Nodes().Find(state.ByName("name" + strconv.Itoa(i)))
 		}
-		return nil
 	})
 }
 
 func BenchmarkFindNodeByQuery(b *testing.B) {
 	s, _ := setupNodes(b, benchmarkNumNodes)
 	b.ResetTimer()
-	_ = s.View(func(tx1 state.ReadTx) error {
+	s.View(func(tx1 state.ReadTx) {
 		for i := 0; i < b.N; i++ {
 			_, _ = tx1.Nodes().Find(state.ByQuery("name" + strconv.Itoa(i)))
 		}
-		return nil
 	})
 }
 
@@ -1380,11 +1328,10 @@ func BenchmarkNodeConcurrency(b *testing.B) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = s.View(func(tx1 state.ReadTx) error {
+			s.View(func(tx1 state.ReadTx) {
 				for i := 0; i < b.N; i++ {
 					_ = tx1.Nodes().Get(nodeIDs[i%benchmarkNumNodes])
 				}
-				return nil
 			})
 		}()
 	}


### PR DESCRIPTION
Viewing the store can't actually fail. The current View method returns
an error which is just a passthrough of the error returned by the
callback. This is convenient for situations that want to pass an error
through, but for most situations, it's just an extra "return nil" in the
callback and an extra error check after View.

This changes View and its callback type not to return errors. In the
cases where a callback needs to signal an error, it can do so by setting
a variable that's visible outside the closure.

Diffstat is:

```
20 files changed, 170 insertions(+), 261 deletions(-)
```

...so I would say this is a net simpification.
