### PR TITLE
agent: Reset picker on a session error

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -197,6 +197,11 @@ func (a *Agent) run(ctx context.Context) {
 			sessionq = nil
 			// if we're here before <-registered, do nothing for that event
 			registered = nil
+
+			// Bounce the connection.
+			if a.config.Picker != nil {
+				a.config.Picker.Reset()
+			}
 		case <-session.closed:
 			log.G(ctx).Debugf("agent: rebuild session")
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -19,8 +19,14 @@ type Config struct {
 	// updated with managers weights as observed by the agent.
 	Managers picker.Remotes
 
-	// Conn specifies the client connection Agent will use
+	// Conn specifies the client connection Agent will use.
 	Conn *grpc.ClientConn
+
+	// Picker is the picker used by Conn.
+	// TODO(aaronl): This is only part of the config to allow resetting the
+	// GRPC connection. This should be refactored to address the coupling
+	// between Conn and Picker.
+	Picker *picker.Picker
 
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor

--- a/agent/node.go
+++ b/agent/node.go
@@ -375,8 +375,9 @@ func (n *Node) runAgent(ctx context.Context, db *bolt.DB, creds credentials.Tran
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+	picker := picker.NewPicker(n.remotes, manager.Addr)
 	conn, err := grpc.Dial(manager.Addr,
-		grpc.WithPicker(picker.NewPicker(n.remotes, manager.Addr)),
+		grpc.WithPicker(picker),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithBackoffMaxDelay(maxSessionFailureBackoff))
 	if err != nil {
@@ -389,6 +390,7 @@ func (n *Node) runAgent(ctx context.Context, db *bolt.DB, creds credentials.Tran
 		Executor:         n.config.Executor,
 		DB:               db,
 		Conn:             conn,
+		Picker:           picker,
 		NotifyRoleChange: n.roleChangeReq,
 	})
 	if err != nil {


### PR DESCRIPTION
This will cause the picker to open a new connection for the next attempt
at establishing a session.

cc @stevvooe @tonistiigi @LK4D4