### PR TITLE
dispatcher: Batch node updates

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -234,10 +234,10 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 		case <-publishTicker.C:
 			publishManagers()
 		case <-d.processUpdatesTrigger:
-			d.processTaskAndNodeUpdates()
+			d.processUpdates()
 			batchTimer.Reset(maxBatchInterval)
 		case <-batchTimer.C:
-			d.processTaskAndNodeUpdates()
+			d.processUpdates()
 			batchTimer.Reset(maxBatchInterval)
 		case v := <-configWatcher:
 			cluster := v.(state.EventUpdateCluster)
@@ -492,7 +492,7 @@ func (d *Dispatcher) UpdateTaskStatus(ctx context.Context, r *api.UpdateTaskStat
 	return nil, nil
 }
 
-func (d *Dispatcher) processTaskAndNodeUpdates() {
+func (d *Dispatcher) processUpdates() {
 	var (
 		taskUpdates map[string]*api.TaskStatus
 		nodeUpdates map[string]nodeUpdate
@@ -516,7 +516,7 @@ func (d *Dispatcher) processTaskAndNodeUpdates() {
 	}
 
 	log := log.G(d.ctx).WithFields(logrus.Fields{
-		"method": "(*Dispatcher).processTaskAndNodeUpdates",
+		"method": "(*Dispatcher).processUpdates",
 	})
 
 	_, err := d.store.Batch(func(batch *store.Batch) error {

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -652,7 +652,7 @@ func TestTaskUpdate(t *testing.T) {
 		assert.Equal(t, grpc.Code(err), codes.PermissionDenied)
 	}
 
-	gd.dispatcherServer.processTaskUpdates()
+	gd.dispatcherServer.processTaskAndNodeUpdates()
 
 	gd.Store.View(func(readTx store.ReadTx) {
 		storeTask1 := store.GetTask(readTx, testTask1.ID)

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -652,7 +652,7 @@ func TestTaskUpdate(t *testing.T) {
 		assert.Equal(t, grpc.Code(err), codes.PermissionDenied)
 	}
 
-	gd.dispatcherServer.processTaskAndNodeUpdates()
+	gd.dispatcherServer.processUpdates()
 
 	gd.Store.View(func(readTx store.ReadTx) {
 		storeTask1 := store.GetTask(readTx, testTask1.ID)


### PR DESCRIPTION
When setting nodes to ready, down, or disconnected, do so in a batch
instead of one node at a time. This can avoid very slow responses to
network partitions or recovery from network partitions.

Tested manually and with the Docker integration tests (needs a slight tweak to one integration test, PR https://github.com/docker/docker/pull/25342).

Fixes #1289

cc @dongluochen @aluzzardi