### PR TITLE
Fix confusing result of listing service

### DIFF
--- a/cmd/swarmctl/service/list.go
+++ b/cmd/swarmctl/service/list.go
@@ -41,7 +41,8 @@ var (
 
 				running := map[string]int{}
 				for _, task := range tr.Tasks {
-					if task.Status.State == api.TaskStateRunning {
+					if task.Status.State == api.TaskStateRunning &&
+						task.DesiredState == api.TaskStateRunning {
 						running[task.ServiceID]++
 					}
 				}


### PR DESCRIPTION
When a node was down, and the tasks on the node have been migrated to
other nodes, the result of listing service is a bit confusing like
following, the Replicas is 3/2. It means the number of running tasks
is three while the number of replicas is two. To avoid the confusion,
we should not count the tasks whose desired state is shutdown as
running tasks.
```
$ swarmctl service ls
ID                         Name         Image           Replicas
--                         ----         -----           --------
974qragx7kjotucroesg17hcx  busybox-top  busybox:latest  3/2
```
Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>