### PR TITLE
agent/exec/container: always pull when preparing

### DIFF
--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -39,15 +39,16 @@ func newContainerAdapter(client engineapi.APIClient, task *api.Task) (*container
 
 func noopPrivilegeFn() (string, error) { return "", nil }
 
-func (c *containerAdapter) pullImage(ctx context.Context) error {
-	// if the image needs to be pulled, the auth config will be retrieved and updated
-	encodedConfig := c.container.spec().RegistryAuth
+func (c *containerConfig) imagePullOptions() types.ImagePullOptions {
+	return types.ImagePullOptions{
+		// if the image needs to be pulled, the auth config will be retrieved and updated
+		RegistryAuth:  c.spec().RegistryAuth,
+		PrivilegeFunc: noopPrivilegeFn,
+	}
+}
 
-	rc, err := c.client.ImagePull(ctx, c.container.image(),
-		types.ImagePullOptions{
-			RegistryAuth:  encodedConfig,
-			PrivilegeFunc: noopPrivilegeFn,
-		})
+func (c *containerAdapter) pullImage(ctx context.Context) error {
+	rc, err := c.client.ImagePull(ctx, c.container.image(), c.container.imagePullOptions())
 	if err != nil {
 		return err
 	}

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -86,33 +86,32 @@ func (r *controller) Prepare(ctx context.Context) error {
 		return err
 	}
 
-	for {
-		if err := r.checkClosed(); err != nil {
-			return err
-		}
+	if err := r.adapter.pullImage(ctx); err != nil {
+		// NOTE(stevvooe): We always try to pull the image to make sure we have
+		// the most up to date version. This will return an error, but we only
+		// log it. If the image truly doesn't exist, the create below will
+		// error out.
+		//
+		// This gives us some nice behavior where we use up to date versions of
+		// mutable tags, but will still run if the old image is available but a
+		// registry is down.
+		//
+		// If you don't want this behavior, lock down your image to an
+		// immutable tag or digest.
+		log.G(ctx).WithError(err).Error("pulling image failed")
+	}
 
-		if err := r.adapter.create(ctx); err != nil {
-			if isContainerCreateNameConflict(err) {
-				if _, err := r.adapter.inspect(ctx); err != nil {
-					return err
-				}
-
-				// container is already created. success!
-				return exec.ErrTaskPrepared
-			}
-
-			if !engineapi.IsErrImageNotFound(err) {
+	if err := r.adapter.create(ctx); err != nil {
+		if isContainerCreateNameConflict(err) {
+			if _, err := r.adapter.inspect(ctx); err != nil {
 				return err
 			}
 
-			if err := r.adapter.pullImage(ctx); err != nil {
-				return err
-			}
-
-			continue // retry to create the container
+			// container is already created. success!
+			return exec.ErrTaskPrepared
 		}
 
-		break
+		return err
 	}
 
 	return nil

--- a/agent/exec/container/controller_test.go
+++ b/agent/exec/container/controller_test.go
@@ -35,7 +35,9 @@ func TestControllerPrepare(t *testing.T) {
 	defer finish(t)
 
 	gomock.InOrder(
-		client.EXPECT().ContainerCreate(ctx, config.config(), config.hostConfig(), config.networkingConfig(), config.name()).
+		client.EXPECT().ImagePull(gomock.Any(), config.image(), gomock.Any()).
+			Return(ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil),
+		client.EXPECT().ContainerCreate(gomock.Any(), config.config(), config.hostConfig(), config.networkingConfig(), config.name()).
 			Return(types.ContainerCreateResponse{ID: "contianer-id-" + task.ID}, nil),
 	)
 
@@ -48,6 +50,8 @@ func TestControllerPrepareAlreadyPrepared(t *testing.T) {
 	defer finish(t)
 
 	gomock.InOrder(
+		client.EXPECT().ImagePull(gomock.Any(), config.image(), gomock.Any()).
+			Return(ioutil.NopCloser(bytes.NewBuffer([]byte{})), nil),
 		client.EXPECT().ContainerCreate(
 			ctx, config.config(), config.hostConfig(), config.networkingConfig(), config.name()).
 			Return(types.ContainerCreateResponse{}, fmt.Errorf("Conflict. The name")),


### PR DESCRIPTION
To avoid out of date images when using mutable tags, we now always pull
when preparing a task. This avoids needing a flag, since those who want
to lock an image name can use immutable tags and those who want to
update images on every task creation get the behavior for free.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @samalba @tonistiigi @aluzzardi 