### PR TITLE
Add a random offset to the key's clock

### DIFF
--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -7,6 +7,7 @@ package keymanager
 // plane information. It can also be used to encrypt overlay data traffic.
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"sync"
 	"time"
@@ -87,7 +88,7 @@ func New(store *store.MemoryStore, config *Config) *KeyManager {
 	return &KeyManager{
 		config:  config,
 		store:   store,
-		keyRing: &keyRing{},
+		keyRing: &keyRing{lClock: genSkew()},
 	}
 }
 
@@ -229,4 +230,13 @@ func (k *KeyManager) Stop() error {
 	}
 	k.cancel()
 	return nil
+}
+
+// genSkew generates a random uint64 number between 0 and 65535
+func genSkew() uint64 {
+	b := make([]byte, 2)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return uint64(binary.BigEndian.Uint16(b))
 }


### PR DESCRIPTION

Given the key's clock may be used to derive some key material and security indices by the datapath encryption layer, it is better to add some random offset.

Otherwise the key's clock value is very well predictable today on a freshly started swarm cluster.

Signed-off-by: Alessandro Boch <aboch@docker.com>