### PR TITLE
orchestrator: Trigger rolling updates when endpoints change

### DIFF
--- a/manager/orchestrator/updater.go
+++ b/manager/orchestrator/updater.go
@@ -103,7 +103,8 @@ func (u *Updater) Run(ctx context.Context, service *api.Service, tasks []*api.Ta
 
 	dirtyTasks := []*api.Task{}
 	for _, t := range tasks {
-		if !reflect.DeepEqual(service.Spec.Task, t.Spec) {
+		if !reflect.DeepEqual(service.Spec.Task, t.Spec) ||
+			!reflect.DeepEqual(service.Endpoint, t.Endpoint) {
 			dirtyTasks = append(dirtyTasks, t)
 		}
 	}


### PR DESCRIPTION
This checks the task's Endpoint field against the service's Endpoint
field to see if tasks need to be replaced to take into account new
endpoint settings.

Endpoint is not a spec, but it is copied directly from the service, so
it's safe to do this comparison. It's actually better than comparing the
specs, because if an arbitrary port is allocated at runtime, this will
ensure that the task and service share the same port value.