### PR TITLE
Add regex to check if name is valid

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/docker/swarmkit/api"
@@ -8,6 +9,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
+
+var isValidName = regexp.MustCompile(`^[a-zA-Z0-9](?:[-_]*[A-Za-z0-9]+)*$`)
 
 func buildFilters(by func(string) store.By, values []string) store.By {
 	filters := make([]store.By, 0, len(values))
@@ -61,6 +64,9 @@ func filterMatchLabels(match map[string]string, candidates map[string]string) bo
 func validateAnnotations(m api.Annotations) error {
 	if m.Name == "" {
 		return grpc.Errorf(codes.InvalidArgument, "meta: name must be provided")
+	} else if !isValidName.MatchString(m.Name) {
+		// if the name doesn't match the regex
+		return grpc.Errorf(codes.InvalidArgument, "invalid name, only [a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9] are allowed")
 	}
 	return nil
 }

--- a/manager/controlapi/common_test.go
+++ b/manager/controlapi/common_test.go
@@ -21,8 +21,25 @@ func TestValidateAnnotations(t *testing.T) {
 
 	for _, good := range []api.Annotations{
 		{Name: "name"},
+		{Name: "n-me"},
+		{Name: "n_me"},
+		{Name: "n-m-e"},
+		{Name: "n--d"},
 	} {
 		err := validateAnnotations(good)
-		assert.NoError(t, err)
+		assert.NoError(t, err, "string: "+good.Name)
+	}
+
+	for _, bad := range []api.Annotations{
+		{Name: "_nam"},
+		{Name: ".nam"},
+		{Name: "-nam"},
+		{Name: "nam-"},
+		{Name: "n/me"},
+		{Name: "n&me"},
+		{Name: "////"},
+	} {
+		err := validateAnnotations(bad)
+		assert.Error(t, err, "string: "+bad.Name)
 	}
 }


### PR DESCRIPTION
Restricts to the same names that are allowed for docker containers.
Prevents users from creating services that cannot start because their
names cannot be used as part of docker containers. fixes #897

Signed-off-by: Drew Erny <drew.erny@docker.com>