### PR TITLE
agent, manager: decrease backoff for session and raftproxy

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	initialSessionFailureBackoff = time.Second
+	initialSessionFailureBackoff = 100 * time.Millisecond
 	maxSessionFailureBackoff     = 8 * time.Second
 )
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -426,7 +426,7 @@ func (m *Manager) Run(parent context.Context) error {
 	}()
 
 	proxyOpts := []grpc.DialOption{
-		grpc.WithBackoffMaxDelay(2 * time.Second),
+		grpc.WithBackoffMaxDelay(time.Second),
 		grpc.WithTransportCredentials(m.config.SecurityConfig.ClientTLSCreds),
 	}
 


### PR DESCRIPTION
We need to recover from "failed node" case as fast as possible.

ping @aaronlehmann @aluzzardi @dongluochen @stevvooe 