### PR TITLE
Block creating network with a non-default driver

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -14,7 +14,10 @@ import (
 )
 
 const (
-	defaultDriver = "overlay"
+	// DefaultDriver defines the name of the driver to be used by
+	// default if a network without any driver name specified is
+	// created.
+	DefaultDriver = "overlay"
 )
 
 var (
@@ -69,7 +72,7 @@ func New() (*NetworkAllocator, error) {
 	}
 
 	// Add the manager component of overlay driver to the registry.
-	if err := reg.AddDriver(defaultDriver, defaultDriverInitFunc, nil); err != nil {
+	if err := reg.AddDriver(DefaultDriver, defaultDriverInitFunc, nil); err != nil {
 		return nil, err
 	}
 
@@ -520,7 +523,7 @@ func (na *NetworkAllocator) allocateDriverState(n *api.Network) error {
 
 // Resolve network driver
 func (na *NetworkAllocator) resolveDriver(n *api.Network) (driverapi.Driver, string, error) {
-	dName := defaultDriver
+	dName := DefaultDriver
 	if n.Spec.DriverConfig != nil && n.Spec.DriverConfig.Name != "" {
 		dName = n.Spec.DriverConfig.Name
 	}

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -3,8 +3,10 @@ package controlapi
 import (
 	"net"
 
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -57,6 +59,10 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 		return err
 	}
 
+	if ipam.Driver != nil && ipam.Driver.Name != ipamapi.DefaultIPAM {
+		return grpc.Errorf(codes.InvalidArgument, "invalid IPAM specified")
+	}
+
 	for _, ipamConf := range ipam.Configs {
 		if err := validateIPAMConfiguration(ipamConf); err != nil {
 			return err
@@ -77,6 +83,10 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 
 	if err := validateDriver(spec.DriverConfig); err != nil {
 		return err
+	}
+
+	if spec.DriverConfig != nil && spec.DriverConfig.Name != networkallocator.DefaultDriver {
+		return grpc.Errorf(codes.InvalidArgument, "invalid driver specified")
 	}
 
 	if err := validateIPAM(spec.IPAM); err != nil {

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -145,10 +145,28 @@ func TestValidateIPAMConfiguration(t *testing.T) {
 
 func TestValidateIPAM(t *testing.T) {
 	assert.NoError(t, validateIPAM(nil))
+	ipam := &api.IPAMOptions{
+		Driver: &api.Driver{
+			Name: "external",
+		},
+	}
+
+	err := validateIPAM(ipam)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }
 
 func TestValidateNetworkSpec(t *testing.T) {
 	err := validateNetworkSpec(nil)
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	spec := createNetworkSpec("invalid_driver")
+	spec.DriverConfig = &api.Driver{
+		Name: "external",
+	}
+
+	err = validateNetworkSpec(spec)
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }


### PR DESCRIPTION
Since we do not support any other driver for both IPAM and network other
than the default, it is better to block a network creation backed by a
non-default driver, right when the network is created.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>