### PR TITLE
Sort map keys in deepcopy code generator

### DIFF
--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -686,15 +686,6 @@ func (m *ServiceSpec) Copy() *ServiceSpec {
 		}
 	}
 
-	switch m.RuntimeSpec.(type) {
-	case *ServiceSpec_Container:
-		i := &ServiceSpec_Container{
-			Container: m.GetContainer().Copy(),
-		}
-
-		o.RuntimeSpec = i
-	}
-
 	switch m.Mode.(type) {
 	case *ServiceSpec_Replicated:
 		i := &ServiceSpec_Replicated{
@@ -708,6 +699,15 @@ func (m *ServiceSpec) Copy() *ServiceSpec {
 		}
 
 		o.Mode = i
+	}
+
+	switch m.RuntimeSpec.(type) {
+	case *ServiceSpec_Container:
+		i := &ServiceSpec_Container{
+			Container: m.GetContainer().Copy(),
+		}
+
+		o.RuntimeSpec = i
 	}
 
 	return o

--- a/protobuf/plugin/deepcopy/deepcopy.go
+++ b/protobuf/plugin/deepcopy/deepcopy.go
@@ -1,6 +1,8 @@
 package deepcopy
 
 import (
+	"sort"
+
 	"github.com/docker/swarm-v2/protobuf/plugin"
 	"github.com/gogo/protobuf/gogoproto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
@@ -89,7 +91,16 @@ func (d *deepCopyGen) genMsgDeepCopy(m *generator.Descriptor) {
 		fn()
 	}
 
-	for _, oneOfNameFuncs := range oneOfFuncs {
+	// Sort map keys from oneOfFuncs so that generated code has consistent
+	// ordering.
+	oneOfKeys := make([]string, 0, len(oneOfFuncs))
+	for key := range oneOfFuncs {
+		oneOfKeys = append(oneOfKeys, key)
+	}
+	sort.Strings(oneOfKeys)
+
+	for _, key := range oneOfKeys {
+		oneOfNameFuncs := oneOfFuncs[key]
 		for _, oneOfFunc := range oneOfNameFuncs {
 			oneOfFunc()
 		}


### PR DESCRIPTION
This fixes a problem where the ordering of some generated code could
change, causing "make checkprotos" to fail.

cc @mrjana @dperny
