### PR TITLE
Adding message for cert acceptance

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -115,7 +115,7 @@ func (rca *RootCA) IssueAndSaveNewCertificates(ctx context.Context, paths CertPa
 			return nil, err
 		}
 
-		log.Debugf("downloaded TLS credentials with role: %s and from %s.", role, remoteAddr)
+		log.Infof("Downloaded TLS credentials with role %s from %s.", role, remoteAddr)
 	}
 
 	// Ensure directory exists


### PR DESCRIPTION
When agent joins the cluster, it seems to hang with the message

```
INFO[0000] Waiting for TLS certificate to be issued...
```

even when the cert is issued. This PR adds a message for when cert is successfully issued (for both manager and agent)

```
INFO[0000] Waiting for TLS certificate to be issued...
INFO[0000] downloaded TLS credentials with role: swarm-worker and from localhost:4242
```

Signed-off-by: Nishant Totla nishanttotla@gmail.com
