### PR TITLE
support windows named pipe

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/docker/swarmkit/manager"
 	"github.com/docker/swarmkit/picker"
+	"github.com/docker/swarmkit/xnet"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -546,7 +547,11 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 	addr := n.config.ListenControlAPI
 	opts = append(opts, grpc.WithDialer(
 		func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+			proto, addr, err := xnet.ParseProtoAddr(addr)
+			if err != nil {
+				return nil, err
+			}
+			return xnet.DialTimeout(proto, addr, timeout)
 		}))
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
@@ -584,8 +589,8 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 			m, err := manager.New(&manager.Config{
 				ForceNewCluster: n.config.ForceNewCluster,
 				ProtoAddr: map[string]string{
-					"tcp":  n.config.ListenRemoteAPI,
-					"unix": n.config.ListenControlAPI,
+					"remote":  n.config.ListenRemoteAPI,
+					"control": n.config.ListenControlAPI,
 				},
 				SecurityConfig: securityConfig,
 				JoinRaft:       remoteAddr.Addr,

--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/xnet"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -25,7 +26,11 @@ func Dial(cmd *cobra.Command) (api.ControlClient, error) {
 	opts = append(opts, grpc.WithTransportCredentials(insecureCreds))
 	opts = append(opts, grpc.WithDialer(
 		func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+			proto, addr, err := xnet.ParseProtoAddr(addr)
+			if err != nil {
+				return nil, err
+			}
+			return xnet.DialTimeout(proto, addr, timeout)
 		}))
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -68,8 +68,9 @@ var (
 					fmt.Println("Warning: Specifying a valid address with --listen-remote-api may be necessary for other managers to reach this one.")
 				}
 			}
+			addr = "tcp://" + addr
 
-			unix, err := cmd.Flags().GetString("listen-control-api")
+			controlAddr, err := cmd.Flags().GetString("listen-control-api")
 			if err != nil {
 				return err
 			}
@@ -148,7 +149,7 @@ var (
 			n, err := agent.NewNode(&agent.NodeConfig{
 				Hostname:         hostname,
 				ForceNewCluster:  forceNewCluster,
-				ListenControlAPI: unix,
+				ListenControlAPI: controlAddr,
 				ListenRemoteAPI:  addr,
 				JoinAddr:         managerAddr,
 				StateDir:         stateDir,
@@ -195,7 +196,7 @@ func init() {
 	mainCmd.Flags().String("engine-addr", "unix:///var/run/docker.sock", "Address of engine instance of agent.")
 	mainCmd.Flags().String("hostname", "", "Override reported agent hostname")
 	mainCmd.Flags().String("listen-remote-api", "0.0.0.0:4242", "Listen address for remote API")
-	mainCmd.Flags().String("listen-control-api", "/var/run/docker/cluster/docker-swarmd.sock", "Listen socket for control API")
+	mainCmd.Flags().String("listen-control-api", "unix:///var/run/docker/cluster/docker-swarmd.sock", "Listen socket for control API")
 	mainCmd.Flags().String("listen-debug", "", "Bind the Go debug server on the provided address")
 	mainCmd.Flags().String("join-addr", "", "Join cluster with a node at this address")
 	mainCmd.Flags().Bool("force-new-cluster", false, "Force the creation of a new cluster from data directory")

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -438,7 +438,7 @@ func (na *NetworkAllocator) allocateNetworkIPs(nAttach *api.NetworkAttachment) e
 			}
 
 			// If we got an address then we are done.
-			if err == nil {
+			if err == nil && ip != nil {
 				ipStr := ip.String()
 				localNet.endpoints[ipStr] = poolID
 				addresses[i] = ipStr

--- a/xnet/net_unix.go
+++ b/xnet/net_unix.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package xnet
+
+import (
+	"net"
+	"time"
+)
+
+// Listen Wrapper for net.Listen
+func Listen(proto string, addr string) (net.Listener, error) {
+	return net.Listen(proto, addr)
+}
+
+// DialTimeout Wrapper for net.Listen
+func DialTimeout(proto string, addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(proto, addr, timeout)
+}

--- a/xnet/net_windows.go
+++ b/xnet/net_windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package xnet
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// Listen Wrapper for net.Listen and Windows named pipe
+func Listen(proto string, addr string) (net.Listener, error) {
+	if proto == "npipe" {
+		return winio.ListenPipe(addr, "")
+	}
+	return net.Listen(proto, addr)
+}
+
+// DialTimeout Wrapper for net.DialTimeout and Windows named pipe (winio.DialPipe)
+func DialTimeout(proto string, addr string, timeout time.Duration) (net.Conn, error) {
+	if proto == "npipe" {
+		return winio.DialPipe(addr, &timeout)
+	}
+	return net.DialTimeout(proto, addr, timeout)
+}

--- a/xnet/util.go
+++ b/xnet/util.go
@@ -1,0 +1,19 @@
+package xnet
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// ParseProtoAddr parses an address as a protcol and address pair.
+// If no protocol specified, this function return an error
+func ParseProtoAddr(s string) (string, string, error) {
+	logrus.Debugf("parse proto addr: %s", s)
+	parts := strings.SplitN(s, "://", 2)
+	if len(parts) == 1 {
+		return "", "", fmt.Errorf("No protocol is specified in '%s'", s)
+	}
+	return parts[0], parts[1], nil
+}


### PR DESCRIPTION
This PR adds Windows named pipe support for SwarmKit to allow running a Worker on Windows and also forming a cluster. Instead of listening a Unix socket, this PR uses Microsoft's `go-winio` to start a named pipe server.

Tested on a Windows box:

```
swarmd -l debug -d c:/tmp/node1 --listen-control-api npipe:////./pipe/swarmd.sock --hostname node1 --listen-remote-api 127.0.0.1:4242 --engine-addr <REMOTE DOCKER_HOST>:2375
```

Then
`set SWARM_SOCKET=npipe:////./pipe/swarmd.sock`

```
swarmctl task ls hello_world
ID                         Service        Desired State  Last State              Node
--                         -------        -------------  ----------              ----
33fufdzwywh8p5u9vl8cidy99  hello_world.2  RUNNING        RUNNING 22 minutes ago  node1
ejoseszph4xukbp8e9wkggibt  hello_world.1  RUNNING        RUNNING 22 minutes ago  node1
```

Updated: to make parsing different kind of protocols (`unix`, `tcp`, `npipe`) being more deterministic, I changed the default sock from `/var/...` to `unix:///var/...`.