### PR TITLE
orchestrator: Only consider DOWN nodes invalid.

### DIFF
--- a/manager/orchestrator/tasks.go
+++ b/manager/orchestrator/tasks.go
@@ -19,7 +19,7 @@ import (
 
 func invalidNode(n *api.Node) bool {
 	return n == nil ||
-		n.Status.State != api.NodeStatus_READY ||
+		n.Status.State == api.NodeStatus_DOWN ||
 		n.Spec.Availability == api.NodeAvailabilityDrain
 }
 


### PR DESCRIPTION
When the dispatcher starts, it sets all nodes status as UNKNOWN.

This is a valid state and we should not attempt to re-schedule tasks at
that time.

If the node still fails to reconnect, at that point the Dispatcher will
set the status to DOWN and the orchestrator will reschedule tasks.

Fixes #921

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>