### PR TITLE
agent: backoff on ErrTaskRetry

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"reflect"
+	"time"
 
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -144,8 +145,16 @@ func (tm *taskManager) run(ctx context.Context) {
 				if !updated {
 					continue // wait till getting pumped via update.
 				}
-			case nil:
-			case context.Canceled, context.DeadlineExceeded:
+			case exec.ErrTaskRetry:
+				// TODO(stevvooe): Add exponential backoff with random jitter
+				// here. For now, this backoff is enough to keep the task
+				// manager from running away with the CPU.
+				time.AfterFunc(time.Second, func() {
+					errs <- nil // repump this branch, with no err
+				})
+				continue
+			case nil, context.Canceled, context.DeadlineExceeded:
+				// no log in this case
 			default:
 				log.G(ctx).WithError(err).Error("task operation failed")
 			}


### PR DESCRIPTION
To avoid heavy CPU usage when encountering ErrTaskRetry, backoff before
issuing a secondary task run. It would be better to do backoff with
jitter but this is sufficient to avoid runaway CPU usage.

Signed-off-by: Stephen J Day <stephen.day@docker.com>