### PR TITLE
Add constrained scheduler benchmarks

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -92,9 +92,12 @@ func (f *PluginFilter) Check(t *api.Task, n *NodeInfo) bool {
 	nodePlugins := n.Description.Engine.Plugins
 
 	// Check if all volume plugins required by task are installed on node
-	for _, tv := range t.GetContainer().Volumes {
-		if !f.pluginExistsOnNode("Volume", tv.Spec.DriverConfiguration.Name, nodePlugins) {
-			return false
+	container := t.GetContainer()
+	if container != nil {
+		for _, tv := range container.Volumes {
+			if !f.pluginExistsOnNode("Volume", tv.Spec.DriverConfiguration.Name, nodePlugins) {
+				return false
+			}
 		}
 	}
 


### PR DESCRIPTION
This benchmarks scheduling with constraints, where only 1% of the nodes
are eligible to run the tasks.

Under the current implementation, this converges towards the worst-case
linear behavior, because the few nodes that meet the constraints end up
at the end of the heap, and findMin has to scan nearly the whole heap to
find them.

cc @runshenzhu

Depends on https://github.com/docker/go-events/pull/11