### PR TITLE
cmd: correctly plumb context in swarmd, swarm-bench

### DIFF
--- a/cmd/swarm-bench/collector.go
+++ b/cmd/swarm-bench/collector.go
@@ -30,12 +30,12 @@ func (c *Collector) Listen(port int) error {
 }
 
 // Collect blocks until `count` tasks phoned home.
-func (c *Collector) Collect(count uint64) {
+func (c *Collector) Collect(ctx context.Context, count uint64) {
 	start := time.Now()
 	for i := uint64(0); i < count; i++ {
 		conn, err := c.ln.Accept()
 		if err != nil {
-			log.G(context.Background()).WithError(err).Error("failure accepting connection")
+			log.G(ctx).WithError(err).Error("failure accepting connection")
 			continue
 		}
 		c.t.UpdateSince(start)

--- a/cmd/swarm-bench/main.go
+++ b/cmd/swarm-bench/main.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 var (
@@ -13,6 +14,7 @@ var (
 		Use:   os.Args[0],
 		Short: "Benchmark swarm",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
 			count, err := cmd.Flags().GetUint64("count")
 			if err != nil {
 				return err
@@ -40,7 +42,7 @@ var (
 				Port:    port,
 				Unit:    time.Second,
 			})
-			return b.Run()
+			return b.Run(ctx)
 		},
 	}
 )

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -117,8 +117,8 @@ var (
 				return err
 			}
 
-			// Create a context for our GRPC call
-			ctx, cancel := context.WithCancel(context.Background())
+			// Create a cancellable context for our GRPC call
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			client, err := engineapi.NewClient(engineAddr, "", nil, nil)
@@ -175,7 +175,7 @@ var (
 				}
 			}()
 
-			return n.Err(context.Background())
+			return n.Err(ctx)
 		},
 	}
 )


### PR DESCRIPTION
The context has been correctly plumbed for future use for cancellation
and timeouts. This PR is a little silly but I thought it would be good
to show how to do this correctly.

Signed-off-by: Stephen J Day <stephen.day@docker.com>