### PR TITLE
Fixing node inspect output

### DIFF
--- a/cmd/swarmctl/node/inspect.go
+++ b/cmd/swarmctl/node/inspect.go
@@ -46,7 +46,10 @@ func printNodeSummary(node *api.Node) {
 	var pluginTypes []string
 	pluginNamesByType := map[string][]string{}
 	for _, p := range desc.Engine.Plugins {
-		pluginTypes = append(pluginTypes, p.Type)
+		// append to pluginTypes only if not done previously
+		if _, ok := pluginNamesByType[p.Type]; !ok {
+			pluginTypes = append(pluginTypes, p.Type)
+		}
 		pluginNamesByType[p.Type] = append(pluginNamesByType[p.Type], p.Name)
 	}
 


### PR DESCRIPTION
Bug from #585 caused plugin output to repeat in `node inspect`, as below

```
Plugins:
  Network                 : [bridge null host]
  Network                 : [bridge null host]
  Network                 : [bridge null host]
  Volume                  : [local]
```

This PR fixes that, so output looks like

```
Plugins:
  Network                 : [bridge null host]
  Volume                  : [local]
```

Signed-off-by: Nishant Totla nishanttotla@gmail.com
