### PR TITLE
Comment out spammy log message during image pull

### DIFF
--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	engineapi "github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/events"
@@ -68,8 +67,11 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 			}
 			return err
 		}
-		// TOOD(stevvooe): Report this status somewhere.
-		logrus.Debugln("pull progress", m)
+		// TODO(stevvooe): Report this status somewhere.
+		// TODO(dperny): commented out, this spams the logs too hard. should
+		// still report errors if they occur, but won't report generic pull
+		// progress.
+		// logrus.Debugln("pull progress", m)
 	}
 	// if the final stream object contained an error, return it
 	if errMsg, ok := m["error"]; ok {


### PR DESCRIPTION
Commented out the spammy log message during image pull. The existing
code seems adequate to report most errors. There may be a more correct
way to report pull status, but I don't know what it is.

Closes #935

Signed-off-by: Drew Erny <drew.erny@docker.com>