### PR TITLE
Check empty messages array

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -348,9 +348,11 @@ func (n *Node) Run(ctx context.Context) error {
 				n.Config.Logger.Error(err)
 			}
 
-			// Send raft messages to peers
-			if err := n.send(rd.Messages); err != nil {
-				n.Config.Logger.Error(err)
+			if len(rd.Messages) != 0 {
+				// Send raft messages to peers
+				if err := n.send(rd.Messages); err != nil {
+					n.Config.Logger.Error(err)
+				}
 			}
 
 			// Apply snapshot to memory store. The snapshot


### PR DESCRIPTION
During debugging, I noticed that there are many calls to n.send
with empty messages array. Add a check to avoid unnecessary
locking.

Signed-off-by: Jin Xu <jinuxstyle@hotmail.com>