### PR TITLE
judge if key manager is nil and fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,7 +363,7 @@ The rules:
 5. Document _all_ declarations and methods, even private ones. Declare
    expectations, caveats and anything else that may be important. If a type
    gets exported, having the comments already there will ensure it's ready.
-6. Variable name length should be proportional to it's context and no longer.
+6. Variable name length should be proportional to its context and no longer.
    `noCommaALongVariableNameLikeThisIsNotMoreClearWhenASimpleCommentWouldDo`.
    In practice, short methods will have short variable names and globals will
    have longer names.
@@ -371,7 +371,7 @@ The rules:
    and re-examine why you need a compound name. If you still think you need a
    compound name, lose the underscore.
 8. No utils or helpers packages. If a function is not general enough to
-   warrant it's own package, it has not been written generally enough to be a
+   warrant its own package, it has not been written generally enough to be a
    part of a util package. Just leave it unexported and well-documented.
 9. All tests should run with `go test` and outside tooling should not be
    required. No, we don't need another unit testing framework. Assertion

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -232,7 +232,7 @@ func (na *NetworkAllocator) IsAllocated(n *api.Network) bool {
 	return ok
 }
 
-// IsTaskAllocated returns if the passed task has it's network resources allocated or not.
+// IsTaskAllocated returns if the passed task has its network resources allocated or not.
 func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 	// If the task is not found in the allocated set, then it is
 	// not allocated.
@@ -245,7 +245,7 @@ func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 		return false
 	}
 
-	// To determine whether the task has it's resources allocated,
+	// To determine whether the task has its resources allocated,
 	// we just need to look at one network(in case of
 	// multi-network attachment).  This is because we make sure we
 	// allocate for every network or we allocate for none.
@@ -269,7 +269,7 @@ func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 	return true
 }
 
-// IsServiceAllocated returns if the passed service has it's network resources allocated or not.
+// IsServiceAllocated returns if the passed service has its network resources allocated or not.
 func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
 	if _, ok := na.services[s.ID]; !ok {
 		return false

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -341,11 +341,13 @@ func (m *Manager) Run(parent context.Context) error {
 					// creating the allocator but then use it anyway.
 				}
 
-				go func(keyManager *keymanager.KeyManager) {
-					if err := keyManager.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("keymanager failed with an error")
-					}
-				}(m.keyManager)
+				if m.keyManager != nil {
+					go func(keyManager *keymanager.KeyManager) {
+						if err := keyManager.Run(ctx); err != nil {
+							log.G(ctx).WithError(err).Error("keymanager failed with an error")
+						}
+					}(m.keyManager)
+				}
 
 				go func(d *dispatcher.Dispatcher) {
 					if err := d.Run(ctx); err != nil {
@@ -376,14 +378,17 @@ func (m *Manager) Run(parent context.Context) error {
 						log.G(ctx).WithError(err).Error("scheduler exited with an error")
 					}
 				}(m.scheduler)
+
 				go func(taskReaper *orchestrator.TaskReaper) {
 					taskReaper.Run()
 				}(m.taskReaper)
+
 				go func(orchestrator *orchestrator.ReplicatedOrchestrator) {
 					if err := orchestrator.Run(ctx); err != nil {
 						log.G(ctx).WithError(err).Error("replicated orchestrator exited with an error")
 					}
 				}(m.replicatedOrchestrator)
+
 				go func(globalOrchestrator *orchestrator.GlobalOrchestrator) {
 					if err := globalOrchestrator.Run(ctx); err != nil {
 						log.G(ctx).WithError(err).Error("global orchestrator exited with an error")
@@ -411,8 +416,10 @@ func (m *Manager) Run(parent context.Context) error {
 				m.scheduler.Stop()
 				m.scheduler = nil
 
-				m.keyManager.Stop()
-				m.keyManager = nil
+				if m.keyManager != nil {
+					m.keyManager.Stop()
+					m.keyManager = nil
+				}
 			}
 			m.mu.Unlock()
 		}


### PR DESCRIPTION
What I did:
1. fix typos 
2. judge if keymanager is nil.

Since in initialization of keymanager, scheduler, dispatcher, and so on, in keymanager.go:
```
// New creates an instance of keymanager with the given config
func New(store *store.MemoryStore, config *Config) *KeyManager {
	for _, subsys := range config.Subsystems {
		if subsys != SubsystemGossip && subsys != SubsystemIPSec {
			return nil
		}
	}
	return &KeyManager{
		config:  config,
		store:   store,
		keyRing: &keyRing{lClock: genSkew()},
	}
}
```

There is possibility that returned keymanager is nil. As a result, I think we need to judge if it is a nil in manager.

Signed-off-by: allencloud <allen.sun@daocloud.io>