### PR TITLE
Dispatcher sends task modifications in batches

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -1,12 +1,12 @@
 package agent
 
 import (
-	"reflect"
 	"time"
 
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/dispatcher"
 	"golang.org/x/net/context"
 )
 
@@ -175,7 +175,7 @@ func (tm *taskManager) run(ctx context.Context) {
 		case status := <-statusq:
 			tm.task.Status = *status
 		case task := <-tm.updateq:
-			if tasksEqual(task, tm.task) {
+			if dispatcher.TasksEqual(task, tm.task) {
 				continue // ignore the update
 			}
 
@@ -240,18 +240,4 @@ func (tm *taskManager) run(ctx context.Context) {
 			return
 		}
 	}
-}
-
-// tasksEqual returns true if the tasks are functionaly equal, ignoring status,
-// version and other superfluous fields.
-//
-// This used to decide whether or not to propagate a task update to a controller.
-func tasksEqual(a, b *api.Task) bool {
-	// shallow copy
-	copyA, copyB := *a, *b
-
-	copyA.Status, copyB.Status = api.TaskStatus{}, api.TaskStatus{}
-	copyA.Meta, copyB.Meta = api.Meta{}, api.Meta{}
-
-	return reflect.DeepEqual(&copyA, &copyB)
 }

--- a/agent/task.go
+++ b/agent/task.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/equality"
 	"github.com/docker/swarmkit/log"
-	"github.com/docker/swarmkit/manager/dispatcher"
 	"golang.org/x/net/context"
 )
 
@@ -175,7 +175,7 @@ func (tm *taskManager) run(ctx context.Context) {
 		case status := <-statusq:
 			tm.task.Status = *status
 		case task := <-tm.updateq:
-			if dispatcher.TasksEqual(task, tm.task) {
+			if equality.TasksEqualStable(task, tm.task) {
 				continue // ignore the update
 			}
 

--- a/api/equality/equality.go
+++ b/api/equality/equality.go
@@ -1,0 +1,21 @@
+package equality
+
+import (
+	"reflect"
+
+	"github.com/docker/swarmkit/api"
+)
+
+// TasksEqualStable returns true if the tasks are functionaly equal, ignoring status,
+// version and other superfluous fields.
+//
+// This used to decide whether or not to propagate a task update to a controller.
+func TasksEqualStable(a, b *api.Task) bool {
+	// shallow copy
+	copyA, copyB := *a, *b
+
+	copyA.Status, copyB.Status = api.TaskStatus{}, api.TaskStatus{}
+	copyA.Meta, copyB.Meta = api.Meta{}, api.Meta{}
+
+	return reflect.DeepEqual(&copyA, &copyB)
+}

--- a/api/equality/equality_test.go
+++ b/api/equality/equality_test.go
@@ -1,0 +1,55 @@
+package equality
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTasksEqualStable(t *testing.T) {
+	const taskCount = 5
+	var tasks [taskCount]*api.Task
+
+	for i := 0; i < taskCount; i++ {
+		tasks[i] = &api.Task{
+			ID:   "task-id",
+			Meta: api.Meta{Version: api.Version{Index: 6}},
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{
+						Image: "redis:3.0.7",
+					},
+				},
+			},
+			ServiceID:    "service-id",
+			Slot:         3,
+			NodeID:       "node-id",
+			Status:       api.TaskStatus{State: api.TaskStateAssigned},
+			DesiredState: api.TaskStateReady,
+		}
+	}
+
+	tasks[1].Status.State = api.TaskStateFailed
+	tasks[2].Meta.Version.Index = 7
+	tasks[3].DesiredState = api.TaskStateRunning
+	tasks[4].Spec.Runtime = &api.TaskSpec_Container{
+		Container: &api.ContainerSpec{
+			Image: "redis:3.2.1",
+		},
+	}
+
+	var tests = []struct {
+		task        *api.Task
+		expected    bool
+		failureText string
+	}{
+		{tasks[1], true, "Tasks with different Status should be equal"},
+		{tasks[2], true, "Tasks with different Meta should be equal"},
+		{tasks[3], false, "Tasks with different DesiredState are not equal"},
+		{tasks[4], false, "Tasks with different Spec are not equal"},
+	}
+	for _, test := range tests {
+		assert.Equal(t, TasksEqualStable(tasks[0], test.task), test.expected, test.failureText)
+	}
+}

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -358,12 +358,22 @@ func TestTasks(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
+	resp, err := stream.Recv()
+	assert.NoError(t, err)
+	// initially no tasks
+	assert.Equal(t, 0, len(resp.Tasks))
+
 	err = gd.Store.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.CreateTask(tx, testTask1))
 		assert.NoError(t, store.CreateTask(tx, testTask2))
 		return nil
 	})
 	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 2)
