### PR TITLE
raft: Fix edge case panic

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -842,7 +842,7 @@ func (n *Node) sendToMember(members map[uint64]*membership.Member, m raftpb.Mess
 			}
 		}
 
-		if queryMember == nil {
+		if queryMember == nil || queryMember.RaftID == n.Config.ID {
 			n.Config.Logger.Error("could not find cluster member to query for leader address")
 			return
 		}


### PR DESCRIPTION
The logic in sendToMember is slightly wrong. We look for a member other
than ourself to query, but there's no error case if we are the only
member in the list. Add a check to make sure

This code should normally not be reached if we are the only member, but
appears to run when an invalid address is passed to Join. A separate
change will prevent nodes with invalid addresses from being added to the
cluster.

Related to #983