### PR TITLE
agent/exec: revise error handling approach

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,6 @@
 {
 	"ImportPath": "github.com/docker/swarmkit",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
 	"Packages": [
 		"./..."
 	],
@@ -245,73 +244,78 @@
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/client/transport/cancellable",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/blkiodev",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/container",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/events",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/filters",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/network",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/reference",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/registry",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/strslice",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
+		},
+		{
+			"ImportPath": "github.com/docker/engine-api/types/swarm",
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/time",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/engine-api/types/versions",
-			"Comment": "v0.3.1-153-g8c2141e",
-			"Rev": "8c2141e14bb9e7540938d155976b3ef0661e4814"
+			"Comment": "v0.3.1-188-gde0bc7e",
+			"Rev": "de0bc7ec1a2b90b7191e63d3d6f06833188bbd85"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
@@ -765,6 +769,11 @@
 		{
 			"ImportPath": "github.com/pivotal-golang/clock/fakeclock",
 			"Rev": "3fd3c1944c59d9742e1cd333672181cd1a6f9fa0"
+		},
+		{
+			"ImportPath": "github.com/pkg/errors",
+			"Comment": "v0.7.0",
+			"Rev": "01fa4104b9c248c8945d14d9f128454d5b28d595"
 		},
 		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",

--- a/agent/exec/container/api_client_test.mock.go
+++ b/agent/exec/container/api_client_test.mock.go
@@ -4,15 +4,17 @@
 package container
 
 import (
+	io "io"
+	time "time"
+
 	types "github.com/docker/engine-api/types"
 	container "github.com/docker/engine-api/types/container"
 	filters "github.com/docker/engine-api/types/filters"
 	network "github.com/docker/engine-api/types/network"
 	registry "github.com/docker/engine-api/types/registry"
+	swarm "github.com/docker/engine-api/types/swarm"
 	gomock "github.com/golang/mock/gomock"
 	context "golang.org/x/net/context"
-	io "io"
-	time "time"
 )
 
 // Mock of APIClient interface
@@ -34,37 +36,6 @@ func NewMockAPIClient(ctrl *gomock.Controller) *MockAPIClient {
 
 func (_m *MockAPIClient) EXPECT() *_MockAPIClientRecorder {
 	return _m.recorder
-}
-
-func (_m *MockAPIClient) CheckpointCreate(_param0 context.Context, _param1 string, _param2 types.CheckpointCreateOptions) error {
-	ret := _m.ctrl.Call(_m, "CheckpointCreate", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockAPIClientRecorder) CheckpointCreate(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckpointCreate", arg0, arg1, arg2)
-}
-
-func (_m *MockAPIClient) CheckpointDelete(_param0 context.Context, _param1 string, _param2 string) error {
-	ret := _m.ctrl.Call(_m, "CheckpointDelete", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-func (_mr *_MockAPIClientRecorder) CheckpointDelete(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckpointDelete", arg0, arg1, arg2)
-}
-
-func (_m *MockAPIClient) CheckpointList(_param0 context.Context, _param1 string) ([]types.Checkpoint, error) {
-	ret := _m.ctrl.Call(_m, "CheckpointList", _param0, _param1)
-	ret0, _ := ret[0].([]types.Checkpoint)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockAPIClientRecorder) CheckpointList(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CheckpointList", arg0, arg1)
 }
 
 func (_m *MockAPIClient) ClientVersion() string {
@@ -636,6 +607,48 @@ func (_mr *_MockAPIClientRecorder) NetworkRemove(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NetworkRemove", arg0, arg1)
 }
 
+func (_m *MockAPIClient) NodeInspect(_param0 context.Context, _param1 string) (swarm.Node, error) {
+	ret := _m.ctrl.Call(_m, "NodeInspect", _param0, _param1)
+	ret0, _ := ret[0].(swarm.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) NodeInspect(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NodeInspect", arg0, arg1)
+}
+
+func (_m *MockAPIClient) NodeList(_param0 context.Context, _param1 types.NodeListOptions) ([]swarm.Node, error) {
+	ret := _m.ctrl.Call(_m, "NodeList", _param0, _param1)
+	ret0, _ := ret[0].([]swarm.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) NodeList(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NodeList", arg0, arg1)
+}
+
+func (_m *MockAPIClient) NodeRemove(_param0 context.Context, _param1 string) error {
+	ret := _m.ctrl.Call(_m, "NodeRemove", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) NodeRemove(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NodeRemove", arg0, arg1)
+}
+
+func (_m *MockAPIClient) NodeUpdate(_param0 context.Context, _param1 string, _param2 swarm.Version, _param3 swarm.NodeSpec) error {
+	ret := _m.ctrl.Call(_m, "NodeUpdate", _param0, _param1, _param2, _param3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) NodeUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "NodeUpdate", arg0, arg1, arg2, arg3)
+}
+
 func (_m *MockAPIClient) RegistryLogin(_param0 context.Context, _param1 types.AuthConfig) (types.AuthResponse, error) {
 	ret := _m.ctrl.Call(_m, "RegistryLogin", _param0, _param1)
 	ret0, _ := ret[0].(types.AuthResponse)
@@ -656,6 +669,134 @@ func (_m *MockAPIClient) ServerVersion(_param0 context.Context) (types.Version, 
 
 func (_mr *_MockAPIClientRecorder) ServerVersion(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServerVersion", arg0)
+}
+
+func (_m *MockAPIClient) ServiceCreate(_param0 context.Context, _param1 swarm.ServiceSpec) (types.ServiceCreateResponse, error) {
+	ret := _m.ctrl.Call(_m, "ServiceCreate", _param0, _param1)
+	ret0, _ := ret[0].(types.ServiceCreateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) ServiceCreate(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceCreate", arg0, arg1)
+}
+
+func (_m *MockAPIClient) ServiceInspect(_param0 context.Context, _param1 string) (swarm.Service, error) {
+	ret := _m.ctrl.Call(_m, "ServiceInspect", _param0, _param1)
+	ret0, _ := ret[0].(swarm.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) ServiceInspect(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceInspect", arg0, arg1)
+}
+
+func (_m *MockAPIClient) ServiceList(_param0 context.Context, _param1 types.ServiceListOptions) ([]swarm.Service, error) {
+	ret := _m.ctrl.Call(_m, "ServiceList", _param0, _param1)
+	ret0, _ := ret[0].([]swarm.Service)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) ServiceList(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceList", arg0, arg1)
+}
+
+func (_m *MockAPIClient) ServiceRemove(_param0 context.Context, _param1 string) error {
+	ret := _m.ctrl.Call(_m, "ServiceRemove", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) ServiceRemove(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceRemove", arg0, arg1)
+}
+
+func (_m *MockAPIClient) ServiceUpdate(_param0 context.Context, _param1 string, _param2 swarm.Version, _param3 swarm.ServiceSpec) error {
+	ret := _m.ctrl.Call(_m, "ServiceUpdate", _param0, _param1, _param2, _param3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) ServiceUpdate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ServiceUpdate", arg0, arg1, arg2, arg3)
+}
+
+func (_m *MockAPIClient) SwarmInit(_param0 context.Context, _param1 swarm.InitRequest) (string, error) {
+	ret := _m.ctrl.Call(_m, "SwarmInit", _param0, _param1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) SwarmInit(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SwarmInit", arg0, arg1)
+}
+
+func (_m *MockAPIClient) SwarmInspect(_param0 context.Context) (swarm.Swarm, error) {
+	ret := _m.ctrl.Call(_m, "SwarmInspect", _param0)
+	ret0, _ := ret[0].(swarm.Swarm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) SwarmInspect(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SwarmInspect", arg0)
+}
+
+func (_m *MockAPIClient) SwarmJoin(_param0 context.Context, _param1 swarm.JoinRequest) error {
+	ret := _m.ctrl.Call(_m, "SwarmJoin", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) SwarmJoin(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SwarmJoin", arg0, arg1)
+}
+
+func (_m *MockAPIClient) SwarmLeave(_param0 context.Context, _param1 bool) error {
+	ret := _m.ctrl.Call(_m, "SwarmLeave", _param0, _param1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) SwarmLeave(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SwarmLeave", arg0, arg1)
+}
+
+func (_m *MockAPIClient) SwarmUpdate(_param0 context.Context, _param1 swarm.Version, _param2 swarm.Spec) error {
+	ret := _m.ctrl.Call(_m, "SwarmUpdate", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockAPIClientRecorder) SwarmUpdate(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "SwarmUpdate", arg0, arg1, arg2)
+}
+
+func (_m *MockAPIClient) TaskInspectWithRaw(_param0 context.Context, _param1 string) (swarm.Task, []byte, error) {
+	ret := _m.ctrl.Call(_m, "TaskInspectWithRaw", _param0, _param1)
+	ret0, _ := ret[0].(swarm.Task)
+	ret1, _ := ret[1].([]byte)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+func (_mr *_MockAPIClientRecorder) TaskInspectWithRaw(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskInspectWithRaw", arg0, arg1)
+}
+
+func (_m *MockAPIClient) TaskList(_param0 context.Context, _param1 types.TaskListOptions) ([]swarm.Task, error) {
+	ret := _m.ctrl.Call(_m, "TaskList", _param0, _param1)
+	ret0, _ := ret[0].([]swarm.Task)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAPIClientRecorder) TaskList(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "TaskList", arg0, arg1)
 }
 
 func (_m *MockAPIClient) UpdateClientVersion(_param0 string) {

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -6,15 +6,9 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
-
-// ContainerController controls execution of container tasks.
-type ContainerController interface {
-	// ContainerStatus returns the status of the target container, if
-	// available. When the container is not available, the status will be nil.
-	ContainerStatus(ctx context.Context) (*api.ContainerStatus, error)
-}
 
 // Controller controls execution of a task.
 type Controller interface {
@@ -46,6 +40,15 @@ type Controller interface {
 
 	// Close closes any ephemeral resources associated with controller instance.
 	Close() error
+}
+
+// ContainerStatuser reports status of a container.
+//
+// This can be implemented by controllers or error types.
+type ContainerStatuser interface {
+	// ContainerStatus returns the status of the target container, if
+	// available. When the container is not available, the status will be nil.
+	ContainerStatus(ctx context.Context) (*api.ContainerStatus, error)
 }
 
 // Resolve attempts to get a controller from the executor and reports the
@@ -121,6 +124,13 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 		return status, nil
 	}
 
+	// containerStatus exitCode keeps track of whether or not we've set it in
+	// this particular method. Eventually, we assemble this as part of a defer.
+	var (
+		containerStatus *api.ContainerStatus
+		exitCode        int
+	)
+
 	// returned when a fatal execution of the task is fatal. In this case, we
 	// proceed to a terminal error state and set the appropriate fields.
 	//
@@ -131,28 +141,37 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 			panic("err must not be nil when fatal")
 		}
 
-		if IsTemporary(err) {
-			switch Cause(err) {
-			case context.DeadlineExceeded, context.Canceled:
-				// no need to set these errors, since these will more common.
-			default:
-				status.Err = err.Error()
+		if cs, ok := err.(ContainerStatuser); ok {
+			var err error
+			containerStatus, err = cs.ContainerStatus(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("error resolving container status on fatal")
 			}
+		}
 
+		// make sure we've set the *correct* exit code
+		if ec, ok := err.(ExitCoder); ok {
+			exitCode = ec.ExitCode()
+		}
+
+		if cause := errors.Cause(err); cause == context.DeadlineExceeded || cause == context.Canceled {
 			return retry()
 		}
 
-		if cause := Cause(err); cause == context.DeadlineExceeded || cause == context.Canceled {
+		status.Err = err.Error() // still reported on temporary
+		if IsTemporary(err) {
 			return retry()
 		}
 
+		// only at this point do we consider the error fatal to the task.
 		log.G(ctx).WithError(err).Error("fatal task error")
-		status.Err = err.Error()
 
+		// NOTE(stevvooe): The following switch dictates the terminal failure
+		// state based on the state in which the failure was encountered.
 		switch {
 		case status.State < api.TaskStateStarting:
 			status.State = api.TaskStateRejected
-		case status.State > api.TaskStateStarting:
+		case status.State >= api.TaskStateStarting:
 			status.State = api.TaskStateFailed
 		}
 
@@ -172,21 +191,37 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 			return
 		}
 
-		cctlr, ok := ctlr.(ContainerController)
-		if !ok {
-			return
-		}
-
-		cstatus, err := cctlr.ContainerStatus(ctx)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("container status unavailable")
-			return
-		}
-
-		if cstatus != nil {
-			status.RuntimeStatus = &api.TaskStatus_Container{
-				Container: cstatus,
+		if containerStatus == nil {
+			// collect this, if we haven't
+			cctlr, ok := ctlr.(ContainerStatuser)
+			if !ok {
+				return
 			}
+
+			var err error
+			containerStatus, err = cctlr.ContainerStatus(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).Error("container status unavailable")
+			}
+
+			// at this point, things have gone fairly wrong. Remain positive
+			// and let's get something out the door.
+			if containerStatus == nil {
+				containerStatus = new(api.ContainerStatus)
+				containerStatusTask := task.Status.GetContainer()
+				if containerStatusTask != nil {
+					*containerStatus = *containerStatusTask // copy it over.
+				}
+			}
+		}
+
+		// at this point, we *must* have a containerStatus.
+		if exitCode != 0 {
+			containerStatus.ExitCode = int32(exitCode)
+		}
+
+		status.RuntimeStatus = &api.TaskStatus_Container{
+			Container: containerStatus,
 		}
 	}()
 
@@ -222,17 +257,7 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 		return transition(api.TaskStateRunning, "started")
 	case api.TaskStateRunning:
 		if err := ctlr.Wait(ctx); err != nil {
-			// Wait should only proceed to failed if there is a terminal
-			// error. The only two conditions when this happens are when we
-			// get an exit code or when the container doesn't exist.
-			switch err := err.(type) {
-			case ExitCoder:
-				return transition(api.TaskStateFailed, "failed")
-			default:
-				// pursuant to the above comment, report fatal, but wrap as
-				// temporary.
-				return fatal(MakeTemporary(err))
-			}
+			return fatal(err)
 		}
 
 		return transition(api.TaskStateCompleted, "finished")

--- a/agent/exec/controller_test.go
+++ b/agent/exec/controller_test.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-//go:generate mockgen -package exec -destination controller_test.mock.go -source controller.go Controller Reporter
+//go:generate mockgen -package exec -destination controller_test.mock.go -source controller.go Controller StatusReporter
 
 func TestResolve(t *testing.T) {
 	var (

--- a/agent/exec/controller_test.go
+++ b/agent/exec/controller_test.go
@@ -243,7 +243,8 @@ func TestReadyRunningExitFailure(t *testing.T) {
 				ExitCode: 1,
 			},
 		},
-		Message: "failed",
+		Message: "started",
+		Err:     "test error, exit code=1",
 	})
 }
 
@@ -298,7 +299,8 @@ func TestAlreadyStarted(t *testing.T) {
 				ExitCode: 1,
 			},
 		},
-		Message: "failed",
+		Message: "started",
+		Err:     "test error, exit code=1",
 	})
 
 }

--- a/agent/exec/controller_test.mock.go
+++ b/agent/exec/controller_test.mock.go
@@ -9,38 +9,6 @@ import (
 	context "golang.org/x/net/context"
 )
 
-// Mock of ContainerController interface
-type MockContainerController struct {
-	ctrl     *gomock.Controller
-	recorder *_MockContainerControllerRecorder
-}
-
-// Recorder for MockContainerController (not exported)
-type _MockContainerControllerRecorder struct {
-	mock *MockContainerController
-}
-
-func NewMockContainerController(ctrl *gomock.Controller) *MockContainerController {
-	mock := &MockContainerController{ctrl: ctrl}
-	mock.recorder = &_MockContainerControllerRecorder{mock}
-	return mock
-}
-
-func (_m *MockContainerController) EXPECT() *_MockContainerControllerRecorder {
-	return _m.recorder
-}
-
-func (_m *MockContainerController) ContainerStatus(ctx context.Context) (*api.ContainerStatus, error) {
-	ret := _m.ctrl.Call(_m, "ContainerStatus", ctx)
-	ret0, _ := ret[0].(*api.ContainerStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockContainerControllerRecorder) ContainerStatus(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerStatus", arg0)
-}
-
 // Mock of Controller interface
 type MockController struct {
 	ctrl     *gomock.Controller
@@ -140,4 +108,36 @@ func (_m *MockController) Close() error {
 
 func (_mr *_MockControllerRecorder) Close() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "Close")
+}
+
+// Mock of ContainerStatuser interface
+type MockContainerStatuser struct {
+	ctrl     *gomock.Controller
+	recorder *_MockContainerStatuserRecorder
+}
+
+// Recorder for MockContainerStatuser (not exported)
+type _MockContainerStatuserRecorder struct {
+	mock *MockContainerStatuser
+}
+
+func NewMockContainerStatuser(ctrl *gomock.Controller) *MockContainerStatuser {
+	mock := &MockContainerStatuser{ctrl: ctrl}
+	mock.recorder = &_MockContainerStatuserRecorder{mock}
+	return mock
+}
+
+func (_m *MockContainerStatuser) EXPECT() *_MockContainerStatuserRecorder {
+	return _m.recorder
+}
+
+func (_m *MockContainerStatuser) ContainerStatus(ctx context.Context) (*api.ContainerStatus, error) {
+	ret := _m.ctrl.Call(_m, "ContainerStatus", ctx)
+	ret0, _ := ret[0].(*api.ContainerStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockContainerStatuserRecorder) ContainerStatus(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerStatus", arg0)
 }

--- a/vendor/github.com/docker/engine-api/client/client.go
+++ b/vendor/github.com/docker/engine-api/client/client.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
+// DefaultVersion is the version of the current stable API
+const DefaultVersion string = "1.23"
+
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
@@ -59,13 +62,22 @@ func NewEnvClient() (*Client, error) {
 	if host == "" {
 		host = DefaultDockerHost
 	}
-	return NewClient(host, os.Getenv("DOCKER_API_VERSION"), client, nil)
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		version = DefaultVersion
+	}
+
+	return NewClient(host, version, client, nil)
 }
 
 // NewClient initializes a new API client for the given host and API version.
-// It won't send any version information if the version number is empty.
 // It uses the given http client as transport.
 // It also initializes the custom http headers to add to each request.
+//
+// It won't send any version information if the version number is empty. It is
+// highly recommended that you set a version or your client may break if the
+// server is upgraded.
 func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
 	proto, addr, basePath, err := ParseHost(host)
 	if err != nil {

--- a/vendor/github.com/docker/engine-api/client/errors.go
+++ b/vendor/github.com/docker/engine-api/client/errors.go
@@ -120,3 +120,69 @@ func IsErrUnauthorized(err error) bool {
 	_, ok := err.(unauthorizedError)
 	return ok
 }
+
+// nodeNotFoundError implements an error returned when a node is not found.
+type nodeNotFoundError struct {
+	nodeID string
+}
+
+// Error returns a string representation of a nodeNotFoundError
+func (e nodeNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such node: %s", e.nodeID)
+}
+
+// IsErrNodeNotFound returns true if the error is caused
+// when a node is not found.
+func IsErrNodeNotFound(err error) bool {
+	_, ok := err.(nodeNotFoundError)
+	return ok
+}
+
+// serviceNotFoundError implements an error returned when a service is not found.
+type serviceNotFoundError struct {
+	serviceID string
+}
+
+// Error returns a string representation of a serviceNotFoundError
+func (e serviceNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such service: %s", e.serviceID)
+}
+
+// IsErrServiceNotFound returns true if the error is caused
+// when a service is not found.
+func IsErrServiceNotFound(err error) bool {
+	_, ok := err.(serviceNotFoundError)
+	return ok
+}
+
+// taskNotFoundError implements an error returned when a task is not found.
+type taskNotFoundError struct {
+	taskID string
+}
+
+// Error returns a string representation of a taskNotFoundError
+func (e taskNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such task: %s", e.taskID)
+}
+
+// IsErrTaskNotFound returns true if the error is caused
+// when a task is not found.
+func IsErrTaskNotFound(err error) bool {
+	_, ok := err.(taskNotFoundError)
+	return ok
+}
+
+type pluginPermissionDenied struct {
+	name string
+}
+
+func (e pluginPermissionDenied) Error() string {
+	return "Permission denied while installing plugin " + e.name
+}
+
+// IsErrPluginPermissionDenied returns true if the error is caused
+// when a user denies a plugin's permissions
+func IsErrPluginPermissionDenied(err error) bool {
+	_, ok := err.(pluginPermissionDenied)
+	return ok
+}

--- a/vendor/github.com/docker/engine-api/client/interface.go
+++ b/vendor/github.com/docker/engine-api/client/interface.go
@@ -4,21 +4,32 @@ import (
 	"io"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
 )
 
-// APIClient is an interface that clients that talk with a docker server must implement.
-type APIClient interface {
+// CommonAPIClient is the common methods between stable and experimental versions of APIClient.
+type CommonAPIClient interface {
+	ContainerAPIClient
+	ImageAPIClient
+	NodeAPIClient
+	NetworkAPIClient
+	ServiceAPIClient
+	SwarmAPIClient
+	SystemAPIClient
+	VolumeAPIClient
 	ClientVersion() string
-	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
-	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
-	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+	ServerVersion(ctx context.Context) (types.Version, error)
+	UpdateClientVersion(v string)
+}
+
+// ContainerAPIClient defines API client methods for the containers
+type ContainerAPIClient interface {
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
@@ -49,7 +60,10 @@ type APIClient interface {
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
+}
+
+// ImageAPIClient defines API client methods for the images
+type ImageAPIClient interface {
 	ImageBuild(ctx context.Context, context io.Reader, options types.ImageBuildOptions) (types.ImageBuildResponse, error)
 	ImageCreate(ctx context.Context, parentReference string, options types.ImageCreateOptions) (io.ReadCloser, error)
 	ImageHistory(ctx context.Context, image string) ([]types.ImageHistory, error)
@@ -63,7 +77,10 @@ type APIClient interface {
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
-	Info(ctx context.Context) (types.Info, error)
+}
+
+// NetworkAPIClient defines API client methods for the networks
+type NetworkAPIClient interface {
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 	NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error
@@ -71,15 +88,48 @@ type APIClient interface {
 	NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
+}
+
+// NodeAPIClient defines API client methods for the nodes
+type NodeAPIClient interface {
+	NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error)
+	NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error)
+	NodeRemove(ctx context.Context, nodeID string) error
+	NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error
+}
+
+// ServiceAPIClient defines API client methods for the services
+type ServiceAPIClient interface {
+	ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error)
+	ServiceInspect(ctx context.Context, serviceID string) (swarm.Service, error)
+	ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error)
+	ServiceRemove(ctx context.Context, serviceID string) error
+	ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error
+	TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error)
+	TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error)
+}
+
+// SwarmAPIClient defines API client methods for the swarm
+type SwarmAPIClient interface {
+	SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error)
+	SwarmJoin(ctx context.Context, req swarm.JoinRequest) error
+	SwarmLeave(ctx context.Context, force bool) error
+	SwarmInspect(ctx context.Context) (swarm.Swarm, error)
+	SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error
+}
+
+// SystemAPIClient defines API client methods for the system
+type SystemAPIClient interface {
+	Events(ctx context.Context, options types.EventsOptions) (io.ReadCloser, error)
+	Info(ctx context.Context) (types.Info, error)
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
-	ServerVersion(ctx context.Context) (types.Version, error)
-	UpdateClientVersion(v string)
+}
+
+// VolumeAPIClient defines API client methods for the volumes
+type VolumeAPIClient interface {
 	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string) error
 }
-
-// Ensure that Client always implements APIClient.
-var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/interface_experimental.go
+++ b/vendor/github.com/docker/engine-api/client/interface_experimental.go
@@ -1,0 +1,39 @@
+// +build experimental
+
+package client
+
+import (
+	"io"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// APIClient is an interface that clients that talk with a docker server must implement.
+type APIClient interface {
+	CommonAPIClient
+	CheckpointAPIClient
+	PluginAPIClient
+}
+
+// CheckpointAPIClient defines API client methods for the checkpoints
+type CheckpointAPIClient interface {
+	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
+	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
+	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
+}
+
+// PluginAPIClient defines API client methods for the plugins
+type PluginAPIClient interface {
+	PluginList(ctx context.Context) (types.PluginsListResponse, error)
+	PluginRemove(ctx context.Context, name string) error
+	PluginEnable(ctx context.Context, name string) error
+	PluginDisable(ctx context.Context, name string) error
+	PluginInstall(ctx context.Context, name, registryAuth string, acceptAllPermissions, noEnable bool, in io.ReadCloser, out io.Writer) error
+	PluginPush(ctx context.Context, name string, registryAuth string) error
+	PluginSet(ctx context.Context, name string, args []string) error
+	PluginInspect(ctx context.Context, name string) (*types.Plugin, error)
+}
+
+// Ensure that Client always implements APIClient.
+var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/interface_stable.go
+++ b/vendor/github.com/docker/engine-api/client/interface_stable.go
@@ -1,0 +1,11 @@
+// +build !experimental
+
+package client
+
+// APIClient is an interface that clients that talk with a docker server must implement.
+type APIClient interface {
+	CommonAPIClient
+}
+
+// Ensure that Client always implements APIClient.
+var _ APIClient = &Client{}

--- a/vendor/github.com/docker/engine-api/client/node_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/node_inspect.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeInspect returns the node information.
+func (cli *Client) NodeInspect(ctx context.Context, nodeID string) (swarm.Node, error) {
+	serverResp, err := cli.get(ctx, "/nodes/"+nodeID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Node{}, nodeNotFoundError{nodeID}
+		}
+		return swarm.Node{}, err
+	}
+
+	var response swarm.Node
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/node_list.go
+++ b/vendor/github.com/docker/engine-api/client/node_list.go
@@ -1,0 +1,36 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeList returns the list of nodes.
+func (cli *Client) NodeList(ctx context.Context, options types.NodeListOptions) ([]swarm.Node, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/nodes", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []swarm.Node
+	err = json.NewDecoder(resp.body).Decode(&nodes)
+	ensureReaderClosed(resp)
+	return nodes, err
+}

--- a/vendor/github.com/docker/engine-api/client/node_remove.go
+++ b/vendor/github.com/docker/engine-api/client/node_remove.go
@@ -1,0 +1,10 @@
+package client
+
+import "golang.org/x/net/context"
+
+// NodeRemove removes a Node.
+func (cli *Client) NodeRemove(ctx context.Context, nodeID string) error {
+	resp, err := cli.delete(ctx, "/nodes/"+nodeID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/node_update.go
+++ b/vendor/github.com/docker/engine-api/client/node_update.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// NodeUpdate updates a Node.
+func (cli *Client) NodeUpdate(ctx context.Context, nodeID string, version swarm.Version, node swarm.NodeSpec) error {
+	query := url.Values{}
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+	resp, err := cli.post(ctx, "/nodes/"+nodeID+"/update", query, node, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_disable.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_disable.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginDisable disables a plugin
+func (cli *Client) PluginDisable(ctx context.Context, name string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_enable.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_enable.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginEnable enables a plugin
+func (cli *Client) PluginEnable(ctx context.Context, name string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/enable", nil, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_inspect.go
@@ -1,0 +1,22 @@
+// +build experimental
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginInspect inspects an existing plugin
+func (cli *Client) PluginInspect(ctx context.Context, name string) (*types.Plugin, error) {
+	var p types.Plugin
+	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	err = json.NewDecoder(resp.body).Decode(&p)
+	ensureReaderClosed(resp)
+	return &p, err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_install.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_install.go
@@ -1,0 +1,54 @@
+// +build experimental
+
+package client
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginInstall installs a plugin
+func (cli *Client) PluginInstall(ctx context.Context, name, registryAuth string, acceptAllPermissions, noEnable bool, in io.ReadCloser, out io.Writer) error {
+	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+	resp, err := cli.post(ctx, "/plugins/pull", url.Values{"name": []string{name}}, nil, headers)
+	if err != nil {
+		ensureReaderClosed(resp)
+		return err
+	}
+	var privileges types.PluginPrivileges
+	if err := json.NewDecoder(resp.body).Decode(&privileges); err != nil {
+		return err
+	}
+	ensureReaderClosed(resp)
+
+	if !acceptAllPermissions && len(privileges) > 0 {
+
+		fmt.Fprintf(out, "Plugin %q requested the following privileges:\n", name)
+		for _, privilege := range privileges {
+			fmt.Fprintf(out, " - %s: %v\n", privilege.Name, privilege.Value)
+		}
+
+		fmt.Fprint(out, "Do you grant the above permissions? [y/N] ")
+		reader := bufio.NewReader(in)
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(string(line)) != "y" {
+			resp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
+			ensureReaderClosed(resp)
+			return pluginPermissionDenied{name}
+		}
+	}
+	if noEnable {
+		return nil
+	}
+	return cli.PluginEnable(ctx, name)
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_list.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_list.go
@@ -1,0 +1,23 @@
+// +build experimental
+
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// PluginList returns the installed plugins
+func (cli *Client) PluginList(ctx context.Context) (types.PluginsListResponse, error) {
+	var plugins types.PluginsListResponse
+	resp, err := cli.get(ctx, "/plugins", nil, nil)
+	if err != nil {
+		return plugins, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&plugins)
+	ensureReaderClosed(resp)
+	return plugins, err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_push.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_push.go
@@ -1,0 +1,15 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginPush pushes a plugin to a registry
+func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) error {
+	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_remove.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_remove.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginRemove removes a plugin
+func (cli *Client) PluginRemove(ctx context.Context, name string) error {
+	resp, err := cli.delete(ctx, "/plugins/"+name, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/plugin_set.go
+++ b/vendor/github.com/docker/engine-api/client/plugin_set.go
@@ -1,0 +1,14 @@
+// +build experimental
+
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// PluginSet modifies settings for an existing plugin
+func (cli *Client) PluginSet(ctx context.Context, name string, args []string) error {
+	resp, err := cli.post(ctx, "/plugins/"+name+"/set", nil, args, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/request.go
+++ b/vendor/github.com/docker/engine-api/client/request.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/docker/engine-api/client/transport/cancellable"
 	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/versions"
 	"golang.org/x/net/context"
 )
 
@@ -133,7 +134,8 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		}
 
 		var errorMessage string
-		if resp.Header.Get("Content-Type") == "application/json" {
+		if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) &&
+			resp.Header.Get("Content-Type") == "application/json" {
 			var errorResponse types.ErrorResponse
 			if err := json.Unmarshal(body, &errorResponse); err != nil {
 				return serverResp, fmt.Errorf("Error reading JSON: %v", err)

--- a/vendor/github.com/docker/engine-api/client/service_create.go
+++ b/vendor/github.com/docker/engine-api/client/service_create.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceCreate creates a new Service.
+func (cli *Client) ServiceCreate(ctx context.Context, service swarm.ServiceSpec) (types.ServiceCreateResponse, error) {
+	var response types.ServiceCreateResponse
+	resp, err := cli.post(ctx, "/services/create", nil, service, nil)
+	if err != nil {
+		return response, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&response)
+	ensureReaderClosed(resp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/service_inspect.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceInspect returns the service information.
+func (cli *Client) ServiceInspect(ctx context.Context, serviceID string) (swarm.Service, error) {
+	serverResp, err := cli.get(ctx, "/services/"+serviceID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Service{}, serviceNotFoundError{serviceID}
+		}
+		return swarm.Service{}, err
+	}
+
+	var response swarm.Service
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_list.go
+++ b/vendor/github.com/docker/engine-api/client/service_list.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceList returns the list of services.
+func (cli *Client) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/services", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var services []swarm.Service
+	err = json.NewDecoder(resp.body).Decode(&services)
+	ensureReaderClosed(resp)
+	return services, err
+}

--- a/vendor/github.com/docker/engine-api/client/service_remove.go
+++ b/vendor/github.com/docker/engine-api/client/service_remove.go
@@ -1,0 +1,10 @@
+package client
+
+import "golang.org/x/net/context"
+
+// ServiceRemove kills and removes a service.
+func (cli *Client) ServiceRemove(ctx context.Context, serviceID string) error {
+	resp, err := cli.delete(ctx, "/services/"+serviceID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/service_update.go
+++ b/vendor/github.com/docker/engine-api/client/service_update.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// ServiceUpdate updates a Service.
+func (cli *Client) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec) error {
+	query := url.Values{}
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+	resp, err := cli.post(ctx, "/services/"+serviceID+"/update", query, service, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_init.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_init.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmInit initializes the Swarm.
+func (cli *Client) SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error) {
+	serverResp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var response string
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_inspect.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmInspect inspects the Swarm.
+func (cli *Client) SwarmInspect(ctx context.Context) (swarm.Swarm, error) {
+	serverResp, err := cli.get(ctx, "/swarm", nil, nil)
+	if err != nil {
+		return swarm.Swarm{}, err
+	}
+
+	var response swarm.Swarm
+	err = json.NewDecoder(serverResp.body).Decode(&response)
+	ensureReaderClosed(serverResp)
+	return response, err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_join.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_join.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmJoin joins the Swarm.
+func (cli *Client) SwarmJoin(ctx context.Context, req swarm.JoinRequest) error {
+	resp, err := cli.post(ctx, "/swarm/join", nil, req, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_leave.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_leave.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+)
+
+// SwarmLeave leaves the Swarm.
+func (cli *Client) SwarmLeave(ctx context.Context, force bool) error {
+	query := url.Values{}
+	if force {
+		query.Set("force", "1")
+	}
+	resp, err := cli.post(ctx, "/swarm/leave", query, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/swarm_update.go
+++ b/vendor/github.com/docker/engine-api/client/swarm_update.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"net/url"
+	"strconv"
+
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// SwarmUpdate updates the Swarm.
+func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec) error {
+	query := url.Values{}
+	query.Set("version", strconv.FormatUint(version.Index, 10))
+	resp, err := cli.post(ctx, "/swarm/update", query, swarm, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/task_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/task_inspect.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/docker/engine-api/types/swarm"
+
+	"golang.org/x/net/context"
+)
+
+// TaskInspectWithRaw returns the task information and its raw representation..
+func (cli *Client) TaskInspectWithRaw(ctx context.Context, taskID string) (swarm.Task, []byte, error) {
+	serverResp, err := cli.get(ctx, "/tasks/"+taskID, nil, nil)
+	if err != nil {
+		if serverResp.statusCode == http.StatusNotFound {
+			return swarm.Task{}, nil, taskNotFoundError{taskID}
+		}
+		return swarm.Task{}, nil, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	body, err := ioutil.ReadAll(serverResp.body)
+	if err != nil {
+		return swarm.Task{}, nil, err
+	}
+
+	var response swarm.Task
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&response)
+	return response, body, err
+}

--- a/vendor/github.com/docker/engine-api/client/task_list.go
+++ b/vendor/github.com/docker/engine-api/client/task_list.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
+	"github.com/docker/engine-api/types/swarm"
+	"golang.org/x/net/context"
+)
+
+// TaskList returns the list of tasks.
+func (cli *Client) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	query := url.Values{}
+
+	if options.Filter.Len() > 0 {
+		filterJSON, err := filters.ToParam(options.Filter)
+		if err != nil {
+			return nil, err
+		}
+
+		query.Set("filters", filterJSON)
+	}
+
+	resp, err := cli.get(ctx, "/tasks", query, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tasks []swarm.Task
+	err = json.NewDecoder(resp.body).Decode(&tasks)
+	ensureReaderClosed(resp)
+	return tasks, err
+}

--- a/vendor/github.com/docker/engine-api/types/client.go
+++ b/vendor/github.com/docker/engine-api/types/client.go
@@ -240,3 +240,25 @@ type VersionResponse struct {
 func (v VersionResponse) ServerOK() bool {
 	return v.Server != nil
 }
+
+// NodeListOptions holds parameters to list  nodes with.
+type NodeListOptions struct {
+	Filter filters.Args
+}
+
+// ServiceCreateResponse contains the information returned to a client
+// on the  creation of a new service.
+type ServiceCreateResponse struct {
+	// ID is the ID of the created service.
+	ID string
+}
+
+// ServiceListOptions holds parameters to list  services with.
+type ServiceListOptions struct {
+	Filter filters.Args
+}
+
+// TaskListOptions holds parameters to list  tasks with.
+type TaskListOptions struct {
+	Filter filters.Args
+}

--- a/vendor/github.com/docker/engine-api/types/network/network.go
+++ b/vendor/github.com/docker/engine-api/types/network/network.go
@@ -23,8 +23,9 @@ type IPAMConfig struct {
 
 // EndpointIPAMConfig represents IPAM configurations for the endpoint
 type EndpointIPAMConfig struct {
-	IPv4Address string `json:",omitempty"`
-	IPv6Address string `json:",omitempty"`
+	IPv4Address  string   `json:",omitempty"`
+	IPv6Address  string   `json:",omitempty"`
+	LinkLocalIPs []string `json:",omitempty"`
 }
 
 // EndpointSettings stores the network endpoint details

--- a/vendor/github.com/docker/engine-api/types/plugin.go
+++ b/vendor/github.com/docker/engine-api/types/plugin.go
@@ -1,0 +1,160 @@
+// +build experimental
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// PluginConfig represents the values of settings potentially modifiable by a user
+type PluginConfig struct {
+	Mounts  []PluginMount
+	Env     []string
+	Args    []string
+	Devices []PluginDevice
+}
+
+// Plugin represents a Docker plugin for the remote API
+type Plugin struct {
+	ID       string `json:"Id,omitempty"`
+	Name     string
+	Tag      string
+	Active   bool
+	Config   PluginConfig
+	Manifest PluginManifest
+}
+
+// PluginsListResponse contains the response for the remote API
+type PluginsListResponse []*Plugin
+
+const (
+	authzDriver   = "AuthzDriver"
+	graphDriver   = "GraphDriver"
+	ipamDriver    = "IpamDriver"
+	networkDriver = "NetworkDriver"
+	volumeDriver  = "VolumeDriver"
+)
+
+// PluginInterfaceType represents a type that a plugin implements.
+type PluginInterfaceType struct {
+	Prefix     string // This is always "docker"
+	Capability string // Capability should be validated against the above list.
+	Version    string // Plugin API version. Depends on the capability
+}
+
+// UnmarshalJSON implements json.Unmarshaler for PluginInterfaceType
+func (t *PluginInterfaceType) UnmarshalJSON(p []byte) error {
+	versionIndex := len(p)
+	prefixIndex := 0
+	if len(p) < 2 || p[0] != '"' || p[len(p)-1] != '"' {
+		return fmt.Errorf("%q is not a plugin interface type", p)
+	}
+	p = p[1 : len(p)-1]
+loop:
+	for i, b := range p {
+		switch b {
+		case '.':
+			prefixIndex = i
+		case '/':
+			versionIndex = i
+			break loop
+		}
+	}
+	t.Prefix = string(p[:prefixIndex])
+	t.Capability = string(p[prefixIndex+1 : versionIndex])
+	if versionIndex < len(p) {
+		t.Version = string(p[versionIndex+1:])
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler for PluginInterfaceType
+func (t *PluginInterfaceType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+// String implements fmt.Stringer for PluginInterfaceType
+func (t PluginInterfaceType) String() string {
+	return fmt.Sprintf("%s.%s/%s", t.Prefix, t.Capability, t.Version)
+}
+
+// PluginInterface describes the interface between Docker and plugin
+type PluginInterface struct {
+	Types  []PluginInterfaceType
+	Socket string
+}
+
+// PluginSetting is to be embedded in other structs, if they are supposed to be
+// modifiable by the user.
+type PluginSetting struct {
+	Name        string
+	Description string
+	Settable    []string
+}
+
+// PluginNetwork represents the network configuration for a plugin
+type PluginNetwork struct {
+	Type string
+}
+
+// PluginMount represents the mount configuration for a plugin
+type PluginMount struct {
+	PluginSetting
+	Source      *string
+	Destination string
+	Type        string
+	Options     []string
+}
+
+// PluginEnv represents an environment variable for a plugin
+type PluginEnv struct {
+	PluginSetting
+	Value *string
+}
+
+// PluginArgs represents the command line arguments for a plugin
+type PluginArgs struct {
+	PluginSetting
+	Value []string
+}
+
+// PluginDevice represents a device for a plugin
+type PluginDevice struct {
+	PluginSetting
+	Path *string
+}
+
+// PluginUser represents the user for the plugin's process
+type PluginUser struct {
+	UID uint32 `json:"Uid,omitempty"`
+	GID uint32 `json:"Gid,omitempty"`
+}
+
+// PluginManifest represents the manifest of a plugin
+type PluginManifest struct {
+	ManifestVersion string
+	Description     string
+	Documentation   string
+	Interface       PluginInterface
+	Entrypoint      []string
+	Workdir         string
+	User            PluginUser `json:",omitempty"`
+	Network         PluginNetwork
+	Capabilities    []string
+	Mounts          []PluginMount
+	Devices         []PluginDevice
+	Env             []PluginEnv
+	Args            PluginArgs
+}
+
+// PluginPrivilege describes a permission the user has to accept
+// upon installing a plugin.
+type PluginPrivilege struct {
+	Name        string
+	Description string
+	Value       []string
+}
+
+// PluginPrivileges is a list of PluginPrivilege
+type PluginPrivileges []PluginPrivilege

--- a/vendor/github.com/docker/engine-api/types/swarm/common.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/common.go
@@ -1,0 +1,21 @@
+package swarm
+
+import "time"
+
+// Version represent the internal object version.
+type Version struct {
+	Index uint64 `json:",omitempty"`
+}
+
+// Meta is  base object inherited by most of the other once.
+type Meta struct {
+	Version   Version   `json:",omitempty"`
+	CreatedAt time.Time `json:",omitempty"`
+	UpdatedAt time.Time `json:",omitempty"`
+}
+
+// Annotations represents how to describe an object.
+type Annotations struct {
+	Name   string            `json:",omitempty"`
+	Labels map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/container.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/container.go
@@ -1,0 +1,67 @@
+package swarm
+
+import "time"
+
+// ContainerSpec represents the spec of a container.
+type ContainerSpec struct {
+	Image           string            `json:",omitempty"`
+	Labels          map[string]string `json:",omitempty"`
+	Command         []string          `json:",omitempty"`
+	Args            []string          `json:",omitempty"`
+	Env             []string          `json:",omitempty"`
+	Dir             string            `json:",omitempty"`
+	User            string            `json:",omitempty"`
+	Mounts          []Mount           `json:",omitempty"`
+	StopGracePeriod *time.Duration    `json:",omitempty"`
+}
+
+// MountType represents the type of a mount.
+type MountType string
+
+const (
+	// MountTypeBind BIND
+	MountTypeBind MountType = "bind"
+	// MountTypeVolume VOLUME
+	MountTypeVolume MountType = "volume"
+)
+
+// Mount represents a mount (volume).
+type Mount struct {
+	Type     MountType `json:",omitempty"`
+	Source   string    `json:",omitempty"`
+	Target   string    `json:",omitempty"`
+	Writable bool      `json:",omitempty"`
+
+	BindOptions   *BindOptions   `json:",omitempty"`
+	VolumeOptions *VolumeOptions `json:",omitempty"`
+}
+
+// MountPropagation represents the propagation of a mount.
+type MountPropagation string
+
+const (
+	// MountPropagationRPrivate RPRIVATE
+	MountPropagationRPrivate MountPropagation = "rprivate"
+	// MountPropagationPrivate PRIVATE
+	MountPropagationPrivate MountPropagation = "private"
+	// MountPropagationRShared RSHARED
+	MountPropagationRShared MountPropagation = "rshared"
+	// MountPropagationShared SHARED
+	MountPropagationShared MountPropagation = "shared"
+	// MountPropagationRSlave RSLAVE
+	MountPropagationRSlave MountPropagation = "rslave"
+	// MountPropagationSlave SLAVE
+	MountPropagationSlave MountPropagation = "slave"
+)
+
+// BindOptions define options specific to mounts of type "bind".
+type BindOptions struct {
+	Propagation MountPropagation `json:",omitempty"`
+}
+
+// VolumeOptions represents the options for a mount of type volume.
+type VolumeOptions struct {
+	Populate     bool              `json:",omitempty"`
+	Labels       map[string]string `json:",omitempty"`
+	DriverConfig *Driver           `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/network.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/network.go
@@ -1,0 +1,99 @@
+package swarm
+
+// Endpoint represents an endpoint.
+type Endpoint struct {
+	Spec       EndpointSpec        `json:",omitempty"`
+	Ports      []PortConfig        `json:",omitempty"`
+	VirtualIPs []EndpointVirtualIP `json:",omitempty"`
+}
+
+// EndpointSpec represents the spec of an endpoint.
+type EndpointSpec struct {
+	Mode  ResolutionMode `json:",omitempty"`
+	Ports []PortConfig   `json:",omitempty"`
+}
+
+// ResolutionMode represents a resolution mode.
+type ResolutionMode string
+
+const (
+	// ResolutionModeVIP VIP
+	ResolutionModeVIP ResolutionMode = "vip"
+	// ResolutionModeDNSRR DNSRR
+	ResolutionModeDNSRR ResolutionMode = "dnsrr"
+)
+
+// PortConfig represents the config of a port.
+type PortConfig struct {
+	Name          string             `json:",omitempty"`
+	Protocol      PortConfigProtocol `json:",omitempty"`
+	TargetPort    uint32             `json:",omitempty"`
+	PublishedPort uint32             `json:",omitempty"`
+}
+
+// PortConfigProtocol represents the protocol of a port.
+type PortConfigProtocol string
+
+const (
+	// TODO(stevvooe): These should be used generally, not just for PortConfig.
+
+	// PortConfigProtocolTCP TCP
+	PortConfigProtocolTCP PortConfigProtocol = "tcp"
+	// PortConfigProtocolUDP UDP
+	PortConfigProtocolUDP PortConfigProtocol = "udp"
+)
+
+// EndpointVirtualIP represents the virtual ip of a port.
+type EndpointVirtualIP struct {
+	NetworkID string `json:",omitempty"`
+	Addr      string `json:",omitempty"`
+}
+
+// Network represents a network.
+type Network struct {
+	ID string
+	Meta
+	Spec        NetworkSpec  `json:",omitempty"`
+	DriverState Driver       `json:",omitempty"`
+	IPAMOptions *IPAMOptions `json:",omitempty"`
+}
+
+// NetworkSpec represents the spec of a network.
+type NetworkSpec struct {
+	Annotations
+	DriverConfiguration *Driver      `json:",omitempty"`
+	IPv6Enabled         bool         `json:",omitempty"`
+	Internal            bool         `json:",omitempty"`
+	IPAMOptions         *IPAMOptions `json:",omitempty"`
+}
+
+// NetworkAttachmentConfig represents the configuration of a network attachement.
+type NetworkAttachmentConfig struct {
+	Target  string   `json:",omitempty"`
+	Aliases []string `json:",omitempty"`
+}
+
+// NetworkAttachment represents a network attchement.
+type NetworkAttachment struct {
+	Network   Network  `json:",omitempty"`
+	Addresses []string `json:",omitempty"`
+}
+
+// IPAMOptions represents ipam options.
+type IPAMOptions struct {
+	Driver  Driver       `json:",omitempty"`
+	Configs []IPAMConfig `json:",omitempty"`
+}
+
+// IPAMConfig represents ipam configuration.
+type IPAMConfig struct {
+	Subnet  string `json:",omitempty"`
+	Range   string `json:",omitempty"`
+	Gateway string `json:",omitempty"`
+}
+
+// Driver represents a driver (network/volume).
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/node.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/node.go
@@ -1,0 +1,118 @@
+package swarm
+
+// Node represents a node.
+type Node struct {
+	ID string
+	Meta
+
+	Spec          NodeSpec        `json:",omitempty"`
+	Description   NodeDescription `json:",omitempty"`
+	Status        NodeStatus      `json:",omitempty"`
+	ManagerStatus *ManagerStatus  `json:",omitempty"`
+}
+
+// NodeSpec represents the spec of a node.
+type NodeSpec struct {
+	Annotations
+	Role         NodeRole         `json:",omitempty"`
+	Membership   NodeMembership   `json:",omitempty"`
+	Availability NodeAvailability `json:",omitempty"`
+}
+
+// NodeRole represents the role of a node.
+type NodeRole string
+
+const (
+	// NodeRoleWorker WORKER
+	NodeRoleWorker NodeRole = "worker"
+	// NodeRoleManager MANAGER
+	NodeRoleManager NodeRole = "manager"
+)
+
+// NodeMembership represents the membership of a node.
+type NodeMembership string
+
+const (
+	// NodeMembershipPending PENDING
+	NodeMembershipPending NodeMembership = "pending"
+	// NodeMembershipAccepted ACCEPTED
+	NodeMembershipAccepted NodeMembership = "accepted"
+)
+
+// NodeAvailability represents the availability of a node.
+type NodeAvailability string
+
+const (
+	// NodeAvailabilityActive ACTIVE
+	NodeAvailabilityActive NodeAvailability = "active"
+	// NodeAvailabilityPause PAUSE
+	NodeAvailabilityPause NodeAvailability = "pause"
+	// NodeAvailabilityDrain DRAIN
+	NodeAvailabilityDrain NodeAvailability = "drain"
+)
+
+// NodeDescription represents the description of a node.
+type NodeDescription struct {
+	Hostname  string            `json:",omitempty"`
+	Platform  Platform          `json:",omitempty"`
+	Resources Resources         `json:",omitempty"`
+	Engine    EngineDescription `json:",omitempty"`
+}
+
+// Platform represents the platfrom (Arch/OS).
+type Platform struct {
+	Architecture string `json:",omitempty"`
+	OS           string `json:",omitempty"`
+}
+
+// EngineDescription represents the description of an engine.
+type EngineDescription struct {
+	EngineVersion string              `json:",omitempty"`
+	Labels        map[string]string   `json:",omitempty"`
+	Plugins       []PluginDescription `json:",omitempty"`
+}
+
+// PluginDescription represents the description of an engine plugin.
+type PluginDescription struct {
+	Type string `json:",omitempty"`
+	Name string `json:",omitempty"`
+}
+
+// NodeStatus represents the status of a node.
+type NodeStatus struct {
+	State   NodeState `json:",omitempty"`
+	Message string    `json:",omitempty"`
+}
+
+// Reachability represents the reachability of a node.
+type Reachability string
+
+const (
+	// ReachabilityUnknown UNKNOWN
+	ReachabilityUnknown Reachability = "unknown"
+	// ReachabilityUnreachable UNREACHABLE
+	ReachabilityUnreachable Reachability = "unreachable"
+	// ReachabilityReachable REACHABLE
+	ReachabilityReachable Reachability = "reachable"
+)
+
+// ManagerStatus represents the status of a manager.
+type ManagerStatus struct {
+	Leader       bool         `json:",omitempty"`
+	Reachability Reachability `json:",omitempty"`
+	Addr         string       `json:",omitempty"`
+}
+
+// NodeState represents the state of a node.
+type NodeState string
+
+const (
+	// NodeStateUnknown UNKNOWN
+	NodeStateUnknown NodeState = "unknown"
+	// NodeStateDown DOWN
+	NodeStateDown NodeState = "down"
+	// NodeStateReady READY
+	NodeStateReady NodeState = "ready"
+	// NodeStateDisconnected DISCONNECTED
+	NodeStateDisconnected NodeState = "disconnected"
+)

--- a/vendor/github.com/docker/engine-api/types/swarm/service.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/service.go
@@ -1,0 +1,44 @@
+package swarm
+
+import "time"
+
+// Service represents a service.
+type Service struct {
+	ID string
+	Meta
+	Spec     ServiceSpec `json:",omitempty"`
+	Endpoint Endpoint    `json:",omitempty"`
+}
+
+// ServiceSpec represents the spec of a service.
+type ServiceSpec struct {
+	Annotations
+
+	// TaskTemplate defines how the service should construct new tasks when
+	// ochestrating this service.
+	TaskTemplate TaskSpec                  `json:",omitempty"`
+	Mode         ServiceMode               `json:",omitempty"`
+	UpdateConfig *UpdateConfig             `json:",omitempty"`
+	Networks     []NetworkAttachmentConfig `json:",omitempty"`
+	EndpointSpec *EndpointSpec             `json:",omitempty"`
+}
+
+// ServiceMode represents the mode of a service.
+type ServiceMode struct {
+	Replicated *ReplicatedService `json:",omitempty"`
+	Global     *GlobalService     `json:",omitempty"`
+}
+
+// ReplicatedService is a kind of ServiceMode.
+type ReplicatedService struct {
+	Replicas *uint64 `json:",omitempty"`
+}
+
+// GlobalService is a kind of ServiceMode.
+type GlobalService struct{}
+
+// UpdateConfig represents the update configuration.
+type UpdateConfig struct {
+	Parallelism uint64        `json:",omitempty"`
+	Delay       time.Duration `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/swarm.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/swarm.go
@@ -1,0 +1,107 @@
+package swarm
+
+import "time"
+
+// Swarm represents a swarm.
+type Swarm struct {
+	ID string
+	Meta
+	Spec Spec
+}
+
+// Spec represents the spec of a swarm.
+type Spec struct {
+	Annotations
+
+	AcceptancePolicy AcceptancePolicy    `json:",omitempty"`
+	Orchestration    OrchestrationConfig `json:",omitempty"`
+	Raft             RaftConfig          `json:",omitempty"`
+	Dispatcher       DispatcherConfig    `json:",omitempty"`
+	CAConfig         CAConfig            `json:",omitempty"`
+}
+
+// AcceptancePolicy represents the list of policies.
+type AcceptancePolicy struct {
+	Policies []Policy `json:",omitempty"`
+}
+
+// Policy represents a role, autoaccept and secret.
+type Policy struct {
+	Role       NodeRole
+	Autoaccept bool
+	Secret     string `json:",omitempty"`
+}
+
+// OrchestrationConfig represents ochestration configuration.
+type OrchestrationConfig struct {
+	TaskHistoryRetentionLimit int64 `json:",omitempty"`
+}
+
+// RaftConfig represents raft configuration.
+type RaftConfig struct {
+	SnapshotInterval           uint64 `json:",omitempty"`
+	KeepOldSnapshots           uint64 `json:",omitempty"`
+	LogEntriesForSlowFollowers uint64 `json:",omitempty"`
+	HeartbeatTick              uint32 `json:",omitempty"`
+	ElectionTick               uint32 `json:",omitempty"`
+}
+
+// DispatcherConfig represents dispatcher configuration.
+type DispatcherConfig struct {
+	HeartbeatPeriod uint64 `json:",omitempty"`
+}
+
+// CAConfig represents CA configuration.
+type CAConfig struct {
+	NodeCertExpiry time.Duration `json:",omitempty"`
+}
+
+// InitRequest is the request used to init a swarm.
+type InitRequest struct {
+	ListenAddr      string
+	ForceNewCluster bool
+	Spec            Spec
+}
+
+// JoinRequest is the request used to join a swarm.
+type JoinRequest struct {
+	ListenAddr  string
+	RemoteAddrs []string
+	Secret      string // accept by secret
+	CACertHash  string
+	Manager     bool
+}
+
+// LocalNodeState represents the state of the local node.
+type LocalNodeState string
+
+const (
+	// LocalNodeStateInactive INACTIVE
+	LocalNodeStateInactive LocalNodeState = "inactive"
+	// LocalNodeStatePending PENDING
+	LocalNodeStatePending LocalNodeState = "pending"
+	// LocalNodeStateActive ACTIVE
+	LocalNodeStateActive LocalNodeState = "active"
+	// LocalNodeStateError ERROR
+	LocalNodeStateError LocalNodeState = "error"
+)
+
+// Info represents generic information about swarm.
+type Info struct {
+	NodeID string
+
+	LocalNodeState   LocalNodeState
+	ControlAvailable bool
+	Error            string
+
+	RemoteManagers []Peer
+	Nodes          int
+	Managers       int
+	CACertHash     string
+}
+
+// Peer represents a peer.
+type Peer struct {
+	NodeID string
+	Addr   string
+}

--- a/vendor/github.com/docker/engine-api/types/swarm/task.go
+++ b/vendor/github.com/docker/engine-api/types/swarm/task.go
@@ -1,0 +1,110 @@
+package swarm
+
+import "time"
+
+// TaskState represents the state of a task.
+type TaskState string
+
+const (
+	// TaskStateNew NEW
+	TaskStateNew TaskState = "new"
+	// TaskStateAllocated ALLOCATED
+	TaskStateAllocated TaskState = "allocated"
+	// TaskStatePending PENDING
+	TaskStatePending TaskState = "pending"
+	// TaskStateAssigned ASSIGNED
+	TaskStateAssigned TaskState = "assigned"
+	// TaskStateAccepted ACCEPTED
+	TaskStateAccepted TaskState = "accepted"
+	// TaskStatePreparing PREPARING
+	TaskStatePreparing TaskState = "preparing"
+	// TaskStateReady READY
+	TaskStateReady TaskState = "ready"
+	// TaskStateStarting STARTING
+	TaskStateStarting TaskState = "starting"
+	// TaskStateRunning RUNNING
+	TaskStateRunning TaskState = "running"
+	// TaskStateComplete COMPLETE
+	TaskStateComplete TaskState = "complete"
+	// TaskStateShutdown SHUTDOWN
+	TaskStateShutdown TaskState = "shutdown"
+	// TaskStateFailed FAILED
+	TaskStateFailed TaskState = "failed"
+	// TaskStateRejected REJECTED
+	TaskStateRejected TaskState = "rejected"
+)
+
+// Task represents a task.
+type Task struct {
+	ID string
+	Meta
+
+	Spec                TaskSpec            `json:",omitempty"`
+	ServiceID           string              `json:",omitempty"`
+	Slot                int                 `json:",omitempty"`
+	NodeID              string              `json:",omitempty"`
+	Status              TaskStatus          `json:",omitempty"`
+	DesiredState        TaskState           `json:",omitempty"`
+	NetworksAttachments []NetworkAttachment `json:",omitempty"`
+}
+
+// TaskSpec represents the spec of a task.
+type TaskSpec struct {
+	ContainerSpec ContainerSpec         `json:",omitempty"`
+	Resources     *ResourceRequirements `json:",omitempty"`
+	RestartPolicy *RestartPolicy        `json:",omitempty"`
+	Placement     *Placement            `json:",omitempty"`
+}
+
+// Resources represents resources (CPU/Memory).
+type Resources struct {
+	NanoCPUs    int64 `json:",omitempty"`
+	MemoryBytes int64 `json:",omitempty"`
+}
+
+// ResourceRequirements represents resources requirements.
+type ResourceRequirements struct {
+	Limits       *Resources `json:",omitempty"`
+	Reservations *Resources `json:",omitempty"`
+}
+
+// Placement represents orchestration parameters.
+type Placement struct {
+	Constraints []string `json:",omitempty"`
+}
+
+// RestartPolicy represents the restart policy.
+type RestartPolicy struct {
+	Condition   RestartPolicyCondition `json:",omitempty"`
+	Delay       *time.Duration         `json:",omitempty"`
+	MaxAttempts *uint64                `json:",omitempty"`
+	Window      *time.Duration         `json:",omitempty"`
+}
+
+// RestartPolicyCondition represents when to restart.
+type RestartPolicyCondition string
+
+const (
+	// RestartPolicyConditionNone NONE
+	RestartPolicyConditionNone RestartPolicyCondition = "none"
+	// RestartPolicyConditionOnFailure ON_FAILURE
+	RestartPolicyConditionOnFailure RestartPolicyCondition = "on_failure"
+	// RestartPolicyConditionAny ANY
+	RestartPolicyConditionAny RestartPolicyCondition = "any"
+)
+
+// TaskStatus represents the status of a task.
+type TaskStatus struct {
+	Timestamp       time.Time       `json:",omitempty"`
+	State           TaskState       `json:",omitempty"`
+	Message         string          `json:",omitempty"`
+	Err             string          `json:",omitempty"`
+	ContainerStatus ContainerStatus `json:",omitempty"`
+}
+
+// ContainerStatus represents the status of a container.
+type ContainerStatus struct {
+	ContainerID string `json:",omitempty"`
+	PID         int    `json:",omitempty"`
+	ExitCode    int    `json:",omitempty"`
+}

--- a/vendor/github.com/docker/engine-api/types/types.go
+++ b/vendor/github.com/docker/engine-api/types/types.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/engine-api/types/registry"
+	"github.com/docker/engine-api/types/swarm"
 	"github.com/docker/go-connections/nat"
 )
 
@@ -254,6 +255,7 @@ type Info struct {
 	SecurityOptions    []string
 	Runtimes           map[string]Runtime
 	DefaultRuntime     string
+	Swarm              swarm.Info
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -323,7 +325,7 @@ type ContainerNode struct {
 	Addr      string
 	Name      string
 	Cpus      int
-	Memory    int
+	Memory    int64
 	Labels    map[string]string
 }
 

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,50 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,211 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type Causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type StackTrace interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stacktrace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stacktrace of this error. For example:
+//
+//     if err, ok := err.(StackTrace); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// _error is an error implementation returned by New and Errorf
+// that implements its own fmt.Formatter.
+type _error struct {
+	msg string
+	*stack
+}
+
+func (e _error) Error() string { return e.msg }
+
+func (e _error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, e.msg)
+			fmt.Fprintf(s, "%+v", e.StackTrace())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.msg)
+	}
+}
+
+// New returns an error with the supplied message.
+func New(message string) error {
+	return _error{
+		message,
+		callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+func Errorf(format string, args ...interface{}) error {
+	return _error{
+		fmt.Sprintf(format, args...),
+		callers(),
+	}
+}
+
+type cause struct {
+	cause error
+	msg   string
+}
+
+func (c cause) Error() string { return fmt.Sprintf("%s: %v", c.msg, c.Cause()) }
+func (c cause) Cause() error  { return c.cause }
+
+// wrapper is an error implementation returned by Wrap and Wrapf
+// that implements its own fmt.Formatter.
+type wrapper struct {
+	cause
+	*stack
+}
+
+func (w wrapper) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			fmt.Fprintf(s, "%+v: %s", w.StackTrace()[0], w.msg)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   message,
+		},
+		stack: callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	return wrapper{
+		cause: cause{
+			cause: err,
+			msg:   fmt.Sprintf(format, args...),
+		},
+		stack: callers(),
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type Causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,165 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
Errors returned from controller methods are now all treated as fatal by
the the task controller. The defers most retries to the orchestration
layer, where they can be better handled. We also cement the concept of a
"Temporary" error, allowing an Executor/Controller to signal to the
caller that the error is actually temporary. We can mark these as
temporary as we find cases where it makes more sense.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes #970, among others.

cc @tonistiigi @dongluochen @cpuguy83 @aluzzardi 