### PR TITLE
raft: Handle unresponsive managers even when the TCP socket stays open

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -113,6 +113,24 @@ func (c *Cluster) RemoveMember(id uint64) error {
 	return nil
 }
 
+// ReplaceMemberConnection replaces the member's GRPC connection and GRPC
+// client.
+func (c *Cluster) ReplaceMemberConnection(id uint64, member *Member) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	oldMember, ok := c.members[id]
+	if !ok {
+		return ErrIDNotFound
+	}
+
+	oldMember.Conn.Close()
+
+	oldMember.Conn = member.Conn
+	oldMember.RaftClient = member.RaftClient
+	return nil
+}
+
 // IsIDRemoved checks if a Member is in the remove set.
 func (c *Cluster) IsIDRemoved(id uint64) bool {
 	c.mu.RLock()

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1000,6 +1000,14 @@ func (n *Node) sendToMember(members map[uint64]*membership.Member, m raftpb.Mess
 			panic("node is nil")
 		}
 		n.ReportUnreachable(m.To)
+
+		// Bounce the connection
+		newConn, err := n.ConnectToMember(conn.Addr, 0)
+		if err != nil {
+			n.Config.Logger.Errorf("could connect to member ID %x at %s: %v", m.To, conn.Addr, err)
+		} else {
+			n.cluster.ReplaceMemberConnection(m.To, newConn)
+		}
 	} else if m.Type == raftpb.MsgSnap {
 		n.ReportSnapshot(m.To, raft.SnapshotFinish)
 	}


### PR DESCRIPTION
If a manager is unresponsive, we may report it as reachable as long as
the TCP socket hasn't closed.

To fix this, bounce the GRPC connection when a ProcessRaftMessage RPC
times out.

This is the manager-side version of the problem in #1136.
See https://github.com/docker/docker/issues/24329

cc @abronan @tonistiigi 