### PR TITLE
picker: Fix data race in PickAddr

### DIFF
--- a/picker/picker.go
+++ b/picker/picker.go
@@ -272,7 +272,7 @@ func (p *Picker) PickAddr() (string, error) {
 	p.mu.Lock()
 	p.peer = peer
 	p.mu.Unlock()
-	return p.peer.Addr, err
+	return peer.Addr, err
 }
 
 // State returns the connectivity state of the underlying connections.


### PR DESCRIPTION
PickAddr sets p.peer to peer, then returns p.peer.Addr after unlocking
its mutex. It should return peer.Addr instead to avoid triggering a data
race.

Fixes #1052

cc @stevvooe