### PR TITLE
orchestrator: Don't restart tasks whose desired state is already DEAD

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -219,7 +219,7 @@ func taskRunning(t *api.Task) bool {
 
 // taskDead checks whether a task is not actively running as far as allocator purposes are concerned.
 func taskDead(t *api.Task) bool {
-	return t.DesiredState == api.TaskStateDead && t.Status.State > api.TaskStateRunning
+	return t.DesiredState > api.TaskStateRunning && t.Status.State > api.TaskStateRunning
 }
 
 func (a *Allocator) doTaskAlloc(ctx context.Context, nc *networkContext, ev events.Event) {

--- a/manager/orchestrator/fill.go
+++ b/manager/orchestrator/fill.go
@@ -119,9 +119,9 @@ func (f *FillOrchestrator) Run(ctx context.Context) error {
 					continue
 				}
 				// fill orchestrator needs to inspect when a task has terminated
-				// it should ignore tasks whose DesiredState is dead, which means the
-				// task has been processed
-				if isTaskTerminated(v.Task) && v.Task.DesiredState != api.TaskStateDead {
+				// it should ignore tasks whose DesiredState is past running, which
+				// means the task has been processed
+				if isTaskTerminated(v.Task) && v.Task.DesiredState <= api.TaskStateRunning {
 					f.reconcileServiceOneNode(ctx, v.Task.ServiceID, v.Task.NodeID)
 				}
 			case state.EventDeleteTask:


### PR DESCRIPTION
When reacting to a node change, skip restarting tasks whose desired
state we've already set to DEAD.

Add a check to the tickTasks as well for good measure.

Fixes #515

cc @stevvooe @aluzzardi @dongluochen
