### PR TITLE
Fix possible race on saving NodeID

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -194,11 +194,9 @@ func (n *Node) run(ctx context.Context) (err error) {
 	// - Given a valid certificate, spin a renewal go-routine that will ensure that certificates stay
 	// up to date.
 	nodeIDChan := make(chan string, 1)
-	caLoadDone := make(chan struct{})
 	go func() {
 		select {
 		case <-ctx.Done():
-		case <-caLoadDone:
 		case nodeID := <-nodeIDChan:
 			logrus.Debugf("Requesting certificate for NodeID: %v", nodeID)
 			n.Lock()
@@ -209,7 +207,6 @@ func (n *Node) run(ctx context.Context) (err error) {
 
 	certDir := filepath.Join(n.config.StateDir, "certificates")
 	securityConfig, err := ca.LoadOrCreateSecurityConfig(ctx, certDir, n.config.CAHash, n.config.Secret, csrRole, picker.NewPicker(n.remotes), nodeIDChan)
-	close(caLoadDone)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In case `LoadOrCreateSecurityConfig` returns before a goroutine is scheduled we may not catch `NodeID`. This logic for cleaning up goroutine turned out to be unnecessary because the only case when `nodeIDChan` is not being written to is the error case and this is already handled by closing the context.

@diogomonica  

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>