### PR TITLE
agent: Fix concurrent remove.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -372,7 +372,6 @@ func (a *Agent) handleTaskRemoved(id string) {
 	delete(a.controllers, id)
 	delete(a.tasks, id)
 	delete(a.shutdown, id)
-	delete(a.remove, id)
 }
 
 func (a *Agent) unblockTaskStatusReport(ctx context.Context, session *session, report taskStatusReport) error {


### PR DESCRIPTION
There's no point to remove the task from `a.remove` since the removal
goroutine is already taking care of that.

Fixes #710

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
