### PR TITLE
store: Make names case insensitive.

### DIFF
--- a/manager/state/store/clusters.go
+++ b/manager/state/store/clusters.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"strings"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	memdb "github.com/hashicorp/go-memdb"
@@ -131,7 +133,7 @@ func (c clusterEntry) EventDelete() state.Event {
 // Returns ErrExist if the ID is already taken.
 func CreateCluster(tx Tx, c *api.Cluster) error {
 	// Ensure the name is not already in use.
-	if tx.lookup(tableCluster, indexName, c.Spec.Annotations.Name) != nil {
+	if tx.lookup(tableCluster, indexName, strings.ToLower(c.Spec.Annotations.Name)) != nil {
 		return ErrNameConflict
 	}
 
@@ -142,7 +144,7 @@ func CreateCluster(tx Tx, c *api.Cluster) error {
 // Returns ErrNotExist if the cluster doesn't exist.
 func UpdateCluster(tx Tx, c *api.Cluster) error {
 	// Ensure the name is either not in use or already used by this same Cluster.
-	if existing := tx.lookup(tableCluster, indexName, c.Spec.Annotations.Name); existing != nil {
+	if existing := tx.lookup(tableCluster, indexName, strings.ToLower(c.Spec.Annotations.Name)); existing != nil {
 		if existing.ID() != c.ID {
 			return ErrNameConflict
 		}
@@ -221,5 +223,5 @@ func (ci clusterIndexerByName) FromObject(obj interface{}) (bool, []byte, error)
 	}
 
 	// Add the null character as a terminator
-	return true, []byte(c.Spec.Annotations.Name + "\x00"), nil
+	return true, []byte(strings.ToLower(c.Spec.Annotations.Name) + "\x00"), nil
 }

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -560,7 +561,7 @@ func (tx readTx) findIterators(table string, by By, checkType func(By) error) ([
 		}
 		return iters, nil
 	case byName:
-		it, err := tx.memDBTx.Get(table, indexName, string(v))
+		it, err := tx.memDBTx.Get(table, indexName, strings.ToLower(string(v)))
 		if err != nil {
 			return nil, err
 		}

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -288,6 +288,16 @@ func TestStoreService(t *testing.T) {
 					},
 				},
 			}), ErrNameConflict, "duplicate names must be rejected")
+
+		assert.Equal(t,
+			CreateService(tx, &api.Service{
+				ID: "id4",
+				Spec: api.ServiceSpec{
+					Annotations: api.Annotations{
+						Name: "NAME1",
+					},
+				},
+			}), ErrNameConflict, "duplicate check should be case insensitive")
 		return nil
 	})
 	assert.NoError(t, err)
