### PR TITLE
raft: wait for 10 seconds for leader on obtaining address

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -610,6 +610,11 @@ func (n *Node) ResolveAddress(ctx context.Context, msg *api.ResolveAddressReques
 func (n *Node) LeaderAddr() (string, error) {
 	n.stopMu.RLock()
 	defer n.stopMu.RUnlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := WaitForLeader(ctx, n); err != nil {
+		return "", ErrNoClusterLeader
+	}
 	if n.Node == nil {
 		return "", ErrStopped
 	}


### PR DESCRIPTION
It should allow clients to not handle errors on initial join or reelection.
ping @tonistiigi @aaronlehmann 
