### PR TITLE
Persist vip allocs for a service across restart

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -45,6 +45,11 @@ func TestAllocator(t *testing.T) {
 				Annotations: api.Annotations{
 					Name: "service1",
 				},
+				Networks: []*api.ServiceSpec_NetworkAttachmentConfig{
+					{
+						Target: "testID1",
+					},
+				},
 				Endpoint: &api.EndpointSpec{},
 			},
 		}

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -193,11 +193,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 	}
 
 	for _, s := range services {
-		if s.Spec.Endpoint == nil {
-			continue
-		}
-
-		if na.IsServiceAllocated(s) {
+		if !serviceAllocationNeeded(s, nc) {
 			continue
 		}
 
@@ -379,7 +375,7 @@ func (a *Allocator) doNodeAlloc(ctx context.Context, nc *networkContext, ev even
 			node.Attachment = &api.NetworkAttachment{}
 		}
 
-		node.Attachment.Network = a.netCtx.ingressNetwork.Copy()
+		node.Attachment.Network = nc.ingressNetwork.Copy()
 		if err := a.allocateNode(ctx, nc, node); err != nil {
 			log.G(ctx).Errorf("Fauled to allocate network resources for node %s: %v", node.ID, err)
 		}
@@ -585,7 +581,7 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 		if len(s.Spec.Endpoint.Ports) != 0 {
 			var found bool
 			for _, vip := range s.Endpoint.VirtualIPs {
-				if vip.NetworkID == a.netCtx.ingressNetwork.ID {
+				if vip.NetworkID == nc.ingressNetwork.ID {
 					found = true
 					break
 				}
@@ -593,7 +589,7 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 
 			if !found {
 				s.Endpoint.VirtualIPs = append(s.Endpoint.VirtualIPs,
-					&api.Endpoint_VirtualIP{NetworkID: a.netCtx.ingressNetwork.ID})
+					&api.Endpoint_VirtualIP{NetworkID: nc.ingressNetwork.ID})
 			}
 		}
 	}

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -376,8 +376,18 @@ func (na *NetworkAllocator) allocateVIP(vip *api.Endpoint_VirtualIP) error {
 		return fmt.Errorf("failed to resolve IPAM while allocating : %v", err)
 	}
 
+	var addr net.IP
+	if vip.Addr != "" {
+		var err error
+
+		addr, _, err = net.ParseCIDR(vip.Addr)
+		if err != nil {
+			return err
+		}
+	}
+
 	for _, poolID := range localNet.pools {
-		ip, _, err := ipam.RequestAddress(poolID, nil, nil)
+		ip, _, err := ipam.RequestAddress(poolID, addr, nil)
 		if err != nil && err != ipamapi.ErrNoAvailableIPs && err != ipamapi.ErrIPOutOfRange {
 			return fmt.Errorf("could not allocate VIP from IPAM: %v", err)
 		}

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -43,6 +43,14 @@ type NetworkAllocator struct {
 	// Allocator state to indicate if allocation has been
 	// successfully completed for this service.
 	services map[string]struct{}
+
+	// Allocator state to indicate if allocation has been
+	// successfully completed for this task.
+	tasks map[string]struct{}
+
+	// Allocator state to indicate if allocation has been
+	// successfully completed for this node.
+	nodes map[string]struct{}
 }
 
 // Local in-memory state related to netwok that need to be tracked by NetworkAllocator
@@ -64,6 +72,8 @@ func New() (*NetworkAllocator, error) {
 	na := &NetworkAllocator{
 		networks: make(map[string]*network),
 		services: make(map[string]struct{}),
+		tasks:    make(map[string]struct{}),
+		nodes:    make(map[string]struct{}),
 	}
 
 	// There are no driver configurations and notification
@@ -223,6 +233,12 @@ func (na *NetworkAllocator) IsAllocated(n *api.Network) bool {
 
 // IsTaskAllocated returns if the passed task has it's network resources allocated or not.
 func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
+	// If the task is not found in the allocated set, then it is
+	// not allocated.
+	if _, ok := na.tasks[t.ID]; !ok {
+		return false
+	}
+
 	// If Networks is empty there is no way this Task is allocated.
 	if len(t.Networks) == 0 {
 		return false
@@ -267,6 +283,12 @@ func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
 
 // IsNodeAllocated returns if the passed node has its network resources allocated or not.
 func (na *NetworkAllocator) IsNodeAllocated(node *api.Node) bool {
+	// If the node is not found in the allocated set, then it is
+	// not allocated.
+	if _, ok := na.nodes[node.ID]; !ok {
+		return false
+	}
+
 	// If no attachment, not allocated.
 	if node.Attachment == nil {
 		return false
@@ -294,12 +316,18 @@ func (na *NetworkAllocator) IsNodeAllocated(node *api.Node) bool {
 // AllocateNode allocates the IP addresses for the network to which
 // the node is attached.
 func (na *NetworkAllocator) AllocateNode(node *api.Node) error {
-	return na.allocateNetworkIPs(node.Attachment)
+	if err := na.allocateNetworkIPs(node.Attachment); err != nil {
+		return err
+	}
+
+	na.nodes[node.ID] = struct{}{}
+	return nil
 }
 
 // DeallocateNode deallocates the IP addresses for the network to
 // which the node is attached.
 func (na *NetworkAllocator) DeallocateNode(node *api.Node) error {
+	delete(na.nodes, node.ID)
 	return na.releaseEndpoints([]*api.NetworkAttachment{node.Attachment})
 }
 
@@ -315,12 +343,15 @@ func (na *NetworkAllocator) AllocateTask(t *api.Task) error {
 		}
 	}
 
+	na.tasks[t.ID] = struct{}{}
+
 	return nil
 }
 
 // DeallocateTask releases all the endpoint resources for all the
 // networks that a task is attached to.
 func (na *NetworkAllocator) DeallocateTask(t *api.Task) error {
+	delete(na.tasks, t.ID)
 	return na.releaseEndpoints(t.Networks)
 }
 


### PR DESCRIPTION
Make sure once a vip is allocated for a service it is persisted across
restarts and failovers.

Also fixed an issue in task/node allocation tracking logic.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>