### PR TITLE
agent: Consider removal successful if unknown container.

### DIFF
--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -234,6 +234,10 @@ func (r *controller) Remove(ctx context.Context) error {
 
 	// It may be necessary to shut down the task before removing it.
 	if err := r.Shutdown(ctx); err != nil {
+		if isUnknownContainer(err) {
+			return nil
+		}
+
 		// This may fail if the task was already shut down.
 		log.G(ctx).WithError(err).Debug("shutdown failed on removal")
 	}


### PR DESCRIPTION
I noticed that when a container moved into `REJECTED` state (invalid image), the agent would keep trying removing it.

With an invalid image the problem got really nasty: the orchestrator would try re-starting that same task again over and over again, and the agent would pile up removal attempts.

/cc @stevvooe 
