### PR TITLE
raft: Avoid deadlock on demotion

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -935,7 +935,9 @@ func (n *Node) processInternalRaftRequest(ctx context.Context, r *api.InternalRa
 		return nil, ErrRequestTooLarge
 	}
 
-	err = n.Propose(ctx, data)
+	// This must use the context which is cancelled by stop() to avoid a
+	// deadlock on shutdown.
+	err = n.Propose(n.Ctx, data)
 	if err != nil {
 		n.wait.cancel(r.ID)
 		return nil, err


### PR DESCRIPTION
Demotion depends on raft's Run function noticing that it has been
removed from the cluster, and returning an error.

Before it returns the error, it calls stop() to shut down raft. This
could deadlock in some cases if a proposal was in progress.

Change the context passed to Propose so the proposal will get cancelled
when stop() cancels the context.

cc @LK4D4 @abronan