### PR TITLE
orchestrator: Better balancing on scale down

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -326,7 +326,7 @@ func (m *Manager) Run(parent context.Context) error {
 					log.G(ctx).WithError(err).Error("root key-encrypting-key rotation failed")
 				}
 
-				m.replicatedOrchestrator = orchestrator.New(s)
+				m.replicatedOrchestrator = orchestrator.NewReplicatedOrchestrator(s)
 				m.globalOrchestrator = orchestrator.NewGlobalOrchestrator(s)
 				m.taskReaper = orchestrator.NewTaskReaper(s)
 				m.scheduler = scheduler.New(s)

--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -189,7 +189,7 @@ func TestDrain(t *testing.T) {
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
 	defer cancel()
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	go func() {

--- a/manager/orchestrator/replicated.go
+++ b/manager/orchestrator/replicated.go
@@ -29,8 +29,8 @@ type ReplicatedOrchestrator struct {
 	restarts *RestartSupervisor
 }
 
-// New creates a new ReplicatedOrchestrator.
-func New(store *store.MemoryStore) *ReplicatedOrchestrator {
+// NewReplicatedOrchestrator creates a new ReplicatedOrchestrator.
+func NewReplicatedOrchestrator(store *store.MemoryStore) *ReplicatedOrchestrator {
 	restartSupervisor := NewRestartSupervisor(store)
 	updater := NewUpdateSupervisor(store, restartSupervisor)
 	return &ReplicatedOrchestrator{

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -17,7 +17,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
@@ -119,7 +119,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
@@ -219,7 +219,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
@@ -313,7 +313,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
@@ -402,7 +402,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
@@ -537,7 +537,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)

--- a/manager/orchestrator/task_reaper_test.go
+++ b/manager/orchestrator/task_reaper_test.go
@@ -33,7 +33,7 @@ func TestTaskHistory(t *testing.T) {
 
 	taskReaper := NewTaskReaper(s)
 	defer taskReaper.Stop()
-	orchestrator := New(s)
+	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)


### PR DESCRIPTION
The existing replicated orchestrator scales down by deleting tasks with
the highest slot numbers. This means that if you have a service with the
following tasks:

    task slot 1 on node A
    task slot 2 on node A
    task slot 3 on node A
    task slot 4 on node B
    task slot 5 on node C

... then scaling from 5 replicas to 3 replicas will shut down all tasks
on nodes B and C, and you end up with 3 tasks on node A.

Improve downscaling to be aware of how many tasks are on each node, and
prefer to shut down tasks in a way that balances the resulting tasks.
After this change, the result in the example above would be one task
each on nodes A, B, and C.

In addition to improving the behavior, this provides an important workaround
for the current lack of rebalancing: one can scale a service up and then scale it
back down.

ping @aluzzardi @dongluochen