### PR TITLE
agent: don't handle registered on error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -195,6 +195,8 @@ func (a *Agent) run(ctx context.Context) {
 				log.G(ctx).WithError(err).Error("agent: closing session failed")
 			}
 			sessionq = nil
+			// if we're here before <-registered, do nothing for that event
+			registered = nil
 		case <-session.closed:
 			log.G(ctx).Debugf("agent: rebuild session")
 


### PR DESCRIPTION
There is non-zero chance that select will choose session.errs before
registered if they occured at the same time. So it's possible to get
sequence session.errs -> registered -> session.closed. In that case
backoff will be zero and rand.Int63n will panic.

Fix #1131

ping @stevvooe 