### PR TITLE
agent: partition certificates under state directory

### DIFF
--- a/cmd/swarmd/agent.go
+++ b/cmd/swarmd/agent.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"path/filepath"
+
 	engineapi "github.com/docker/engine-api/client"
 	"github.com/docker/swarm-v2/agent"
 	"github.com/docker/swarm-v2/agent/exec/container"
@@ -40,6 +42,8 @@ already present, the agent will recover and startup.`,
 				return err
 			}
 
+			certDir := filepath.Join(stateDir, "certificates")
+
 			token, err := cmd.Flags().GetString("token")
 			if err != nil {
 				return err
@@ -55,7 +59,7 @@ already present, the agent will recover and startup.`,
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			securityConfig, err := ca.LoadOrCreateAgentSecurityConfig(ctx, stateDir, token, managerAddr)
+			securityConfig, err := ca.LoadOrCreateAgentSecurityConfig(ctx, certDir, token, managerAddr)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Rather than a flat structure for the state directory, the certificates
now have their own directory. This ensures we can add further state
within the agent in the future.

Signed-off-by: Stephen J Day stephen.day@docker.com
