### PR TITLE
change keyring size to 3.

### DIFF
--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -32,6 +32,8 @@ const (
 
 	// DefaultSubsystem is gossip
 	DefaultSubsystem = SubsystemGossip
+	// number of keys to mainrain in the key ring.
+	keyringSize = 3
 )
 
 // map of subsystems and corresponding encryption algorithm. Initially only
@@ -148,7 +150,7 @@ func (k *KeyManager) rotateKey(ctx context.Context) error {
 	// We maintain the latest key and the one before in the key ring to allow
 	// agents to communicate without disruption on key change.
 	for subsys, keys := range subsysKeys {
-		if len(keys) > 1 {
+		if len(keys) == keyringSize {
 			min := 0
 			for i, key := range keys[1:] {
 				if key.LamportTime < keys[min].LamportTime {
@@ -189,7 +191,9 @@ func (k *KeyManager) Run(ctx context.Context) error {
 	cluster := clusters[0]
 	if len(cluster.NetworkBootstrapKeys) == 0 {
 		for _, subsys := range k.config.Subsystems {
-			k.keyRing.keys = append(k.keyRing.keys, k.allocateKey(ctx, subsys))
+			for i := 0; i < keyringSize; i++ {
+				k.keyRing.keys = append(k.keyRing.keys, k.allocateKey(ctx, subsys))
+			}
 		}
 		if err := k.updateKey(cluster); err != nil {
 			log.Errorf("store update failed %v", err)


### PR DESCRIPTION
Having the keyring size 3 allows the key rotation to happen across the cluster without packet loss even if nodes receive the new key set with some time difference.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>