### PR TITLE
Fix exiting goroutine on context cancel

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -195,7 +195,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 					continue
 				}
 			case <-ctx.Done():
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
This was fixed before in https://github.com/docker/swarm-v2/pull/694/commits/caa2de9d264e13f52969c96ba1b0e84738d23071 but that PR never got merged.

@diogomonica 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
