### PR TITLE
agent/exec/container: remove client from methods

### DIFF
--- a/agent/exec/container/controller_integration_test.go
+++ b/agent/exec/container/controller_integration_test.go
@@ -56,7 +56,7 @@ func TestControllerFlowIntegration(t *testing.T) {
 		},
 	}
 
-	ctlr, err := NewController(client, task)
+	ctlr, err := newController(client, task)
 	assert.NoError(t, err)
 	assert.NotNil(t, ctlr)
 	assert.NoError(t, ctlr.Prepare(ctx))

--- a/agent/exec/container/controller_test.go
+++ b/agent/exec/container/controller_test.go
@@ -246,10 +246,10 @@ func TestControllerRemove(t *testing.T) {
 	assert.NoError(t, ctlr.Remove(ctx))
 }
 
-func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *MockAPIClient, *Controller, *containerConfig, func(t *testing.T)) {
+func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *MockAPIClient, exec.Controller, *containerConfig, func(t *testing.T)) {
 	mocks := gomock.NewController(t)
 	client := NewMockAPIClient(mocks)
-	ctlr, err := NewController(client, task)
+	ctlr, err := newController(client, task)
 	assert.NoError(t, err)
 
 	config, err := newContainerConfig(task)

--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -10,8 +10,6 @@ import (
 )
 
 type executor struct {
-	// TODO(stevvooe): This type needs to become much more sophisticated. It
-	// needs to handle reconnection, errors and authentication.
 	client engineapi.APIClient
 }
 
@@ -78,7 +76,7 @@ func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
 
 // Controller returns a docker container controller.
 func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
-	ctlr, err := NewController(e.client, t)
+	ctlr, err := newController(e.client, t)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/exec/executor.go
+++ b/agent/exec/executor.go
@@ -7,8 +7,6 @@ import (
 
 // Executor provides controllers for tasks.
 type Executor interface {
-	// TODO(stevvooe): Allow instropsection of tasks known by executor.
-
 	// Describe returns the underlying node description.
 	Describe(ctx context.Context) (*api.NodeDescription, error)
 


### PR DESCRIPTION
Rather than distribute client directly in method calls, we set it within
the adapter. This is preparation for better task state management on
startup of the agent.

Signed-off-by: Stephen J Day stephen.day@docker.com
