### PR TITLE
manager/scheduler: disable plugin filter

### DIFF
--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -7,7 +7,12 @@ var (
 		// Always check for readiness first.
 		&ReadyFilter{},
 		&ResourceFilter{},
-		&PluginFilter{},
+
+		// TODO(stevvooe): Do not filter based on plugins since they are lazy
+		// loaded in the engine. We can add this back when we can schedule
+		// plugins in the future.
+		// &PluginFilter{},
+
 		&ConstraintFilter{},
 	}
 )

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -716,6 +716,7 @@ func watchAssignment(t *testing.T, watch chan events.Event) *api.Task {
 }
 
 func TestSchedulerPluginConstraint(t *testing.T) {
+	t.Skip("plugin filtering disabled since plugins on the engine are lazy loaded")
 	ctx := context.Background()
 
 	// Node1: vol plugin1


### PR DESCRIPTION
Since plugins are lazy loaded on use in the engine, tasks that require a
plugin that hasn't been used yet will never be dispatched until the
engine description reports it.

Rather than remove all this code, we have left it in place to be used
when plugin scheduling is added in the future.

cc @aluzzardi @tiborvass

Signed-off-by: Stephen J Day <stephen.day@docker.com>