### PR TITLE
codecov.yml: Try setting "target" to 0

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
     project:
       default:
         enabled: yes
-        threshold: 0
+        target: 0
     changes: false


### PR DESCRIPTION
I don't want PRs to show up as failing test because the code coverage
decreased by some miniscule amount. This is an attempt to make codecov's
GitHub status notification not influence the PR status.
