### PR TITLE
Update the family field correctly for auto subnets

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -434,7 +434,7 @@ func (na *NetworkAllocator) allocatePools(n *api.Network) (map[string]string, er
 		}
 
 		if ipamConfigs == nil {
-			ipamConfigs = append(ipamConfigs, &api.IPAMConfig{})
+			ipamConfigs = append(ipamConfigs, &api.IPAMConfig{Family: api.IPAMConfig_IPV4})
 		}
 	}
 


### PR DESCRIPTION
For networks which are created without a subnets, a default subnet in
ipv4 is auto-generated. The auto-generated IPAM config needs to populate
the address family with the right value which this PR addresses.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
