### PR TITLE
Scheduler filters out nodes without the correct volume and/or network plugin

### DIFF
--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -8,6 +8,7 @@ var (
 		&ReadyFilter{},
 		&ResourceFilter{},
 		&PortFilter{},
+		&PluginFilter{},
 	}
 )
 


### PR DESCRIPTION
Added VolumePluginFilter that filters out nodes that don't have the volume plugins required by a task.
CC: @aaronlehmann @aluzzardi 

Signed-off-by: amitshukla amit.shukla@gmail.com
