### PR TITLE
Remove unused variable - once

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -83,8 +83,7 @@ type Manager struct {
 	localserver            *grpc.Server
 	RaftNode               *raft.Node
 
-	mu   sync.Mutex
-	once sync.Once
+	mu sync.Mutex
 
 	stopped chan struct{}
 }


### PR DESCRIPTION
Reading the code and find unused `once` variable.
Feel free to close this PR if have something meaningful here.

Signed-off-by: Xian Chaobo <xianchaobo@huawei.com>