### PR TITLE
agent: simplify Start and Stop

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -31,11 +32,13 @@ type Agent struct {
 	sessionq chan sessionOperation
 	worker   Worker
 
-	started chan struct{}
-	ready   chan struct{}
-	stopped chan struct{} // requests shutdown
-	closed  chan struct{} // only closed in run
-	err     error         // read only after closed is closed
+	started   chan struct{}
+	startOnce sync.Once // start only once
+	ready     chan struct{}
+	stopped   chan struct{} // requests shutdown
+	stopOnce  sync.Once     // only allow stop to be called once
+	closed    chan struct{} // only closed in run
+	err       error         // read only after closed is closed
 }
 
 // New returns a new agent, ready for task dispatch.
@@ -59,57 +62,50 @@ func New(config *Config) (*Agent, error) {
 
 // Start begins execution of the agent in the provided context, if not already
 // started.
+//
+// Start returns an error if the agent has already started.
 func (a *Agent) Start(ctx context.Context) error {
-	select {
-	case <-a.started:
-		select {
-		case <-a.closed:
-			return a.err
-		case <-a.stopped:
-			return errAgentStopped
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			return errAgentStarted
-		}
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-	}
+	err := errAgentStarted
 
-	close(a.started)
-	go a.run(ctx)
+	a.startOnce.Do(func() {
+		close(a.started)
+		go a.run(ctx)
+		err = nil // clear error above, only once.
+	})
 
-	return nil
+	return err
 }
 
 // Stop shuts down the agent, blocking until full shutdown. If the agent is not
-// started, Stop will block until Started.
+// started, Stop will block until the agent has fully shutdown.
 func (a *Agent) Stop(ctx context.Context) error {
 	select {
 	case <-a.started:
-		select {
-		case <-a.closed:
-			return a.err
-		case <-a.stopped:
-			select {
-			case <-a.closed:
-				return a.err
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			close(a.stopped)
-			// recurse and wait for closure
-			return a.Stop(ctx)
-		}
-	case <-ctx.Done():
-		return ctx.Err()
 	default:
 		return errAgentNotStarted
 	}
+
+	a.stop()
+
+	// wait till closed or context cancelled
+	select {
+	case <-a.closed:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// stop signals the agent shutdown process, returning true if this call was the
+// first to actually shutdown the agent.
+func (a *Agent) stop() bool {
+	var stopped bool
+	a.stopOnce.Do(func() {
+		close(a.stopped)
+		stopped = true
+	})
+
+	return stopped
 }
 
 // Err returns the error that caused the agent to shutdown or nil. Err blocks

--- a/agent/errors.go
+++ b/agent/errors.go
@@ -10,10 +10,11 @@ var (
 	ErrClosed = errors.New("agent: closed")
 
 	errNodeNotRegistered = fmt.Errorf("node not registered")
+	errNodeStarted       = errors.New("node: already started")
+	errNodeNotStarted    = errors.New("node: not started")
 
-	errAgentNotStarted = errors.New("agent: not started")
 	errAgentStarted    = errors.New("agent: already started")
-	errAgentStopped    = errors.New("agent: stopped")
+	errAgentNotStarted = errors.New("agent: not started")
 
 	errTaskNoContoller          = errors.New("agent: no task controller")
 	errTaskNotAssigned          = errors.New("agent: task not assigned")


### PR DESCRIPTION
After finding a possible race condition, `Agent`/`Node` `Start` and
`Stop` methods have been greatly simplified. While this race condition
is very unlikely to occur in the wild, there are possible panics if the
caller is not careful about calling `Start` and `Stop` from multiple
goroutines.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Related to #1269.

cc @LK4D4 @aaronlehmann 