### PR TITLE
Validate endpointspec in control api

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -156,7 +156,14 @@ func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 		}
 	}
 
+outer:
 	for _, nAttach := range s.Spec.Networks {
+		for _, vip := range s.Endpoint.VirtualIPs {
+			if vip.NetworkID == nAttach.Target {
+				continue outer
+			}
+		}
+
 		vip := &api.Endpoint_VirtualIP{NetworkID: nAttach.Target}
 		if err = na.allocateVIP(vip); err != nil {
 			return

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -67,6 +67,24 @@ func validateServiceSpecTemplate(spec *api.ServiceSpec) error {
 	return nil
 }
 
+func validateEndpointSpec(epSpec *api.EndpointSpec) error {
+	// Endpoint spec is optional
+	if epSpec == nil {
+		return nil
+	}
+
+	portSet := make(map[api.PortConfig]struct{})
+	for _, port := range epSpec.Ports {
+		if _, ok := portSet[*port]; ok {
+			return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: duplicate ports provided")
+		}
+
+		portSet[*port] = struct{}{}
+	}
+
+	return nil
+}
+
 func validateServiceSpec(spec *api.ServiceSpec) error {
 	if spec == nil {
 		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())


### PR DESCRIPTION
Currently endpoint spec is not validated at the control api to see if
there are duplicate port configs. Also fixed a duplicate VIP problem
when the endpoint spec was getting updated.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>