### PR TITLE
dispatcher, raft: cancel proposals on node shutdown

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -96,7 +96,6 @@ type Dispatcher struct {
 	cluster              Cluster
 	ctx                  context.Context
 	cancel               context.CancelFunc
-	wg                   sync.WaitGroup
 
 	taskUpdates     map[string]*api.TaskStatus // indexed by task ID
 	taskUpdatesLock sync.Mutex
@@ -153,8 +152,6 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 		d.mu.Unlock()
 		return fmt.Errorf("dispatcher is stopped")
 	}
-	d.wg.Add(1)
-	defer d.wg.Done()
 	logger := log.G(ctx).WithField("module", "dispatcher")
 	ctx = log.WithLogger(ctx, logger)
 	if err := d.markNodesUnknown(ctx); err != nil {
@@ -237,25 +234,17 @@ func (d *Dispatcher) Stop() error {
 	d.cancel()
 	d.mu.Unlock()
 	d.nodes.Clean()
-	// wait for all handlers to finish their raft deals, because manager will
-	// set raftNode to nil
-	d.wg.Wait()
 	return nil
 }
 
-func (d *Dispatcher) addTask() error {
+func (d *Dispatcher) isRunningLocked() error {
 	d.mu.Lock()
 	if !d.isRunning() {
 		d.mu.Unlock()
 		return grpc.Errorf(codes.Aborted, "dispatcher is stopped")
 	}
-	d.wg.Add(1)
 	d.mu.Unlock()
 	return nil
-}
-
-func (d *Dispatcher) doneTask() {
-	d.wg.Done()
 }
 
 func (d *Dispatcher) markNodesUnknown(ctx context.Context) error {
@@ -326,10 +315,9 @@ func (d *Dispatcher) isRunning() bool {
 // register is used for registration of node with particular dispatcher.
 func (d *Dispatcher) register(ctx context.Context, nodeID string, description *api.NodeDescription) (string, string, error) {
 	// prevent register until we're ready to accept it
-	if err := d.addTask(); err != nil {
+	if err := d.isRunningLocked(); err != nil {
 		return "", "", err
 	}
-	defer d.doneTask()
 
 	// create or update node in store
 	// TODO(stevvooe): Validate node specification.
@@ -391,10 +379,9 @@ func (d *Dispatcher) UpdateTaskStatus(ctx context.Context, r *api.UpdateTaskStat
 	}
 	log := log.G(ctx).WithFields(fields)
 
-	if err := d.addTask(); err != nil {
+	if err := d.isRunningLocked(); err != nil {
 		return nil, err
 	}
-	defer d.doneTask()
 
 	if _, err := d.nodes.GetWithSession(nodeID, r.SessionID); err != nil {
 		return nil, err
@@ -506,10 +493,9 @@ func (d *Dispatcher) Tasks(r *api.TasksRequest, stream api.Dispatcher_TasksServe
 	}
 	nodeID := nodeInfo.NodeID
 
-	if err := d.addTask(); err != nil {
+	if err := d.isRunningLocked(); err != nil {
 		return err
 	}
-	defer d.doneTask()
 
 	fields := logrus.Fields{
 		"node.id":      nodeID,
@@ -586,10 +572,9 @@ func (d *Dispatcher) Tasks(r *api.TasksRequest, stream api.Dispatcher_TasksServe
 }
 
 func (d *Dispatcher) nodeRemove(id string, status api.NodeStatus) error {
-	if err := d.addTask(); err != nil {
+	if err := d.isRunningLocked(); err != nil {
 		return err
 	}
-	defer d.doneTask()
 	// TODO(aaronl): Is it worth batching node removals?
 	err := d.store.Update(func(tx store.Tx) error {
 		node := store.GetNode(tx, id)
@@ -641,10 +626,9 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 	}
 	nodeID := nodeInfo.NodeID
 
-	if err := d.addTask(); err != nil {
+	if err := d.isRunningLocked(); err != nil {
 		return err
 	}
-	defer d.doneTask()
 
 	// register the node.
 	nodeID, sessionID, err := d.register(stream.Context(), nodeID, r.Description)


### PR DESCRIPTION
This PR should fix the deadlock with the dispatcher on loss of quorum, this:
- Removes `sync.WaitGroup` on dispatcher waiting for proposals to be completed
- Keeps track of the proposals on the raft side and cancel the proposals on node shutdown

This impacts the dispatcher though as this will give:

```
ERRO[0099] failed deregistering node after heartbeat expiration  error=failed to update node 3p7qdlm85il8a status to down: context canceled
```

My guess is that this should be harmless as this should retry or recover on Manager(s) restart but I may be missing something so this is worth a careful review.

Please let me know if you have a better approach.

/cc @LK4D4 @aaronlehmann @tonistiigi 

Signed-off-by: Alexandre Beslic <alexandre.beslic@gmail.com>