### PR TITLE
api: clarify Command/Args distinction

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -96,8 +96,8 @@ func (c *containerConfig) config() *enginecontainer.Config {
 		// If Command is provided, we replace the whole invocation with Command
 		// by replacing Entrypoint and specifying Cmd. Args is ignored in this
 		// case.
-		config.Entrypoint = append(config.Entrypoint, c.spec().Command[0])
-		config.Cmd = append(config.Cmd, c.spec().Command[1:]...)
+		config.Entrypoint = append(config.Entrypoint, c.spec().Command...)
+		config.Cmd = append(config.Cmd, c.spec().Args...)
 	} else if len(c.spec().Args) > 0 {
 		// In this case, we assume the image has an Entrypoint and Args
 		// specifies the arguments for that entrypoint.

--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -415,9 +415,12 @@ type ContainerSpec struct {
 	// executable and the following elements are treated as arguments.
 	//
 	// If command is empty, execution will fall back to the image's entrypoint.
+	//
+	// Command should only be used when overriding entrypoint.
 	Command []string `protobuf:"bytes,3,rep,name=command" json:"command,omitempty"`
 	// Args specifies arguments provided to the image's entrypoint.
-	// Ignored if command is specified.
+	//
+	// If Command and Args are provided, Args will be appended to Command.
 	Args []string `protobuf:"bytes,4,rep,name=args" json:"args,omitempty"`
 	// Env specifies the environment variables for the container in NAME=VALUE
 	// format. These must be compliant with  [IEEE Std

--- a/api/specs.proto
+++ b/api/specs.proto
@@ -138,10 +138,13 @@ message ContainerSpec {
 	// executable and the following elements are treated as arguments.
 	//
 	// If command is empty, execution will fall back to the image's entrypoint.
+	//
+	// Command should only be used when overriding entrypoint.
 	repeated string command = 3;
 
 	// Args specifies arguments provided to the image's entrypoint.
-	// Ignored if command is specified.
+	//
+	// If Command and Args are provided, Args will be appended to Command.
 	repeated string args = 4;
 
 	// Env specifies the environment variables for the container in NAME=VALUE

--- a/cmd/swarmctl/service/flagparser/container.go
+++ b/cmd/swarmctl/service/flagparser/container.go
@@ -14,6 +14,14 @@ func parseContainer(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
 		spec.Task.GetContainer().Image = image
 	}
 
+	if flags.Changed("command") {
+		command, err := flags.GetStringSlice("command")
+		if err != nil {
+			return err
+		}
+		spec.Task.GetContainer().Command = command
+	}
+
 	if flags.Changed("args") {
 		args, err := flags.GetStringSlice("args")
 		if err != nil {

--- a/cmd/swarmctl/service/flagparser/flags.go
+++ b/cmd/swarmctl/service/flagparser/flags.go
@@ -17,6 +17,7 @@ func AddServiceFlags(flags *pflag.FlagSet) {
 	flags.Uint64("replicas", 1, "number of replicas for the service (only works in replicated service mode)")
 
 	flags.String("image", "", "container image")
+	flags.StringSlice("command", nil, "override entrypoint")
 	flags.StringSlice("args", nil, "container args")
 	flags.StringSlice("env", nil, "container env")
 


### PR DESCRIPTION
To address some issues with using `Command`/`Args`, the field
documentation has been updated to clarify that Command should only be
used when overriding Entrypoint. For most docker uses, only `Args`
should ever be used, as is done in `runc`.

`Args` is now appended to `Command` if both are present.

A `--command` flag has been added to be able to test that the feature is
working correctly across systems.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @aluzzardi 