### PR TITLE
Add overlay by default into the node description

### DIFF
--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -38,7 +38,9 @@ func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
 	}
 
 	addPlugins("Volume", info.Plugins.Volume)
-	addPlugins("Network", info.Plugins.Network)
+	// Add builtin driver "overlay" (the only builtin multi-host driver) to
+	// the plugin list by default.
+	addPlugins("Network", append([]string{"overlay"}, info.Plugins.Network...))
 	addPlugins("Authorization", info.Plugins.Authorization)
 
 	// parse []string labels into a map[string]string


### PR DESCRIPTION
Since overlay driver is a builtin driver and would not show up as a
plugin it needs to be added by default. This problem does not exist for
volumes as there are no builtin volume drivers.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com

/cc @amitshukla 
