### PR TITLE
Fix flaky test TestUpdaterFailureAction

### DIFF
--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -209,6 +209,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 			Update: &api.UpdateConfig{
 				FailureAction: api.UpdateConfig_PAUSE,
 				Parallelism:   1,
+				Delay:         *ptypes.DurationProto(500 * time.Millisecond),
 			},
 		},
 	}


### PR DESCRIPTION
This test ran an update that encountered an error and checked that it
stopped after the first task. Because there was no update delay, the
updater could update more than one task before the failure was noticed
(the notification would race with the next update). Add an update delay
to prevent this from happening.

cc @LK4D4 @dongluochen