### PR TITLE
swarmd: Explicitly define advertise address.

### DIFF
--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -15,7 +15,7 @@ import (
 // Dial establishes a connection and creates a client.
 // It infers connection parameters from CLI options.
 func Dial(cmd *cobra.Command) (api.ControlClient, error) {
-	addr, err := cmd.Flags().GetString("socket")
+	addr, err := cmd.Flags().GetString("control-socket")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -40,11 +40,11 @@ func defaultSocket() string {
 	if swarmSocket != "" {
 		return swarmSocket
 	}
-	return "/var/run/docker/cluster/docker-swarmd.sock"
+	return "/var/run/docker/swarm/docker-swarmd.sock"
 }
 
 func init() {
-	mainCmd.PersistentFlags().StringP("socket", "s", defaultSocket(), "Socket to connect to the Swarm manager")
+	mainCmd.PersistentFlags().StringP("control-socket", "c", defaultSocket(), "Socket to connect to the Swarm manager")
 	mainCmd.PersistentFlags().BoolP("no-resolve", "n", false, "Do not try to map IDs to Names when displaying them")
 
 	mainCmd.AddCommand(


### PR DESCRIPTION
- `--advertise-addr` is now separate from `--listen-addr`
- We now make it obvious when falling back to auto-detection:
`WARN[0000] Advertise address not specified, falling back to
auto-detection: 192.168.100.242:4242`

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>