### PR TITLE
manager: Return an error if no TCP listen address is provided

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -100,6 +101,10 @@ func New(config *Config) (*Manager, error) {
 	}
 
 	tcpAddr := config.ProtoAddr["tcp"]
+
+	if tcpAddr == "" {
+		return nil, errors.New("no tcp listen address or listener provided")
+	}
 
 	listenHost, listenPort, err := net.SplitHostPort(tcpAddr)
 	if err == nil {
@@ -664,7 +669,7 @@ func (m *Manager) rotateRootCAKEK(ctx context.Context, clusterID string) error {
 	return s.Update(func(tx store.Tx) error {
 		cluster = store.GetCluster(tx, clusterID)
 		if cluster == nil {
-			return fmt.Errorf("cluster not found")
+			return fmt.Errorf("cluster not found: %s", clusterID)
 		}
 		cluster.RootCA.CAKey = finalKey
 		return store.UpdateCluster(tx, cluster)


### PR DESCRIPTION
One of the necessary parameters for creating a manager is the TCP
address where it will listen for GRPC traffic. It's okay to use a
wildcard address like 0.0.0.0:4242, but the port is still important, so
an empty string isn't a usable value.

Return an error from (*Manager).New if no listen address (or listener)
is provided. This avoids bad behavior in raft if the address is omitted.

cc @abronan @dhiltgen @LK4D4

Closes #983