### PR TITLE
Handle multiple services in "swarmctl service remove"

### DIFF
--- a/cmd/swarmctl/service/remove.go
+++ b/cmd/swarmctl/service/remove.go
@@ -23,15 +23,17 @@ var (
 				return err
 			}
 
-			service, err := getService(common.Context(cmd), c, args[0])
-			if err != nil {
-				return err
+			for _, serviceName := range args {
+				service, err := getService(common.Context(cmd), c, serviceName)
+				if err != nil {
+					return err
+				}
+				_, err = c.RemoveService(common.Context(cmd), &api.RemoveServiceRequest{ServiceID: service.ID})
+				if err != nil {
+					return err
+				}
+				fmt.Println(serviceName)
 			}
-			_, err = c.RemoveService(common.Context(cmd), &api.RemoveServiceRequest{ServiceID: service.ID})
-			if err != nil {
-				return err
-			}
-			fmt.Println(args[0])
 			return nil
 		},
 	}


### PR DESCRIPTION
Instead of only using the first argument, it should remove each service
specified in the arguments list.

Fixes #466
