### PR TITLE
orchestrator: Set desired state to "shutdown" rather than "dead"

### DIFF
--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -189,9 +189,9 @@ func TestDrain(t *testing.T) {
 	}()
 
 	// id2, id3, and id5 should be killed immediately
-	deletion1 := watchDeadTask(t, watch)
-	deletion2 := watchDeadTask(t, watch)
-	deletion3 := watchDeadTask(t, watch)
+	deletion1 := watchShutdownTask(t, watch)
+	deletion2 := watchShutdownTask(t, watch)
+	deletion3 := watchShutdownTask(t, watch)
 
 	assert.Regexp(t, "id(2|3|5)", deletion1.ID)
 	assert.Regexp(t, "id(2|3|5)", deletion1.NodeID)
@@ -210,7 +210,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	deletion4 := watchDeadTask(t, watch)
+	deletion4 := watchShutdownTask(t, watch)
 	assert.Equal(t, "newtask", deletion4.ID)
 	assert.Equal(t, "id2", deletion4.NodeID)
 
@@ -223,7 +223,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	deletion5 := watchDeadTask(t, watch)
+	deletion5 := watchShutdownTask(t, watch)
 	assert.Equal(t, "id4", deletion5.ID)
 	assert.Equal(t, "id4", deletion5.NodeID)
 
@@ -234,7 +234,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	deletion6 := watchDeadTask(t, watch)
+	deletion6 := watchShutdownTask(t, watch)
 	assert.Equal(t, "id1", deletion6.ID)
 	assert.Equal(t, "id1", deletion6.NodeID)
 }

