### PR TITLE
set RestartOnAny as default restart condition

### DIFF
--- a/cmd/swarmctl/service/flagparser/restart.go
+++ b/cmd/swarmctl/service/flagparser/restart.go
@@ -10,26 +10,25 @@ import (
 )
 
 func parseRestart(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
-	if flags.Changed("restart-condition") {
-		condition, err := flags.GetString("restart-condition")
-		if err != nil {
-			return err
-		}
+	// parse restart-condition
+	condition, err := flags.GetString("restart-condition")
+	if err != nil {
+		return err
+	}
 
-		if spec.Task.Restart == nil {
-			spec.Task.Restart = &api.RestartPolicy{}
-		}
+	if spec.Task.Restart == nil {
+		spec.Task.Restart = &api.RestartPolicy{}
+	}
 
-		switch condition {
-		case "none":
-			spec.Task.Restart.Condition = api.RestartOnNone
-		case "failure":
-			spec.Task.Restart.Condition = api.RestartOnFailure
-		case "any":
-			spec.Task.Restart.Condition = api.RestartOnAny
-		default:
-			return fmt.Errorf("invalid restart condition: %s", condition)
-		}
+	switch condition {
+	case "none":
+		spec.Task.Restart.Condition = api.RestartOnNone
+	case "failure":
+		spec.Task.Restart.Condition = api.RestartOnFailure
+	case "any":
+		spec.Task.Restart.Condition = api.RestartOnAny
+	default:
+		return fmt.Errorf("invalid restart condition: %s", condition)
 	}
 
 	if flags.Changed("restart-delay") {
@@ -43,9 +42,6 @@ func parseRestart(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
 			return err
 		}
 
-		if spec.Task.Restart == nil {
-			spec.Task.Restart = &api.RestartPolicy{}
-		}
 		spec.Task.Restart.Delay = ptypes.DurationProto(delayDuration)
 	}
 
@@ -55,9 +51,6 @@ func parseRestart(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
 			return err
 		}
 
-		if spec.Task.Restart == nil {
-			spec.Task.Restart = &api.RestartPolicy{}
-		}
 		spec.Task.Restart.MaxAttempts = attempts
 	}
 
@@ -72,9 +65,6 @@ func parseRestart(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
 			return err
 		}
 
-		if spec.Task.Restart == nil {
-			spec.Task.Restart = &api.RestartPolicy{}
-		}
 		spec.Task.Restart.Window = ptypes.DurationProto(windowDelay)
 	}
 


### PR DESCRIPTION
command `./swarmctl service create --name hello --image busybox --args sleep --args 5s --restart-delay 5s` will create a `restart` and set `condition` as `NONE`, as indicated [here](https://github.com/runshenzhu/swarmkit/blob/5c0c815bd465dbb086bca58701e1a86603dfe311/cmd/swarmctl/service/flagparser/restart.go#L46)

Signed-off-by: runshenzhu <runshen.zhu@gmail.com>