### PR TITLE
Accepting auth token on deploy

### DIFF
--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -38,8 +38,12 @@ func newContainerAdapter(client engineapi.APIClient, task *api.Task) (*container
 func noopPrivilegeFn() (string, error) { return "", nil }
 
 func (c *containerAdapter) pullImage(ctx context.Context) error {
+	// if the image needs to be pulled, the auth config will be retrieved and updated
+	encodedConfig := c.container.task.ServiceAnnotations.Labels[fmt.Sprintf("%v.registryauth", systemLabelPrefix)]
+
 	rc, err := c.client.ImagePull(ctx, c.container.image(),
 		types.ImagePullOptions{
+			RegistryAuth:  encodedConfig,
 			PrivilegeFunc: noopPrivilegeFn,
 		})
 	if err != nil {


### PR DESCRIPTION
Fixes #735 

We currently don't allow for downloading from private registries, or from Docker Hub when an authorization is needed. This change allows the user to input an `--auth` flag while doing `swarmctl deploy` that is a base64 encoded auth token created during `docker login`. This is then added as a label in the service annotations and is pushed down to the agent (via ServiceAnnotations in tasks) where it is used during image pulls.

This is a simple temporary fix that should eventually be taken over by a proper secret sharing mechanism.

Signed-off-by: Nishant Totla nishanttotla@gmail.com
