### PR TITLE
raft: fix Campaign on restore if the node id is not in the progress list

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -401,7 +401,9 @@ func (n *Node) Run(ctx context.Context) error {
 			// restoring from the state, campaign to be the
 			// leader.
 			if !n.restored {
-				if len(n.cluster.Members()) <= 1 {
+				// Node ID should be in the progress list to Campaign
+				_, ok := n.Node.Status().Progress[n.Config.ID]
+				if len(n.cluster.Members()) <= 1 && ok {
 					if err := n.Campaign(n.Ctx); err != nil {
 						panic("raft: cannot campaign to be the leader on node restore")
 					}


### PR DESCRIPTION
When restarting a node from its state, logs are reapplied to
restore the cluster membership with `ConfChangeAddNode` log
entries.

There is a chance to reach the portion calling `Campaign` to
restart a single cluster member faster when we are still
in the process of restoring the memberlist. In this case
the node may not appear in the progress list and we might
call `MaybeUpdate` on the node id from the map without
sanity checking thus resulting in a panic.

To avoid that, check if the node is present in the Progress
list before trying to Campaign on node restore.

Fix #1196 

/cc @aaronlehmann @LK4D4 

Signed-off-by: Alexandre Beslic <alexandre.beslic@gmail.com>