### PR TITLE
Fix bad merge in agent_test.go

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -94,18 +94,6 @@ func TestAgentStartStop(t *testing.T) {
 	}
 
 	assert.NoError(t, agent.Stop(ctx))
-	ready := agent.Ready()
-
-	if ready != nil {
-		t.Fatalf("ready cannot return nil channel")
-	}
-	agent.Start(ctx)
-
-	ready = agent.Ready()
-	if ready != nil {
-		t.Fatalf("ready cannot be nil")
-	}
-
 }
 
 func TestHandleSessionMessage(t *testing.T) {


### PR DESCRIPTION
These additions to agent_test.go passed originally, but after being
merged to master, they fail since the behavior has changed. Remove the
newly-added lines causing the failure.

cc @LK4D4 @stevvooe 