+	assert.True(t, resp.Tasks[0].ID == "testTask1" && resp.Tasks[1].ID == "testTask2" || resp.Tasks[0].ID == "testTask2" && resp.Tasks[1].ID == "testTask1")
 
 	err = gd.Store.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, &api.Task{
@@ -375,26 +385,6 @@ func TestTasks(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	err = gd.Store.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
-		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
-		return nil
-	})
-	assert.NoError(t, err)
-
-	resp, err := stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(resp.Tasks))
-
-	resp, err = stream.Recv()
-	assert.Equal(t, len(resp.Tasks), 1)
-	assert.Equal(t, resp.Tasks[0].ID, "testTask1")
-
-	resp, err = stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 2)
-	assert.True(t, resp.Tasks[0].ID == "testTask1" && resp.Tasks[1].ID == "testTask2" || resp.Tasks[0].ID == "testTask2" && resp.Tasks[1].ID == "testTask1")
-
 	resp, err = stream.Recv()
 	assert.NoError(t, err)
 	assert.Equal(t, len(resp.Tasks), 2)
@@ -405,12 +395,72 @@ func TestTasks(t *testing.T) {
 		}
 	}
 
-	resp, err = stream.Recv()
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
+		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
+		return nil
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 1)
 
 	resp, err = stream.Recv()
 	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 0)
