### PR TITLE
Support node labels

### DIFF
--- a/cmd/swarmctl/node/cmd.go
+++ b/cmd/swarmctl/node/cmd.go
@@ -12,13 +12,14 @@ var (
 
 func init() {
 	Cmd.AddCommand(
-		removeCmd,
+		activateCmd,
+		demoteCmd,
+		drainCmd,
 		inspectCmd,
 		listCmd,
-		activateCmd,
 		pauseCmd,
-		drainCmd,
 		promoteCmd,
-		demoteCmd,
+		removeCmd,
+		updateCmd,
 	)
 }

--- a/cmd/swarmctl/node/inspect.go
+++ b/cmd/swarmctl/node/inspect.go
@@ -26,9 +26,21 @@ func printNodeSummary(node *api.Node) {
 		desc = &api.NodeDescription{}
 	}
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", node.ID)
-	common.FprintfIfNotEmpty(w, "Name\t: %s\n", spec.Annotations.Name)
 	if node.Description != nil {
 		common.FprintfIfNotEmpty(w, "Hostname\t: %s\n", node.Description.Hostname)
+	}
+	if len(spec.Annotations.Labels) != 0 {
+		fmt.Fprintf(w, "Node Labels\t:")
+		// sort label output for readability
+		var keys []string
+		for k := range spec.Annotations.Labels {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(w, " %s=%s", k, spec.Annotations.Labels[k])
+		}
+		fmt.Fprintln(w)
 	}
 	fmt.Fprintln(w, "Status:\t")
 	common.FprintfIfNotEmpty(w, "  State\t: %s\n", node.Status.State.String())
@@ -80,10 +92,16 @@ func printNodeSummary(node *api.Node) {
 		common.FprintfIfNotEmpty(w, "Engine Version\t: %s\n", desc.Engine.EngineVersion)
 
 		if len(desc.Engine.Labels) != 0 {
-			fmt.Fprintln(w, "Engine Labels:\t")
-			for k, v := range desc.Engine.Labels {
-				fmt.Fprintf(w, "  %s = %s", k, v)
+			fmt.Fprintf(w, "Engine Labels\t:")
+			var keys []string
+			for k := range desc.Engine.Labels {
+				keys = append(keys, k)
 			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(w, " %s=%s", k, desc.Engine.Labels[k])
+			}
+			fmt.Fprintln(w)
 		}
 	}
 }

--- a/cmd/swarmctl/node/update.go
+++ b/cmd/swarmctl/node/update.go
@@ -1,0 +1,28 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	updateCmd = &cobra.Command{
+		Use:   "update [OPTIONS] <node ID>",
+		Short: "Update a node",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := updateNode(cmd, args); err != nil {
+				if err == errNoChange {
+					return fmt.Errorf("No change for node %s", args[0])
+				}
+				return err
+			}
+			return nil
+		},
+	}
+)
+
+func init() {
+	flags := updateCmd.Flags()
+	flags.StringSlice(flagLabel, nil, "node label (key=value)")
+}

--- a/cmd/swarmctl/service/flagparser/flags.go
+++ b/cmd/swarmctl/service/flagparser/flags.go
@@ -38,7 +38,7 @@ func AddServiceFlags(flags *pflag.FlagSet) {
 	flags.Uint64("restart-max-attempts", 0, "maximum number of restart attempts (0 = unlimited)")
 	flags.String("restart-window", "0s", "time window to evaluate restart attempts (0 = unbound)")
 
-	flags.StringSlice("constraint", nil, "Placement constraint (node.labels.key==value)")
+	flags.StringSlice("constraint", nil, "Placement constraint (e.g. node.labels.key==value)")
 
 	// TODO(stevvooe): Replace these with a more interesting mount flag.
 	flags.StringSlice("bind", nil, "define a bind mount")


### PR DESCRIPTION
This change supports add and remove node labels. 

```
dchen@vm2:~/go/src/github.com/docker/swarmkit/bin$ ./swarmctl  node label --help
Update labels for a node

Usage:
  ./swarmctl node label <node ID> [flags]

Flags:
      --add value   add node labels (key1=value1,key2=value2) (default [])
      --rm value    remove node labels (key1,key2) (default [])

Global Flags:
  -n, --no-resolve      Do not try to map IDs to Names when displaying them
  -s, --socket string   Socket to connect to the Swarm manager (default "./swarmkitstate/swarmd.sock")

dchen@vm2:~/go/src/github.com/docker/swarmkit/bin$ ./swarmctl  node inspect vm2
ID                        : a28i8j8zat8b5jlc86o4pk1bw
Hostname                  : vm2
Node Labels               :  nextmaintenance=07-14-2016  security=medium
Status:
  State                   : READY
  Availability            : ACTIVE
Manager status:
  Address                 : 10.0.2.15:4242
  Raft status             : REACHABLE
  Leader                  : yes
Platform:
  Operating System        : linux
  Architecture            : x86_64
Resources:
  CPUs                    : 2
  Memory                  : 3.9 GiB
Plugins:
  Network                 : [overlay bridge host null overlay]
  Volume                  : [local]
Engine Version            : 1.12.0-dev

Task ID                      Service    Slot    Image    Desired State    Last State               Node
-------                      -------    ----    -----    -------------    ----------               ----
an5dmb8y3c1qetlrczubw363g    test3      1       redis    RUNNING          RUNNING 4 minutes ago    vm2
1let7ra2pwt5olfaum7w9jpju    hello      1       redis    RUNNING          RUNNING 6 minutes ago    vm2

dchen@vm2:~/go/src/github.com/docker/swarmkit/bin$ ./swarmctl service create --image redis --name t4 --constraint node.labels.security==high
51qjs1brs4hhm7mqro1f72ors

dchen@vm2:~/go/src/github.com/docker/swarmkit/bin$ ./swarmctl  service inspect t4
ID                   : 51qjs1brs4hhm7mqro1f72ors
Name                 : t4
Replicas             : 0/1
Template
 Container
  Image              : redis
  Constraints        : node.labels.security==high

Task ID                      Service    Slot    Image    Desired State    Last State                  Node
-------                      -------    ----    -----    -------------    ----------                  ----
272rtghlqk9xf2352dm8gl008    t4         1       redis    RUNNING          ALLOCATED 13 seconds ago
```

cc @diogomonica @aaronlehmann @aluzzardi.

Signed-off-by: Dong Chen <dongluo.chen@docker.com>