### PR TITLE
ca: Verify that CSR in NodeCertificateStatus response matches

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -644,7 +644,15 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, role, secret st
 			if statusResponse.Certificate == nil {
 				return nil, fmt.Errorf("no certificate in CertificateStatus response")
 			}
-			return statusResponse.Certificate.Certificate, nil
+
+			// The certificate in the response must match the CSR
+			// we submitted. If we are getting a response for a
+			// certificate that was previously issued, we need to
+			// retry until the certificate gets updated per our
+			// current request.
+			if bytes.Equal(statusResponse.Certificate.CSR, csr) {
+				return statusResponse.Certificate.Certificate, nil
+			}
 		}
 
 		// If we're still pending, the issuance failed, or the state is unknown


### PR DESCRIPTION
A race condition is possible when we renew a certificate at the same
time as another update is being made to a node object.
NodeCertificateStatus is meant to wait until the certificate is issued,
but it does so by waiting for an update to the node object that has the
certificate issuance status set to "issued". If another certificate is
issued shortly before the renewal request, or an unrelated change to the
node object happens at the same time, NodeCertificateStatus may return
the old certificate instead of waiting for the new one.

To work around this, the caller of NodeCertificateStatus must verify
that it's getting a certificate corresponding to the CSR it submitted,
and retry if the CSR does not match.

@jlhawn hit this while testing support for external root CAs.

cc @diogomonica