### PR TITLE
agent: deal with flaky unit test

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -150,7 +150,10 @@ func (tm *taskManager) run(ctx context.Context) {
 				log.G(ctx).WithError(err).Error("task operation failed")
 			}
 
-			run <- struct{}{}
+			select {
+			case run <- struct{}{}:
+			default:
+			}
 		case status := <-statusq:
 			tm.task.Status = *status
 		case task := <-tm.updateq:
@@ -178,8 +181,12 @@ func (tm *taskManager) run(ctx context.Context) {
 			if cancel != nil {
 				cancel() // cancel outstanding if necessary.
 			} else {
-				// no outstanding operation, pump run queue
-				run <- struct{}{}
+				// If this channel op fails, it means there is already a
+				// message un the run queue.
+				select {
+				case run <- struct{}{}:
+				default:
+				}
 			}
 		case <-shutdown:
 			if cancel != nil {

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -61,11 +61,6 @@ func TestTaskManager(t *testing.T) {
 		return nil
 	}))
 
-	// let's timeout this test, as any delay represents a problem with
-	// progressing the state machine.
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-
 	acceptedWait := accepted
 	readyWait := ready
 	shutdownWait := shutdown


### PR DESCRIPTION
A flaky unit test exposed a bug in the agent that could lead to
deadlock. The change is simply to avoid the channel send if a run of the
task op is already queued.

Deals with the deadlock in https://circleci.com/gh/docker/swarmkit/2917.

Signed-off-by: Stephen J Day <stephen.day@docker.com>