### PR TITLE
raft: Detect remote address on Join

### DIFF
--- a/ca/forward.go
+++ b/ca/forward.go
@@ -3,6 +3,7 @@ package ca
 import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 const (
@@ -10,20 +11,24 @@ const (
 	certCNKey        = "forwarded_cert_cn"
 	certOUKey        = "forwarded_cert_ou"
 	certOrgKey       = "forwarded_cert_org"
+	remoteAddrKey    = "remote_addr"
 )
 
 // forwardedTLSInfoFromContext obtains forwarded TLS CN/OU from the grpc.MD
 // object in ctx.
-func forwardedTLSInfoFromContext(ctx context.Context) (string, string, []string) {
-	var cn, org string
+func forwardedTLSInfoFromContext(ctx context.Context) (remoteAddr string, cn string, org string, ous []string) {
 	md, _ := metadata.FromContext(ctx)
+	if len(md[remoteAddrKey]) != 0 {
+		remoteAddr = md[remoteAddrKey][0]
+	}
 	if len(md[certCNKey]) != 0 {
 		cn = md[certCNKey][0]
 	}
 	if len(md[certOrgKey]) != 0 {
 		org = md[certOrgKey][0]
 	}
-	return cn, org, md[certOUKey]
+	ous = md[certOUKey]
+	return
 }
 
 func isForwardedRequest(ctx context.Context) bool {
@@ -54,6 +59,7 @@ func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
 			org = certSubj.Organization[0]
 		}
 	}
+
 	// If there's no TLS cert, forward with blank TLS metadata.
 	// Note that the presence of this blank metadata is extremely
 	// important. Without it, it would look like manager is making
@@ -62,6 +68,10 @@ func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
 	md[certCNKey] = []string{cn}
 	md[certOrgKey] = []string{org}
 	md[certOUKey] = ous
+	peer, ok := peer.FromContext(ctx)
+	if ok {
+		md[remoteAddrKey] = []string{peer.Addr.String()}
+	}
 
 	return metadata.NewContext(ctx, md), nil
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -111,37 +111,13 @@ func New(config *Config) (*Manager, error) {
 		return nil, errors.New("no tcp listen address or listener provided")
 	}
 
-	listenHost, listenPort, err := net.SplitHostPort(tcpAddr)
-	if err == nil {
-		ip := net.ParseIP(listenHost)
-		if ip != nil && ip.IsUnspecified() {
-			// Find our local IP address associated with the default route.
-			// This may not be the appropriate address to use for internal
-			// cluster communications, but it seems like the best default.
-			// The admin can override this address if necessary.
-			conn, err := net.Dial("udp", "8.8.8.8:53")
-			if err != nil {
-				return nil, fmt.Errorf("could not determine local IP address: %v", err)
-			}
-			localAddr := conn.LocalAddr().String()
-			conn.Close()
-
-			listenHost, _, err = net.SplitHostPort(localAddr)
-			if err != nil {
-				return nil, fmt.Errorf("could not split local IP address: %v", err)
-			}
-
-			tcpAddr = net.JoinHostPort(listenHost, listenPort)
-		}
-	}
-
 	// TODO(stevvooe): Reported address of manager is plumbed to listen addr
 	// for now, may want to make this separate. This can be tricky to get right
 	// so we need to make it easy to override. This needs to be the address
 	// through which agent nodes access the manager.
 	dispatcherConfig.Addr = tcpAddr
 
-	err = os.MkdirAll(filepath.Dir(config.ProtoAddr["unix"]), 0700)
+	err := os.MkdirAll(filepath.Dir(config.ProtoAddr["unix"]), 0700)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create socket directory: %v", err)
 	}

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -2,8 +2,10 @@ package raft
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/rand"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -524,13 +526,33 @@ func (n *Node) Join(ctx context.Context, req *api.JoinRequest) (*api.JoinRespons
 		}
 	}
 
+	remoteAddr := req.Addr
+
+	// If the joining node sent an address like 0.0.0.0:4242, automatically
+	// determine its actual address based on the GRPC connection. This
+	// avoids the need for a prospective member to know its own address.
+
+	requestHost, requestPort, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address %s in raft join request", remoteAddr)
+	}
+
+	requestIP := net.ParseIP(requestHost)
+	if requestIP != nil && requestIP.IsUnspecified() {
+		remoteHost, _, err := net.SplitHostPort(nodeInfo.RemoteAddr)
+		if err != nil {
+			return nil, err
+		}
+		remoteAddr = net.JoinHostPort(remoteHost, requestPort)
+	}
+
 	// We do not bother submitting a configuration change for the
 	// new member if we can't contact it back using its address
-	if err := n.checkHealth(ctx, req.Addr, 5*time.Second); err != nil {
+	if err := n.checkHealth(ctx, remoteAddr, 5*time.Second); err != nil {
 		return nil, err
 	}
 
-	err = n.addMember(ctx, req.Addr, raftID, nodeInfo.NodeID)
+	err = n.addMember(ctx, remoteAddr, raftID, nodeInfo.NodeID)
 	if err != nil {
 		log.WithError(err).Errorf("failed to add member")
 		return nil, err


### PR DESCRIPTION
Previously, we required a joining node to provide its remotely-reachable
address in the Addr field of the Join request. This places a burden on
admins because they must set up every node that may potentially become a
manager with an IP address in mind.

Allow an address of the form "0.0.0.0:4242" in Addr, and if this is
found, replace it with the address seen by the manager. Add support for
forwarding remote addresses in GRPC headers, for cases where the join
request is proxied.

**Depends on #1119**