### PR TITLE
remove redundant code in raft test

### DIFF
--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -232,9 +232,6 @@ func TestRaftFollowerLeave(t *testing.T) {
 	nodes, clockSource := raftutils.NewRaftCluster(t, tc)
 	raftutils.AddRaftNode(t, clockSource, nodes, tc)
 	raftutils.AddRaftNode(t, clockSource, nodes, tc)
-	nodes, clockSource = raftutils.NewRaftCluster(t, tc)
-	raftutils.AddRaftNode(t, clockSource, nodes, tc)
-	raftutils.AddRaftNode(t, clockSource, nodes, tc)
 	defer raftutils.TeardownCluster(t, nodes)
 
 	// Node 5 leaves the cluster


### PR DESCRIPTION
In test, it says we need 5 nodes. But actually we boot 10 nodes and only use 5 of them.

Signed-off-by: runshenzhu <runshen.zhu@gmail.com>