### PR TITLE
Changing top-level SigningPolicy from var to func

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -90,14 +90,14 @@ func (s *SecurityConfig) UpdateRootCA(cert, key []byte, certExpiry time.Duration
 
 // DefaultPolicy is the default policy used by the signers to ensure that the only fields
 // from the remote CSRs we trust are: PublicKey, PublicKeyAlgorithm and SignatureAlgorithm.
-var DefaultPolicy = func() *cfconfig.Signing {
+func DefaultPolicy() *cfconfig.Signing {
 	return SigningPolicy(DefaultNodeCertExpiration)
 }
 
 // SigningPolicy creates a policy used by the signer to ensure that the only fields
 // from the remote CSRs we trust are: PublicKey, PublicKeyAlgorithm and SignatureAlgorithm.
 // It receives the duration a certificate will be valid for
-var SigningPolicy = func(certExpiry time.Duration) *cfconfig.Signing {
+func SigningPolicy(certExpiry time.Duration) *cfconfig.Signing {
 	// Force the minimum Certificate expiration to be fifteen minutes
 	if certExpiry < MinNodeCertExpiration {
 		certExpiry = DefaultNodeCertExpiration

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -315,7 +315,7 @@ func createAndWriteRootCA(rootCN string, paths ca.CertPaths, expiry time.Duratio
 	}
 
 	// Create a Signer out of the private key
-	signer, err := local.NewSigner(parsedKey, parsedCert, cfsigner.DefaultSigAlgo(parsedKey), ca.SigningPolicy(ca.DefaultNodeCertExpiration))
+	signer, err := local.NewSigner(parsedKey, parsedCert, cfsigner.DefaultSigAlgo(parsedKey), ca.SigningPolicy(expiry))
 	if err != nil {
 		log.Errorf("failed to create signer: %v", err)
 		return ca.RootCA{}, err


### PR DESCRIPTION
@aaronlehmann alternatively I can change them to normal `func`.

https://github.com/docker/swarmkit/pull/842