### PR TITLE
swarmctl: Don't print out hashed secret

### DIFF
--- a/cmd/swarmctl/cluster/inspect.go
+++ b/cmd/swarmctl/cluster/inspect.go
@@ -24,7 +24,9 @@ func printClusterSummary(cluster *api.Cluster) {
 			fmt.Fprintf(w, "  Role\t: %v\n", policy.Role)
 			fmt.Fprintf(w, "    Autoaccept\t: %v\n", policy.Autoaccept)
 			if policy.Secret != nil {
-				fmt.Fprintf(w, "    Secret\t: %v\n", string(policy.Secret.Data))
+				fmt.Fprintln(w, "    Secret\t: yes")
+			} else {
+				fmt.Fprintln(w, "    Secret\t: no")
 			}
 		}
 	}


### PR DESCRIPTION
Currently, swarmctl prints out the bcrypted secret and makes it look
like this is the secret that can be specified to join the cluster.
Change it to only indicate whether a secret is set or not.

Fixes #1123 

cc @diogomonica