### PR TITLE
Remove dial-based address detection logic

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -111,37 +111,13 @@ func New(config *Config) (*Manager, error) {
 		return nil, errors.New("no tcp listen address or listener provided")
 	}
 
-	listenHost, listenPort, err := net.SplitHostPort(tcpAddr)
-	if err == nil {
-		ip := net.ParseIP(listenHost)
-		if ip != nil && ip.IsUnspecified() {
-			// Find our local IP address associated with the default route.
-			// This may not be the appropriate address to use for internal
-			// cluster communications, but it seems like the best default.
-			// The admin can override this address if necessary.
-			conn, err := net.Dial("udp", "8.8.8.8:53")
-			if err != nil {
-				return nil, fmt.Errorf("could not determine local IP address: %v", err)
-			}
-			localAddr := conn.LocalAddr().String()
-			conn.Close()
-
-			listenHost, _, err = net.SplitHostPort(localAddr)
-			if err != nil {
-				return nil, fmt.Errorf("could not split local IP address: %v", err)
-			}
-
-			tcpAddr = net.JoinHostPort(listenHost, listenPort)
-		}
-	}
-
 	// TODO(stevvooe): Reported address of manager is plumbed to listen addr
 	// for now, may want to make this separate. This can be tricky to get right
 	// so we need to make it easy to override. This needs to be the address
 	// through which agent nodes access the manager.
 	dispatcherConfig.Addr = tcpAddr
 
-	err = os.MkdirAll(filepath.Dir(config.ProtoAddr["unix"]), 0700)
+	err := os.MkdirAll(filepath.Dir(config.ProtoAddr["unix"]), 0700)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create socket directory: %v", err)
 	}


### PR DESCRIPTION
This didn't prove as usable as we hoped, since often cloud setups have
separate network interfaces for internal and external communication.
Instead, we're taking the approach of requiring the user to specify an
address or interface if there's any ambiguity.

Remove the logic that finds the IP address associated with the default
route, since it will no longer be used.

Do not merge until after https://github.com/docker/docker/pull/24237