### PR TITLE
Fix confusing result of listing service

### DIFF
--- a/cmd/swarmctl/service/list.go
+++ b/cmd/swarmctl/service/list.go
@@ -31,6 +31,17 @@ var (
 				return err
 			}
 
+			nr, err := c.ListNodes(common.Context(cmd), &api.ListNodesRequest{})
+			if err != nil {
+				return err
+			}
+			liveNodes := make(map[string]struct{})
+			for _, n := range nr.Nodes {
+				if n.Status.State != api.NodeStatus_DOWN {
+					liveNodes[n.ID] = struct{}{}
+				}
+			}
+
 			var output func(j *api.Service)
 
 			if !quiet {
@@ -41,7 +52,8 @@ var (
 
 				running := map[string]int{}
 				for _, task := range tr.Tasks {
-					if task.Status.State == api.TaskStateRunning {
+					if _, nodeLive := liveNodes[task.NodeID]; nodeLive &&
+						task.Status.State == api.TaskStateRunning {
 						running[task.ServiceID]++
 					}
 				}


### PR DESCRIPTION
When a node was down, and the tasks on the node have been migrated to
other nodes, the result of listing service is a bit confusing like
following, the Replicas is 3/2. It means the number of running tasks
is three while the number of replicas is two. To avoid the confusion,
we should not count the tasks whose hosting node is down as running
tasks.
```
$ swarmctl service ls
ID                         Name         Image           Replicas
--                         ----         -----           --------
974qragx7kjotucroesg17hcx  busybox-top  busybox:latest  3/2
```
Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>
v3: check node status not down, suggested by @dongluochen.
v2: ported from docker swarm client based on suggestion from
@aaronlehmann.