### PR TITLE
Dispatcher sends bursty task updates in batches

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -358,12 +358,22 @@ func TestTasks(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
+	resp, err := stream.Recv()
+	assert.NoError(t, err)
+	// initially no tasks
+	assert.Equal(t, 0, len(resp.Tasks))
+
 	err = gd.Store.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.CreateTask(tx, testTask1))
 		assert.NoError(t, store.CreateTask(tx, testTask2))
 		return nil
 	})
 	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 2)
+	assert.True(t, resp.Tasks[0].ID == "testTask1" && resp.Tasks[1].ID == "testTask2" || resp.Tasks[0].ID == "testTask2" && resp.Tasks[1].ID == "testTask1")
 
 	err = gd.Store.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, &api.Task{
@@ -375,26 +385,6 @@ func TestTasks(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = gd.Store.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
-		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
-		return nil
-	})
-	assert.NoError(t, err)
-
-	resp, err := stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(resp.Tasks))
-
-	resp, err = stream.Recv()
-	assert.Equal(t, len(resp.Tasks), 1)
-	assert.Equal(t, resp.Tasks[0].ID, "testTask1")
-
-	resp, err = stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 2)
-	assert.True(t, resp.Tasks[0].ID == "testTask1" && resp.Tasks[1].ID == "testTask2" || resp.Tasks[0].ID == "testTask2" && resp.Tasks[1].ID == "testTask1")
-
 	resp, err = stream.Recv()
 	assert.NoError(t, err)
 	assert.Equal(t, len(resp.Tasks), 2)
@@ -405,12 +395,72 @@ func TestTasks(t *testing.T) {
 		}
 	}
 
-	resp, err = stream.Recv()
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
+		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 1)
 
 	resp, err = stream.Recv()
 	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 0)
+}
+
+func TestTasksBatch(t *testing.T) {
+	gd, err := startDispatcher(DefaultConfig())
+	assert.NoError(t, err)
+	defer gd.Close()
+
+	var expectedSessionID string
+	var nodeID string
+	{
+		stream, err := gd.Clients[0].Session(context.Background(), &api.SessionRequest{})
+		assert.NoError(t, err)
+		defer stream.CloseSend()
+		resp, err := stream.Recv()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.SessionID)
+		expectedSessionID = resp.SessionID
+		nodeID = resp.Node.ID
+	}
+
+	testTask1 := &api.Task{
+		NodeID: nodeID,
+		ID:     "testTask1",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
+	}
+	testTask2 := &api.Task{
+		NodeID: nodeID,
+		ID:     "testTask2",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
+	}
+
+	stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{SessionID: expectedSessionID})
+	assert.NoError(t, err)
+
+	resp, err := stream.Recv()
+	assert.NoError(t, err)
+	// initially no tasks
+	assert.Equal(t, 0, len(resp.Tasks))
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateTask(tx, testTask1))
+		assert.NoError(t, store.CreateTask(tx, testTask2))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
+		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	// all tasks have been deleted
 	assert.Equal(t, len(resp.Tasks), 0)
 }
 


### PR DESCRIPTION
Issue #1156 shows long converge time when a node has bursty task updates. This change make dispatcher process bursty updates and send out snapshots.  

In a 3 managers (drain) and 2 workers cluster, the converge time for the next example decreases from 45 mins to 6 mins. 
```
$ docker service create --replicas 1000 --name stest redis:3.0.7 

# Directly after
$ docker service update --replicas 2 stest
```

cc @abronan @stevvooe @aluzzardi @aaronlehmann. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>