### PR TITLE
Remove parallel processing of task assignments

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -163,11 +163,9 @@ func (a *Agent) run(ctx context.Context) {
 		case operation := <-sessionq:
 			operation.response <- operation.fn(session)
 		case msg := <-session.tasks:
-			go func() {
-				if err := a.worker.Assign(ctx, msg.Tasks); err != nil {
-					log.G(ctx).WithError(err).Error("task assignment failed")
-				}
-			}()
+			if err := a.worker.Assign(ctx, msg.Tasks); err != nil {
+				log.G(ctx).WithError(err).Error("task assignment failed")
+			}
 		case msg := <-session.messages:
 			if err := a.handleSessionMessage(ctx, msg); err != nil {
 				log.G(ctx).WithError(err).Error("session message handler failed")


### PR DESCRIPTION
Current implementation doesn’t keep the order of incoming tasks list. Goroutines can be scheduled in a different order than they were created. This results multiple `taskManager` instances created for the same task and eventually some tasks getting rejected instead of running.

@stevvooe If you think it's important to not block the main loop you can implement some queue logic there, I went for a simple solution for now. Before #883 there also was no extra goroutine.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>