### PR TITLE
Don't error out on CA server shutdown

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -314,7 +314,7 @@ func (s *Server) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-s.ctx.Done():
-			return s.ctx.Err()
+			return nil
 		}
 	}
 }


### PR DESCRIPTION
The CA server was changed to return an error when s.ctx is cancelled.
This shouldn't be considered an error because this is the normal process
for shutting down the server. Return nil instead of s.ctx.Err().

This fixes `ERRO[0002] CA signer exited with an error                error=context canceled` on shutdown.

cc @tonistiigi @diogomonica
