### PR TITLE
Removing Started from CA

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -33,7 +33,7 @@ type Server struct {
 
 	// Started is a channel which gets closed once the server is running
 	// and able to service RPCs.
-	Started chan struct{}
+	started chan struct{}
 }
 
 // DefaultAcceptancePolicy returns the default acceptance policy.
@@ -64,7 +64,7 @@ func NewServer(store *store.MemoryStore, securityConfig *SecurityConfig) *Server
 	return &Server{
 		store:          store,
 		securityConfig: securityConfig,
-		Started:        make(chan struct{}),
+		started:        make(chan struct{}),
 	}
 }
 
@@ -358,7 +358,14 @@ func (s *Server) Run(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.mu.Unlock()
 
-	close(s.Started)
+	// Run() should never be called twice, but just in case, we're
+	// attempting to close the started channel in a safe way
+	select {
+	case <-s.started:
+		return fmt.Errorf("CA server cannot be started more than once")
+	default:
+		close(s.started)
+	}
 
 	// Retrieve the channels to keep track of changes in the cluster
 	// Retrieve all the currently registered nodes
@@ -437,6 +444,11 @@ func (s *Server) Stop() error {
 	// wait for all handlers to finish their CA deals,
 	s.wg.Wait()
 	return nil
+}
+
+// Ready waits on the ready channel and returns when the server is ready to serve.
+func (s *Server) Ready() <-chan struct{} {
+	return s.started
 }
 
 func (s *Server) addTask() error {

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -165,7 +165,8 @@ func NewTestCA(t *testing.T, policy api.AcceptancePolicy) *TestCA {
 		caServer.Run(ctx)
 	}()
 
-	<-caServer.Started
+	// Wait for caServer to be ready to serve
+	<-caServer.Ready()
 
 	remotes := picker.NewRemotes(api.Peer{Addr: l.Addr().String()})
 	picker := picker.NewPicker(remotes, l.Addr().String())


### PR DESCRIPTION
No one uses `Started` from the `CAServer`, but in general we should fix this pattern because it leads to this bug: https://github.com/docker/swarmkit/issues/998

Signed-off-by: Diogo Monica <diogo.monica@gmail.com>

/cc @aaronlehmann 