### PR TITLE
dispatcher: Batch task updates

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -356,6 +356,8 @@ func TestTaskUpdate(t *testing.T) {
 	updReq.SessionID = expectedSessionID
 	_, err = gd.Clients[0].UpdateTaskStatus(context.Background(), updReq)
 	assert.NoError(t, err)
+	gd.dispatcherServer.processTaskUpdates()
+
 	gd.Store.View(func(readTx store.ReadTx) {
 		storeTask1 := store.GetTask(readTx, testTask1.ID)
 		assert.NotNil(t, storeTask1)


### PR DESCRIPTION
The dispatcher currently does a raft write for each task status it needs to update. This can become a bottleneck because a raft write can involve significant latency.

This commit changes the dispatcher to maintain a map of outstanding updates. When this map reaches a certain size, or a certain amount of time elapses, the updates are flushed to raft in a batch.

Note that this will cause agents to receive "eventually consistent" task statuses - updates that they make to a task's status won't immediately be reflected in task assignments returned to the agent. By my reading of the agent code, this shouldn't be a problem - the agent seems to explicitly ignore the Status field in tasks in the assignment set sent by the manager - but it would be good if someone could confirm.

Fixes #516

cc @aluzzardi @LK4D4 @stevvooe
