### PR TITLE
Add SilenceUsage flag to swarmd command

### DIFF
--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -17,8 +17,9 @@ func main() {
 
 var (
 	mainCmd = &cobra.Command{
-		Use:   os.Args[0],
-		Short: "Run a swarm control process",
+		Use:          os.Args[0],
+		Short:        "Run a swarm control process",
+		SilenceUsage: true,
 		PersistentPreRun: func(cmd *cobra.Command, _ []string) {
 			logrus.SetOutput(os.Stderr)
 			flag, err := cmd.Flags().GetString("log-level")


### PR DESCRIPTION
Without this flag, any error that the manager encounters produces a
usage message. Many errors are not about flags but are about other
things (permissions, failure to connect), etc, so showing a usage
message is not always appropriate. We should trigger a usage message
explicitly when there's an issue parsing a flag, or a missing required
flag.

Fixes: #541
