### PR TITLE
Fix container command parsing

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -98,7 +98,7 @@ func (c *containerConfig) config() *enginecontainer.Config {
 		Volumes:      c.ephemeralDirs(),
 	}
 
-	if len(c.spec().Command) > 1 {
+	if len(c.spec().Command) > 0 {
 		// If Command is provided, we replace the whole invocation with Command
 		// by replacing Entrypoint and specifying Cmd. Args is ignored in this
 		// case.


### PR DESCRIPTION
Previously command with a single element was being ignored.

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
