### PR TITLE
[ca] Only get remote CA if local CA cert missing

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -35,6 +36,10 @@ const (
 	// RootKeyAlgo defines the default algorithm for the root CA Key
 	RootKeyAlgo = "ecdsa"
 )
+
+// ErrNoLocalRootCA is an error type used to indicate that the local root CA
+// certificate file does not exist.
+var ErrNoLocalRootCA = errors.New("local root CA certificate does not exist")
 
 func init() {
 	cflog.Level = 5
@@ -222,6 +227,10 @@ func GetLocalRootCA(baseDir string) (RootCA, error) {
 	// Check if we have a Certificate file
 	cert, err := ioutil.ReadFile(paths.RootCA.Cert)
 	if err != nil {
+		if os.IsNotExist(err) {
+			err = ErrNoLocalRootCA
+		}
+
 		return RootCA{}, err
 	}
 

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -64,6 +64,11 @@ func TestGetLocalRootCA(t *testing.T) {
 
 	paths := ca.NewConfigPaths(tempBaseDir)
 
+	// First, try to load the local Root CA with the certificate missing.
+	_, err = ca.GetLocalRootCA(tempBaseDir)
+	assert.Equal(t, ca.ErrNoLocalRootCA, err)
+
+	// Create the local Root CA to ensure that we can reload it correctly.
 	rootCA, err := ca.CreateAndWriteRootCA("rootCN", paths.RootCA)
 	assert.True(t, rootCA.CanSign())
 	assert.NoError(t, err)

--- a/ca/config.go
+++ b/ca/config.go
@@ -144,7 +144,10 @@ func LoadOrCreateSecurityConfig(ctx context.Context, baseCertDir, caHash, propos
 
 	// Check if we already have a CA certificate on disk. We need a CA to have a valid SecurityConfig
 	rootCA, err = GetLocalRootCA(baseCertDir)
-	if err != nil {
+	switch err {
+	case nil:
+		log.Debugf("loaded local CA certificate: %s.", paths.RootCA.Cert)
+	case ErrNoLocalRootCA:
 		log.Debugf("no valid local CA certificate found: %v", err)
 
 		// Get the remote CA certificate, verify integrity with the hash provided
@@ -159,9 +162,8 @@ func LoadOrCreateSecurityConfig(ctx context.Context, baseCertDir, caHash, propos
 		}
 
 		log.Debugf("downloaded remote CA certificate.")
-
-	} else {
-		log.Debugf("loaded local CA certificate: %s.", paths.RootCA.Cert)
+	default:
+		return nil, err
 	}
 
 	// At this point we've successfully loaded the CA details from disk, or successfully

--- a/cmd/swarmd/manager.go
+++ b/cmd/swarmd/manager.go
@@ -80,13 +80,17 @@ var managerCmd = &cobra.Command{
 			p = picker.NewPicker(managerAddr, managers)
 		} else {
 			_, err := ca.GetLocalRootCA(certDir)
-			if err != nil {
-				// If we are not provided a valid join address and there is no local valid Root CA
-				// we should bootstrap a new cluster
-				if err := ca.BootstrapCluster(certDir); err != nil {
-					return err
-				}
+			if err == ca.ErrNoLocalRootCA {
+				// If we are not provided a valid join address
+				// and there is no local Root CA we should
+				// bootstrap a new cluster.
+				err = ca.BootstrapCluster(certDir)
 			}
+
+			if err != nil {
+				return err
+			}
+
 			managers := picker.NewRemotes(addr)
 			p = picker.NewPicker(addr, managers)
 		}


### PR DESCRIPTION
This patch updates the behavior of `ca.GetLocalRootCA()` to return a specific error value when the local root CA certificate file does not exist. The `ca.LoadOrCreateSecurityConfig()` function as well as the
manager command entrypoint will now check for this `ErrNoLocalRootCA` value to decide to fallback to getting a remote CA or bootstrapping a new CA keypair.

Unit tests for the `ca` package have also been updated.

fixes #749
