### PR TITLE
Do not allow removal of networks in use

### DIFF
--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -144,11 +144,31 @@ func (s *Server) GetNetwork(ctx context.Context, request *api.GetNetworkRequest)
 // - Returns `NotFound` if the Network is not found.
 // - Returns an error if the deletion fails.
 func (s *Server) RemoveNetwork(ctx context.Context, request *api.RemoveNetworkRequest) (*api.RemoveNetworkResponse, error) {
+	var (
+		services []*api.Service
+		err      error
+	)
+
 	if request.NetworkID == "" {
 		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
-	err := s.store.Update(func(tx store.Tx) error {
+	s.store.View(func(tx store.ReadTx) {
+		services, err = store.FindServices(tx, store.All)
+	})
+	if err != nil {
+		return nil, grpc.Errorf(codes.Internal, "could not find services using network %s", request.NetworkID)
+	}
+
+	for _, s := range services {
+		for _, na := range s.Spec.Networks {
+			if na.GetNetworkID() == request.NetworkID {
+				return nil, grpc.Errorf(codes.FailedPrecondition, "network %s is in use", request.NetworkID)
+			}
+		}
+	}
+
+	err = s.store.Update(func(tx store.Tx) error {
 		nw := store.GetNetwork(tx, request.NetworkID)
 		if _, ok := nw.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
 			return grpc.Errorf(codes.PermissionDenied, "%s is a pre-defined network and cannot be removed", request.NetworkID)


### PR DESCRIPTION
Added checks in control api to ensure networks which are still attached
to services are not removed from the store.

Fixes #772 

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>