### PR TITLE
scheduler: Fix problem with node updates

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -212,7 +212,10 @@ func (s *Scheduler) createOrUpdateNode(n *api.Node) {
 	if n.Description != nil && n.Description.Resources != nil {
 		resources = *n.Description.Resources
 	}
-	s.nodeHeap.addOrUpdateNode(newNodeInfo(n, map[string]*api.Task{}, resources))
+	nodeInfo := s.nodeHeap.nodeInfo(n.ID)
+	nodeInfo.Node = n
+	nodeInfo.AvailableResources = resources
+	s.nodeHeap.addOrUpdateNode(nodeInfo)
 }
 
 func (s *Scheduler) processPreassignedTasks(ctx context.Context) {

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -124,6 +124,16 @@ func TestScheduler(t *testing.T) {
 	}
 
 	err = store.Update(func(tx state.Tx) error {
+		// Update each node to make sure this doesn't mess up the
+		// scheduler's state.
+		for _, n := range initialNodeSet {
+			assert.NoError(t, tx.Nodes().Update(n))
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	err = store.Update(func(tx state.Tx) error {
 		// Delete the task associated with node 1 so it's now the most lightly
 		// loaded node.
 		assert.NoError(t, tx.Tasks().Delete("id1"))


### PR DESCRIPTION
Node updates were wrongly clearing the list of tasks assigned to that
node.
