### PR TITLE
manager: create keymanager only when leader

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -212,7 +212,6 @@ func New(config *Config) (*Manager, error) {
 		listeners:   listeners,
 		caserver:    ca.NewServer(RaftNode.MemoryStore(), config.SecurityConfig),
 		Dispatcher:  dispatcher.New(RaftNode, dispatcherConfig),
-		keyManager:  keymanager.New(RaftNode.MemoryStore(), keymanager.DefaultConfig()),
 		server:      grpc.NewServer(opts...),
 		localserver: grpc.NewServer(opts...),
 		RaftNode:    RaftNode,
@@ -326,6 +325,7 @@ func (m *Manager) Run(parent context.Context) error {
 				m.globalOrchestrator = orchestrator.NewGlobalOrchestrator(s)
 				m.taskReaper = orchestrator.NewTaskReaper(s)
 				m.scheduler = scheduler.New(s)
+				m.keyManager = keymanager.New(m.RaftNode.MemoryStore(), keymanager.DefaultConfig())
 
 				// TODO(stevvooe): Allocate a context that can be used to
 				// shutdown underlying manager processes when leadership is
@@ -564,6 +564,9 @@ func (m *Manager) Stop(ctx context.Context) {
 	}
 	if m.scheduler != nil {
 		m.scheduler.Stop()
+	}
+	if m.keyManager != nil {
+		m.keyManager.Stop()
 	}
 
 	m.RaftNode.Shutdown()


### PR DESCRIPTION
It fixes panic when node loses leadership and obtains it again later.