### PR TITLE
raft membership: fix promotion/demotion workflow

### DIFF
--- a/manager/controlapi/node.go
+++ b/manager/controlapi/node.go
@@ -2,6 +2,7 @@ package controlapi
 
 import (
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -187,9 +188,15 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 	}
 
 	var (
-		node   *api.Node
-		demote bool
+		node     *api.Node
+		member   *membership.Member
+		initSpec api.NodeSpec
+		demote   bool
 	)
+
+	s.updateLock.Lock()
+	defer s.updateLock.Unlock()
+
 	err := s.store.Update(func(tx store.Tx) error {
 		node = store.GetNode(tx, request.NodeID)
 		if node == nil {
@@ -199,12 +206,25 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 		// Demotion sanity checks.
 		if node.Spec.Role == api.NodeRoleManager && request.Spec.Role == api.NodeRoleWorker {
 			demote = true
+			initSpec = node.Spec
+
+			// Check for manager entries in Store.
 			managers, err := store.FindNodes(tx, store.ByRole(api.NodeRoleManager))
 			if err != nil {
 				return grpc.Errorf(codes.Internal, "internal store error: %v", err)
 			}
 			if len(managers) == 1 && managers[0].ID == node.ID {
 				return grpc.Errorf(codes.FailedPrecondition, "attempting to demote the last manager of the swarm")
+			}
+
+			// Check for node in memberlist
+			if member = s.raft.GetMemberByNodeID(request.NodeID); member == nil {
+				return grpc.Errorf(codes.NotFound, "can't find manager in raft memberlist")
+			}
+
+			// Quorum safeguard
+			if !s.raft.CanRemoveMember(member.RaftID) {
+				return grpc.Errorf(codes.FailedPrecondition, "can't remove member from the raft: this would result in a loss of quorum")
 			}
 		}
 
@@ -220,14 +240,19 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 	}
 
 	if demote && s.raft != nil {
-		memberlist := s.raft.GetMemberlist()
-		for raftID, member := range memberlist {
-			if member.NodeID == request.NodeID {
-				if err := s.raft.RemoveMember(ctx, raftID); err != nil {
-					return nil, err
+		if err := s.raft.RemoveMember(ctx, member.RaftID); err != nil {
+			// Rollback to the initial Spec if we can't finalize the role
+			// change by removing the member from raft.
+			s.store.Update(func(tx store.Tx) error {
+				node = store.GetNode(tx, request.NodeID)
+				if node == nil {
+					return nil
 				}
-				break
-			}
+
+				node.Spec = initSpec
+				return store.UpdateNode(tx, node)
+			})
+			return nil, grpc.Errorf(codes.Internal, "cannot demote manager to worker: %v", err)
 		}
 	}
 

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -2,6 +2,7 @@ package controlapi
 
 import (
 	"errors"
+	"sync"
 
 	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -14,8 +15,9 @@ var (
 
 // Server is the Cluster API gRPC server.
 type Server struct {
-	store *store.MemoryStore
-	raft  *raft.Node
+	store      *store.MemoryStore
+	raft       *raft.Node
+	updateLock sync.Mutex
 }
 
 // NewServer creates a Cluster API server.

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -2,7 +2,6 @@ package controlapi
 
 import (
 	"errors"
-	"sync"
 
 	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -15,9 +14,8 @@ var (
 
 // Server is the Cluster API gRPC server.
 type Server struct {
-	store      *store.MemoryStore
-	raft       *raft.Node
-	updateLock sync.Mutex
+	store *store.MemoryStore
+	raft  *raft.Node
 }
 
 // NewServer creates a Cluster API server.

--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -165,19 +165,11 @@ func (c *Cluster) ValidateConfigurationChange(cc raftpb.ConfChange) error {
 // that might block or harm the Cluster on Member recovery
 func (c *Cluster) CanRemoveMember(from uint64, id uint64) bool {
 	members := c.Members()
-
-	nmembers := 0
 	nreachable := 0
 
 	for _, m := range members {
-		// Skip the node that is going to be deleted
-		if m.RaftID == id {
-			continue
-		}
-
 		// Local node from where the remove is issued
 		if m.RaftID == from {
-			nmembers++
 			nreachable++
 			continue
 		}
@@ -186,8 +178,6 @@ func (c *Cluster) CanRemoveMember(from uint64, id uint64) bool {
 		if err == nil && connState == grpc.Ready {
 			nreachable++
 		}
-
-		nmembers++
 	}
 
 	// Special case of 2 managers
@@ -195,7 +185,7 @@ func (c *Cluster) CanRemoveMember(from uint64, id uint64) bool {
 		return false
 	}
 
-	nquorum := nmembers/2 + 1
+	nquorum := (len(members)+1)/2 + 1
 	if nreachable < nquorum {
 		return false
 	}


### PR DESCRIPTION
Simply rolls back the role on `node demote` if this fails. There is opportunity for a refactoring here as we can add a check upstream and only selectively update node Spec fields, but not sure if really necessary.

/cc @aaronlehmann @tonistiigi 

Signed-off-by: Alexandre Beslic <alexandre.beslic@gmail.com>