### PR TITLE
Fix race condition between task creation and removal

### DIFF
--- a/agent/exec/errors.go
+++ b/agent/exec/errors.go
@@ -22,6 +22,9 @@ var (
 	// ErrControllerClosed returned when a task controller has been closed.
 	ErrControllerClosed = errors.New("exec: controller closed")
 
+	// ErrControllerRemoved returned when a task controller has been removed.
+	ErrControllerRemoved = errors.New("exec: controller removed")
+
 	// ErrTaskRetry is returned by Do when an operation failed by should be
 	// retried. The status should still be reported in this case.
 	ErrTaskRetry = errors.New("exec: task retry")

--- a/agent/task.go
+++ b/agent/task.go
@@ -200,10 +200,6 @@ func (tm *taskManager) run(ctx context.Context) {
 				}
 			}
 		case <-shutdown:
-			if cancel != nil {
-				// cancel outstanding operation.
-				cancel()
-			}
 
 			// TODO(stevvooe): This should be left for the repear.
 
@@ -211,6 +207,11 @@ func (tm *taskManager) run(ctx context.Context) {
 			// retried by the reaper later.
 			if err := tm.ctlr.Remove(ctx); err != nil {
 				log.G(ctx).WithError(err).WithField("task.id", tm.task.ID).Error("remove task failed")
+			}
+
+			if cancel != nil {
+				// cancel outstanding operation.
+				cancel()
 			}
 
 			if err := tm.ctlr.Close(); err != nil {


### PR DESCRIPTION
This commit fixes a race condition between task creation and removal
which could causes orphan containers. It happens when a agent task is
handling creation event and creating a container, a removal event
comes in and cancels the task's context. Both the creation and
removal would fail but the container would still created by the docker
daemon. The removal fails because when the DELETE request arrives the
docker daemon, the container is still being created.

    goroutine (creation)                   task (removal)
    ---------                              ----
    
    ...                                    ...
    ctlr.Prepare(ctx)
      r.adapter.createNetworks(ctx)
      ...                                  case <-shutdown
      r.adapter.create(ctx)                  cancel()
      //failed due to context cancelled      tm.ctlr.Remove(ctx)
      //container still createdby daemon     //failed due to "No such
                                             //container" error because
                                             //the container not created
                                             //yet
      ...
      //the container created by docker
      //daemon but becomes orphan

This patch fixes it by moving the cancel operation to be after the
remove operation. In addition, a lock is added for exclusive access
to the container resouces between creation and removal operations.
These ensures that the creation of a container could either be
finished or not started when the remove operation enters the critical
section. The pull operation is moved out the critical section because
it might be too time consuming.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>