### PR TITLE
Update go-events dependency

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -324,7 +324,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/go-events",
-			"Rev": "39718a26497694185f8fb58a7d6f31947f3dc42d"
+			"Rev": "75bd8e1de6126833daf8df682aa10f17cea7e011"
 		},
 		{
 			"ImportPath": "github.com/docker/go-units",

--- a/vendor/github.com/docker/go-events/queue.go
+++ b/vendor/github.com/docker/go-events/queue.go
@@ -72,10 +72,17 @@ func (eq *Queue) run() {
 		}
 
 		if err := eq.dst.Write(event); err != nil {
+			// TODO(aaronl): Dropping events could be bad depending
+			// on the application. We should have a way of
+			// communicating this condition. However, logging
+			// at a log level above debug may not be appropriate.
+			// Eventually, go-events should not use logrus at all,
+			// and should bubble up conditions like this through
+			// error values.
 			logrus.WithFields(logrus.Fields{
 				"event": event,
 				"sink":  eq.dst,
-			}).WithError(err).Warnf("eventqueue: dropped event")
+			}).WithError(err).Debug("eventqueue: dropped event")
 		}
 	}
 }


### PR DESCRIPTION
This vendors a new go-events, which changes the warning log line when a
queue is closed with outstanding events to a debug log line. This
suppresses some spurious log output when shutting down a manager, and
also from unit tests and benchmarks that don't fully read from their
event queues.
