### PR TITLE
ca: Don't close "started" channel until the CA server is actually ready

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -309,15 +309,6 @@ func (s *Server) Run(ctx context.Context) error {
 	logger := log.G(ctx).WithField("module", "ca")
 	ctx = log.WithLogger(ctx, logger)
 
-	// Run() should never be called twice, but just in case, we're
-	// attempting to close the started channel in a safe way
-	select {
-	case <-s.started:
-		return fmt.Errorf("CA server cannot be started more than once")
-	default:
-		close(s.started)
-	}
-
 	// Retrieve the channels to keep track of changes in the cluster
 	// Retrieve all the currently registered nodes
 	var nodes []*api.Node
@@ -346,6 +337,7 @@ func (s *Server) Run(ctx context.Context) error {
 	s.mu.Lock()
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.mu.Unlock()
+	close(s.started)
 
 	if err != nil {
 		log.G(ctx).WithFields(logrus.Fields{


### PR DESCRIPTION
"started" is closed slightly too early, so tests could start sending
requests to the CA server before it was ready to handle them. This bug
was present for awhile, but it was hidden before the join-token changes
because context was also set too early, so isRunning would return true.

This only affects unit tests, since the "started" channel is just used
to make the tests wait for the server to start up. So there should be no
impact on real-world use.

Fixes: #1255

cc @abronan @diogomonica 