@@ -298,6 +308,9 @@ func TestStoreService(t *testing.T) {
 		assert.Equal(t, serviceSet[2], GetService(readTx, "id3"))
 
 		foundServices, err := FindServices(readTx, ByName("name1"))
+		assert.NoError(t, err)
+		assert.Len(t, foundServices, 1)
+		foundServices, err = FindServices(readTx, ByName("NAME1"))
 		assert.NoError(t, err)
 		assert.Len(t, foundServices, 1)
 		foundServices, err = FindServices(readTx, ByName("invalid"))
@@ -331,6 +344,9 @@ func TestStoreService(t *testing.T) {
 		update = GetService(tx, update.ID)
 		update.Spec.Annotations.Name = "name2"
 		assert.Equal(t, UpdateService(tx, update), ErrNameConflict, "duplicate names should be rejected")
+		update = GetService(tx, update.ID)
+		update.Spec.Annotations.Name = "NAME2"
+		assert.Equal(t, UpdateService(tx, update), ErrNameConflict, "duplicate check should be case insensitive")
 
 		// Name change.
 		update = GetService(tx, update.ID)

--- a/manager/state/store/networks.go
+++ b/manager/state/store/networks.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"strings"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	memdb "github.com/hashicorp/go-memdb"
@@ -125,7 +127,7 @@ func (n networkEntry) EventDelete() state.Event {
 // Returns ErrExist if the ID is already taken.
 func CreateNetwork(tx Tx, n *api.Network) error {
 	// Ensure the name is not already in use.
-	if tx.lookup(tableNetwork, indexName, n.Spec.Annotations.Name) != nil {
+	if tx.lookup(tableNetwork, indexName, strings.ToLower(n.Spec.Annotations.Name)) != nil {
 		return ErrNameConflict
 	}
 
@@ -136,7 +138,7 @@ func CreateNetwork(tx Tx, n *api.Network) error {
 // Returns ErrNotExist if the network doesn't exist.
 func UpdateNetwork(tx Tx, n *api.Network) error {
 	// Ensure the name is either not in use or already used by this same Network.
-	if existing := tx.lookup(tableNetwork, indexName, n.Spec.Annotations.Name); existing != nil {
+	if existing := tx.lookup(tableNetwork, indexName, strings.ToLower(n.Spec.Annotations.Name)); existing != nil {
 		if existing.ID() != n.ID {
 			return ErrNameConflict
 		}
@@ -215,5 +217,5 @@ func (ni networkIndexerByName) FromObject(obj interface{}) (bool, []byte, error)
 	}
 
 	// Add the null character as a terminator
-	return true, []byte(n.Spec.Annotations.Name + "\x00"), nil
+	return true, []byte(strings.ToLower(n.Spec.Annotations.Name) + "\x00"), nil
 }

--- a/manager/state/store/nodes.go
+++ b/manager/state/store/nodes.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
@@ -217,7 +218,7 @@ func (ni nodeIndexerByHostname) FromObject(obj interface{}) (bool, []byte, error
 		return false, nil, nil
 	}
 	// Add the null character as a terminator
-	return true, []byte(n.Description.Hostname + "\x00"), nil
+	return true, []byte(strings.ToLower(n.Description.Hostname) + "\x00"), nil
 }
 
 type nodeIndexerByRole struct{}

--- a/manager/state/store/services.go
+++ b/manager/state/store/services.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"strings"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	memdb "github.com/hashicorp/go-memdb"
@@ -125,7 +127,7 @@ func (s serviceEntry) EventDelete() state.Event {
 // Returns ErrExist if the ID is already taken.
 func CreateService(tx Tx, s *api.Service) error {
 	// Ensure the name is not already in use.
-	if tx.lookup(tableService, indexName, s.Spec.Annotations.Name) != nil {
+	if tx.lookup(tableService, indexName, strings.ToLower(s.Spec.Annotations.Name)) != nil {
 		return ErrNameConflict
 	}
 
@@ -136,7 +138,7 @@ func CreateService(tx Tx, s *api.Service) error {
 // Returns ErrNotExist if the service doesn't exist.
 func UpdateService(tx Tx, s *api.Service) error {
 	// Ensure the name is either not in use or already used by this same Service.
-	if existing := tx.lookup(tableService, indexName, s.Spec.Annotations.Name); existing != nil {
+	if existing := tx.lookup(tableService, indexName, strings.ToLower(s.Spec.Annotations.Name)); existing != nil {
 		if existing.ID() != s.ID {
 			return ErrNameConflict
 		}
@@ -215,5 +217,5 @@ func (si serviceIndexerByName) FromObject(obj interface{}) (bool, []byte, error)
 	}
 
 	// Add the null character as a terminator
-	return true, []byte(s.Spec.Annotations.Name + "\x00"), nil
+	return true, []byte(strings.ToLower(s.Spec.Annotations.Name) + "\x00"), nil
 }

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"strconv"
+	"strings"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
@@ -224,7 +225,7 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 	}
 
 	// Add the null character as a terminator
-	return true, []byte(t.ServiceAnnotations.Name + "\x00"), nil
+	return true, []byte(strings.ToLower(t.ServiceAnnotations.Name) + "\x00"), nil
 }
 
 type taskIndexerByServiceID struct{}


### PR DESCRIPTION
Names should adhere to DNS conventions, therefore we must make sure we
don't end up with duplicates having the same name with different casing.

Fixes #929

Signed-off-by: Andrea Luzzardi <aluzzardi@gmail.com>