### PR TITLE
allocator: Batch task updates

### DIFF
--- a/manager/allocator/volumeallocator/volumeallocator.go
+++ b/manager/allocator/volumeallocator/volumeallocator.go
@@ -49,8 +49,7 @@ func (va *VolumeAllocator) RemoveVolumeFromCache(name string) {
 
 // AllocateTask marks a task as allocated
 func (va *VolumeAllocator) AllocateTask(t *api.Task) {
-	var a struct{}
-	va.allocatedTasks[t.ID] = a
+	va.allocatedTasks[t.ID] = struct{}{}
 }
 
 // DeallocateTask releases all the resources for all the


### PR DESCRIPTION
Currently, the allocators use a separate transaction for each task
update in some cases. Each one of these entails a raft round trip. So if
the orchestrator creates 1000 tasks for a new service, it could take a
long time to move all of them to the allocated state.

This commit changes it to batch these task updates. Instead of updating
a task within its own transaction, changes are always made as part of
procUnallocatedTasksNetwork / procUnallocatedTasksVolume, which are now
triggered on a transaction commit.

Fixes #326

**Note**: This needs careful review. I am not very familiar with the allocator
code, and I'm not confident that this approach of pushing all unallocated
tasks to `unallocatedTasks` for later processing is correct.

ping @mrjana @amitshukla
