### PR TITLE
agent: better handling of state resolution

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -211,6 +211,10 @@ func (s *session) sendTaskStatus(ctx context.Context, taskID string, status api.
 			},
 		},
 	}); err != nil {
+		if grpc.Code(err) == codes.NotFound {
+			return errTaskUnknown
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Agent task state reporting is slightly cleaned up here for tasks that
are already running. The most interesting change happens directly in the
controller where we handle exited containers on the Wait call. Task
updates are also de-bounced in this changeset, removing a lot of the
warning messages encountered in the controller.

cc @aaronlehmann @LK4D4 @tonistiigi 

Signed-off-by: Stephen J Day stephen.day@docker.com
