### PR TITLE
support health check in image

### DIFF
--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -193,6 +193,14 @@ func (r *controller) Wait(pctx context.Context) error {
 				// If we get here, something has gone wrong but we want to exit
 				// and report anyways.
 				return ErrContainerDestroyed
+
+			case "health_status: unhealthy":
+				// in this case, we stop the container and report unhealthy status
+				// TODO(runshenzhu): double check if it can cause a dead lock issue here
+				if err := r.Shutdown(ctx); err != nil {
+					return errors.Wrap(err, "unhealthy container")
+				}
+				return ErrContainerUnhealthy
 			}
 		case <-closed:
 			// restart!

--- a/agent/exec/container/controller_test.go
+++ b/agent/exec/container/controller_test.go
@@ -139,6 +139,30 @@ func TestControllerWait(t *testing.T) {
 	assert.NoError(t, ctlr.Wait(ctx))
 }
 
+func TestControllerWaitUnhealthy(t *testing.T) {
+	task := genTask(t)
+	ctx, client, ctlr, config, finish := genTestControllerEnv(t, task)
+	defer finish(t)
+
+	gomock.InOrder(
+		client.EXPECT().ContainerInspect(gomock.Any(), config.name()).
+			Return(types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					State: &types.ContainerState{
+						Status: "running",
+					},
+				},
+			}, nil),
+		client.EXPECT().Events(gomock.Any(), types.EventsOptions{
+			Since:   "0",
+			Filters: config.eventFilter(),
+		}).Return(makeEvents(t, config, "create", "health_status: unhealthy"), nil),
+		client.EXPECT().ContainerStop(gomock.Any(), config.name(), 10*time.Second),
+	)
+
+	assert.Equal(t, ctlr.Wait(ctx), ErrContainerUnhealthy)
+}
+
 func TestControllerWaitExitError(t *testing.T) {
 	task := genTask(t)
 	ctx, client, ctlr, config, finish := genTestControllerEnv(t, task)

--- a/agent/exec/container/errors.go
+++ b/agent/exec/container/errors.go
@@ -9,4 +9,7 @@ var (
 	// ErrContainerDestroyed returned when a container is prematurely destroyed
 	// during a wait call.
 	ErrContainerDestroyed = fmt.Errorf("dockerexec: container destroyed")
+
+	// ErrContainerUnhealthy returned if controller detects the health check failure
+	ErrContainerUnhealthy = fmt.Errorf("dockerexec: unhealthy container")
 )


### PR DESCRIPTION
This PR supports health check defined in container image. #975 is relevant, which add the support of health check in cli. 

ping @aluzzardi @stevvooe @nishanttotla 
Signed-off-by: runshenzhu <runshen.zhu@gmail.com>