### PR TITLE
swarmctl: show replicas as a quotient against running

### DIFF
--- a/cmd/swarmctl/service/common.go
+++ b/cmd/swarmctl/service/common.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"strconv"
 
 	"golang.org/x/net/context"
 
@@ -38,12 +37,12 @@ func getService(ctx context.Context, c api.ControlClient, input string) (*api.Se
 	return rg.Service, nil
 }
 
-func getServiceReplicasTxt(s *api.Service) string {
+func getServiceReplicasTxt(s *api.Service, running int) string {
 	switch t := s.Spec.GetMode().(type) {
 	case *api.ServiceSpec_Global:
 		return "global"
 	case *api.ServiceSpec_Replicated:
-		return strconv.FormatUint(t.Replicated.Replicas, 10)
+		return fmt.Sprintf("%d/%d", running, t.Replicated.Replicas)
 	}
 	return ""
 }

--- a/cmd/swarmctl/service/list.go
+++ b/cmd/swarmctl/service/list.go
@@ -34,6 +34,18 @@ var (
 			var output func(j *api.Service)
 
 			if !quiet {
+				tr, err := c.ListTasks(common.Context(cmd), &api.ListTasksRequest{})
+				if err != nil {
+					return err
+				}
+
+				running := map[string]int{}
+				for _, task := range tr.Tasks {
+					if task.Status.State == api.TaskStateRunning {
+						running[task.ServiceID]++
+					}
+				}
+
 				w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 				defer func() {
 					// Ignore flushing errors - there's nothing we can do.
@@ -52,7 +64,7 @@ var (
 						s.ID,
 						spec.Annotations.Name,
 						reference,
-						getServiceReplicasTxt(s),
+						getServiceReplicasTxt(s, running[s.ID]),
 					)
 				}
 


### PR DESCRIPTION
For replicated services, we now show replicas as a quotient of running
tasks over desired number of tasks. While the query is expensive, the
wow factor is more than worth it.

Example: 

```
ID                         Name    Image                 Replicas
--                         ----    -----                 --------
c69kj7q8whljylvpl55kvxilp  alpine  alpine                10/10
dhrhzorbf6akupexh5qp1mtsr  redis   localhost:5000/redis  20/20
```

Try it with several services and scale them up and down for maximum OMGZ.

Signed-off-by: Stephen J Day <stephen.day@docker.com>