+}
+
+func TestTasksBatch(t *testing.T) {
+	gd, err := startDispatcher(DefaultConfig())
+	assert.NoError(t, err)
+	defer gd.Close()
+
+	var expectedSessionID string
+	var nodeID string
+	{
+		stream, err := gd.Clients[0].Session(context.Background(), &api.SessionRequest{})
+		assert.NoError(t, err)
+		defer stream.CloseSend()
+		resp, err := stream.Recv()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.SessionID)
+		expectedSessionID = resp.SessionID
+		nodeID = resp.Node.ID
+	}
+
+	testTask1 := &api.Task{
+		NodeID: nodeID,
+		ID:     "testTask1",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
+	}
+	testTask2 := &api.Task{
+		NodeID: nodeID,
+		ID:     "testTask2",
+		Status: api.TaskStatus{State: api.TaskStateAssigned},
+	}
+
+	stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{SessionID: expectedSessionID})
+	assert.NoError(t, err)
+
+	resp, err := stream.Recv()
+	assert.NoError(t, err)
+	// initially no tasks
+	assert.Equal(t, 0, len(resp.Tasks))
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateTask(tx, testTask1))
+		assert.NoError(t, store.CreateTask(tx, testTask2))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
+		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	// all tasks have been deleted
 	assert.Equal(t, len(resp.Tasks), 0)
 }
 

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -332,14 +332,112 @@ func TestTasks(t *testing.T) {
 	}
 
 	testTask1 := &api.Task{
-		NodeID: nodeID,
-		ID:     "testTask1",
-		Status: api.TaskStatus{State: api.TaskStateAssigned},
+		NodeID:       nodeID,
+		ID:           "testTask1",
+		Status:       api.TaskStatus{State: api.TaskStateAssigned},
+		DesiredState: api.TaskStateReady,
 	}
 	testTask2 := &api.Task{
-		NodeID: nodeID,
-		ID:     "testTask2",
-		Status: api.TaskStatus{State: api.TaskStateAssigned},
+		NodeID:       nodeID,
+		ID:           "testTask2",
+		Status:       api.TaskStatus{State: api.TaskStateAssigned},
+		DesiredState: api.TaskStateReady,
+	}
+
+	{
+		// without correct SessionID should fail
+		stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{})
+		assert.NoError(t, err)
+		assert.NotNil(t, stream)
+		resp, err := stream.Recv()
+		assert.Nil(t, resp)
+		assert.Error(t, err)
+		assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+	}
+
+	stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{SessionID: expectedSessionID})
+	assert.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	resp, err := stream.Recv()
+	assert.NoError(t, err)
+	// initially no tasks
+	assert.Equal(t, 0, len(resp.Tasks))
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateTask(tx, testTask1))
+		assert.NoError(t, store.CreateTask(tx, testTask2))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 2)
+	assert.True(t, resp.Tasks[0].ID == "testTask1" && resp.Tasks[1].ID == "testTask2" || resp.Tasks[0].ID == "testTask2" && resp.Tasks[1].ID == "testTask1")
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.UpdateTask(tx, &api.Task{
+			ID:           testTask1.ID,
+			NodeID:       nodeID,
+			Status:       api.TaskStatus{State: api.TaskStateAssigned},
+			DesiredState: api.TaskStateRunning,
+		}))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 2)
+	for _, task := range resp.Tasks {
+		if task.ID == "testTask1" {
+			assert.Equal(t, task.DesiredState, api.TaskStateRunning)
+		}
+	}
+
+	err = gd.Store.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
+		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	resp, err = stream.Recv()
+	assert.NoError(t, err)
+	assert.Equal(t, len(resp.Tasks), 0)
+}
+
+func TestTasksStatusChange(t *testing.T) {
+	gd, err := startDispatcher(DefaultConfig())
+	assert.NoError(t, err)
+	defer gd.Close()
+
+	var expectedSessionID string
+	var nodeID string
+	{
+		stream, err := gd.Clients[0].Session(context.Background(), &api.SessionRequest{})
+		assert.NoError(t, err)
+		defer stream.CloseSend()
+		resp, err := stream.Recv()
+		assert.NoError(t, err)
+		assert.NotEmpty(t, resp.SessionID)
+		expectedSessionID = resp.SessionID
+		nodeID = resp.Node.ID
+	}
+
+	testTask1 := &api.Task{
+		NodeID:       nodeID,
+		ID:           "testTask1",
+		Status:       api.TaskStatus{State: api.TaskStateAssigned},
+		DesiredState: api.TaskStateReady,
+	}
+	testTask2 := &api.Task{
+		NodeID:       nodeID,
+		ID:           "testTask2",
+		Status:       api.TaskStatus{State: api.TaskStateAssigned},
+		DesiredState: api.TaskStateReady,
 	}
 
 	{
@@ -379,32 +477,26 @@ func TestTasks(t *testing.T) {
 		assert.NoError(t, store.UpdateTask(tx, &api.Task{
 			ID:     testTask1.ID,
 			NodeID: nodeID,
-			Status: api.TaskStatus{State: api.TaskStateFailed, Err: "1234"},
+			// only Status is changed for task1
+			Status:       api.TaskStatus{State: api.TaskStateFailed, Err: "1234"},
+			DesiredState: api.TaskStateReady,
 		}))
 		return nil
 	})
 	assert.NoError(t, err)
 
-	resp, err = stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 2)
-	for _, task := range resp.Tasks {
-		if task.ID == "testTask1" {
-			assert.Equal(t, task.Status.State, api.TaskStateFailed)
-			assert.Equal(t, task.Status.Err, "1234")
-		}
+	// dispatcher shouldn't send snapshot for this update
+	recvChan := make(chan struct{})
+	go func() {
+		_, _ = stream.Recv()
+		recvChan <- struct{}{}
+	}()
+
+	select {
+	case <-recvChan:
+		assert.Fail(t, "task.Status update should not trigger dispatcher update")
+	case <-time.After(250 * time.Millisecond):
 	}
-
-	err = gd.Store.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteTask(tx, testTask1.ID))
-		assert.NoError(t, store.DeleteTask(tx, testTask2.ID))
-		return nil
-	})
-	assert.NoError(t, err)
-
-	resp, err = stream.Recv()
-	assert.NoError(t, err)
-	assert.Equal(t, len(resp.Tasks), 0)
 }
 
 func TestTasksBatch(t *testing.T) {


### PR DESCRIPTION
From issue #1209 @aluzzardi's comment:  

> The dispatcher sends tasks down to the agent for ANY reason, including task status change. There's no point in sending tasks down to the agent if the status changes since it's the agent updating the status in the first place. Every time the agent updates the status of a task (e.g. From PREPARING to READY), it sends an update to the dispatcher which in turn sends back the list of tasks which is pointless

This change uses `TasksEqual` to decide if a task change should trigger a dispatcher notification to agent. `TasksEqual` is moved from agent to apiutils so that it can be used by agent and dispatcher.  

This change is based on #1216. 

cc @aluzzardi @runshenzhu @stevvooe @aaronlehmann. 
 