### PR TITLE
ca: Fix restarts of the CA server

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -450,6 +450,7 @@ func (s *Server) Stop() error {
 	s.mu.Unlock()
 	// wait for all handlers to finish their CA deals,
 	s.wg.Wait()
+	s.started = make(chan struct{})
 	return nil
 }
 

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -23,6 +23,22 @@ func TestGetRootCACertificate(t *testing.T) {
 	assert.NotEmpty(t, resp.Certificate)
 }
 
+func TestRestartRootCA(t *testing.T) {
+	tc := testutils.NewTestCA(t, ca.DefaultAcceptancePolicy())
+	defer tc.Stop()
+
+	resp1, err := tc.CAClients[0].GetRootCACertificate(context.Background(), &api.GetRootCACertificateRequest{})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, resp1.Certificate)
+
+	tc.CAServer.Stop()
+	go tc.CAServer.Run(context.Background())
+
+	resp2, err := tc.CAClients[0].GetRootCACertificate(context.Background(), &api.GetRootCACertificateRequest{})
+	assert.NoError(t, err)
+	assert.Equal(t, resp1.Certificate, resp2.Certificate)
+}
+
 func TestIssueNodeCertificate(t *testing.T) {
 	tc := testutils.NewTestCA(t, ca.DefaultAcceptancePolicy())
 	defer tc.Stop()

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -158,12 +158,8 @@ func NewTestCA(t *testing.T, policy api.AcceptancePolicy) *TestCA {
 
 	ctx := context.Background()
 
-	go func() {
-		grpcServer.Serve(l)
-	}()
-	go func() {
-		caServer.Run(ctx)
-	}()
+	go grpcServer.Serve(l)
+	go caServer.Run(ctx)
 
 	// Wait for caServer to be ready to serve
 	<-caServer.Ready()


### PR DESCRIPTION
We start the CA server when we become the leader. We stop the CA server
when we're no longer the leader.

The Run function has protection against being called multiple times,
which is good. But if we shut down the CA, we need to be able to start
it again later, so Stop needs to reset this channel.

cc @tonistiigi @diogomonica