### PR TITLE
node: let manager handle demoting itself

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -623,10 +623,10 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 			select {
 			case <-ctx.Done():
 				m.Stop(context.Background()) // todo: this should be sync like other components
-			case <-n.waitRole(ctx, ca.AgentRole):
+				<-done
+			// in case of demotion manager will stop itself
+			case <-done:
 			}
-
-			<-done
 
 			ready = nil // ready event happens once, even on multiple starts
 			n.Lock()


### PR DESCRIPTION
There was non-zero chance to get <-waitRole if the context was cancelled,
but the role was unchanged. Because the behavior of "demote" and context cancel
is different(wait for a manager to stop vs. stop manager) it could lead to
forever hanged managers.
ping @tonistiigi @aaronlehmann 