### PR TITLE
[WIP] Abstract external CAs and add Vault provider

### DIFF
--- a/ca/external.go
+++ b/ca/external.go
@@ -1,141 +1,23 @@
 package ca
 
 import (
-	"bytes"
 	"crypto/tls"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"sync"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/signer"
 )
 
-// ErrNoExternalCAURLs is an error used it indicate that an ExternalCA is
-// configured with no URLs to which it can proxy certificate signing requests.
-var ErrNoExternalCAURLs = errors.New("no external CA URLs")
+// ErrNoExternalCAs is an error used it indicate that no properly configured
+// ExternalCA is available to which it can proxy certificate signing requests.
+var ErrNoExternalCAs = errors.New("no external CAs configured")
+
+// ErrNoExternalCAURL is an error used to indicate that a given external CA
+// does not have a properly configured URL
+var ErrNoExternalCAURL = errors.New("no URL found for external CA")
 
 // ExternalCA is able to make certificate signing requests to one of a list
 // remote CFSSL API endpoints.
-type ExternalCA struct {
-	mu     sync.Mutex
-	rootCA *RootCA
-	urls   []string
-	client *http.Client
-}
-
-// NewExternalCA creates a new ExternalCA which uses the given tlsConfig to
-// authenticate to any of the given URLS of CFSSL API endpoints.
-func NewExternalCA(rootCA *RootCA, tlsConfig *tls.Config, urls ...string) *ExternalCA {
-	return &ExternalCA{
-		rootCA: rootCA,
-		urls:   urls,
-		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: tlsConfig,
-			},
-		},
-	}
-}
-
-// UpdateTLSConfig updates the HTTP Client for this ExternalCA by creating
-// a new client which uses the given tlsConfig.
-func (eca *ExternalCA) UpdateTLSConfig(tlsConfig *tls.Config) {
-	eca.mu.Lock()
-	defer eca.mu.Unlock()
-
-	eca.client = &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
-	}
-}
-
-// UpdateURLs updates the list of CSR API endpoints by setting it to the given
-// urls.
-func (eca *ExternalCA) UpdateURLs(urls ...string) {
-	eca.mu.Lock()
-	defer eca.mu.Unlock()
-
-	eca.urls = urls
-}
-
-// Sign signs a new certificate by proxying the given certificate signing
-// request to an external CFSSL API server.
-func (eca *ExternalCA) Sign(req signer.SignRequest) (cert []byte, err error) {
-	// Get the current HTTP client and list of URLs in a small critical
-	// section. We will use these to make certificate signing requests.
-	eca.mu.Lock()
-	urls := eca.urls
-	client := eca.client
-	eca.mu.Unlock()
-
-	if len(urls) == 0 {
-		return nil, ErrNoExternalCAURLs
-	}
-
-	csrJSON, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("unable to JSON-encode CFSSL signing request: %s", err)
-	}
-
-	// Try each configured proxy URL. Return after the first success. If
-	// all fail then the last error will be returned.
-	for _, url := range urls {
-		cert, err = makeExternalSignRequest(client, url, csrJSON)
-		if err == nil {
-			return eca.rootCA.AppendFirstRootPEM(cert)
-		}
-
-		log.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
-	}
-
-	return nil, err
-}
-
-func makeExternalSignRequest(client *http.Client, url string, csrJSON []byte) (cert []byte, err error) {
-	resp, err := client.Post(url, "application/json", bytes.NewReader(csrJSON))
-	if err != nil {
-		return nil, fmt.Errorf("unable to perform certificate signing request: %s", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read CSR response body: %s", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code in CSR response: %d - %s", resp.StatusCode, string(body))
-	}
-
-	var apiResponse api.Response
-	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		log.Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
-		return nil, fmt.Errorf("unable to parse JSON response: %s", err)
-	}
-
-	if !apiResponse.Success || apiResponse.Result == nil {
-		if len(apiResponse.Errors) > 0 {
-			return nil, fmt.Errorf("response errors: %v", apiResponse.Errors)
-		}
-
-		return nil, fmt.Errorf("certificate signing request failed")
-	}
-
-	result, ok := apiResponse.Result.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("invalid result type: %T", apiResponse.Result)
-	}
-
-	certPEM, ok := result["certificate"].(string)
-	if !ok {
-		return nil, fmt.Errorf("invalid result certificate field type: %T", result["certificate"])
-	}
-
-	return []byte(certPEM), nil
+type ExternalCA interface {
+	UpdateTLSConfig(*tls.Config)
+	Sign(signer.SignRequest) ([]byte, error)
 }

