### PR TITLE
Ensure endpoint spec is updated on service update

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -188,6 +188,7 @@ outer:
 
 		s.Endpoint.VirtualIPs = append(s.Endpoint.VirtualIPs, vip)
 	}
+	s.Endpoint.Spec = s.Spec.Endpoint.Copy()
 
 	na.services[s.ID] = struct{}{}
 	return

--- a/manager/allocator/networkallocator/networkallocator_test.go
+++ b/manager/allocator/networkallocator/networkallocator_test.go
@@ -563,6 +563,8 @@ func TestServiceAllocate(t *testing.T) {
 
 	assert.Equal(t, 1, len(s.Endpoint.VirtualIPs))
 
+	assert.Equal(t, s.Endpoint.Spec, s.Spec.Endpoint)
+
 	ip, _, err := net.ParseCIDR(s.Endpoint.VirtualIPs[0].Addr)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
When creating a service, the `service.Endpoint.Sepc` gets a copy of
`service.Spec.Endpoint`, however when performing an update,
`service.Endpoint` was not being updated.

This adjusts the network allocator for services to set
`service.Endpoint.Spec` after everything has been allocated.