### PR TITLE
scheduler: Take port allocations into consideration

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -68,3 +68,35 @@ func (f *ResourceFilter) Check(t *api.Task, n *NodeInfo) bool {
 
 	return true
 }
+
+// PortFilter checks that the node has the requested network ports available.
+type PortFilter struct {
+}
+
+// Enabled returns true when the filter is enabled for a given task.
+func (f *PortFilter) Enabled(t *api.Task) bool {
+	c := t.Spec.GetContainer()
+	if c == nil || len(c.ExposedPorts) == 0 {
+		return false
+	}
+	return true
+}
+
+// Check returns true if the task can be scheduled into the given node.
+func (f *PortFilter) Check(t *api.Task, n *NodeInfo) bool {
+	container := t.Spec.GetContainer()
+	if container == nil {
+		return true
+	}
+
+	for _, ep := range container.ExposedPorts {
+		if ep.HostPort == 0 {
+			continue
+		}
+		if _, found := n.ReservedPorts[ep.HostPort]; found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -7,23 +7,64 @@ type NodeInfo struct {
 	*api.Node
 	Tasks              map[string]*api.Task
 	AvailableResources api.Resources
+
+	// There are some corner cases where we may assign multiple tasks that
+	// need the same port to a single node. To deal with this properly,
+	// ReservedPorts has a set of tasks using each port rather than just a
+	// set of ports.
+	ReservedPorts map[uint32]map[string]struct{}
 }
 
 func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api.Resources) NodeInfo {
-	return NodeInfo{
+	nodeInfo := NodeInfo{
 		Node:               n,
-		Tasks:              tasks,
+		Tasks:              make(map[string]*api.Task),
 		AvailableResources: availableResources,
+		ReservedPorts:      make(map[uint32]map[string]struct{}),
 	}
+
+	for _, t := range tasks {
+		nodeInfo.addTask(t)
+	}
+	return nodeInfo
 }
 
 func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
 	if nodeInfo.Tasks != nil {
 		if _, ok := nodeInfo.Tasks[t.ID]; ok {
 			delete(nodeInfo.Tasks, t.ID)
-			reservations := taskReservations(t)
-			nodeInfo.AvailableResources.MemoryBytes += reservations.MemoryBytes
-			nodeInfo.AvailableResources.NanoCPUs += reservations.NanoCPUs
+			specContainer := t.Spec.GetContainer()
+			if specContainer != nil {
+				reservations := taskReservations(specContainer)
+				nodeInfo.AvailableResources.MemoryBytes += reservations.MemoryBytes
+				nodeInfo.AvailableResources.NanoCPUs += reservations.NanoCPUs
+
+				for _, ep := range specContainer.ExposedPorts {
+					if ep.HostPort == 0 {
+						continue
+					}
+					if nodeInfo.ReservedPorts[ep.HostPort] != nil {
+						delete(nodeInfo.ReservedPorts[ep.HostPort], t.ID)
+						if len(nodeInfo.ReservedPorts[ep.HostPort]) == 0 {
+							delete(nodeInfo.ReservedPorts, ep.HostPort)
+						}
+					}
+				}
+			}
+			if statusContainer := t.Status.GetContainer(); statusContainer != nil {
+				for _, ep := range statusContainer.ExposedPorts {
+					if ep.HostPort == 0 {
+						continue
+					}
+					if nodeInfo.ReservedPorts[ep.HostPort] != nil {
+						delete(nodeInfo.ReservedPorts[ep.HostPort], t.ID)
+						if len(nodeInfo.ReservedPorts[ep.HostPort]) == 0 {
+							delete(nodeInfo.ReservedPorts, ep.HostPort)
+						}
+					}
+				}
+
+			}
 			return true
 		}
 	}
@@ -34,18 +75,50 @@ func (nodeInfo *NodeInfo) addTask(t *api.Task) bool {
 	if nodeInfo.Tasks == nil {
 		nodeInfo.Tasks = make(map[string]*api.Task)
 	}
+	specContainer := t.Spec.GetContainer()
 	if _, ok := nodeInfo.Tasks[t.ID]; !ok {
 		nodeInfo.Tasks[t.ID] = t
-		reservations := taskReservations(t)
-		nodeInfo.AvailableResources.MemoryBytes -= reservations.MemoryBytes
-		nodeInfo.AvailableResources.NanoCPUs -= reservations.NanoCPUs
+		if specContainer != nil {
+			reservations := taskReservations(specContainer)
+			nodeInfo.AvailableResources.MemoryBytes -= reservations.MemoryBytes
+			nodeInfo.AvailableResources.NanoCPUs -= reservations.NanoCPUs
+
+			for _, ep := range specContainer.ExposedPorts {
+				if ep.HostPort == 0 {
+					continue
+				}
+				if _, found := nodeInfo.ReservedPorts[ep.HostPort]; !found {
+					nodeInfo.ReservedPorts[ep.HostPort] = make(map[string]struct{})
+				}
+				if _, found := nodeInfo.ReservedPorts[ep.HostPort][t.ID]; !found {
+					nodeInfo.ReservedPorts[ep.HostPort][t.ID] = struct{}{}
+				}
+			}
+		}
 		return true
 	}
-	return false
+
+	// If a task is not new to this node, it could have a new port
+	// allocated.
+	changes := false
+	if statusContainer := t.Status.GetContainer(); statusContainer != nil {
+		for _, ep := range statusContainer.ExposedPorts {
+			if ep.HostPort == 0 {
+				continue
+			}
+			if _, found := nodeInfo.ReservedPorts[ep.HostPort]; !found {
+				nodeInfo.ReservedPorts[ep.HostPort] = make(map[string]struct{})
+			}
+			if _, found := nodeInfo.ReservedPorts[ep.HostPort][t.ID]; !found {
+				changes = true
+				nodeInfo.ReservedPorts[ep.HostPort][t.ID] = struct{}{}
+			}
+		}
+	}
+	return changes
 }
 
-func taskReservations(t *api.Task) (reservations api.Resources) {
-	container := t.Spec.GetContainer()
+func taskReservations(container *api.Container) (reservations api.Resources) {
 	if container != nil && container.Resources != nil && container.Resources.Reservations != nil {
 		reservations = *container.Resources.Reservations
 	}

--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -7,6 +7,7 @@ var (
 		// Always check for readiness first.
 		&ReadyFilter{},
 		&ResourceFilter{},
+		&PortFilter{},
 	}
 )
 

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -195,7 +195,7 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) int {
 		if oldTask != nil {
 			s.deleteTask(ctx, oldTask)
 		}
-		return 0
+		return 1
 	}
 
 	if t.NodeID == "" {
@@ -378,7 +378,7 @@ func (s *Scheduler) scheduleTask(ctx context.Context, t *api.Task) *api.Task {
 	pipeline := NewPipeline(t)
 	n, _ := s.nodeHeap.findMin(pipeline.Process, s.scanAllNodes)
 	if n == nil {
-		log.G(ctx).WithField("task.id", t.ID).Debug("No nodes available to assign tasks to")
+		log.G(ctx).WithField("task.id", t.ID).Debug("No suitable node available for task")
 		return nil
 	}
 


### PR DESCRIPTION
The scheduler should consider host ports as part of scheduling
decisions. It needs to take into account both requested host ports in
Spec, and host ports that were dynamically assigned in Status.

This adds a PortFilter to the scheduler pipeline, and keeps track of
host ports used on each node in the NodeInfo struct.

ping @aluzzardi @mrjana
