### PR TITLE
Removing dependancy on remote IPAM driver

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -358,88 +358,88 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/bitseq",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/datastore",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/discoverapi",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/driverapi",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/drivers/overlay/ovmanager",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/drvregistry",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/idm",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipam",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipamapi",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipams/builtin",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipams/null",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipams/remote",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipams/remote/api",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipams/windowsipam",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipamutils",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/netlabel",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/types",
-			"Comment": "v0.8.0-dev.2-189-g8b04235",
-			"Rev": "8b042357ca814a0c611b21147c1b6c1d1969ba10"
+			"Comment": "v0.8.0-dev.2-201-g2205999",
+			"Rev": "2205999d8d40edf92cff7e9b5ef509ce818a3bcf"
 		},
 		{
 			"ImportPath": "github.com/dustin/go-humanize",

--- a/vendor/github.com/docker/libnetwork/drvregistry/drvregistry.go
+++ b/vendor/github.com/docker/libnetwork/drvregistry/drvregistry.go
@@ -8,10 +8,6 @@ import (
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/libnetwork/types"
-
-	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
-	nullIpam "github.com/docker/libnetwork/ipams/null"
-	remoteIpam "github.com/docker/libnetwork/ipams/remote"
 )
 
 type driverData struct {
@@ -62,10 +58,6 @@ func New(lDs, gDs interface{}, dfn DriverNotifyFunc, ifn IPAMNotifyFunc) (*DrvRe
 		ipamDrivers: make(ipamTable),
 		dfn:         dfn,
 		ifn:         ifn,
-	}
-
-	if err := r.initIPAMs(lDs, gDs); err != nil {
-		return nil, err
 	}
 
 	return r, nil
@@ -155,20 +147,6 @@ func (r *DrvRegistry) IPAMDefaultAddressSpaces(name string) (string, string, err
 	}
 
 	return i.defaultLocalAddressSpace, i.defaultGlobalAddressSpace, nil
-}
-
-func (r *DrvRegistry) initIPAMs(lDs, gDs interface{}) error {
-	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
-		builtinIpam.Init,
-		remoteIpam.Init,
-		nullIpam.Init,
-	} {
-		if err := fn(r, nil, gDs); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 // RegisterDriver registers the network driver when it gets discovered.


### PR DESCRIPTION
swarmkit currently doesnt support remote network drivers (via plugins). But it was dependent on libnetwork's drvregistry which was loading remote IPAM driver by default. This causes https://github.com/docker/docker/issues/23990

The fix is to remove such built-in dependencies in drvregistry and move it to the caller similar to remote network driver.

