### PR TITLE
Assign ready channel to nil only if it is not nil

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -571,8 +571,8 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 			n.setControlSocket(conn)
 			if ready != nil {
 				close(ready)
+				ready = nil
 			}
-			ready = nil
 		} else if state == grpc.Shutdown {
 			n.setControlSocket(nil)
 		}
@@ -635,9 +635,8 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 					case <-connCtx.Done():
 					}
 				}(ready)
+				ready = nil
 			}
-
-			ready = nil
 
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
If the ready channel is already nil, it's not necessary to assign
it to nil.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>