### PR TITLE
manager: Keep waiting for leader

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -293,12 +293,10 @@ func (m *Manager) Run(ctx context.Context) error {
 		errServe <- m.server.Serve(m.listener)
 	}()
 
-	leaderCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	if err := raft.WaitForLeader(leaderCtx, m.raftNode); err != nil {
+	if err := raft.WaitForLeader(ctx, m.raftNode); err != nil {
 		m.server.Stop()
 		return err
 	}
-	cancel()
 	close(m.started)
 	return <-errServe
 }


### PR DESCRIPTION
The manager has a 10 second timeout on resolving the cluster's leader.
This will time out if there's no quorum, and the manager process will
exit. I think this timeout is incorrect, because if no quorum exists, we
should wait for enough managers to be available, instead of exiting.

cc @LK4D4 @abronan
