### PR TITLE
orchestrator: Use correct desired state checks.

### DIFF
--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -28,7 +28,7 @@ func TestDrain(t *testing.T) {
 			},
 			Mode: &api.ServiceSpec_Replicated{
 				Replicated: &api.ReplicatedService{
-					Instances: 1,
+					Instances: 6,
 				},
 			},
 		},
@@ -185,11 +185,11 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	orchestrator := New(s)
-	defer orchestrator.Stop()
-
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
 	defer cancel()
+
+	orchestrator := New(s)
+	defer orchestrator.Stop()
 
 	go func() {
 		assert.NoError(t, orchestrator.Run(ctx))

--- a/manager/orchestrator/restart.go
+++ b/manager/orchestrator/restart.go
@@ -328,7 +328,7 @@ func (r *RestartSupervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask 
 // up.
 func (r *RestartSupervisor) StartNow(tx store.Tx, taskID string) error {
 	t := store.GetTask(tx, taskID)
-	if t == nil || t.DesiredState > api.TaskStateReady {
+	if t == nil || t.DesiredState >= api.TaskStateRunning {
 		return nil
 	}
 	t.DesiredState = api.TaskStateRunning

--- a/manager/orchestrator/services.go
+++ b/manager/orchestrator/services.go
@@ -87,7 +87,7 @@ func (r *ReplicatedOrchestrator) reconcile(ctx context.Context, service *api.Ser
 		// Technically the check below could just be
 		// t.DesiredState <= api.TaskStateRunning, but ignoring tasks
 		// with DesiredState == NEW simplifies the drainer unit tests.
-		if t.DesiredState >= api.TaskStateReady && t.DesiredState <= api.TaskStateRunning {
+		if t.DesiredState > api.TaskStateNew && t.DesiredState <= api.TaskStateRunning {
 			runningTasks = append(runningTasks, t)
 			runningInstances[t.Instance] = struct{}{}
 		}

--- a/manager/orchestrator/tasks.go
+++ b/manager/orchestrator/tasks.go
@@ -55,7 +55,8 @@ func (r *ReplicatedOrchestrator) initTasks(ctx context.Context, readTx store.Rea
 				}
 				continue
 			}
-			if t.DesiredState != api.TaskStateReady || !isReplicatedService(service) {
+			// TODO(aluzzardi): This is shady. We should have a more generic condition.
+			if t.DesiredState != api.TaskStateAccepted || !isReplicatedService(service) {
 				continue
 			}
 			restartDelay := defaultRestartDelay
@@ -78,7 +79,8 @@ func (r *ReplicatedOrchestrator) initTasks(ctx context.Context, readTx store.Rea
 					if restartDelay > 0 {
 						_ = batch.Update(func(tx store.Tx) error {
 							t := store.GetTask(tx, t.ID)
-							if t == nil || t.DesiredState != api.TaskStateReady {
+							// TODO(aluzzardi): This is shady as well. We should have a more generic condition.
+							if t == nil || t.DesiredState != api.TaskStateAccepted {
 								return nil
 							}
 							r.restarts.DelayStart(ctx, tx, nil, t.ID, restartDelay, true)


### PR DESCRIPTION
Desired state checking was wrong which lead to several race conditions.

Fixes #907

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>