### PR TITLE
agent: remove agent id from config

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -142,9 +142,11 @@ func (a *Agent) run(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
-		"agent.id": a.config.ID,
-	}))
+	// TODO(stevvooe): Bring this back when we can extract Agent ID from
+	// security configuration.
+	// ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+	// 	"agent.id": a.config.ID,
+	// }))
 
 	log.G(ctx).Debugf("(*Agent).run")
 	defer log.G(ctx).Debugf("(*Agent).run exited")

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -54,7 +54,6 @@ func TestAgentStartStop(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	agent, err := New(&Config{
-		ID:             "test",
 		Executor:       &NoopExecutor{},
 		Managers:       NewManagers("localhost:4949"),
 		SecurityConfig: agentSecurityConfigs[0],

--- a/agent/config.go
+++ b/agent/config.go
@@ -9,9 +9,6 @@ import (
 
 // Config provides values for an Agent.
 type Config struct {
-	// ID is the identifier to be used for the agent.
-	ID string
-
 	// Hostname the name of host for agent instance.
 	Hostname string
 
@@ -27,10 +24,6 @@ type Config struct {
 }
 
 func (c *Config) validate() error {
-	if c.ID == "" {
-		return fmt.Errorf("config: id required")
-	}
-
 	if c.SecurityConfig == nil {
 		return fmt.Errorf("config: SecurityConfig required")
 	}

--- a/cmd/swarmd/agent.go
+++ b/cmd/swarmd/agent.go
@@ -5,7 +5,6 @@ import (
 	"github.com/docker/swarm-v2/agent"
 	"github.com/docker/swarm-v2/agent/exec/container"
 	"github.com/docker/swarm-v2/ca"
-	"github.com/docker/swarm-v2/identity"
 	"github.com/docker/swarm-v2/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -23,16 +22,6 @@ already present, the agent will recover and startup.`,
 			hostname, err := cmd.Flags().GetString("hostname")
 			if err != nil {
 				return err
-			}
-
-			id, err := cmd.Flags().GetString("id")
-			if err != nil {
-				return err
-			}
-
-			if id == "" {
-				log.G(ctx).Debugf("agent: generated random identifier")
-				id = identity.NewID()
 			}
 
 			managerAddrs, err := cmd.Flags().GetStringSlice("manager")
@@ -79,7 +68,6 @@ already present, the agent will recover and startup.`,
 			executor := container.NewExecutor(client)
 
 			ag, err := agent.New(&agent.Config{
-				ID:             id,
 				Hostname:       hostname,
 				Managers:       managers,
 				Executor:       executor,
@@ -101,7 +89,6 @@ already present, the agent will recover and startup.`,
 )
 
 func init() {
-	agentCmd.Flags().String("id", "", "Specifies the identity of the node")
 	agentCmd.Flags().String("engine-addr", "unix:///var/run/docker.sock", "Address of engine instance of agent.")
 	agentCmd.Flags().String("hostname", "", "Override reported agent hostname")
 	agentCmd.Flags().StringSliceP("manager", "m", []string{"localhost:4242"}, "Specify one or more manager addresses")

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -128,7 +128,6 @@ func TestManagerNodeCount(t *testing.T) {
 
 	managers := agent.NewManagers(l.Addr().String())
 	a1, err := agent.New(&agent.Config{
-		ID:             "test1",
 		Hostname:       "hostname1",
 		Managers:       managers,
 		Executor:       &NoopExecutor{},
@@ -136,7 +135,6 @@ func TestManagerNodeCount(t *testing.T) {
 	})
 	require.NoError(t, err)
 	a2, err := agent.New(&agent.Config{
-		ID:             "test2",
 		Hostname:       "hostname2",
 		Managers:       managers,
 		Executor:       &NoopExecutor{},


### PR DESCRIPTION
Agent identification is now done through the x509 certificate. The value
of Config.ID is no longer correct and is not used, except to confuse
readers of log messages. We will add this back into the log messages
when we can make the ID availabe from the security context.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @diogomonica 

Closes #500
