### PR TITLE
Migrate codecov settings to codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment:
+  layout: header, changes, diff, sunburst
+coverage:
+  status:
+    patch: false
+    project: true
+      default:
+        enabled: yes
+        threshold: 0
+    changes: false


### PR DESCRIPTION
Hoping the addition of `changes: false` will fix builds incorrectly marked broken.
