### PR TITLE
Reset connection on manager context cancellation

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -562,6 +562,7 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 	for {
 		s, err := conn.WaitForStateChange(ctx, state)
 		if err != nil {
+			n.setControlSocket(nil)
 			return err
 		}
 		if s == grpc.Ready {


### PR DESCRIPTION
#1046 added new context for single manager session. This resets manager connection if this context is cancelled(on demotion) before connection state changes.

@LK4D4 @aaronlehmann 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>