### PR TITLE
More sensible swarmctl service create syntax

### DIFF
--- a/cmd/swarmctl/service/create.go
+++ b/cmd/swarmctl/service/create.go
@@ -12,11 +12,14 @@ import (
 
 var (
 	createCmd = &cobra.Command{
-		Use:   "create",
+		Use:   "create [OPTIONS] IMAGE [COMMAND] [ARG...]",
 		Short: "Create a service",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !cmd.Flags().Changed("name") || !cmd.Flags().Changed("image") {
-				return errors.New("--name and --image are mandatory")
+			if !cmd.Flags().Changed("name") {
+				return errors.New("--name is mandatory")
+			}
+			if len(args) < 1 {
+				return errors.New("IMAGE is required")
 			}
 
 			c, err := common.Dial(cmd)
@@ -39,6 +42,12 @@ var (
 
 			if err := flagparser.Merge(cmd, spec, c); err != nil {
 				return err
+			}
+
+			// do all of this after we set up the spec
+			spec.Task.GetContainer().Image = args[0]
+			if len(args) > 1 {
+				spec.Task.GetContainer().Args = args[1:]
 			}
 
 			r, err := c.CreateService(common.Context(cmd), &api.CreateServiceRequest{Spec: spec})

--- a/cmd/swarmctl/service/flagparser/container.go
+++ b/cmd/swarmctl/service/flagparser/container.go
@@ -6,22 +6,6 @@ import (
 )
 
 func parseContainer(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
-	if flags.Changed("image") {
-		image, err := flags.GetString("image")
-		if err != nil {
-			return err
-		}
-		spec.Task.GetContainer().Image = image
-	}
-
-	if flags.Changed("args") {
-		args, err := flags.GetStringSlice("args")
-		if err != nil {
-			return err
-		}
-		spec.Task.GetContainer().Args = args
-	}
-
 	if flags.Changed("env") {
 		env, err := flags.GetStringSlice("env")
 		if err != nil {

--- a/cmd/swarmctl/service/flagparser/flags.go
+++ b/cmd/swarmctl/service/flagparser/flags.go
@@ -17,8 +17,6 @@ func AddServiceFlags(flags *pflag.FlagSet) {
 	flags.String("mode", "replicated", "one of replicated, global")
 	flags.Uint64("replicas", 1, "number of replicas for the service (only works in replicated service mode)")
 
-	flags.String("image", "", "container image")
-	flags.StringSlice("args", nil, "container args")
 	flags.StringSlice("env", nil, "container env")
 
 	flags.StringSlice("ports", nil, "ports")

--- a/cmd/swarmctl/service/update.go
+++ b/cmd/swarmctl/service/update.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	updateCmd = &cobra.Command{
-		Use:   "update <service ID>",
+		Use:   "update [OPTIONS] SERVICE [IMAGE] [ARGS...]",
 		Short: "Update a service",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) == 0 {
@@ -34,6 +34,16 @@ var (
 
 			if err := flagparser.Merge(cmd, spec, c); err != nil {
 				return err
+			}
+
+			// change the image if that positional arg is present
+			if len(args) > 1 {
+				spec.Task.GetContainer().Image = args[1]
+			}
+
+			// change the args too, if those positional args are present
+			if len(args) > 2 {
+				spec.Task.GetContainer().Args = args[2:]
 			}
 
 			if reflect.DeepEqual(spec, &service.Spec) {


### PR DESCRIPTION
Changed the syntax of the swarmctl service create to take image and args
as positional arguments. This fix is kind of a hack, but anything beyond
this is going to require some pretty beefy rewriting of swarmctl.

Signed-off-by: Drew Erny <drew.erny@docker.com>