### PR TITLE
dispatcher: disallow invalid or redundant task status updates

### DIFF
--- a/agent/exec/container/runner.go
+++ b/agent/exec/container/runner.go
@@ -145,8 +145,6 @@ func (r *Runner) Wait(pctx context.Context) error {
 	for {
 		select {
 		case event := <-eventq:
-			log.G(ctx).Debugf("%v", event)
-
 			if !r.matchevent(event) {
 				continue
 			}


### PR DESCRIPTION
This adds checks to avoid invalid and redundan task status transitions.
Doing so doesn't address redundant task assignment updates but does help
with possibly bad input.

Signed-off-by: Stephen J Day stephen.day@docker.com
