### PR TITLE
Don't apply restart delay to replacement tasks for drained nodes

### DIFF
--- a/manager/orchestrator/fill.go
+++ b/manager/orchestrator/fill.go
@@ -334,7 +334,7 @@ func (f *FillOrchestrator) restartTask(ctx context.Context, taskID string, servi
 		if service == nil {
 			return nil
 		}
-		return f.restarts.Restart(ctx, tx, service, *t)
+		return f.restarts.Restart(ctx, tx, service, *t, false)
 	})
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("FillOrchestrator: restartTask transaction failed")

--- a/manager/orchestrator/orchestrator.go
+++ b/manager/orchestrator/orchestrator.go
@@ -18,7 +18,7 @@ type Orchestrator struct {
 	store *store.MemoryStore
 
 	reconcileServices map[string]*api.Service
-	restartTasks      map[string]struct{}
+	restartTasks      map[string]restartTask
 
 	// stopChan signals to the state machine to stop running.
 	stopChan chan struct{}
@@ -29,6 +29,13 @@ type Orchestrator struct {
 	restarts *RestartSupervisor
 }
 
+// restartTask contains information about a task that needs to be restarted.
+type restartTask struct {
+	// drained is set to true if the task is being restarted because the
+	// node it was assigned to was drained.
+	drained bool
+}
+
 // New creates a new orchestrator.
 func New(store *store.MemoryStore) *Orchestrator {
 	return &Orchestrator{
@@ -36,7 +43,7 @@ func New(store *store.MemoryStore) *Orchestrator {
 		stopChan:          make(chan struct{}),
 		doneChan:          make(chan struct{}),
 		reconcileServices: make(map[string]*api.Service),
-		restartTasks:      make(map[string]struct{}),
+		restartTasks:      make(map[string]restartTask),
 		updater:           NewUpdateSupervisor(store),
 		restarts:          NewRestartSupervisor(store),
 	}

--- a/manager/orchestrator/restart.go
+++ b/manager/orchestrator/restart.go
@@ -29,7 +29,7 @@ func NewRestartSupervisor(store *store.MemoryStore) *RestartSupervisor {
 
 // Restart initiates a new task to replace t if appropriate under the service's
 // restart policy.
-func (r *RestartSupervisor) Restart(ctx context.Context, tx store.Tx, service *api.Service, t api.Task) error {
+func (r *RestartSupervisor) Restart(ctx context.Context, tx store.Tx, service *api.Service, t api.Task, drained bool) error {
 	t.DesiredState = api.TaskStateDead
 	err := store.UpdateTask(tx, &t)
 	if err != nil {
@@ -57,7 +57,7 @@ func (r *RestartSupervisor) Restart(ctx context.Context, tx store.Tx, service *a
 		return nil
 	}
 
-	if service.Spec.Restart != nil && service.Spec.Restart.Delay != 0 {
+	if !drained && service.Spec.Restart != nil && service.Spec.Restart.Delay != 0 {
 		restartTask.DesiredState = api.TaskStateReady
 	}
 	if err := store.CreateTask(tx, restartTask); err != nil {


### PR DESCRIPTION
When draining a node, we want the replacement tasks to start
immediately, not after the restart delay.

Keeping the old task and new task from being in the running state at the
same time will be handled as part of #488.

Fixes #577

cc @aluzzardi @dongluochen
