### PR TITLE
picker: exclude some peers in select

### DIFF
--- a/picker/picker.go
+++ b/picker/picker.go
@@ -104,10 +104,12 @@ func (mwr *remotesWeightedRandom) Select(excludes ...string) (api.Peer, error) {
 
 	cum := 0.0
 	// calculate CDF over weights
+Loop:
 	for peer, weight := range mwr.remotes {
 		for _, exclude := range excludes {
 			if peer.NodeID == exclude || peer.Addr == exclude {
-				continue
+				// if this peer is excluded, ignore it by continuing the loop to label Loop
+				continue Loop
 			}
 		}
 		if weight < 0 {
@@ -126,6 +128,7 @@ func (mwr *remotesWeightedRandom) Select(excludes ...string) (api.Peer, error) {
 
 	r := mwr.cdf[len(mwr.cdf)-1] * rand.Float64()
 	i := sort.SearchFloat64s(mwr.cdf, r)
+
 	return mwr.peers[i], nil
 }
 
@@ -261,7 +264,7 @@ func (p *Picker) PickAddr() (string, error) {
 	p.r.ObserveIfExists(peer, -1) // downweight the current addr
 
 	var err error
-	peer, err = p.r.Select("")
+	peer, err = p.r.Select()
 	if err != nil {
 		return "", err
 	}

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -65,6 +65,42 @@ func TestRemotesEmpty(t *testing.T) {
 
 }
 
+func TestRemotesExclude(t *testing.T) {
+	peers := []api.Peer{{Addr: "one"}, {Addr: "two"}, {Addr: "three"}}
+	excludes := []string{"one", "two", "three"}
+	remotes := NewRemotes(peers...)
+
+	// exclude all
+	_, err := remotes.Select(excludes...)
+	if err != errRemotesUnavailable {
+		t.Fatal("select an excluded peer")
+	}
+
+	// exclude one peer
+	for i := 0; i < len(peers)*10; i++ {
+		next, err := remotes.Select(excludes[0])
+		if err != nil {
+			t.Fatalf("error selecting remote: %v", err)
+		}
+
+		if next == peers[0] {
+			t.Fatal("select an excluded peer")
+		}
+	}
+
+	// exclude 2 peers
+	for i := 0; i < len(peers)*10; i++ {
+		next, err := remotes.Select(excludes[1:]...)
+		if err != nil {
+			t.Fatalf("error selecting remote: %v", err)
+		}
+
+		if next != peers[0] {
+			t.Fatalf("select an excluded peer: %v", next)
+		}
+	}
+}
+
 // TestRemotesConvergence ensures that as we get positive observations,
 // the actual weight increases or converges to a value higher than the initial
 // value.


### PR DESCRIPTION
fix exclude bug in picker select

related to [PR#1001](https://github.com/docker/swarmkit/pull/1001)
Signed-off-by: runshenzhu <runshen.zhu@gmail.com>

ping @stevvooe @sqleejan