### PR TITLE
Add AdvertiseRemoteAPI node config parameter

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -60,6 +60,10 @@ type NodeConfig struct {
 	// and raft members connect to.
 	ListenRemoteAPI string
 
+	// AdvertiseRemoteAPI specifies the address that should be advertised
+	// for connections to the remote API (including the raft service).
+	AdvertiseRemoteAPI string
+
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor
 
@@ -545,6 +549,8 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 	opts := []grpc.DialOption{}
 	insecureCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
 	opts = append(opts, grpc.WithTransportCredentials(insecureCreds))
+	// Using listen address instead of advertised address because this is a
+	// local connection.
 	addr := n.config.ListenControlAPI
 	opts = append(opts, grpc.WithDialer(
 		func(addr string, timeout time.Duration) (net.Conn, error) {
@@ -612,6 +618,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 				"tcp":  n.config.ListenRemoteAPI,
 				"unix": n.config.ListenControlAPI,
 			},
+			AdvertiseAddr:  n.config.AdvertiseRemoteAPI,
 			SecurityConfig: securityConfig,
 			ExternalCAs:    n.config.ExternalCAs,
 			JoinRaft:       remoteAddr.Addr,

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -49,6 +49,9 @@ type Config struct {
 	// ProtoAddr fields will be used to create listeners otherwise.
 	ProtoListener map[string]net.Listener
 
+	// AdvertiseAddr is a map of addresses to advertise, by protocol.
+	AdvertiseAddr string
+
 	// JoinRaft is an optional address of a node in an existing raft
 	// cluster to join.
 	JoinRaft string
@@ -120,14 +123,14 @@ func New(config *Config) (*Manager, error) {
 
 	tcpAddr := config.ProtoAddr["tcp"]
 
+	if config.AdvertiseAddr != "" {
+		tcpAddr = config.AdvertiseAddr
+	}
+
 	if tcpAddr == "" {
 		return nil, errors.New("no tcp listen address or listener provided")
 	}
 
-	// TODO(stevvooe): Reported address of manager is plumbed to listen addr
-	// for now, may want to make this separate. This can be tricky to get right
-	// so we need to make it easy to override. This needs to be the address
-	// through which agent nodes access the manager.
 	dispatcherConfig.Addr = tcpAddr
 
 	err := os.MkdirAll(filepath.Dir(config.ProtoAddr["unix"]), 0700)


### PR DESCRIPTION
This enables us to advertise a different address than the one we listen
on.

Depends on #1119

Should be merged in sync with https://github.com/docker/docker/pull/24237.