### PR TITLE
raft: Attempt to fix flaky tests

### DIFF
--- a/manager/controlapi/manager_test.go
+++ b/manager/controlapi/manager_test.go
@@ -89,7 +89,7 @@ func TestListManagers(t *testing.T) {
 	nodes[5].Shutdown()
 
 	// Node 4 and Node 5 should be listed as Unreachable
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		r, err = ts.Client.ListManagers(context.Background(), &api.ListManagersRequest{})
 		if err != nil {
 			return err
@@ -146,7 +146,7 @@ func TestListManagers(t *testing.T) {
 	raftutils.WaitForCluster(t, clockSource, newCluster)
 
 	// Node 1 should not be the leader anymore
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		r, err = ts.Client.ListManagers(context.Background(), &api.ListManagersRequest{})
 		if err != nil {
 			return err
@@ -224,7 +224,7 @@ func TestRemoveManager(t *testing.T) {
 	nodes[3].Shutdown()
 
 	// Node 2 and Node 3 should be listed as Unreachable
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		lsr, err = ts.Client.ListManagers(context.Background(), &api.ListManagersRequest{})
 		if err != nil {
 			return err
@@ -284,7 +284,7 @@ func TestRemoveManager(t *testing.T) {
 	nodes[3].Server.Stop()
 
 	// Node 3 should be listed as Unreachable
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		lsr, err = ts.Client.ListManagers(context.Background(), &api.ListManagersRequest{})
 		if err != nil {
 			return err
@@ -309,7 +309,7 @@ func TestRemoveManager(t *testing.T) {
 	assert.NotNil(t, rmr)
 
 	// Memberlist from both nodes should not list node 3
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		mlist = ts.Server.raft.GetMemberlist()
 		if len(mlist) != 2 {
 			return fmt.Errorf("expected 2 nodes, got %d", len(mlist))
@@ -337,7 +337,7 @@ func TestRemoveManager(t *testing.T) {
 	nodes[2].Server.Stop()
 
 	// Node 2 should be listed as Unreachable
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		lsr, err = ts.Client.ListManagers(context.Background(), &api.ListManagersRequest{})
 		if err != nil {
 			return err

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -96,7 +96,7 @@ func startDispatcher(c *Config) (*grpcDispatcher, error) {
 		_ = s.Serve(l)
 	}()
 	go d.Run(context.Background())
-	if err := raftutils.PollFuncWithTimeout(func() error {
+	if err := raftutils.PollFuncWithTimeout(nil, func() error {
 		d.mu.Lock()
 		defer d.mu.Unlock()
 		if !d.isRunning() {

--- a/manager/manager_cluster_test.go
+++ b/manager/manager_cluster_test.go
@@ -226,7 +226,7 @@ func TestCluster(t *testing.T) {
 	}
 	c := createManagersCluster(t, 5, 15)
 	defer c.Close()
-	assert.NoError(t, testutils.PollFunc(c.pollRegister))
+	assert.NoError(t, testutils.PollFunc(nil, c.pollRegister))
 	m := c.ms[0]
 	nCount := m.m.dispatcher.NodeCount()
 	assert.Equal(t, 15, nCount)
@@ -238,13 +238,13 @@ func TestClusterReelection(t *testing.T) {
 	}
 	mCount, aCount := 5, 15
 	c := createManagersCluster(t, mCount, aCount)
-	require.NoError(t, testutils.PollFunc(c.pollRegister))
+	require.NoError(t, testutils.PollFunc(nil, c.pollRegister))
 
 	require.NoError(t, c.destroyLeader())
 	// let's down some managers in the meantime
 	require.NoError(t, c.destroyAgents(5))
 	// ensure that cluster will converge to expected number of agents, we need big timeout because of heartbeat times
-	require.NoError(t, testutils.PollFuncWithTimeout(c.pollRegister, 30*time.Second))
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, c.pollRegister, 30*time.Second))
 
 	leader, err := c.leader()
 	assert.NoError(t, err)

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -263,7 +263,7 @@ func TestCanRemoveMember(t *testing.T) {
 	nodes[3].Shutdown()
 
 	// Node 2 and Node 3 should be listed as Unreachable
-	assert.NoError(t, raftutils.PollFunc(func() error {
+	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 		members := nodes[1].GetMemberlist()
 		if len(members) != 3 {
 			return fmt.Errorf("expected 3 nodes, got %d", len(members))

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -103,17 +103,17 @@ func TestRaftLeaderDown(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// The value should be replicated on all remaining nodes
-	raftutils.CheckValue(t, leaderNode, value)
+	raftutils.CheckValue(t, clockSource, leaderNode, value)
 	assert.Equal(t, len(leaderNode.GetMemberlist()), 3)
 
-	raftutils.CheckValue(t, followerNode, value)
+	raftutils.CheckValue(t, clockSource, followerNode, value)
 	assert.Equal(t, len(followerNode.GetMemberlist()), 3)
 }
 
 func TestRaftFollowerDown(t *testing.T) {
 	t.Parallel()
 
-	nodes, _ := raftutils.NewRaftCluster(t, tc)
+	nodes, clockSource := raftutils.NewRaftCluster(t, tc)
 	defer raftutils.TeardownCluster(t, nodes)
 
 	// Stop node 3
@@ -128,17 +128,17 @@ func TestRaftFollowerDown(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// The value should be replicated on all remaining nodes
-	raftutils.CheckValue(t, nodes[1], value)
+	raftutils.CheckValue(t, clockSource, nodes[1], value)
 	assert.Equal(t, len(nodes[1].GetMemberlist()), 3)
 
-	raftutils.CheckValue(t, nodes[2], value)
+	raftutils.CheckValue(t, clockSource, nodes[2], value)
 	assert.Equal(t, len(nodes[2].GetMemberlist()), 3)
 }
 
 func TestRaftLogReplication(t *testing.T) {
 	t.Parallel()
 
-	nodes, _ := raftutils.NewRaftCluster(t, tc)
+	nodes, clockSource := raftutils.NewRaftCluster(t, tc)
 	defer raftutils.TeardownCluster(t, nodes)
 
 	// Propose a value
@@ -146,14 +146,14 @@ func TestRaftLogReplication(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// All nodes should have the value in the physical store
-	raftutils.CheckValue(t, nodes[1], value)
-	raftutils.CheckValue(t, nodes[2], value)
-	raftutils.CheckValue(t, nodes[3], value)
+	raftutils.CheckValue(t, clockSource, nodes[1], value)
+	raftutils.CheckValue(t, clockSource, nodes[2], value)
+	raftutils.CheckValue(t, clockSource, nodes[3], value)
 }
 
 func TestRaftLogReplicationWithoutLeader(t *testing.T) {
 	t.Parallel()
-	nodes, _ := raftutils.NewRaftCluster(t, tc)
+	nodes, clockSource := raftutils.NewRaftCluster(t, tc)
 	defer raftutils.TeardownCluster(t, nodes)
 
 	// Stop the leader
@@ -164,8 +164,8 @@ func TestRaftLogReplicationWithoutLeader(t *testing.T) {
 	assert.Error(t, err)
 
 	// No value should be replicated in the store in the absence of the leader
-	raftutils.CheckNoValue(t, nodes[2])
-	raftutils.CheckNoValue(t, nodes[3])
+	raftutils.CheckNoValue(t, clockSource, nodes[2])
+	raftutils.CheckNoValue(t, clockSource, nodes[3])
 }
 
 func TestRaftQuorumFailure(t *testing.T) {
@@ -188,8 +188,8 @@ func TestRaftQuorumFailure(t *testing.T) {
 	assert.Error(t, err)
 
 	// The value should not be replicated, we have no majority
-	raftutils.CheckNoValue(t, nodes[2])
-	raftutils.CheckNoValue(t, nodes[1])
+	raftutils.CheckNoValue(t, clockSource, nodes[2])
+	raftutils.CheckNoValue(t, clockSource, nodes[1])
 }
 
 func TestRaftQuorumRecovery(t *testing.T) {
@@ -221,7 +221,7 @@ func TestRaftQuorumRecovery(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, node := range nodes {
-		raftutils.CheckValue(t, node, value)
+		raftutils.CheckValue(t, clockSource, node, value)
 	}
 }
 
@@ -257,16 +257,16 @@ func TestRaftFollowerLeave(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// Value should be replicated on every node
-	raftutils.CheckValue(t, nodes[1], value)
+	raftutils.CheckValue(t, clockSource, nodes[1], value)
 	assert.Equal(t, len(nodes[1].GetMemberlist()), 4)
 
-	raftutils.CheckValue(t, nodes[2], value)
+	raftutils.CheckValue(t, clockSource, nodes[2], value)
 	assert.Equal(t, len(nodes[2].GetMemberlist()), 4)
 
-	raftutils.CheckValue(t, nodes[3], value)
+	raftutils.CheckValue(t, clockSource, nodes[3], value)
 	assert.Equal(t, len(nodes[3].GetMemberlist()), 4)
 
-	raftutils.CheckValue(t, nodes[4], value)
+	raftutils.CheckValue(t, clockSource, nodes[4], value)
 	assert.Equal(t, len(nodes[4].GetMemberlist()), 4)
 }
 
@@ -326,10 +326,10 @@ func TestRaftLeaderLeave(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// The value should be replicated on all remaining nodes
-	raftutils.CheckValue(t, leaderNode, value)
+	raftutils.CheckValue(t, clockSource, leaderNode, value)
 	assert.Equal(t, len(leaderNode.GetMemberlist()), 2)
 
-	raftutils.CheckValue(t, followerNode, value)
+	raftutils.CheckValue(t, clockSource, followerNode, value)
 	assert.Equal(t, len(followerNode.GetMemberlist()), 2)
 
 	raftutils.TeardownCluster(t, newCluster)
@@ -353,7 +353,7 @@ func TestRaftNewNodeGetsData(t *testing.T) {
 
 	// Value should be replicated on every node
 	for _, node := range nodes {
-		raftutils.CheckValue(t, node, value)
+		raftutils.CheckValue(t, clockSource, node, value)
 		assert.Equal(t, len(node.GetMemberlist()), 4)
 	}
 }
@@ -373,7 +373,7 @@ func TestRaftRejoin(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// The value should be replicated on node 3
-	raftutils.CheckValue(t, nodes[3], values[0])
+	raftutils.CheckValue(t, clockSource, nodes[3], values[0])
 	assert.Equal(t, len(nodes[3].GetMemberlist()), 3)
 
 	// Stop node 3
@@ -385,14 +385,14 @@ func TestRaftRejoin(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// Nodes 1 and 2 should have the new value
-	raftutils.CheckValuesOnNodes(t, map[uint64]*raftutils.TestNode{1: nodes[1], 2: nodes[2]}, ids, values)
+	raftutils.CheckValuesOnNodes(t, clockSource, map[uint64]*raftutils.TestNode{1: nodes[1], 2: nodes[2]}, ids, values)
 
 	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// Node 3 should have all values, including the one proposed while
 	// it was unavailable.
-	raftutils.CheckValuesOnNodes(t, nodes, ids, values)
+	raftutils.CheckValuesOnNodes(t, clockSource, nodes, ids, values)
 }
 
 func testRaftRestartCluster(t *testing.T, stagger bool) {
@@ -429,7 +429,7 @@ func testRaftRestartCluster(t *testing.T, stagger bool) {
 	assert.NoError(t, err, "failed to propose value")
 
 	for _, node := range nodes {
-		assert.NoError(t, raftutils.PollFunc(func() error {
+		assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 			var err error
 			node.MemoryStore().View(func(tx store.ReadTx) {
 				var allNodes []*api.Node
@@ -534,7 +534,7 @@ func TestRaftForceNewCluster(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	for _, node := range nodes {
-		assert.NoError(t, raftutils.PollFunc(func() error {
+		assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
 			var err error
 			node.MemoryStore().View(func(tx store.ReadTx) {
 				var allNodes []*api.Node
@@ -593,8 +593,8 @@ func TestRaftUnreachableNode(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// All nodes should have the value in the physical store
-	raftutils.CheckValue(t, nodes[1], value)
-	raftutils.CheckValue(t, nodes[2], value)
+	raftutils.CheckValue(t, clockSource, nodes[1], value)
+	raftutils.CheckValue(t, clockSource, nodes[2], value)
 }
 
 func TestRaftJoinFollower(t *testing.T) {
@@ -616,7 +616,7 @@ func TestRaftJoinFollower(t *testing.T) {
 	assert.NoError(t, err, "failed to propose value")
 
 	// All nodes should have the value in the physical store
-	raftutils.CheckValue(t, nodes[1], value)
-	raftutils.CheckValue(t, nodes[2], value)
-	raftutils.CheckValue(t, nodes[3], value)
+	raftutils.CheckValue(t, clockSource, nodes[1], value)
+	raftutils.CheckValue(t, clockSource, nodes[2], value)
+	raftutils.CheckValue(t, clockSource, nodes[3], value)
 }


### PR DESCRIPTION
I've seen raft tests fail occasionally, particularly TestRaftSnapshot
and TestRaftSnapshotRestart. These usually seem to fail becuase the last
proposal does not appear in the store on one of the nodes, even after
several seconds of polling.

I don't know what's going wrong, and it's very hard to track down
because I can't reproduce the failures at will. However, my best guess
is that something requires time to pass to behave properly, and because
of our mock clock source, this might not be happening. For example, a
send may need to be retried in some rare cases, but this would not
happen until the next tick.

This commit attempts to make time pass for the raft state machine during
the polling. I think the likelyhood that this fixes the problems is
relatively low, but it's worth a try.

cc @abronan
