### PR TITLE
manager unit test race work

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -427,7 +427,12 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot) (err erro
 // Before running the main loop, it first starts the raft node based on saved
 // cluster state. If no saved state exists, it starts a single-node cluster.
 func (n *Node) Run(ctx context.Context) error {
-	defer close(n.doneCh)
+	defer func() {
+		close(n.doneCh)
+		if n.leadershipCh != nil {
+			close(n.leadershipCh)
+		}
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
This is yet another attempt to solve races between the manager's Run
and Stop methods.
- For protection against multiple calls to Stop, use a boolean instead
  of setting everything to nil.
- Ignore activity on leadershipCh while the manager is shutting down.
- Block Stop until the manager has finished starting up.

cc @LK4D4 @abronan
