### PR TITLE
Fix doc and remove an useless statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ Initialize the first node:
 $ swarmd -d /tmp/node-1 --listen-control-api /tmp/manager1/swarm.sock --hostname node-1
 ```
 
-In two additional terminals, join two nodes (note: replace `127.0.0.1:4242` with the address of the first node)
+In two additional terminals, join two nodes (note: replace `127.0.0.1:4242` with the address of the first node). The join token can be fetched by inspecting the cluster of the nodes (e.g. swarmctl cluster inspect default).
 
 ```sh
-$ swarmd -d /tmp/node-2 --hostname node-2 --join-addr 127.0.0.1:4242
-$ swarmd -d /tmp/node-3 --hostname node-3 --join-addr 127.0.0.1:4242
+$ swarmd -d /tmp/node-2 --hostname node-2 --join-addr 127.0.0.1:4242 --join-token <TOKEN>
+$ swarmd -d /tmp/node-3 --hostname node-3 --join-addr 127.0.0.1:4242 --join-token <TOKEN>
 ```
 
 In a fourth terminal, use `swarmctl` to explore and control the cluster. Before

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -31,7 +31,7 @@ type controller struct {
 
 var _ exec.Controller = &controller{}
 
-// newController returns a dockerexec controller for the provided task.
+// newController returns a docker exec controller for the provided task.
 func newController(client engineapi.APIClient, task *api.Task) (exec.Controller, error) {
 	adapter, err := newContainerAdapter(client, task)
 	if err != nil {

--- a/agent/task.go
+++ b/agent/task.go
@@ -200,7 +200,7 @@ func (tm *taskManager) run(ctx context.Context) {
 				cancel() // cancel outstanding if necessary.
 			} else {
 				// If this channel op fails, it means there is already a
-				// message un the run queue.
+				// message on the run queue.
 				select {
 				case run <- struct{}{}:
 				default:

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -55,7 +55,6 @@ var (
 			}
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
 			hostname, err := cmd.Flags().GetString("hostname")
 			if err != nil {
 				return err

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1288,7 +1288,7 @@ func (n *Node) ConnectToMember(addr string, timeout time.Duration) (*membership.
 
 // SubscribeLeadership returns channel to which events about leadership change
 // will be sent in form of raft.LeadershipState. Also cancel func is returned -
-// it should be called when listener is not longer interested in events.
+// it should be called when listener is no longer interested in events.
 func (n *Node) SubscribeLeadership() (q chan events.Event, cancel func()) {
 	ch := events.NewChannel(0)
 	sink := events.Sink(events.NewQueue(ch))


### PR DESCRIPTION
1. Fix some comments
2. Update README to indicate that an valid taken is required when
joining a swarm cluster.
3. Remove an useless statement. The ctx variable is never used before
it's re-assigned, so the statement is useless.

Fixes: #1247