### PR TITLE
raft: change 'incorrect cluster state' message to 'no elected leader'

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -2,7 +2,6 @@ package raft
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"math/rand"
 	"strconv"
@@ -53,6 +52,8 @@ var (
 	ErrCannotRemoveMember = errors.New("raft: member cannot be removed, because removing it may result in loss of quorum")
 	// ErrMemberRemoved is thrown when a node was removed from the cluster
 	ErrMemberRemoved = errors.New("raft: member was removed from the cluster")
+	// ErrNoClusterLeader is thrown when the cluster has no elected leader
+	ErrNoClusterLeader = errors.New("raft: no elected cluster leader")
 )
 
 // LeadershipState indicates whether the node is a leader or follower.
@@ -591,7 +592,7 @@ func (n *Node) LeaderAddr() (string, error) {
 	ms := n.cluster.Members()
 	l := ms[n.Leader()]
 	if l == nil {
-		return "", fmt.Errorf("incorrect cluster state")
+		return "", ErrNoClusterLeader
 	}
 	return l.Addr, nil
 }


### PR DESCRIPTION
This is kind of an OCD change but when messing up with my cluster I encounter this message a lot.

The message states `incorrect cluster state` which can be confusing. The right message imho should be `no elected leader`, to emphasize that no action is permitted until a leader is elected rather than worrying the user about a potential corrupted state.

/cc @aaronlehmann @LK4D4 

Signed-off-by: Alexandre Beslic alexandre.beslic@gmail.com
