### PR TITLE
Remove a channel close that can panic

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -367,7 +367,6 @@ func (n *Node) Run(ctx context.Context) error {
 			// send back an error to the caller to start
 			// the shutdown process.
 			if n.mustStop() {
-				close(n.stopCh)
 				return ErrMemberRemoved
 			}
 


### PR DESCRIPTION
This channel close can panic if a different goroutine calls Shutdown at
the same time. The close is redundant anyway - the caller of Run will
call Shutdown on an error. Remove it.
