### PR TITLE
Properly output instances for fill service

### DIFF
--- a/cmd/swarmctl/service/common.go
+++ b/cmd/swarmctl/service/common.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"golang.org/x/net/context"
 
@@ -51,4 +52,11 @@ func getService(ctx context.Context, c api.ControlClient, input string) (*api.Se
 		return rl.Services[0], nil
 	}
 	return rg.Service, nil
+}
+
+func getServiceInstancesTxt(s *api.Service) string {
+	if s.Spec.Mode == api.ServiceModeFill {
+		return "fill"
+	}
+	return strconv.Itoa(int(s.Spec.Instances))
 }

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -21,7 +21,7 @@ func printServiceSummary(service *api.Service) {
 
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", service.ID)
 	common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Annotations.Name)
-	common.FprintfIfNotEmpty(w, "Instances\t: %d\n", service.Spec.Instances)
+	common.FprintfIfNotEmpty(w, "Instances\t: %s\n", getServiceInstancesTxt(service))
 	common.FprintfIfNotEmpty(w, "Strategy\t: %s\n", service.Spec.Strategy)
 	fmt.Fprintln(w, "Template\t")
 	fmt.Fprintln(w, " Container\t")

--- a/cmd/swarmctl/service/list.go
+++ b/cmd/swarmctl/service/list.go
@@ -50,11 +50,11 @@ var (
 						}
 					}
 
-					fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 						s.ID,
 						spec.Annotations.Name,
 						reference,
-						s.Spec.Instances,
+						getServiceInstancesTxt(s),
 					)
 				}
 


### PR DESCRIPTION
Instances is ignored for `fill` service so we shouldn't use its value. This change set `instances` in `swarmctl svc ls` and `swarmctl svc inspect` to keyword `fill`. 

```
dchen@vm2:~/go/src/github.com/docker/swarm-v2/cmd/swarmctl/service$ swarmctl svc ls
ID                         Name      Image                    Instances
--                         ----      -----                    ---------
cbzt33x4fcy5w6dubj4elxsyk  ping      alpine                   2
dhh1877hli26eyath0j3g8oqz  cadvisor  google/cadvisor:v0.22.0  fill
```

cc @aaronlehmann @aluzzardi .

Signed-off-by: Dong Chen dongluo.chen@docker.com
