### PR TITLE
TestCA: Wait for the CA server to be ready

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -30,6 +30,10 @@ type Server struct {
 	store            *store.MemoryStore
 	securityConfig   *SecurityConfig
 	acceptancePolicy *api.AcceptancePolicy
+
+	// Started is a channel which gets closed once the server is running
+	// and able to service RPCs.
+	Started chan struct{}
 }
 
 // DefaultAcceptancePolicy returns the default acceptance policy.
@@ -60,6 +64,7 @@ func NewServer(store *store.MemoryStore, securityConfig *SecurityConfig) *Server
 	return &Server{
 		store:          store,
 		securityConfig: securityConfig,
+		Started:        make(chan struct{}),
 	}
 }
 
@@ -352,6 +357,8 @@ func (s *Server) Run(ctx context.Context) error {
 	ctx = log.WithLogger(ctx, logger)
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.mu.Unlock()
+
+	close(s.Started)
 
 	// Retrieve the channels to keep track of changes in the cluster
 	// Retrieve all the currently registered nodes

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -165,6 +165,8 @@ func NewTestCA(t *testing.T, policy api.AcceptancePolicy) *TestCA {
 		caServer.Run(ctx)
 	}()
 
+	<-caServer.Started
+
 	remotes := picker.NewRemotes(api.Peer{Addr: l.Addr().String()})
 	picker := picker.NewPicker(remotes, l.Addr().String())
 


### PR DESCRIPTION
Since Run is called in a goroutine, the server may not be ready to
handle RPCs immediately. Use a channel to block until the server is
ready.

cc @diogomonica @abronan

Fixes #958