### PR TITLE
swarmctl: instances flag must contain a uint64 value

### DIFF
--- a/cmd/swarmctl/service/create.go
+++ b/cmd/swarmctl/service/create.go
@@ -202,5 +202,5 @@ func init() {
 	createCmd.Flags().String("network", "", "Network name")
 	// TODO(aluzzardi): This should be called `service-instances` so that every
 	// orchestrator can have its own flag namespace.
-	createCmd.Flags().Int64("instances", 1, "Number of instances for the service Service")
+	createCmd.Flags().Uint64("instances", 1, "Number of instances for the service Service")
 }

--- a/cmd/swarmctl/service/update.go
+++ b/cmd/swarmctl/service/update.go
@@ -91,7 +91,7 @@ func init() {
 	updateCmd.Flags().StringP("file", "f", "", "Spec to use")
 	// TODO(aluzzardi): This should be called `service-instances` so that every
 	// orchestrator can have its own flag namespace.
-	updateCmd.Flags().Int64("instances", 0, "Number of instances for the service")
+	updateCmd.Flags().Uint64("instances", 0, "Number of instances for the service")
 	// TODO(vieux): This could probably be done in one step
 	updateCmd.Flags().Lookup("instances").DefValue = ""
 }


### PR DESCRIPTION
The type of "instances" was updated, but the flag definition was not
changed accordingly. Fixes an error:

```
Error: trying to get uint64 value of flag of type int64
```
