### PR TITLE
cmd: fix name prefix matching

### DIFF
--- a/cmd/swarmctl/cluster/common.go
+++ b/cmd/swarmctl/cluster/common.go
@@ -29,6 +29,20 @@ func getCluster(ctx context.Context, c api.ControlClient, input string) (*api.Cl
 	}
 
 	if l := len(rl.Clusters); l > 1 {
+		var match *api.Cluster
+		// Find and return the unique match or fail out
+		for _, c := range rl.Clusters {
+			if c.Spec.Annotations.Name == input {
+				if match != nil {
+					match = nil
+					break
+				}
+				match = c
+			}
+		}
+		if match != nil {
+			return match, nil
+		}
 		return nil, fmt.Errorf("cluster %s is ambiguous (%d matches found)", input, l)
 	}
 

--- a/cmd/swarmctl/network/common.go
+++ b/cmd/swarmctl/network/common.go
@@ -32,6 +32,20 @@ func GetNetwork(ctx context.Context, c api.ControlClient, input string) (*api.Ne
 		}
 
 		if l := len(rl.Networks); l > 1 {
+			var match *api.Network
+			// Find and return the unique match or fail out
+			for _, n := range rl.Networks {
+				if n.Spec.Annotations.Name == input {
+					if match != nil {
+						match = nil
+						break
+					}
+					match = n
+				}
+			}
+			if match != nil {
+				return match, nil
+			}
 			return nil, fmt.Errorf("network %s is ambiguous (%d matches found)", input, l)
 		}
 

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -153,6 +153,24 @@ func getNode(ctx context.Context, c api.ControlClient, input string) (*api.Node,
 		}
 
 		if l := len(rl.Nodes); l > 1 {
+			var match *api.Node
+			// Find and return the unique match or fail out
+			for _, n := range rl.Nodes {
+				name := ""
+				if n.Description != nil {
+					name = n.Description.Hostname
+				}
+				if name == input {
+					if match != nil {
+						match = nil
+						break
+					}
+					match = n
+				}
+			}
+			if match != nil {
+				return match, nil
+			}
 			return nil, fmt.Errorf("node %s is ambiguous (%d matches found)", input, l)
 		}
 

--- a/cmd/swarmctl/node/list.go
+++ b/cmd/swarmctl/node/list.go
@@ -47,11 +47,11 @@ var (
 				common.PrintHeader(w, "ID", "Name", "Membership", "Status", "Availability", "Manager Status")
 				output = func(n *api.Node) {
 					spec := &n.Spec
-					name := spec.Annotations.Name
+					name := ""
 					availability := spec.Availability.String()
 					membership := spec.Membership.String()
 
-					if name == "" && n.Description != nil {
+					if n.Description != nil {
 						name = n.Description.Hostname
 					}
 					reachability := ""

--- a/cmd/swarmctl/service/common.go
+++ b/cmd/swarmctl/service/common.go
@@ -29,6 +29,20 @@ func getService(ctx context.Context, c api.ControlClient, input string) (*api.Se
 		}
 
 		if l := len(rl.Services); l > 1 {
+			var match *api.Service
+			// Find and return the unique match or fail out
+			for _, s := range rl.Services {
+				if s.Spec.Annotations.Name == input {
+					if match != nil {
+						match = nil
+						break
+					}
+					match = s
+				}
+			}
+			if match != nil {
+				return match, nil
+			}
 			return nil, fmt.Errorf("service %s is ambiguous (%d matches found)", input, l)
 		}
 


### PR DESCRIPTION
Currently if there are two services, and one service is named
busybox while the other is busybox-top. It is not possible to
remove the busybox service by giving its full name which is also
a common name prefix of both. The only way out is removing the
busybox-top service first or removing it by ID. This looks not an
acceptable behavior.

The same problem applies to clusters, nodes and networks.

Fix it by finding a full name match if prefix matches are more
than one.

Another way to fix it is that start a request with a full name
filter before doing it with a name prefix filter. But I think
this way just presents the same result but adds one more call
overhead to server.

Signed-off-by: Jin Xu jinuxstyle@hotmail.com
