### PR TITLE
log: improve module-oriented logging

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -133,7 +133,7 @@ func (a *Agent) run(ctx context.Context) {
 	defer cancel()
 	defer close(a.closed) // full shutdown.
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("module", "agent"))
+	ctx = log.WithModule(ctx, "agent")
 
 	log.G(ctx).Debugf("(*Agent).run")
 	defer log.G(ctx).Debugf("(*Agent).run exited")

--- a/agent/node.go
+++ b/agent/node.go
@@ -166,7 +166,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 	}()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("module", "node"))
+	ctx = log.WithModule(ctx, "node")
 
 	go func() {
 		select {

--- a/agent/task.go
+++ b/agent/task.go
@@ -68,7 +68,7 @@ func (tm *taskManager) run(ctx context.Context) {
 	ctx, cancelAll := context.WithCancel(ctx)
 	defer cancelAll() // cancel all child operations on exit.
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("module", "taskmanager"))
+	ctx = log.WithModule(ctx, "taskmanager")
 
 	var (
 		opctx    context.Context

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -57,7 +57,7 @@ func (w *worker) Init(ctx context.Context) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("module", "worker"))
+	ctx = log.WithModule(ctx, "worker")
 
 	// TODO(stevvooe): Start task cleanup process.
 

--- a/ca/server.go
+++ b/ca/server.go
@@ -306,8 +306,7 @@ func (s *Server) Run(ctx context.Context) error {
 	s.mu.Unlock()
 
 	defer s.wg.Done()
-	logger := log.G(ctx).WithField("module", "ca")
-	ctx = log.WithLogger(ctx, logger)
+	ctx = log.WithModule(ctx, "ca")
 
 	// Retrieve the channels to keep track of changes in the cluster
 	// Retrieve all the currently registered nodes

--- a/log/context.go
+++ b/log/context.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"path"
+
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -16,7 +18,10 @@ var (
 	L = logrus.NewEntry(logrus.StandardLogger())
 )
 
-type loggerKey struct{}
+type (
+	loggerKey struct{}
+	moduleKey struct{}
+)
 
 // WithLogger returns a new context with the provided logger. Use in
 // combination with logger.WithField(s) for great effect.
@@ -34,4 +39,43 @@ func GetLogger(ctx context.Context) *logrus.Entry {
 	}
 
 	return logger.(*logrus.Entry)
+}
+
+// WithModule adds the module to the context, appending it with a slash if a
+// module already exists. A module is just an roughly correlated defined by the
+// call tree for a given context.
+//
+// As an example, we might have a "node" module already part of a context. If
+// this function is called with "tls", the new value of module will be
+// "node/tls".
+//
+// Modules represent the call path. If the new module and last module are the
+// same, a new module entry will not be created. If the new module and old
+// older module are the same but separated by other modules, the cycle will be
+// represented by the module path.
+func WithModule(ctx context.Context, module string) context.Context {
+	parent := GetModulePath(ctx)
+
+	if parent != "" {
+		// don't re-append module when module is the same.
+		if path.Base(parent) == module {
+			return ctx
+		}
+
+		module = path.Join(parent, module)
+	}
+
+	ctx = WithLogger(ctx, GetLogger(ctx).WithField("module", module))
+	return context.WithValue(ctx, moduleKey{}, module)
+}
+
+// GetModulePath returns the module path for the provided context. If no module
+// is set, an empty string is returned.
+func GetModulePath(ctx context.Context) string {
+	module := ctx.Value(moduleKey{})
+	if module == nil {
+		return ""
+	}
+
+	return module.(string)
 }

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -157,10 +157,9 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 		d.mu.Unlock()
 		return fmt.Errorf("dispatcher is already running")
 	}
-	logger := log.G(ctx).WithField("module", "dispatcher")
-	ctx = log.WithLogger(ctx, logger)
+	ctx = log.WithModule(ctx, "dispatcher")
 	if err := d.markNodesUnknown(ctx); err != nil {
-		logger.Errorf(`failed to move all nodes to "unknown" state: %v`, err)
+		log.G(ctx).Errorf(`failed to move all nodes to "unknown" state: %v`, err)
 	}
 	configWatcher, cancel, err := store.ViewAndWatch(
 		d.store,

--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -122,7 +122,6 @@ func (k *KeyManager) updateKey(cluster *api.Cluster) error {
 }
 
 func (k *KeyManager) rotateKey(ctx context.Context) error {
-	log := log.G(ctx).WithField("module", "keymanager")
 	var (
 		clusters []*api.Cluster
 		err      error
@@ -132,7 +131,7 @@ func (k *KeyManager) rotateKey(ctx context.Context) error {
 	})
 
 	if err != nil {
-		log.Errorf("reading cluster config failed, %v", err)
+		log.G(ctx).Errorf("reading cluster config failed, %v", err)
 		return err
 	}
 
@@ -173,7 +172,7 @@ func (k *KeyManager) rotateKey(ctx context.Context) error {
 // Run starts the keymanager, it doesn't return
 func (k *KeyManager) Run(ctx context.Context) error {
 	k.mu.Lock()
-	log := log.G(ctx).WithField("module", "keymanager")
+	ctx = log.WithModule(ctx, "keymanager")
 	var (
 		clusters []*api.Cluster
 		err      error
@@ -183,7 +182,7 @@ func (k *KeyManager) Run(ctx context.Context) error {
 	})
 
 	if err != nil {
-		log.Errorf("reading cluster config failed, %v", err)
+		log.G(ctx).Errorf("reading cluster config failed, %v", err)
 		k.mu.Unlock()
 		return err
 	}
@@ -196,7 +195,7 @@ func (k *KeyManager) Run(ctx context.Context) error {
 			}
 		}
 		if err := k.updateKey(cluster); err != nil {
-			log.Errorf("store update failed %v", err)
+			log.G(ctx).Errorf("store update failed %v", err)
 		}
 	} else {
 		k.keyRing.lClock = cluster.EncryptionKeyLamportClock


### PR DESCRIPTION
To improve the output of module logging, we now include a path that
represents the modules that a context has passed through. This makes it
easy to tell if a log line came from a particular module hierarchy.

A helper function, `WithModule`, provides an easy way to mark a context
with a module and inject that module into the logger.

The following log lines are an example:

```
DEBU[0005] Root CA updated successfully                  cluster.id=0iaidzbs0zgfngbj5hk66y56r method=(*Server).updateCluster module=ca
DEBU[0005] (*session).start                              module=node/agent
DEBU[0005] RequestAddress(GlobalDefault/10.255.0.0/16, 10.255.0.3, map[])
DEBU[0005] Root CA updated successfully                  cluster.id=0iaidzbs0zgfngbj5hk66y56r method=(*Server).updateCluster module=ca
DEBU[0005] (*session).listen                             module=node/agent session.id=2ts4ifytrmx6rcd7gsf9m6gru
DEBU[0005] agent: registered                             module=node/agent
```

In the above, we see a few operations under `node/agent` and a few operations in relation to the `ca` module. We can make this more rich as we increase the module decoration in the code base.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @diogomonica 