### PR TITLE
Stop allocator when manager shuts down

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -90,7 +90,9 @@ func TestAllocator(t *testing.T) {
 	defer cancel()
 
 	// Start allocator
-	assert.NoError(t, a.Start(context.Background()))
+	go func() {
+		assert.NoError(t, a.Run(context.Background()))
+	}()
 
 	// Now verify if we get network and tasks updated properly
 	n1, err := watchNetwork(t, netWatch)


### PR DESCRIPTION
This missing call could lead to a panic on shutdown when the running
allocator called into the stopped raft store.

Also, convert allocator to use stopChan/doneChan pattern like the rest
of the services, since the race detector was complaining about
cancelling the context from a different goroutine than the one that
created it once the call to Stop was added.

Fixes #457 

cc @LK4D4 @mrjana
