### PR TITLE
agent/exec/container: correctly pass command arguments

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -85,15 +85,28 @@ func (c *containerConfig) ephemeralDirs() map[string]struct{} {
 }
 
 func (c *containerConfig) config() *enginecontainer.Config {
-	return &enginecontainer.Config{
+	config := &enginecontainer.Config{
 		User:         c.spec().User,
-		Cmd:          c.spec().Command, // TODO(stevvooe): Fall back to entrypoint+args
 		Env:          c.spec().Env,
 		WorkingDir:   c.spec().Dir,
 		Image:        c.image(),
 		ExposedPorts: c.exposedPorts(),
 		Volumes:      c.ephemeralDirs(),
 	}
+
+	if len(c.spec().Command) > 1 {
+		// If Command is provided, we replace the whole invocation with Command
+		// by replacing Entrypoint and specifying Cmd. Args is ignored in this
+		// case.
+		config.Entrypoint = append(config.Entrypoint, c.spec().Command[0])
+		config.Cmd = append(config.Cmd, c.spec().Command[1:]...)
+	} else if len(c.spec().Args) > 0 {
+		// In this case, we assume the image has an Entrypoint and Args
+		// specifies the arguments for that entrypoint.
+		config.Cmd = c.spec().Args
+	}
+
+	return config
 }
 
 func (c *containerConfig) exposedPorts() map[nat.Port]struct{} {


### PR DESCRIPTION
In the ContainerSpec, we've defined the runtime arguments as Command and
Args since this is a more familiar concept outside of the Docker world.
It also provides better behavior in that it is clear when arguments are
passed to an Entrypoint. We do this by ensuring that only Args are
passed to an Entrypoint. If Command is defined, both Entrypoint and Cmd
are replaced on the container to allow one to completely ignore the
entrypoint and run whatever is desired.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @aluzzardi @vieux @tonistiigi 