--- a/ca/external_cfssl.go
+++ b/ca/external_cfssl.go
@@ -1,0 +1,124 @@
+package ca
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"sync"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/cloudflare/cfssl/api"
+	"github.com/cloudflare/cfssl/signer"
+)
+
+// ExternalCFSSLCA is able to make certificate signing requests to one of a list
+// remote CFSSL API endpoints.
+type ExternalCFSSLCA struct {
+	mu     sync.RWMutex
+	rootCA *RootCA
+	url    string
+	client *http.Client
+}
+
+// NewExternalCFSSLCA creates a new ExternalCA which uses the given tlsConfig to
+// authenticate to the given CFSSL API endpoint.
+func NewExternalCFSSLCA(rootCA *RootCA, tlsConfig *tls.Config, url string) ExternalCA {
+	return &ExternalCFSSLCA{
+		rootCA: rootCA,
+		url:    url,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: tlsConfig,
+			},
+		},
+	}
+}
+
+// UpdateTLSConfig updates the HTTP Client for this ExternalCA by creating
+// a new client which uses the given tlsConfig.
+func (eca *ExternalCFSSLCA) UpdateTLSConfig(tlsConfig *tls.Config) {
+	eca.mu.Lock()
+	defer eca.mu.Unlock()
+
+	eca.client = &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}
+}
+
+// Sign signs a new certificate by proxying the given certificate signing
+// request to an external CFSSL API server.
+func (eca *ExternalCFSSLCA) Sign(req signer.SignRequest) (cert []byte, err error) {
+	// Get the current HTTP client and list of URL in a small critical
+	// section. We will use these to make certificate signing requests.
+	eca.mu.RLock()
+	defer eca.mu.RUnlock()
+
+	url := eca.url
+	client := eca.client
+
+	if url == "" {
+		return nil, ErrNoExternalCAURL
+	}
+
+	csrJSON, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to JSON-encode CFSSL signing request: %s", err)
+	}
+
+	cert, err = makeExternalSignRequest(client, url, csrJSON)
+	if err == nil {
+		return eca.rootCA.AppendFirstRootPEM(cert)
+	}
+
+	log.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
+
+	return nil, err
+}
+
+func makeExternalSignRequest(client *http.Client, url string, csrJSON []byte) (cert []byte, err error) {
+	resp, err := client.Post(url, "application/json", bytes.NewReader(csrJSON))
+	if err != nil {
+		return nil, fmt.Errorf("unable to perform certificate signing request: %s", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read CSR response body: %s", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code in CSR response: %d - %s", resp.StatusCode, string(body))
+	}
+
+	var apiResponse api.Response
+	if err := json.Unmarshal(body, &apiResponse); err != nil {
+		log.Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
+		return nil, fmt.Errorf("unable to parse JSON response: %s", err)
+	}
+
+	if !apiResponse.Success || apiResponse.Result == nil {
+		if len(apiResponse.Errors) > 0 {
+			return nil, fmt.Errorf("response errors: %v", apiResponse.Errors)
+		}
+
+		return nil, fmt.Errorf("certificate signing request failed")
+	}
+
+	result, ok := apiResponse.Result.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("invalid result type: %T", apiResponse.Result)
+	}
+
+	certPEM, ok := result["certificate"].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid result certificate field type: %T", result["certificate"])
+	}
+
+	return []byte(certPEM), nil
+}

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -59,18 +59,18 @@ func AcceptancePolicy(worker, manager bool, secret string) api.AcceptancePolicy 
 
 // TestCA is a structure that encapsulates everything needed to test a CA Server
 type TestCA struct {
-	RootCA                ca.RootCA
-	ExternalSigningServer *ExternalSigningServer
-	MemoryStore           *store.MemoryStore
-	TempDir, Organization string
-	Paths                 *ca.SecurityConfigPaths
-	Server                grpc.Server
-	CAServer              *ca.Server
-	Context               context.Context
-	NodeCAClients         []api.NodeCAClient
-	CAClients             []api.CAClient
-	Conns                 []*grpc.ClientConn
-	Picker                *picker.Picker
+	RootCA                     ca.RootCA
+	ExternalCFSSLSigningServer *ExternalCFSSLSigningServer
+	MemoryStore                *store.MemoryStore
+	TempDir, Organization      string
+	Paths                      *ca.SecurityConfigPaths
+	Server                     grpc.Server
+	CAServer                   *ca.Server
+	Context                    context.Context
+	NodeCAClients              []api.NodeCAClient
+	CAClients                  []api.CAClient
+	Conns                      []*grpc.ClientConn
+	Picker                     *picker.Picker
 }
 
 // Stop cleansup after TestCA
