### PR TITLE
Revert "Dynamically update node inventory"

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,7 +14,6 @@ import (
 const (
 	initialSessionFailureBackoff = time.Second
 	maxSessionFailureBackoff     = 8 * time.Second
-	nodeUpdatePeriod             = 20 * time.Second
 )
 
 // Agent implements the primary node functionality for a member of a swarm
@@ -139,19 +138,9 @@ func (a *Agent) run(ctx context.Context) {
 	log.G(ctx).Debugf("(*Agent).run")
 	defer log.G(ctx).Debugf("(*Agent).run exited")
 
-	// get the node description
-	nodeDescription, err := a.nodeDescriptionWithHostname(ctx)
-	if err != nil {
-		log.G(ctx).WithError(err).WithField("agent", a.config.Executor).
-			Errorf("agent: node description unavailable")
-	}
-	// nodeUpdateTicker is used to periodically check for updates to node description
-	nodeUpdateTicker := time.NewTicker(nodeUpdatePeriod)
-	defer nodeUpdateTicker.Stop()
-
 	var (
 		backoff    time.Duration
-		session    = newSession(ctx, a, backoff, nodeDescription) // start the initial session
+		session    = newSession(ctx, a, backoff) // start the initial session
 		registered = session.registered
 		ready      = a.ready // first session ready
 		sessionq   chan sessionOperation
@@ -217,46 +206,10 @@ func (a *Agent) run(ctx context.Context) {
 			log.G(ctx).Debugf("agent: rebuild session")
 
 			// select a session registration delay from backoff range.
-			delay := time.Duration(0)
-			if backoff > 0 {
-				delay = time.Duration(rand.Int63n(int64(backoff)))
-			}
-			session = newSession(ctx, a, delay, nodeDescription)
+			delay := time.Duration(rand.Int63n(int64(backoff)))
+			session = newSession(ctx, a, delay)
 			registered = session.registered
 			sessionq = a.sessionq
-		case <-nodeUpdateTicker.C:
-			// skip this case if the registration isn't finished
-			if registered != nil {
-				continue
-			}
-			// get the current node description
-			newNodeDescription, err := a.nodeDescriptionWithHostname(ctx)
-			if err != nil {
-				log.G(ctx).WithError(err).WithField("agent", a.config.Executor).
-					Errorf("updated node description unavailable")
-			}
-
-			// if newNodeDescription is nil, it will cause a panic when
-			// trying to create a session. Typically this can happen
-			// if the engine goes down
-			if newNodeDescription == nil {
-				continue
-			}
-
-			// If the node description has changed, update it to the new one
-			// and close the session. The old session will be stopped and a
-			// new one will be created with the updated description.
-			if !reflect.DeepEqual(nodeDescription, newNodeDescription) {
-				nodeDescription = newNodeDescription
-				// close the session. A new session will be rebuilt
-				if err := session.close(); err != nil {
-					log.G(ctx).WithError(err).Error("agent: closing session for node update failed")
-				}
-				// Bounce the connection.
-				if a.config.Picker != nil {
-					a.config.Picker.Reset()
-				}
-			}
 		case <-a.stopped:
 			// TODO(stevvooe): Wait on shutdown and cleanup. May need to pump
 			// this loop a few times.
@@ -390,17 +343,6 @@ func (a *Agent) UpdateTaskStatus(ctx context.Context, taskID string, status *api
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-}
-
-// nodeDescriptionWithHostname retrieves node description, and overrides hostname if available
-func (a *Agent) nodeDescriptionWithHostname(ctx context.Context) (*api.NodeDescription, error) {
-	desc, err := a.config.Executor.Describe(ctx)
-
-	// Override hostname
-	if a.config.Hostname != "" && desc != nil {
-		desc.Hostname = a.config.Hostname
-	}
-	return desc, err
 }
 
 // nodesEqual returns true if the node states are functionaly equal, ignoring status,


### PR DESCRIPTION
This reverts commit eb840e19ab40041e96c1957dec8778cadaa0afb3.

This appears to be making certain Docker integration tests flaky after swarmkit is vendored. I'm not 100% sure it's this commit, but reverting it appears to solve the problem in my testing so far. The other commits that I tried reverting did not make a difference.

This may be causing spurious session rebuilds. @aboch reported that with a version of Docker that vendors swarmkit master, he saw errors like this:

```
DEBU[0032] agent: rebuild session                        module=agent
DEBU[0032] (*session).start                              module=agent
ERRO[0032] agent: session failed                         error=rpc error: code = 13 desc = transport: crypto/tls: use of closed connection module=agent
DEBU[0032] agent: rebuild session                        module=agent
DEBU[0032] (*session).start                              module=agent
ERRO[0032] agent: session failed                         error=rpc error: code = 14 desc = node c9y5n3pkgw0pn0f8zzoo4le93 attempted registration too recently module=agent
DEBU[0032] agent: rebuild session                        module=agent
```

Let's revert it temporarily for now so we can move forward PRs that need to vendor swarmkit.

cc @nishanttotla @aluzzardi @stevvooe