### PR TITLE
Raft: send commit ack back to follower before closing connection

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1206,10 +1206,26 @@ func (n *Node) applyRemoveNode(cc raftpb.ConfChange) (err error) {
 	// If the node from where the remove is issued is
 	// a follower and the leader steps down, Campaign
 	// to be the leader.
-	if cc.NodeID == n.Leader() {
+
+	if cc.NodeID == n.Leader() && !n.IsLeader() {
 		if err = n.Campaign(n.Ctx); err != nil {
 			return err
 		}
+	}
+
+	if cc.NodeID == n.Config.ID {
+		// wait the commit ack to be sent before closing connection
+		n.asyncTasks.Wait()
+
+		// if there are only 2 nodes in the cluster, and leader is leaving
+		// before closing the connection, leader has to ensure that follower gets
+		// noticed about this raft conf change commit. Otherwise, follower would
+		// assume there are still 2 nodes in the cluster and won't get elected
+		// into the leader by acquiring the majority (2 nodes)
+
+		// while n.asyncTasks.Wait() could be helpful in this case
+		// it's the best-effort strategy, because this send could be fail due to some errors (such as time limit exceeds)
+		// TODO(Runshen Zhu): use leadership transfer to solve this case, after vendoring raft 3.0+
 	}
 
 	return n.cluster.RemoveMember(cc.NodeID)


### PR DESCRIPTION
if there are only 2 nodes in the cluster, and leader is leaving before closing the connection, leader has to ensure that follower gets noticed about this raft conf change commit. 

Otherwise, follower would assume there are still 2 nodes in the cluster and won't get elected into the leader by acquiring the majority (2 nodes). Check out [my repo](https://github.com/runshenzhu/swarmkit/commits/raft-leave-join) to reproduce this bug.

This PR fix the problem by sending commit ack back to follower manually, before leader closing connection.

An alternative approach is to keep leader from leaving when there are only 2 nodes in the cluster.

Signed-off-by: Runshen Zhu <runshen.zhu@gmail.com>

ping: @dperny @aaronlehmann @abronan 
fix #1178 