### PR TITLE
store: Add an "OR" combinator

### DIFF
--- a/manager/state/store/clusters.go
+++ b/manager/state/store/clusters.go
@@ -169,16 +169,21 @@ func GetCluster(tx ReadTx, id string) *api.Cluster {
 
 // FindClusters selects a set of clusters and returns them.
 func FindClusters(tx ReadTx, by By) ([]*api.Cluster, error) {
-	switch by.(type) {
-	case byAll, byName, byQuery:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName, byQuery:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	clusterList := []*api.Cluster{}
-	err := tx.find(tableCluster, by, func(o Object) {
+	appendResult := func(o Object) {
 		clusterList = append(clusterList, o.(clusterEntry).Cluster)
-	})
+	}
+
+	err := tx.find(tableCluster, by, checkType, appendResult)
 	return clusterList, err
 }
 

--- a/manager/state/store/combinator_test.go
+++ b/manager/state/store/combinator_test.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrCombinator(t *testing.T) {
+	s := NewMemoryStore(nil)
+	assert.NotNil(t, s)
+
+	setupTestStore(t, s)
+
+	s.View(func(readTx ReadTx) {
+		foundNodes, err := FindNodes(readTx, Or())
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 0)
+
+		foundNodes, err = FindNodes(readTx, Or(ByName("name1")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+
+		foundNodes, err = FindNodes(readTx, Or(ByName("name1"), ByName("name1")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+
+		foundNodes, err = FindNodes(readTx, Or(ByName("name1"), ByName("name2")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 3)
+
+		foundNodes, err = FindNodes(readTx, Or(ByName("name1"), ByQuery("id1")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+
+		foundNodes, err = FindNodes(readTx, Or(ByName("name1"), ByQuery("id5295")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 1)
+
+		foundNodes, err = FindNodes(readTx, Or(ByQuery("id1"), ByQuery("id2")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 2)
+
+		foundNodes, err = FindNodes(readTx, Or(ByQuery("id1"), ByQuery("id2"), ByQuery("id3")))
+		assert.NoError(t, err)
+		assert.Len(t, foundNodes, 3)
+	})
+}

--- a/manager/state/store/combinators.go
+++ b/manager/state/store/combinators.go
@@ -1,0 +1,14 @@
+package store
+
+type orCombinator struct {
+	bys []By
+}
+
+func (b orCombinator) isBy() {
+}
+
+// Or returns a combinator that applies OR logic on all the supplied By
+// arguments.
+func Or(bys ...By) By {
+	return orCombinator{bys: bys}
+}

--- a/manager/state/store/networks.go
+++ b/manager/state/store/networks.go
@@ -163,16 +163,21 @@ func GetNetwork(tx ReadTx, id string) *api.Network {
 
 // FindNetworks selects a set of networks and returns them.
 func FindNetworks(tx ReadTx, by By) ([]*api.Network, error) {
-	switch by.(type) {
-	case byAll, byName, byQuery:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName, byQuery:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	networkList := []*api.Network{}
-	err := tx.find(tableNetwork, by, func(o Object) {
+	appendResult := func(o Object) {
 		networkList = append(networkList, o.(networkEntry).Network)
-	})
+	}
+
+	err := tx.find(tableNetwork, by, checkType, appendResult)
 	return networkList, err
 }
 

--- a/manager/state/store/nodes.go
+++ b/manager/state/store/nodes.go
@@ -152,16 +152,21 @@ func GetNode(tx ReadTx, id string) *api.Node {
 
 // FindNodes selects a set of nodes and returns them.
 func FindNodes(tx ReadTx, by By) ([]*api.Node, error) {
-	switch by.(type) {
-	case byAll, byName, byQuery:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName, byQuery:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	nodeList := []*api.Node{}
-	err := tx.find(tableNode, by, func(o Object) {
+	appendResult := func(o Object) {
 		nodeList = append(nodeList, o.(nodeEntry).Node)
-	})
+	}
+
+	err := tx.find(tableNode, by, checkType, appendResult)
 	return nodeList, err
 }
 

--- a/manager/state/store/services.go
+++ b/manager/state/store/services.go
@@ -163,16 +163,21 @@ func GetService(tx ReadTx, id string) *api.Service {
 
 // FindServices selects a set of services and returns them.
 func FindServices(tx ReadTx, by By) ([]*api.Service, error) {
-	switch by.(type) {
-	case byAll, byName, byQuery:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName, byQuery:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	serviceList := []*api.Service{}
-	err := tx.find(tableService, by, func(o Object) {
+	appendResult := func(o Object) {
 		serviceList = append(serviceList, o.(serviceEntry).Service)
-	})
+	}
+
+	err := tx.find(tableService, by, checkType, appendResult)
 	return serviceList, err
 }
 

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -168,16 +168,21 @@ func GetTask(tx ReadTx, id string) *api.Task {
 
 // FindTasks selects a set of tasks and returns them.
 func FindTasks(tx ReadTx, by By) ([]*api.Task, error) {
-	switch by.(type) {
-	case byAll, byName, byNode, byService, byInstance:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName, byNode, byService, byInstance:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	taskList := []*api.Task{}
-	err := tx.find(tableTask, by, func(o Object) {
+	appendResult := func(o Object) {
 		taskList = append(taskList, o.(taskEntry).Task)
-	})
+	}
+
+	err := tx.find(tableTask, by, checkType, appendResult)
 	return taskList, err
 }
 

--- a/manager/state/store/volumes.go
+++ b/manager/state/store/volumes.go
@@ -163,16 +163,21 @@ func GetVolume(tx ReadTx, id string) *api.Volume {
 
 // FindVolumes selects a set of volumes and returns them.
 func FindVolumes(tx ReadTx, by By) ([]*api.Volume, error) {
-	switch by.(type) {
-	case byAll, byName:
-	default:
-		return nil, ErrInvalidFindBy
+	checkType := func(by By) error {
+		switch by.(type) {
+		case byName:
+			return nil
+		default:
+			return ErrInvalidFindBy
+		}
 	}
 
 	volumeList := []*api.Volume{}
-	err := tx.find(tableVolume, by, func(o Object) {
+	appendResult := func(o Object) {
 		volumeList = append(volumeList, o.(volumeEntry).Volume)
-	})
+	}
+
+	err := tx.find(tableVolume, by, checkType, appendResult)
 	return volumeList, err
 }
 


### PR DESCRIPTION
This allows queries like:

`store.FindTasks(store.Or(store.ByName(name), store.ByNodeID(nodeID), store.ByServiceID(serviceID)))`

I also considered adding AND, but I don't think we should support it at
this time. The best way to compute the intersection is to start with the
most specific dimension and then narrow the results from there, but a
generic AND operator would only be able to do the query in a naive way.
It's probably better for callers to implement their own AND logic.
But we might add AND in the future.

cc @aluzzardi @stevvooe
