### PR TITLE
Raft/Node: stop ticker when node is shutdown

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -449,6 +449,7 @@ func (n *Node) stop() {
 		}
 	}
 	n.Stop()
+	n.ticker.Stop()
 	if err := n.wal.Close(); err != nil {
 		n.Config.Logger.Errorf("raft: error closing WAL: %v", err)
 	}


### PR DESCRIPTION
to avoid resource leak

ping @abronan @aaronlehmann 
Signed-off-by: runshenzhu <runshen.zhu@gmail.com>