### PR TITLE
agent: Don't remove tasks from local task map until they disppear from the assignment list

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -339,6 +339,11 @@ func (a *Agent) handleTaskAssignment(ctx context.Context, tasks []*api.Task) err
 		if err := a.removeTask(ctx, task); err != nil {
 			log.G(ctx).WithError(err).Error("removing task failed")
 		}
+
+		delete(a.controllers, id)
+		delete(a.tasks, id)
+		delete(a.shutdown, id)
+		delete(a.remove, id)
 	}
 
 	return nil
@@ -500,12 +505,6 @@ func (a *Agent) updateStatus(ctx context.Context, report taskStatusReport) (api.
 		api.TaskStateRemove:
 		delete(a.shutdown, report.taskID) // cleanup shutdown entry
 	case api.TaskStateDead:
-		// once a task is dead, we remove all resources associated with it.
-		delete(a.controllers, report.taskID)
-		delete(a.tasks, report.taskID)
-		delete(a.shutdown, report.taskID)
-		delete(a.remove, report.taskID)
-
 		return api.TaskStatus{}, errTaskDead
 	}
 


### PR DESCRIPTION
Previously, we were removing tasks from this map in updateStatus once
the tasks reached "dead". The problem with this is that the tasks can
still be present in the assignment list, and they will look like new
tasks that the agent needs to start running. Thus the agent may start a
task that replaces one it was supposed to kill.

By removing this map entry when the task is removed from the assignment
set, it won't be possible to unintentionally restart the task.

cc @stevvooe @tonistiigi
