### PR TITLE
Validate constraint form at controlapi

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/docker/engine-api/types/reference"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
+	"github.com/docker/swarmkit/manager/scheduler"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"golang.org/x/net/context"
@@ -75,6 +76,14 @@ func validateRestartPolicy(rp *api.RestartPolicy) error {
 	return nil
 }
 
+func validatePlacement(placement *api.Placement) error {
+	if placement == nil {
+		return nil
+	}
+	_, err := scheduler.ParseExprs(placement.Constraints)
+	return err
+}
+
 func validateUpdate(uc *api.UpdateConfig) error {
 	if uc == nil {
 		return nil
@@ -98,6 +107,10 @@ func validateTask(taskSpec api.TaskSpec) error {
 	}
 
 	if err := validateRestartPolicy(taskSpec.Restart); err != nil {
+		return err
+	}
+
+	if err := validatePlacement(taskSpec.Placement); err != nil {
 		return err
 	}
 

--- a/manager/scheduler/constraint.go
+++ b/manager/scheduler/constraint.go
@@ -18,14 +18,19 @@ type ConstraintFilter struct {
 
 // SetTask returns true when the filter is enable for a given task.
 func (f *ConstraintFilter) SetTask(t *api.Task) bool {
-	if t.Spec.Placement != nil && len(t.Spec.Placement.Constraints) > 0 {
-		constraints, err := ParseExprs(t.Spec.Placement.Constraints)
-		if err == nil {
-			f.constraints = constraints
-			return true
-		}
+	if t.Spec.Placement == nil || len(t.Spec.Placement.Constraints) == 0 {
+		return false
 	}
-	return false
+
+	constraints, err := ParseExprs(t.Spec.Placement.Constraints)
+	if err != nil {
+		// constraints have been validated at controlapi
+		// if in any case it finds an error here, treat this task
+		// as constraint filter disabled.
+		return false
+	}
+	f.constraints = constraints
+	return true
 }
 
 // Check returns true if the task's constraint is supported by the given node.

--- a/manager/scheduler/expr_test.go
+++ b/manager/scheduler/expr_test.go
@@ -7,8 +7,23 @@ import (
 )
 
 func TestParseExprs(t *testing.T) {
+	// empty string
+	_, err := ParseExprs([]string{""})
+	assert.Error(t, err)
+
+	_, err = ParseExprs([]string{" "})
+	assert.Error(t, err)
+
+	// no operator
+	_, err = ParseExprs([]string{"nodeabc"})
+	assert.Error(t, err)
+
+	// incorrect operator
+	_, err = ParseExprs([]string{"node ~ abc"})
+	assert.Error(t, err)
+
 	// Cannot use the leading digit for Key
-	_, err := ParseExprs([]string{"1node==a2"})
+	_, err = ParseExprs([]string{"1node==a2"})
 	assert.Error(t, err)
 
 	// leading and trailing white space are ignored


### PR DESCRIPTION
Malformed constraints like `node.name ~ node-2` should fail the service. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>