### PR TITLE
swarmctl: Use filters to avoid listing all tasks in queries

### DIFF
--- a/cmd/swarmctl/cluster/update.go
+++ b/cmd/swarmctl/cluster/update.go
@@ -132,7 +132,6 @@ var (
 )
 
 func init() {
-	// TODO(aaronl): Acceptance policy will change later.
 	updateCmd.Flags().StringSlice("autoaccept", nil, "Roles to automatically issue certificates for")
 	updateCmd.Flags().StringSlice("secret", nil, "Secret required to join the cluster")
 	updateCmd.Flags().Int64("taskhistory", 0, "Number of historic task entries to retain per slot or node")

--- a/cmd/swarmctl/node/inspect.go
+++ b/cmd/swarmctl/node/inspect.go
@@ -114,22 +114,20 @@ var (
 				return err
 			}
 
-			// TODO(aluzzardi): This should be implemented as a ListOptions filter.
-			r, err := c.ListTasks(common.Context(cmd), &api.ListTasksRequest{})
+			r, err := c.ListTasks(common.Context(cmd),
+				&api.ListTasksRequest{
+					Filters: &api.ListTasksRequest_Filters{
+						NodeIDs: []string{node.ID},
+					},
+				})
 			if err != nil {
 				return err
 			}
-			tasks := []*api.Task{}
-			for _, t := range r.Tasks {
-				if t.NodeID == node.ID {
-					tasks = append(tasks, t)
-				}
-			}
 
 			printNodeSummary(node)
-			if len(tasks) > 0 {
+			if len(r.Tasks) > 0 {
 				fmt.Printf("\n")
-				task.Print(tasks, all, common.NewResolver(cmd, c))
+				task.Print(r.Tasks, all, common.NewResolver(cmd, c))
 			}
 
 			return nil

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -116,28 +116,26 @@ var (
 				return err
 			}
 
-			// TODO(aluzzardi): This should be implemented as a ListOptions filter.
-			r, err := c.ListTasks(common.Context(cmd), &api.ListTasksRequest{})
+			r, err := c.ListTasks(common.Context(cmd),
+				&api.ListTasksRequest{
+					Filters: &api.ListTasksRequest_Filters{
+						ServiceIDs: []string{service.ID},
+					},
+				})
 			if err != nil {
 				return err
 			}
-			tasks := []*api.Task{}
 			var running int
 			for _, t := range r.Tasks {
-				if t.ServiceID != service.ID {
-					continue
-				}
-				tasks = append(tasks, t)
-
 				if t.Status.State == api.TaskStateRunning {
 					running++
 				}
 			}
 
 			printServiceSummary(service, running)
-			if len(tasks) > 0 {
+			if len(r.Tasks) > 0 {
 				fmt.Printf("\n")
-				task.Print(tasks, all, res)
+				task.Print(r.Tasks, all, res)
 			}
 
 			return nil

--- a/cmd/swarmctl/task/inspect.go
+++ b/cmd/swarmctl/task/inspect.go
@@ -79,14 +79,18 @@ var (
 			}
 			task := t.Task
 
-			// TODO(aluzzardi): This should be implemented as a ListOptions filter.
-			r, err := c.ListTasks(common.Context(cmd), &api.ListTasksRequest{})
+			r, err := c.ListTasks(common.Context(cmd),
+				&api.ListTasksRequest{
+					Filters: &api.ListTasksRequest_Filters{
+						ServiceIDs: []string{task.ServiceID},
+					},
+				})
 			if err != nil {
 				return err
 			}
 			previous := []*api.Task{}
 			for _, t := range r.Tasks {
-				if t.ServiceID == task.ServiceID && t.Slot == task.Slot {
+				if t.Slot == task.Slot {
 					previous = append(previous, t)
 				}
 			}


### PR DESCRIPTION
This makes "task inspect", "service inspect", and "node inspect" query
the API for only a subset of tasks, not every task in the system.

cc @aluzzardi