### PR TITLE
scheduler: Fix panic processing preassigned tasks on node removal

### DIFF
--- a/manager/scheduler/indexed_node_heap.go
+++ b/manager/scheduler/indexed_node_heap.go
@@ -2,9 +2,12 @@ package scheduler
 
 import (
 	"container/heap"
+	"errors"
 
 	"github.com/docker/swarmkit/api"
 )
+
+var errNodeNotFound = errors.New("node not found in scheduler heap")
 
 // A nodeHeap implements heap.Interface for nodes. It also includes an index
 // by node id.
@@ -49,20 +52,17 @@ func (nh *nodeHeap) alloc(n int) {
 }
 
 // nodeInfo returns the NodeInfo struct for a given node identified by its ID.
-func (nh *nodeHeap) nodeInfo(nodeID string) NodeInfo {
+func (nh *nodeHeap) nodeInfo(nodeID string) (NodeInfo, error) {
 	index, ok := nh.index[nodeID]
 	if ok {
-		return nh.heap[index]
+		return nh.heap[index], nil
 	}
-	return NodeInfo{}
+	return NodeInfo{}, errNodeNotFound
 }
 
 // addOrUpdateNode sets the number of tasks for a given node. It adds the node
 // to the heap if it wasn't already tracked.
 func (nh *nodeHeap) addOrUpdateNode(n NodeInfo) {
-	if n.Node == nil {
-		return
-	}
 	index, ok := nh.index[n.ID]
 	if ok {
 		nh.heap[index] = n
@@ -75,9 +75,6 @@ func (nh *nodeHeap) addOrUpdateNode(n NodeInfo) {
 // updateNode sets the number of tasks for a given node. It ignores the update
 // if the node isn't already tracked in the heap.
 func (nh *nodeHeap) updateNode(n NodeInfo) {
-	if n.Node == nil {
-		return
-	}
 	index, ok := nh.index[n.ID]
 	if ok {
 		nh.heap[index] = n

--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -23,7 +23,7 @@ func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api
 }
 
 func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
-	if nodeInfo.Tasks == nil || nodeInfo.Node == nil {
+	if nodeInfo.Tasks == nil {
 		return false
 	}
 	if _, ok := nodeInfo.Tasks[t.ID]; !ok {
@@ -39,9 +39,6 @@ func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
 }
 
 func (nodeInfo *NodeInfo) addTask(t *api.Task) bool {
-	if nodeInfo.Node == nil {
-		return false
-	}
 	if nodeInfo.Tasks == nil {
 		nodeInfo.Tasks = make(map[string]*api.Task)
 	}


### PR DESCRIPTION
processPreassignedTasks runs through a list of preassigned global tasks
and tries to see if they can be advanced to the next state. If a node is
deleted, there is a brief window where the global tasks assigned to that
node have not been deleted yet. processPreassignedTasks may call
taskFitNode on one of these global tasks, and since taskFitNode does not
check if the nodeInfo call returns a valid node from the heap, this may
cause a nil pointer dereference.

Fix this by checking if nodeInfo returns a valid result.

See https://github.com/docker/docker/issues/24227

BTW: The original idea here was to have `nodeInfo()` return an empty node struct if the node does not exist, and have functions that operate on the node struct check for this and do nothing in that case. This simplifies the code a bit, so we can have patterns like this:

```go
        nodeInfo := s.nodeHeap.nodeInfo(t.NodeID)
        if nodeInfo.addTask(t) {
                s.nodeHeap.updateNode(nodeInfo)
        }
```

Since `addTask` checks if it's called on a valid `nodeInfo` struct, the code here doesn't need to explicitly check for an error from `nodeInfo`.

I'm not particularly happy with how this turned out. It's led to a few cases where we miss these checks, and have nil pointer dereferences. Should we change it so that `nodeInfo()` returns an error as well, and the calling code must check for an error?

cc @tombee @LK4D4 @dongluochen