### PR TITLE
raft: Fast daemon restart on single Manager cluster member

### DIFF
--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -65,7 +65,6 @@ func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 		return err
 	}
 
-	n.Node = raft.RestartNode(n.Config)
 	return nil
 }
 


### PR DESCRIPTION
This fixes the restart process on a single raft Manager node to bypass waiting for the `ElectionTick`. This way the node elects itself instantly.

Related to docker/docker#24077

/cc @aaronlehmann 