### PR TITLE
Keep a copy of EndpointSpec in Task for update

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -146,7 +146,9 @@ func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 	}
 
 	if s.Endpoint == nil {
-		s.Endpoint = &api.Endpoint{}
+		s.Endpoint = &api.Endpoint{
+			Spec: s.Spec.Endpoint.Copy(),
+		}
 	}
 
 	// First allocate VIPs for all the pre-populated endpoint attachments

--- a/manager/orchestrator/replicated.go
+++ b/manager/orchestrator/replicated.go
@@ -114,6 +114,9 @@ func newTask(service *api.Service, instance uint64) *api.Task {
 			Timestamp: ptypes.MustTimestampProto(time.Now()),
 			Message:   "created",
 		},
+		Endpoint: &api.Endpoint{
+			Spec: service.Spec.Endpoint.Copy(),
+		},
 		DesiredState: api.TaskStateRunning,
 	}
 }

--- a/manager/orchestrator/updater.go
+++ b/manager/orchestrator/updater.go
@@ -104,7 +104,8 @@ func (u *Updater) Run(ctx context.Context, service *api.Service, tasks []*api.Ta
 	dirtyTasks := []*api.Task{}
 	for _, t := range tasks {
 		if !reflect.DeepEqual(service.Spec.Task, t.Spec) ||
-			!reflect.DeepEqual(service.Endpoint, t.Endpoint) {
+			(t.Endpoint != nil &&
+				!reflect.DeepEqual(service.Spec.Endpoint, t.Endpoint.Spec)) {
 			dirtyTasks = append(dirtyTasks, t)
 		}
 	}


### PR DESCRIPTION
To trigger rolling update reliably and more importantly to not trigger
false rolling updates, updater should compare against change in
EndpointSpec between service and what is present in task. For that task
needs to have a copy of EndpointSpec. Made the necessary changes to fix
rolling update of a service.

Fixes #1057 

/cc @aaronlehmann 

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>