### PR TITLE
cli: Change external CA "type" to "protocol"

### DIFF
--- a/cli/external_ca.go
+++ b/cli/external_ca.go
@@ -46,7 +46,7 @@ func (m *ExternalCAOpt) Value() []*api.ExternalCA {
 }
 
 // parseExternalCA parses an external CA specification from the command line,
-// such as type=cfssl,url=https://example.com.
+// such as protocol=cfssl,url=https://example.com.
 func parseExternalCA(caSpec string) (*api.ExternalCA, error) {
 	csvReader := csv.NewReader(strings.NewReader(caSpec))
 	fields, err := csvReader.Read()
@@ -73,12 +73,12 @@ func parseExternalCA(caSpec string) (*api.ExternalCA, error) {
 		key, value := parts[0], parts[1]
 
 		switch strings.ToLower(key) {
-		case "type":
+		case "protocol":
 			hasProtocol = true
 			if strings.ToLower(value) == "cfssl" {
 				externalCA.Protocol = api.ExternalCA_CAProtocolCFSSL
 			} else {
-				return nil, fmt.Errorf("unrecognized external CA type %s", value)
+				return nil, fmt.Errorf("unrecognized external CA protocol %s", value)
 			}
 		case "url":
 			hasURL = true
@@ -89,7 +89,7 @@ func parseExternalCA(caSpec string) (*api.ExternalCA, error) {
 	}
 
 	if !hasProtocol {
-		return nil, errors.New("the external-ca option needs a type= parameter")
+		return nil, errors.New("the external-ca option needs a protocol= parameter")
 	}
 	if !hasURL {
 		return nil, errors.New("the external-ca option needs a url= parameter")

--- a/cli/external_ca_test.go
+++ b/cli/external_ca_test.go
@@ -12,12 +12,12 @@ func TestParseExternalCA(t *testing.T) {
 		"",
 		"asdf",
 		"asdf=",
-		"type",
-		"type=foo",
-		"type=cfssl",
+		"protocol",
+		"protocol=foo",
+		"protocol=cfssl",
 		"url",
 		"url=https://xyz",
-		"url,type",
+		"url,protocol",
 	}
 
 	for _, spec := range invalidSpecs {
@@ -30,7 +30,7 @@ func TestParseExternalCA(t *testing.T) {
 		expected *api.ExternalCA
 	}{
 		{
-			input: "type=cfssl,url=https://example.com",
+			input: "protocol=cfssl,url=https://example.com",
 			expected: &api.ExternalCA{
 				Protocol: api.ExternalCA_CAProtocolCFSSL,
 				URL:      "https://example.com",


### PR DESCRIPTION
When I changed the name of this field in the API, I neglected to make a
matching change to the CLI. Change the parsing so that the format is:

    protocol=cfssl,url=https://example.com

instead of

    type=cfssl,url=https://example.com

cc @stevvooe @tonistiigi