@@ -79,8 +79,8 @@ func (tc *TestCA) Stop() {
 	for _, conn := range tc.Conns {
 		conn.Close()
 	}
-	if tc.ExternalSigningServer != nil {
-		tc.ExternalSigningServer.Stop()
+	if tc.ExternalCFSSLSigningServer != nil {
+		tc.ExternalCFSSLSigningServer.Stop()
 	}
 	tc.CAServer.Stop()
 	tc.Server.Stop()
@@ -88,27 +88,27 @@ func (tc *TestCA) Stop() {
 
 // NewNodeConfig returns security config for a new node, given a role
 func (tc *TestCA) NewNodeConfig(role string) (*ca.SecurityConfig, error) {
-	withNonSigningRoot := tc.ExternalSigningServer != nil
+	withNonSigningRoot := tc.ExternalCFSSLSigningServer != nil
 	return genSecurityConfig(tc.MemoryStore, tc.RootCA, role, tc.Organization, tc.TempDir, withNonSigningRoot)
 }
 
 // WriteNewNodeConfig returns security config for a new node, given a role
 // saving the generated key and certificates to disk
 func (tc *TestCA) WriteNewNodeConfig(role string) (*ca.SecurityConfig, error) {
-	withNonSigningRoot := tc.ExternalSigningServer != nil
+	withNonSigningRoot := tc.ExternalCFSSLSigningServer != nil
 	return genSecurityConfig(tc.MemoryStore, tc.RootCA, role, tc.Organization, tc.TempDir, withNonSigningRoot)
 }
 
 // NewNodeConfigOrg returns security config for a new node, given a role and an org
 func (tc *TestCA) NewNodeConfigOrg(role, org string) (*ca.SecurityConfig, error) {
-	withNonSigningRoot := tc.ExternalSigningServer != nil
+	withNonSigningRoot := tc.ExternalCFSSLSigningServer != nil
 	return genSecurityConfig(tc.MemoryStore, tc.RootCA, role, org, tc.TempDir, withNonSigningRoot)
 }
 
 // WriteNewNodeConfigOrg returns security config for a new node, given a role and an org
 // saving the generated key and certificates to disk
 func (tc *TestCA) WriteNewNodeConfigOrg(role, org string) (*ca.SecurityConfig, error) {
-	withNonSigningRoot := tc.ExternalSigningServer != nil
+	withNonSigningRoot := tc.ExternalCFSSLSigningServer != nil
 	return genSecurityConfig(tc.MemoryStore, tc.RootCA, role, org, tc.TempDir, withNonSigningRoot)
 }
 
@@ -131,13 +131,13 @@ func NewTestCA(t *testing.T, policy api.AcceptancePolicy) *TestCA {
 	assert.NoError(t, err)
 
 	var (
-		externalSigningServer *ExternalSigningServer
+		externalSigningServer *ExternalCFSSLSigningServer
 		externalSigningURLs   []string
 	)
 
 	if External {
 		// Start the CA API server.
-		externalSigningServer, err = NewExternalSigningServer(rootCA, tempBaseDir)
+		externalSigningServer, err = NewExternalCFSSLSigningServer(rootCA, tempBaseDir)
 		assert.NoError(t, err)
 		externalSigningURLs = []string{externalSigningServer.URL}
 	}
@@ -196,18 +196,18 @@ func NewTestCA(t *testing.T, policy api.AcceptancePolicy) *TestCA {
 	conns := []*grpc.ClientConn{conn1, conn2, conn3, conn4}
 
 	return &TestCA{
-		RootCA:                rootCA,
-		ExternalSigningServer: externalSigningServer,
-		MemoryStore:           s,
-		Picker:                picker,
-		TempDir:               tempBaseDir,
-		Organization:          organization,
-		Paths:                 paths,
-		Context:               ctx,
-		CAClients:             caClients,
-		NodeCAClients:         nodeCAClients,
-		Conns:                 conns,
-		CAServer:              caServer,
+		RootCA: rootCA,
+		ExternalCFSSLSigningServer: externalSigningServer,
+		MemoryStore:                s,
+		Picker:                     picker,
+		TempDir:                    tempBaseDir,
+		Organization:               organization,
+		Paths:                      paths,
+		Context:                    ctx,
+		CAClients:                  caClients,
+		NodeCAClients:              nodeCAClients,
+		Conns:                      conns,
+		CAServer:                   caServer,
 	}
 }
 

--- a/ca/testutils/externalutils.go
+++ b/ca/testutils/externalutils.go
@@ -17,14 +17,14 @@ import (
 	"github.com/docker/swarmkit/ca"
 )
 
-// NewExternalSigningServer creates and runs a new ExternalSigningServer which
+// NewExternalCFSSLSigningServer creates and runs a new ExternalCFSSLSigningServer which
 // uses the given rootCA to sign node certificates. A server key and cert are
 // generated and saved into the given basedir and then a TLS listener is
 // started on a random available port. On success, an HTTPS server will be
 // running in a separate goroutine. The URL of the singing endpoint is
 // available in the returned *ExternalSignerServer value. Calling the Close()
 // method will stop the server.
-func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSigningServer, error) {
+func NewExternalCFSSLSigningServer(rootCA ca.RootCA, basedir string) (*ExternalCFSSLSigningServer, error) {
 	serverCN := "external-ca-example-server"
 	serverOU := "localhost" // Make a valid server cert for localhost.
 
@@ -57,9 +57,9 @@ func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSignin
 		Path:   "/sign",
 	}
 
-	ess := &ExternalSigningServer{
+	ess := &ExternalCFSSLSigningServer{
 		listener: tlsListener,
-		URL:      signURL.String(),
+		URL:      "cfssl:" + signURL.String(),
 	}
 
 	mux := http.NewServeMux()
@@ -78,16 +78,16 @@ func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSignin
 	return ess, nil
 }
 
-// ExternalSigningServer runs an HTTPS server with an endpoint at a specified
+// ExternalCFSSLSigningServer runs an HTTPS server with an endpoint at a specified
 // URL which signs node certificate requests from a swarm manager client.
-type ExternalSigningServer struct {
+type ExternalCFSSLSigningServer struct {
 	listener  net.Listener
 	NumIssued uint64
 	URL       string
 }
 
 // Stop stops this signing server by closing the underlying TCP/TLS listener.
-func (ess *ExternalSigningServer) Stop() error {
+func (ess *ExternalCFSSLSigningServer) Stop() error {
 	return ess.listener.Close()
 }
 

--- a/cmd/external-cfssl-ca-example/README.md
+++ b/cmd/external-cfssl-ca-example/README.md
@@ -10,7 +10,7 @@ Now, run `external-ca-example`:
 
 ```
 $ external-ca-example
-INFO[0000] Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url https://localhost:58631/sign
+INFO[0000] Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url cfssl:https://localhost:58631/sign
 ```
 
 This command initializes a new root CA along with the node certificate for the

--- a/cmd/external-cfssl-ca-example/main.go
+++ b/cmd/external-cfssl-ca-example/main.go
@@ -39,7 +39,7 @@ func main() {
 	// CA.
 	ioutil.WriteFile(nodeConfigPaths.RootCA.Cert, rootCA.Cert, os.FileMode(0644))
 
-	server, err := testutils.NewExternalSigningServer(rootCA, "ca")
+	server, err := testutils.NewExternalCFSSLSigningServer(rootCA, "ca")
 	if err != nil {
 		log.Fatalf("unable to start server: %s", err)
 	}


### PR DESCRIPTION
This removes hardcoded dependencies on CFSSL as an external CSR signing endpoint. Given URLs are prefixed with the signing server type, which creates implementations of a signing endpoint interface as needed.

Current internal/external CA tests pass.

The major TODO is adding support for Vault. It's relatively straightforward but I'm still trying to grok the root CA model. After that is some cleanup and adding an example command similar to the CFSSL example.

cc @aaronlehmann @diogomonica 