### PR TITLE
agent: avoid unnecessary task deep copy

### DIFF
--- a/agent/storage.go
+++ b/agent/storage.go
@@ -118,10 +118,10 @@ func WalkTaskStatus(tx *bolt.Tx, fn func(id string, status *api.TaskStatus) erro
 // PutTask places the task into the database.
 func PutTask(tx *bolt.Tx, task *api.Task) error {
 	return withCreateTaskBucketIfNotExists(tx, task.ID, func(bkt *bolt.Bucket) error {
-		task = task.Copy()
-		task.Status = api.TaskStatus{} // blank out the status.
+		taskCopy := *task
+		taskCopy.Status = api.TaskStatus{} // blank out the status.
 
-		p, err := proto.Marshal(task)
+		p, err := proto.Marshal(&taskCopy)
 		if err != nil {
 			return err
 		}

--- a/agent/task.go
+++ b/agent/task.go
@@ -234,10 +234,11 @@ func (tm *taskManager) run(ctx context.Context) {
 //
 // This used to decide whether or not to propagate a task update to a controller.
 func tasksEqual(a, b *api.Task) bool {
-	a, b = a.Copy(), b.Copy()
+	// shallow copy
+	copyA, copyB := *a, *b
 
-	a.Status, b.Status = api.TaskStatus{}, api.TaskStatus{}
-	a.Meta, b.Meta = api.Meta{}, api.Meta{}
+	copyA.Status, copyB.Status = api.TaskStatus{}, api.TaskStatus{}
+	copyA.Meta, copyB.Meta = api.Meta{}, api.Meta{}
 
-	return reflect.DeepEqual(a, b)
+	return reflect.DeepEqual(&copyA, &copyB)
 }


### PR DESCRIPTION
while profiling swarmkit with pprof, I find that lots of cpu cycles are wasted on unnecessary task copy. It takes about 5% -- 8% total cpu cycles, as shown in the graph:

![profile image](https://github.com/runshenzhu/img/blob/ba4fd4c17483c37f530c3cf2b7627d128cb8ae6d/taskcopy.jpg?raw=true)

This PR removes unnecessary task copy.

ping @stevvooe
Signed-off-by: Runshen Zhu <runshen.zhu@gmail.com>