### PR TITLE
Use `servicename.slot` for Task name index.

### DIFF
--- a/manager/controlapi/task.go
+++ b/manager/controlapi/task.go
@@ -1,6 +1,8 @@
 package controlapi
 
 import (
+	"fmt"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
@@ -104,10 +106,22 @@ func (s *Server) ListTasks(ctx context.Context, request *api.ListTasksRequest) (
 	if request.Filters != nil {
 		tasks = filterTasks(tasks,
 			func(e *api.Task) bool {
-				return filterContains(e.ServiceAnnotations.Name, request.Filters.Names)
+				name := e.Annotations.Name
+				if name == "" {
+					// If Task name is not assigned then calculated name is used like before.
+					// This might be removed in the future.
+					name = fmt.Sprintf("%v.%v.%v", e.ServiceAnnotations.Name, e.Slot, e.ID)
+				}
+				return filterContains(name, request.Filters.Names)
 			},
 			func(e *api.Task) bool {
-				return filterContainsPrefix(e.ServiceAnnotations.Name, request.Filters.NamePrefixes)
+				name := e.Annotations.Name
+				if name == "" {
+					// If Task name is not assigned then calculated name is used like before
+					// This might be removed in the future.
+					name = fmt.Sprintf("%v.%v.%v", e.ServiceAnnotations.Name, e.Slot, e.ID)
+				}
+				return filterContainsPrefix(name, request.Filters.NamePrefixes)
 			},
 			func(e *api.Task) bool {
 				return filterContainsPrefix(e.ID, request.Filters.IDPrefixes)

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -82,6 +82,9 @@ var (
 	taskSet = []*api.Task{
 		{
 			ID: "id1",
+			Annotations: api.Annotations{
+				Name: "name1",
+			},
 			ServiceAnnotations: api.Annotations{
 				Name: "name1",
 			},
@@ -90,6 +93,9 @@ var (
 		},
 		{
 			ID: "id2",
+			Annotations: api.Annotations{
+				Name: "name2.1",
+			},
 			ServiceAnnotations: api.Annotations{
 				Name: "name2",
 			},
@@ -98,6 +104,9 @@ var (
 		},
 		{
 			ID: "id3",
+			Annotations: api.Annotations{
+				Name: "name2.2",
+			},
 			ServiceAnnotations: api.Annotations{
 				Name: "name2",
 			},
@@ -471,13 +480,13 @@ func TestStoreTask(t *testing.T) {
 		assert.Equal(t, taskSet[1], GetTask(readTx, "id2"))
 		assert.Equal(t, taskSet[2], GetTask(readTx, "id3"))
 
-		foundTasks, err := FindTasks(readTx, ByName("name1"))
+		foundTasks, err := FindTasks(readTx, ByNamePrefix("name1"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 1)
-		foundTasks, err = FindTasks(readTx, ByName("name2"))
+		foundTasks, err = FindTasks(readTx, ByNamePrefix("name2"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 2)
-		foundTasks, err = FindTasks(readTx, ByName("invalid"))
+		foundTasks, err = FindTasks(readTx, ByNamePrefix("invalid"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 0)
 
@@ -514,6 +523,9 @@ func TestStoreTask(t *testing.T) {
 	// Update.
 	update := &api.Task{
 		ID: "id3",
+		Annotations: api.Annotations{
+			Name: "name3",
+		},
 		ServiceAnnotations: api.Annotations{
 			Name: "name3",
 		},
@@ -523,10 +535,10 @@ func TestStoreTask(t *testing.T) {
 		assert.NoError(t, UpdateTask(tx, update))
 		assert.Equal(t, update, GetTask(tx, "id3"))
 
-		foundTasks, err := FindTasks(tx, ByName("name2"))
+		foundTasks, err := FindTasks(tx, ByNamePrefix("name2"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 1)
-		foundTasks, err = FindTasks(tx, ByName("name3"))
+		foundTasks, err = FindTasks(tx, ByNamePrefix("name3"))
 		assert.NoError(t, err)
 		assert.Len(t, foundTasks, 1)
 
@@ -538,7 +550,7 @@ func TestStoreTask(t *testing.T) {
 		assert.NotNil(t, GetTask(tx, "id1"))
 		assert.NoError(t, DeleteTask(tx, "id1"))
 		assert.Nil(t, GetTask(tx, "id1"))
-		foundTasks, err = FindTasks(tx, ByName("name1"))
+		foundTasks, err = FindTasks(tx, ByNamePrefix("name1"))
 		assert.NoError(t, err)
 		assert.Empty(t, foundTasks)
 

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -224,8 +225,15 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 		panic("unexpected type passed to FromObject")
 	}
 
+	name := t.Annotations.Name
+	if name == "" {
+		// If Task name is not assigned then calculated name is used like before.
+		// This might be removed in the future.
+		name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.Slot, t.Task.ID)
+	}
+
 	// Add the null character as a terminator
-	return true, []byte(strings.ToLower(t.ServiceAnnotations.Name) + "\x00"), nil
+	return true, []byte(strings.ToLower(name) + "\x00"), nil
 }
 
 func (ti taskIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {


### PR DESCRIPTION
This fix is related to
https://github.com/docker/docker/pull/24850

The task name is defined as (`servicename.slot`) yet the index for task name in memdb was using service name only.

This fix assigns Task name to:
`<e.ServiceAnnotations.Name>.<Slot>.<TaskID>`
when Task is created (`newTask()`)

Below is the item list to be done based on the discussion in this thread.
- [X] Need to assign `<ServiceName>.<Slot>.<TaskID>` to TaskName in orchestrator.
- [X] In  `manager/controlapi/task.go` and `manager/state/store/tasks.go`, use `TaskName` but fallback to calculated`<ServiceName>.<Slot>.<TaskID>` (**Verified that fallback is required**).
- [X] Update docker's UI/UX so that `NAME` field in listed tasks shows `<ServiceName>.<Slot>.<TaskID>`.
- [X] Test 1.12.0 client against 1.13.0 daemon.
- [X] Test daemon update from 1.12.0 to 1.13.0.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>