### PR TITLE
reconcile resource in scheduler

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -53,6 +53,9 @@ func (f *ResourceFilter) SetTask(t *api.Task) bool {
 
 // Check returns true if the task can be scheduled into the given node.
 func (f *ResourceFilter) Check(n *NodeInfo) bool {
+	if n.AvailableResources == nil {
+		return false
+	}
 	if f.reservations.NanoCPUs > n.AvailableResources.NanoCPUs {
 		return false
 	}

--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -6,10 +6,10 @@ import "github.com/docker/swarmkit/api"
 type NodeInfo struct {
 	*api.Node
 	Tasks              map[string]*api.Task
-	AvailableResources api.Resources
+	AvailableResources *api.Resources
 }
 
-func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api.Resources) NodeInfo {
+func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources *api.Resources) NodeInfo {
 	nodeInfo := NodeInfo{
 		Node:               n,
 		Tasks:              make(map[string]*api.Task),
@@ -31,9 +31,11 @@ func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
 	}
 
 	delete(nodeInfo.Tasks, t.ID)
-	reservations := taskReservations(t.Spec)
-	nodeInfo.AvailableResources.MemoryBytes += reservations.MemoryBytes
-	nodeInfo.AvailableResources.NanoCPUs += reservations.NanoCPUs
+	if nodeInfo.AvailableResources != nil {
+		reservations := taskReservations(t.Spec)
+		nodeInfo.AvailableResources.MemoryBytes += reservations.MemoryBytes
+		nodeInfo.AvailableResources.NanoCPUs += reservations.NanoCPUs
+	}
 
 	return true
 }
@@ -47,9 +49,11 @@ func (nodeInfo *NodeInfo) addTask(t *api.Task) bool {
 	}
 	if _, ok := nodeInfo.Tasks[t.ID]; !ok {
 		nodeInfo.Tasks[t.ID] = t
-		reservations := taskReservations(t.Spec)
-		nodeInfo.AvailableResources.MemoryBytes -= reservations.MemoryBytes
-		nodeInfo.AvailableResources.NanoCPUs -= reservations.NanoCPUs
+		if nodeInfo.AvailableResources != nil {
+			reservations := taskReservations(t.Spec)
+			nodeInfo.AvailableResources.MemoryBytes -= reservations.MemoryBytes
+			nodeInfo.AvailableResources.NanoCPUs -= reservations.NanoCPUs
+		}
 		return true
 	}
 


### PR DESCRIPTION
in `createOrUpdateNode`, node's resources are reset to the initial value, without checking whether there are some tasks running in the node and reserving resources. This commit fixes the bug.

Here is an example demonstrating this bug:

* boot 2 nodes, suppose both's nanocpu resource is 2e9
```
$ swarmd -d /tmp/node-1 --listen-control-api /tmp/manager1/swarm.sock --hostname node-1
$ swarmd -d /tmp/node-2 --hostname node-2 --join-addr 127.0.0.1:4242
```
* run a service, redis, and reserve 0.5 cpu resources
```
$ swarmctl service create --name redis --image redis:3.0.5 --cpu-reservation 0.5
```
redis will be assigned to node-1. node-1 cpu resource will be 1.5 e9
* drain node-1
```
$ swarmctl node drain node-1
```

while there is still a task of redis in node-1 and about to shut down, cpu resource in this node is reset to 2e9. After node-1's task is shut down, it returns reserved resources to node-1, which makes node-1's cpu resource become 2.5 e9

However, I don't think this bug is harmful. Because when we activate node-1 from draining, its cpu resources will be reset to correct value, 2e9, again.

Signed-off-by: runshenzhu <runshen.zhu@gmail.com>