### PR TITLE
swarmctl: Remove `-f` flag for cluster update.

### DIFF
--- a/cmd/swarmctl/cluster/update.go
+++ b/cmd/swarmctl/cluster/update.go
@@ -122,7 +122,6 @@ var (
 )
 
 func init() {
-	updateCmd.Flags().StringP("file", "f", "", "Spec to use")
 	// TODO(aaronl): Acceptance policy will change later.
 	updateCmd.Flags().StringSlice("autoaccept", nil, "Roles to automatically issue certificates for")
 	updateCmd.Flags().StringSlice("secret", nil, "Secret required to join the cluster")


### PR DESCRIPTION
This is not supported anymore, adds confusion to --help.

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>