### PR TITLE
Follow logs from service

### DIFF
--- a/cmd/swarmctl/service/cmd.go
+++ b/cmd/swarmctl/service/cmd.go
@@ -18,5 +18,6 @@ func init() {
 		createCmd,
 		updateCmd,
 		removeCmd,
+		logsCmd,
 	)
 }

--- a/cmd/swarmctl/service/logs.go
+++ b/cmd/swarmctl/service/logs.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/cmd/swarmctl/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	logsCmd = &cobra.Command{
+		Use:   "logs <service ID>",
+		Short: "",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return errors.New("service ID missing")
+			}
+			c, err := common.Dial(cmd)
+			if err != nil {
+				return err
+			}
+
+			service, err := getService(common.Context(cmd), c, args[0])
+			if err != nil {
+				return err
+			}
+
+			r, err := c.ListTasks(common.Context(cmd),
+				&api.ListTasksRequest{
+					Filters: &api.ListTasksRequest_Filters{
+						ServiceIDs: []string{service.ID},
+					},
+				})
+			if err != nil {
+				return err
+			}
+			for _, task := range r.Tasks {
+				// TODO (gianarb) Magic stuff to grab log
+				fmt.Println(task.Status.GetContainer().ContainerID)
+			}
+			return nil
+		},
+	}
+)


### PR DESCRIPTION
One feature that at the moment we don't have but could be good is
a command to follow logs for a particular service.
With this PR I am trying to implement this feature and also grab some
information about this feature.

This is my first contribution and plese let me know if this idea is
completly wrong.

If someone has feedback for my this is a checklist about my next steps

- [x] Bootstrap new command `swarmctl service logs <service-name>`
- [x] Grab containerId for each task running
- [ ] obtain logs from this list of containers
- [ ] Print something of good to see
- [ ] Implement flags like `-f` to follow or not a stream

Signed-off-by: Gianluca Arbezzano gianarb92@gmail.com