### PR TITLE
Fill service should handle node availability change

### DIFF
--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -31,7 +31,7 @@ func changeNodeAvailability(cmd *cobra.Command, args []string, availability api.
 	spec := &node.Spec
 
 	if spec.Availability == availability {
-		return fmt.Errorf("node %s is already paused", args[0])
+		return errNoChange
 	}
 
 	spec.Availability = availability


### PR DESCRIPTION
In Fill service, node set to drain is equivalent to removing the node, while node back from drain is equivalent to adding the node. 

Fix #524.

Signed-off-by: Dong Chen dongluo.chen@docker.com
