### PR TITLE
orchestrator: Fix rolling update race that could create extra tasks

### DIFF
--- a/manager/orchestrator/updater.go
+++ b/manager/orchestrator/updater.go
@@ -191,6 +191,9 @@ func (u *Updater) updateTask(ctx context.Context, service *api.Service, original
 		if t == nil {
 			return fmt.Errorf("task %s not found while trying to update it", original.ID)
 		}
+		if t.DesiredState > api.TaskStateRunning {
+			return fmt.Errorf("task %s was already shut down when reached by updater", original.ID)
+		}
 		t.DesiredState = api.TaskStateShutdown
 		if err := store.UpdateTask(tx, t); err != nil {
 			return err


### PR DESCRIPTION
The updateTask method atomically shuts down a task and replaces it with
a new one. Calls to updateTask are queued through a channel, and this
happens outside a channel. It's possible that once updateTask is called,
the old task has already been shut down. In this case, shutting down the
task is a no-op, but creating a task adds a new task that shouldn't
exist, and puts us in a bad state. We need to check that the task hasn't
already been shut down to avoid this problem.

Fixes #1054
Fixes #907

cc @tonistiigi @aluzzardi @dongluochen