### PR TITLE
raft: Fix data race caused by ReplaceMemberConnection

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -115,7 +115,7 @@ func (c *Cluster) RemoveMember(id uint64) error {
 
 // ReplaceMemberConnection replaces the member's GRPC connection and GRPC
 // client.
-func (c *Cluster) ReplaceMemberConnection(id uint64, member *Member) error {
+func (c *Cluster) ReplaceMemberConnection(id uint64, newConn *Member) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -126,8 +126,12 @@ func (c *Cluster) ReplaceMemberConnection(id uint64, member *Member) error {
 
 	oldMember.Conn.Close()
 
-	oldMember.Conn = member.Conn
-	oldMember.RaftClient = member.RaftClient
+	newMember := *oldMember
+	newMember.Conn = newConn.Conn
+	newMember.RaftClient = newConn.RaftClient
+
+	c.members[id] = &newMember
+
 	return nil
 }
 


### PR DESCRIPTION
ReplaceMemberConnection was overwriting field in a Member struct, and
this same member struct (not a copy) was being returned by GetMember. So
a different goroutine could potentially be using this struct while it's
being mutated.

Change ReplaceMemberConnection to make a copy of the struct and replace
the entry in the members map with the copy.

See https://circleci.com/gh/docker/swarmkit/3500

cc @abronan