### PR TITLE
scheduler: Refactor Pipeline and filters to allow per-task precomputation

### DIFF
--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -12,27 +12,22 @@ var (
 	}
 )
 
+type checklistEntry struct {
+	f       Filter
+	enabled bool
+}
+
 // Pipeline runs a set of filters against nodes.
 type Pipeline struct {
-	task      *api.Task
-	checklist []Filter
+	checklist []checklistEntry
 }
 
 // NewPipeline returns a pipeline with the default set of filters.
-func NewPipeline(t *api.Task) *Pipeline {
-	p := &Pipeline{
-		task:      t,
-		checklist: []Filter{},
-	}
+func NewPipeline() *Pipeline {
+	p := &Pipeline{}
 
-	// FIXME(aaronl): This is quite alloc-heavy. It may be better to
-	// redesign Pipeline so it doesn't require allocating a separate slice
-	// for each task. Maybe it could use a bitfield to specify which
-	// filters are enabled.
 	for _, f := range defaultFilters {
-		if f.Enabled(t) {
-			p.checklist = append(p.checklist, f)
-		}
+		p.checklist = append(p.checklist, checklistEntry{f: f})
 	}
 
 	return p
@@ -41,11 +36,19 @@ func NewPipeline(t *api.Task) *Pipeline {
 // Process a node through the filter pipeline.
 // Returns true if all filters pass, false otherwise.
 func (p *Pipeline) Process(n *NodeInfo) bool {
-	for _, f := range p.checklist {
-		if !f.Check(p.task, n) {
+	for _, entry := range p.checklist {
+		if entry.enabled && !entry.f.Check(n) {
 			// Immediately stop on first failure.
 			return false
 		}
 	}
 	return true
+}
+
+// SetTask sets up the filters to process a new task. Once this is called,
+// Process can be called repeatedly to try to assign the task various nodes.
+func (p *Pipeline) SetTask(t *api.Task) {
+	for i := range p.checklist {
+		p.checklist[i].enabled = p.checklist[i].f.SetTask(t)
+	}
 }


### PR DESCRIPTION
The current approach creates a new Pipeline for each task we want to
assign. Then we iterate over available nodes and for each filter,
`Check(t *api.Task, n *NodeInfo)` is called. If there is any information
derived from the task, it must be recomputed on every call to Check.

This commit changes the scheduler to use a single Pipeline. Pipeline and
the filters now have SetTask methods to start processing a new task, and
do any necessary precomputation. The Check function only takes a
NodeInfo struct.

This approach avoids redundant computation on each call to Check because
task-specific information can be stored inside the filter objects, and
replaced on the next call to SetTask. It also avoids the allocs involved
in creating a new Pipeline for each task.

cc @dongluochen @aluzzardi
