### PR TITLE
scheduler: Properly handle dead tasks when populating data structures

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -61,8 +61,8 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 	tasksByNode := make(map[string]map[string]*api.Task)
 	for _, t := range tasks {
 		// Ignore all tasks that have not reached ALLOCATED
-		// state.
-		if t.Status.State < api.TaskStateAllocated {
+		// state and tasks that no longer consume resources.
+		if t.Status.State < api.TaskStateAllocated || t.Status.State > api.TaskStateRunning {
 			continue
 		}
 


### PR DESCRIPTION
The logic in `setupTasksList` was incorrect. It treated dead tasks as if
they were running. We didn't catch this because this function only runs
on leader failover.

Corrected the function and added a test.

Fixes #1296 

cc @thaJeztah @LK4D4 @dongluochen