### PR TITLE
controlapi: prevent demote/promote when previous is still in progress

### DIFF
--- a/manager/controlapi/node.go
+++ b/manager/controlapi/node.go
@@ -199,6 +199,10 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 			return nil
 		}
 
+		if node.Certificate.Role != node.Spec.Role {
+			return grpc.Errorf(codes.FailedPrecondition, "demote/promote in progress")
+		}
+
 		// Demotion sanity checks.
 		if node.Spec.Role == api.NodeRoleManager && request.Spec.Role == api.NodeRoleWorker {
 			demote = true


### PR DESCRIPTION
double demote/promote is really confusing for node object, because
manager dies on demote unconditionally, but certificate issuance for
worker might never happen (ca takes role directly from store).

ping @aaronlehmann @tonistiigi 
After this we can return to `waitRole` model.