### PR TITLE
Advertise IP address associated with default route by default

### DIFF
--- a/cmd/swarmd/manager.go
+++ b/cmd/swarmd/manager.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"net"
 	"path/filepath"
 
 	"github.com/docker/swarm-v2/ca"
@@ -17,6 +19,13 @@ var managerCmd = &cobra.Command{
 		addr, err := cmd.Flags().GetString("listen-addr")
 		if err != nil {
 			return err
+		}
+		addrHost, _, err := net.SplitHostPort(addr)
+		if err == nil {
+			ip := net.ParseIP(addrHost)
+			if ip != nil && (ip.IsUnspecified() || ip.IsLoopback()) {
+				fmt.Println("Warning: Specifying a valid address with --listen-addr may be necessary for other managers to reach this one.")
+			}
 		}
 
 		managerAddr, err := cmd.Flags().GetString("join-cluster")


### PR DESCRIPTION
If the admin does not provide a specific --listen-addr value, use the
system's IP address associated with its default route as the address to
hand out to raft peers and agents. This is not guaranteed to be correct,
but it's a much better default than 0.0.0.0, which will never work
outside the same system.

Note that this does not affect the address we actually bind the listener
to. If the --listen-addr flag is left using the default 0.0.0.0 address,
we'll still bind to 0.0.0.0, but have a useful IP to hand out to peers.

Add a warning when starting a manger without specifying --listen-addr.

Fixes #364

cc @abronan
