### PR TITLE
raft: add force-new-cluster switch for disaster recovery in case of loss of quorum

### DIFF
--- a/cmd/swarmd/manager.go
+++ b/cmd/swarmd/manager.go
@@ -22,6 +22,11 @@ var managerCmd = &cobra.Command{
 			return err
 		}
 
+		forceNewCluster, err := cmd.Flags().GetBool("force-new-cluster")
+		if err != nil {
+			return err
+		}
+
 		stateDir, err := cmd.Flags().GetString("state-dir")
 		if err != nil {
 			return err
@@ -42,11 +47,12 @@ var managerCmd = &cobra.Command{
 		}
 
 		m, err := manager.New(&manager.Config{
-			ListenProto:    "tcp",
-			SecurityConfig: securityConfig,
-			ListenAddr:     addr,
-			JoinRaft:       managerAddr,
-			StateDir:       stateDir,
+			ListenProto:     "tcp",
+			SecurityConfig:  securityConfig,
+			ListenAddr:      addr,
+			ForceNewCluster: forceNewCluster,
+			JoinRaft:        managerAddr,
+			StateDir:        stateDir,
 		})
 		if err != nil {
 			return err
@@ -58,4 +64,5 @@ var managerCmd = &cobra.Command{
 func init() {
 	managerCmd.Flags().String("listen-addr", "0.0.0.0:4242", "Listen address")
 	managerCmd.Flags().String("join-cluster", "", "Join cluster with a node at this address")
+	managerCmd.Flags().Bool("force-new-cluster", false, "Force the creation of a new cluster from data directory")
 }

--- a/manager/controlapi/manager_test.go
+++ b/manager/controlapi/manager_test.go
@@ -115,8 +115,8 @@ func TestListManagers(t *testing.T) {
 	}))
 
 	// Restart the 2 nodes
-	nodes[4] = raftutils.RestartNode(t, clockSource, nodes[4], securityConfig)
-	nodes[5] = raftutils.RestartNode(t, clockSource, nodes[5], securityConfig)
+	nodes[4] = raftutils.RestartNode(t, clockSource, nodes[4], securityConfig, false)
+	nodes[5] = raftutils.RestartNode(t, clockSource, nodes[5], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// All the nodes should be reachable again
@@ -169,7 +169,7 @@ func TestListManagers(t *testing.T) {
 
 	// Restart node 1
 	nodes[1].Shutdown()
-	nodes[1] = raftutils.RestartNode(t, clockSource, nodes[1], securityConfig)
+	nodes[1] = raftutils.RestartNode(t, clockSource, nodes[1], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// Ensure that node 1 is not the leader
@@ -278,8 +278,8 @@ func TestRemoveManager(t *testing.T) {
 	)
 
 	// Restart node 2 and node 3
-	nodes[2] = raftutils.RestartNode(t, clockSource, nodes[2], securityConfig)
-	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig)
+	nodes[2] = raftutils.RestartNode(t, clockSource, nodes[2], securityConfig, false)
+	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// Stop node 3 again

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -46,6 +46,10 @@ type Config struct {
 
 	// Top-level state directory
 	StateDir string
+
+	// ForceNewCluster defines if we have to force a new cluster
+	// because we are recovering from a backup data directory.
+	ForceNewCluster bool
 }
 
 // Manager is the cluster manager for Swarm.
@@ -108,11 +112,12 @@ func New(config *Config) (*Manager, error) {
 	raftCfg := raft.DefaultNodeConfig()
 
 	newNodeOpts := raft.NewNodeOptions{
-		Addr:           config.ListenAddr,
-		JoinAddr:       config.JoinRaft,
-		Config:         raftCfg,
-		StateDir:       raftStateDir,
-		TLSCredentials: config.SecurityConfig.ClientTLSCreds,
+		Addr:            config.ListenAddr,
+		JoinAddr:        config.JoinRaft,
+		Config:          raftCfg,
+		StateDir:        raftStateDir,
+		ForceNewCluster: config.ForceNewCluster,
+		TLSCredentials:  config.SecurityConfig.ClientTLSCreds,
 	}
 	raftNode, err := raft.NewNode(context.TODO(), newNodeOpts)
 	if err != nil {

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -290,8 +290,8 @@ func TestCanRemoveMember(t *testing.T) {
 	assert.Equal(t, len(members), 3)
 
 	// Restart node 2 and node 3
-	nodes[2] = raftutils.RestartNode(t, clockSource, nodes[2], securityConfig)
-	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig)
+	nodes[2] = raftutils.RestartNode(t, clockSource, nodes[2], securityConfig, false)
+	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// Removing node 3 should succeed

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -91,6 +91,10 @@ type Node struct {
 	removed     uint32
 	joinAddr    string
 
+	// forceNewCluster is a special flag used to recover from disaster
+	// scenario by pointing to an existing or backed up data directory.
+	forceNewCluster bool
+
 	// snapshotInterval is the number of log messages after which a new
 	// snapshot should be generated.
 	snapshotInterval uint64
@@ -122,6 +126,9 @@ type Node struct {
 type NewNodeOptions struct {
 	// Addr is the address of this node's listener
 	Addr string
+	// ForceNewCluster defines if we have to force a new cluster
+	// because we are recovering from a backup data directory.
+	ForceNewCluster bool
 	// JoinAddr is the cluster to join. May be an empty string to create
 	// a standalone cluster.
 	JoinAddr string
@@ -181,6 +188,7 @@ func NewNode(ctx context.Context, opts NewNodeOptions) (*Node, error) {
 			MaxInflightMsgs: cfg.MaxInflightMsgs,
 			Logger:          cfg.Logger,
 		},
+		forceNewCluster:            opts.ForceNewCluster,
 		snapshotInterval:           1000,
 		logEntriesForSlowFollowers: 500,
 		stopCh:              make(chan struct{}),
@@ -207,7 +215,7 @@ func NewNode(ctx context.Context, opts NewNodeOptions) (*Node, error) {
 		n.sendTimeout = opts.SendTimeout
 	}
 
-	if err := n.loadAndStart(ctx); err != nil {
+	if err := n.loadAndStart(ctx, opts.ForceNewCluster); err != nil {
 		n.ticker.Stop()
 		return nil, err
 	}
@@ -318,7 +326,7 @@ func (n *Node) Run(ctx context.Context) error {
 			// saveToStorage.
 			if !raft.IsEmptySnap(rd.Snapshot) {
 				// Load the snapshot data into the store
-				if err := n.restoreFromSnapshot(rd.Snapshot.Data); err != nil {
+				if err := n.restoreFromSnapshot(rd.Snapshot.Data, n.forceNewCluster); err != nil {
 					n.Config.Logger.Error(err)
 				}
 				n.appliedIndex = rd.Snapshot.Metadata.Index
@@ -1026,4 +1034,102 @@ func (n *Node) SubscribeLeadership() (q chan events.Event, cancel func()) {
 		ch.Close()
 		sink.Close()
 	}
+}
+
+// createConfigChangeEnts creates a series of Raft entries (i.e.
+// EntryConfChange) to remove the set of given IDs from the cluster. The ID
+// `self` is _not_ removed, even if present in the set.
+// If `self` is not inside the given ids, it creates a Raft entry to add a
+// default member with the given `self`.
+func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raftpb.Entry {
+	var ents []raftpb.Entry
+	next := index + 1
+	found := false
+	for _, id := range ids {
+		if id == self {
+			found = true
+			continue
+		}
+		cc := &raftpb.ConfChange{
+			Type:   raftpb.ConfChangeRemoveNode,
+			NodeID: id,
+		}
+		data, err := cc.Marshal()
+		if err != nil {
+			log.G(context.Background()).Panicf("marshal configuration change should never fail: %v", err)
+		}
+		e := raftpb.Entry{
+			Type:  raftpb.EntryConfChange,
+			Data:  data,
+			Term:  term,
+			Index: next,
+		}
+		ents = append(ents, e)
+		next++
+	}
+	if !found {
+		node := &api.Member{RaftID: self}
+		meta, err := node.Marshal()
+		if err != nil {
+			log.G(context.Background()).Panicf("marshal member should never fail: %v", err)
+		}
+		cc := &raftpb.ConfChange{
+			Type:    raftpb.ConfChangeAddNode,
+			NodeID:  self,
+			Context: meta,
+		}
+		data, err := cc.Marshal()
+		if err != nil {
+			log.G(context.Background()).Panicf("marshal configuration change should never fail: %v", err)
+		}
+		e := raftpb.Entry{
+			Type:  raftpb.EntryConfChange,
+			Data:  data,
+			Term:  term,
+			Index: next,
+		}
+		ents = append(ents, e)
+	}
+	return ents
+}
+
+// getIDs returns an ordered set of IDs included in the given snapshot and
+// the entries. The given snapshot/entries can contain two kinds of
+// ID-related entry:
+// - ConfChangeAddNode, in which case the contained ID will be added into the set.
+// - ConfChangeRemoveNode, in which case the contained ID will be removed from the set.
+func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
+	ids := make(map[uint64]bool)
+	if snap != nil {
+		for _, id := range snap.Metadata.ConfState.Nodes {
+			ids[id] = true
+		}
+	}
+	for _, e := range ents {
+		if e.Type != raftpb.EntryConfChange {
+			continue
+		}
+		if snap != nil && e.Index < snap.Metadata.Index {
+			continue
+		}
+		var cc raftpb.ConfChange
+		if err := cc.Unmarshal(e.Data); err != nil {
+			log.G(context.Background()).Panicf("unmarshal configuration change should never fail: %v", err)
+		}
+		switch cc.Type {
+		case raftpb.ConfChangeAddNode:
+			ids[cc.NodeID] = true
+		case raftpb.ConfChangeRemoveNode:
+			delete(ids, cc.NodeID)
+		case raftpb.ConfChangeUpdateNode:
+			// do nothing
+		default:
+			log.G(context.Background()).Panic("ConfChange Type should be either ConfChangeAddNode or ConfChangeRemoveNode!")
+		}
+	}
+	var sids []uint64
+	for id := range ids {
+		sids = append(sids, id)
+	}
+	return sids
 }

--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -28,7 +28,7 @@ func (n *Node) snapDir() string {
 	return filepath.Join(n.StateDir, "snap")
 }
 
-func (n *Node) loadAndStart(ctx context.Context) error {
+func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 	walDir := n.walDir()
 	snapDir := n.snapDir()
 
@@ -74,13 +74,13 @@ func (n *Node) loadAndStart(ctx context.Context) error {
 
 	if snapshot != nil {
 		// Load the snapshot data into the store
-		if err := n.restoreFromSnapshot(snapshot.Data); err != nil {
+		if err := n.restoreFromSnapshot(snapshot.Data, forceNewCluster); err != nil {
 			return err
 		}
 	}
 
 	// Read logs to fully catch up store
-	if err := n.readWAL(ctx, snapshot); err != nil {
+	if err := n.readWAL(ctx, snapshot, forceNewCluster); err != nil {
 		return err
 	}
 
@@ -88,7 +88,7 @@ func (n *Node) loadAndStart(ctx context.Context) error {
 	return nil
 }
 
-func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot) (err error) {
+func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewCluster bool) (err error) {
 	var (
 		walsnap  walpb.Snapshot
 		metadata []byte
@@ -137,6 +137,30 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot) (err erro
 		return fmt.Errorf("error unmarshalling wal metadata: %v", err)
 	}
 	n.Config.ID = raftNode.RaftID
+
+	if forceNewCluster {
+		// discard the previously uncommitted entries
+		for i, ent := range ents {
+			if ent.Index > st.Commit {
+				log.G(context.Background()).Infof("discarding %d uncommitted WAL entries ", len(ents)-i)
+				ents = ents[:i]
+				break
+			}
+		}
+
+		// force append the configuration change entries
+		toAppEnts := createConfigChangeEnts(getIDs(snapshot, ents), uint64(n.Config.ID), st.Term, st.Commit)
+		ents = append(ents, toAppEnts...)
+
+		// force commit newly appended entries
+		err := n.wal.Save(st, toAppEnts)
+		if err != nil {
+			log.G(context.Background()).Fatalf("%v", err)
+		}
+		if len(toAppEnts) != 0 {
+			st.Commit = toAppEnts[len(toAppEnts)-1].Index
+		}
+	}
 
 	if snapshot != nil {
 		if err := n.raftStore.ApplySnapshot(*snapshot); err != nil {
@@ -235,7 +259,7 @@ func (n *Node) doSnapshot() {
 	<-viewStarted
 }
 
-func (n *Node) restoreFromSnapshot(data []byte) error {
+func (n *Node) restoreFromSnapshot(data []byte, forceNewCluster bool) error {
 	var snapshot api.Snapshot
 	if err := snapshot.Unmarshal(data); err != nil {
 		return err
@@ -249,13 +273,16 @@ func (n *Node) restoreFromSnapshot(data []byte) error {
 	}
 
 	n.cluster.Clear()
-	for _, member := range snapshot.Membership.Members {
-		if err := n.registerNode(&api.Member{ID: member.ID, RaftID: member.RaftID, Addr: member.Addr}); err != nil {
-			return err
+
+	if !forceNewCluster {
+		for _, member := range snapshot.Membership.Members {
+			if err := n.registerNode(&api.Member{ID: member.ID, RaftID: member.RaftID, Addr: member.Addr}); err != nil {
+				return err
+			}
 		}
-	}
-	for _, removedMember := range snapshot.Membership.Removed {
-		n.cluster.RemoveMember(removedMember)
+		for _, removedMember := range snapshot.Membership.Removed {
+			n.cluster.RemoveMember(removedMember)
+		}
 	}
 
 	return nil

--- a/manager/state/raft/storage_test.go
+++ b/manager/state/raft/storage_test.go
@@ -180,7 +180,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 	assert.Equal(t, stripMembers(nodes[1].GetMemberlist()), stripMembers(nodes[4].GetMemberlist()))
 
 	// Restart node 3
-	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig)
+	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// Node 3 should know about other nodes, including the new one
@@ -197,7 +197,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 	// Restart node 3 again. It should load the snapshot.
 	nodes[3].Server.Stop()
 	nodes[3].Shutdown()
-	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig)
+	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], securityConfig, false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	assert.Len(t, nodes[3].GetMemberlist(), 5)

--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -261,7 +261,7 @@ func NewJoinNode(t *testing.T, clockSource *fakeclock.FakeClock, join string, se
 }
 
 // RestartNode restarts a raft test node
-func RestartNode(t *testing.T, clockSource *fakeclock.FakeClock, oldNode *TestNode, securityConfig *ca.ManagerSecurityConfig) *TestNode {
+func RestartNode(t *testing.T, clockSource *fakeclock.FakeClock, oldNode *TestNode, securityConfig *ca.ManagerSecurityConfig, forceNewCluster bool) *TestNode {
 	wrappedListener := recycleWrappedListener(oldNode.Listener)
 	serverOpts := []grpc.ServerOption{grpc.Creds(securityConfig.ServerTLSCreds)}
 	s := grpc.NewServer(serverOpts...)
@@ -269,12 +269,13 @@ func RestartNode(t *testing.T, clockSource *fakeclock.FakeClock, oldNode *TestNo
 	cfg := raft.DefaultNodeConfig()
 
 	newNodeOpts := raft.NewNodeOptions{
-		Addr:           oldNode.Address,
-		Config:         cfg,
-		StateDir:       oldNode.StateDir,
-		ClockSource:    clockSource,
-		SendTimeout:    10 * time.Second,
-		TLSCredentials: securityConfig.ClientTLSCreds,
+		Addr:            oldNode.Address,
+		Config:          cfg,
+		StateDir:        oldNode.StateDir,
+		ForceNewCluster: forceNewCluster,
+		ClockSource:     clockSource,
+		SendTimeout:     10 * time.Second,
+		TLSCredentials:  securityConfig.ClientTLSCreds,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Fixes #470 

Using `swarmd manager --force-new-cluster`, we can now create a cluster from scratch with the state directory, voiding the memberlist.

/cc @aaronlehmann @nishanttotla 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