--- a/manager/orchestrator/fill.go
+++ b/manager/orchestrator/fill.go
@@ -343,12 +343,12 @@ func (f *FillOrchestrator) restartTask(ctx context.Context, taskID string, servi
 }
 
 func (f *FillOrchestrator) removeTask(ctx context.Context, batch *store.Batch, t *api.Task) {
-	// set existing task DesiredState to TaskStateDead
+	// set existing task DesiredState to TaskStateShutdown
 	// TODO(aaronl): optimistic update?
 	err := batch.Update(func(tx store.Tx) error {
 		t = store.GetTask(tx, t.ID)
 		if t != nil {
-			t.DesiredState = api.TaskStateDead
+			t.DesiredState = api.TaskStateShutdown
 			return store.UpdateTask(tx, t)
 		}
 		return nil

--- a/manager/orchestrator/fill_test.go
+++ b/manager/orchestrator/fill_test.go
@@ -105,7 +105,7 @@ func TestDeleteNode(t *testing.T) {
 
 	deleteNode(t, store, node1)
 	// task should be set to dead
-	observedTask := watchDeadTask(t, watch)
+	observedTask := watchShutdownTask(t, watch)
 	assert.Equal(t, observedTask.Annotations.Name, "name1")
 	assert.Equal(t, observedTask.NodeID, "id1")
 }
@@ -128,7 +128,7 @@ func TestNodeAvailability(t *testing.T) {
 	updateNodeAvailability(t, store, node1, api.NodeAvailabilityDrain)
 
 	// task should be set to dead
-	observedTask1 := watchDeadTask(t, watch)
+	observedTask1 := watchShutdownTask(t, watch)
 	assert.Equal(t, observedTask1.Annotations.Name, "name1")
 	assert.Equal(t, observedTask1.NodeID, "id1")
 

--- a/manager/orchestrator/orchestrator_test.go
+++ b/manager/orchestrator/orchestrator_test.go
@@ -122,11 +122,11 @@ func TestOrchestrator(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	observedDeletion1 := watchDeadTask(t, watch)
+	observedDeletion1 := watchShutdownTask(t, watch)
 	assert.Equal(t, observedDeletion1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion1.Annotations.Name, "name2")
 
-	observedDeletion2 := watchDeadTask(t, watch)
+	observedDeletion2 := watchShutdownTask(t, watch)
 	assert.Equal(t, observedDeletion2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion2.Annotations.Name, "name2")
 
@@ -256,11 +256,11 @@ func watchTaskUpdate(t *testing.T, watch chan events.Event) *api.Task {
 	}
 }
 
-func watchDeadTask(t *testing.T, watch chan events.Event) *api.Task {
+func watchShutdownTask(t *testing.T, watch chan events.Event) *api.Task {
 	for {
 		select {
 		case event := <-watch:
-			if task, ok := event.(state.EventUpdateTask); ok && task.Task.DesiredState == api.TaskStateDead {
+			if task, ok := event.(state.EventUpdateTask); ok && task.Task.DesiredState == api.TaskStateShutdown {
 				return task.Task
 			}
 			if _, ok := event.(state.EventCreateTask); ok {

--- a/manager/orchestrator/restart.go
+++ b/manager/orchestrator/restart.go
@@ -48,7 +48,7 @@ func NewRestartSupervisor(store *store.MemoryStore) *RestartSupervisor {
 // Restart initiates a new task to replace t if appropriate under the service's
 // restart policy.
 func (r *RestartSupervisor) Restart(ctx context.Context, tx store.Tx, service *api.Service, t api.Task) error {
-	t.DesiredState = api.TaskStateDead
+	t.DesiredState = api.TaskStateShutdown
 	err := store.UpdateTask(tx, &t)
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to set task desired state to dead")

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -60,7 +60,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 
 	// Fail the first task. Confirm that it gets restarted.
 	updatedTask1 := observedTask1.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
 		return nil
@@ -77,7 +77,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 
 	// Mark the second task as completed. Confirm that it gets restarted.
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateCompleted}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateCompleted}
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
 		return nil
@@ -143,7 +143,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	// Fail the first task. Confirm that it gets restarted.
 	updatedTask1 := observedTask1.Copy()
 	updatedTask1.Status.TerminalState = api.TaskStateFailed
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
 		return nil
@@ -160,7 +160,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 
 	// Mark the second task as completed. Confirm that it does not get restarted.
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateCompleted}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateCompleted}
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
 		return nil
@@ -229,7 +229,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	// Fail the first task. Confirm that it does not get restarted.
 	updatedTask1 := observedTask1.Copy()
 	updatedTask1.Status.TerminalState = api.TaskStateFailed
-	updatedTask1.Status.State = api.TaskStateDead
+	updatedTask1.Status.State = api.TaskStateShutdown
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
 		return nil
@@ -249,7 +249,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 
 	// Mark the second task as completed. Confirm that it does not get restarted.
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateCompleted}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateCompleted}
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
 		return nil
@@ -317,7 +317,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 
 	// Fail the first task. Confirm that it gets restarted.
 	updatedTask1 := observedTask1.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before := time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
@@ -399,7 +399,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 
 	// Fail the first task. Confirm that it gets restarted.
 	updatedTask1 := observedTask1.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before := time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
@@ -432,7 +432,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 
 	// Fail the second task. Confirm that it gets restarted.
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
@@ -458,7 +458,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 
 	// Fail the first instance again. It should not be restarted.
 	updatedTask1 = observedTask3.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
@@ -528,7 +528,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 
 	// Fail the first task. Confirm that it gets restarted.
 	updatedTask1 := observedTask1.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before := time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
@@ -561,7 +561,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 
 	// Fail the second task. Confirm that it gets restarted.
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
@@ -587,7 +587,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 
 	// Fail the first instance again. It should not be restarted.
 	updatedTask1 = observedTask3.Copy()
-	updatedTask1.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask1.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
@@ -610,7 +610,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	// Fail the second instance again. It should get restarted because
 	// enough time has elapsed since the last restarts.
 	updatedTask2 = observedTask5.Copy()
-	updatedTask2.Status = api.TaskStatus{State: api.TaskStateDead, TerminalState: api.TaskStateFailed}
+	updatedTask2.Status = api.TaskStatus{State: api.TaskStateShutdown, TerminalState: api.TaskStateFailed}
 	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))

--- a/manager/orchestrator/services.go
+++ b/manager/orchestrator/services.go
@@ -148,7 +148,7 @@ func (o *Orchestrator) removeTasks(ctx context.Context, batch *store.Batch, serv
 			// TODO(aaronl): optimistic update?
 			t = store.GetTask(tx, t.ID)
 			if t != nil {
-				t.DesiredState = api.TaskStateDead
+				t.DesiredState = api.TaskStateShutdown
 				return store.UpdateTask(tx, t)
 			}
 			return nil

--- a/manager/orchestrator/task_reaper_test.go
+++ b/manager/orchestrator/task_reaper_test.go
@@ -75,11 +75,11 @@ func TestTaskHistory(t *testing.T) {
 
 	// Fail both tasks. They should both get restarted.
 	updatedTask1 := observedTask1.Copy()
-	updatedTask1.Status.State = api.TaskStateDead
+	updatedTask1.Status.State = api.TaskStateShutdown
 	updatedTask1.Status.TerminalState = api.TaskStateFailed
 	updatedTask1.Annotations = api.Annotations{Name: "original"}
 	updatedTask2 := observedTask2.Copy()
-	updatedTask2.Status.State = api.TaskStateDead
+	updatedTask2.Status.State = api.TaskStateShutdown
 	updatedTask2.Status.TerminalState = api.TaskStateFailed
 	updatedTask2.Annotations = api.Annotations{Name: "original"}
 	err = s.Update(func(tx store.Tx) error {
@@ -106,10 +106,10 @@ func TestTaskHistory(t *testing.T) {
 	// Fail these replacement tasks. Since TaskHistory is set to 2, this
 	// should cause the oldest tasks for each instance to get deleted.
 	updatedTask3 := observedTask3.Copy()
-	updatedTask3.Status.State = api.TaskStateDead
+	updatedTask3.Status.State = api.TaskStateShutdown
 	updatedTask3.Status.TerminalState = api.TaskStateFailed
 	updatedTask4 := observedTask4.Copy()
-	updatedTask4.Status.State = api.TaskStateDead
+	updatedTask4.Status.State = api.TaskStateShutdown
 	updatedTask4.Status.TerminalState = api.TaskStateFailed
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask3))
@@ -120,9 +120,9 @@ func TestTaskHistory(t *testing.T) {
 	deletedTask1 := watchTaskDelete(t, watch)
 	deletedTask2 := watchTaskDelete(t, watch)
 
-	assert.Equal(t, api.TaskStateDead, deletedTask1.Status.State)
+	assert.Equal(t, api.TaskStateShutdown, deletedTask1.Status.State)
 	assert.Equal(t, "original", deletedTask1.Annotations.Name)
-	assert.Equal(t, api.TaskStateDead, deletedTask2.Status.State)
+	assert.Equal(t, api.TaskStateShutdown, deletedTask2.Status.State)
 	assert.Equal(t, "original", deletedTask2.Annotations.Name)
 
 	var foundTasks []*api.Task

--- a/manager/orchestrator/updater.go
+++ b/manager/orchestrator/updater.go
@@ -179,7 +179,7 @@ func (u *Updater) updateTask(ctx context.Context, original, updated *api.Task) e
 	// Atomically create the updated task and bring down the old one.
 	err := u.store.Update(func(tx store.Tx) error {
 		t := store.GetTask(tx, original.ID)
-		t.DesiredState = api.TaskStateDead
+		t.DesiredState = api.TaskStateShutdown
 		if err := store.UpdateTask(tx, t); err != nil {
 			return err
 		}

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -158,7 +158,7 @@ func (s *Scheduler) enqueue(t *api.Task) {
 func (s *Scheduler) createTask(ctx context.Context, t *api.Task) int {
 	// Ignore all tasks that have not reached ALLOCATED
 	// state, and tasks that no longer consume resources.
-	if t.Status.State < api.TaskStateAllocated || t.Status.State >= api.TaskStateDead {
+	if t.Status.State < api.TaskStateAllocated || t.Status.State > api.TaskStateRunning {
 		return 0
 	}
 
@@ -194,7 +194,7 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) int {
 
 	// Ignore all tasks that have not reached ALLOCATED
 	// state, and tasks that no longer consume resources.
-	if t.Status.State >= api.TaskStateDead {
+	if t.Status.State > api.TaskStateRunning {
 		if oldTask != nil {
 			s.deleteTask(ctx, oldTask)
 		}

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -588,7 +588,7 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 	err = s.Update(func(tx store.Tx) error {
 		// The task becomes dead
 		updatedTask := store.GetTask(tx, bigTask1.ID)
-		updatedTask.Status.State = api.TaskStateDead
+		updatedTask.Status.State = api.TaskStateShutdown
 		return store.UpdateTask(tx, updatedTask)
 	})
 	assert.NoError(t, err)
@@ -714,7 +714,7 @@ func TestSchedulerPortConstraint(t *testing.T) {
 	// Kill original task
 	err = s.Update(func(tx store.Tx) error {
 		updatedTask := store.GetTask(tx, "dynamic")
-		updatedTask.Status.State = api.TaskStateDead
+		updatedTask.Status.State = api.TaskStateShutdown
 		assert.NoError(t, store.UpdateTask(tx, updatedTask))
 		return nil
 	})


### PR DESCRIPTION
When we want a task to stop running, set its desired state to "shutdown"
instead of "dead" so that the container is still available for analysis.
This makes it much easier to debug things like crash loops or incorrect
arguments to a process.

The number of containers to keep around per instance can be controlled
with TaskHistoryRetentionLimit. When this limit is exceeded, the oldest
tasks will be deleted from raft, and therefore from the assignment set
that the agent receives. When old tasks disappear from the assignment
set, the agent will remove their containers.

cc @aluzzardi
