### PR TITLE
Handle endpoint spec changes properly

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -165,15 +165,29 @@ func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 		}
 	}()
 
-	// If ResolutionMode is DNSRR do not try allocating VIPs.
-	if s.Spec.Endpoint != nil && s.Spec.Endpoint.Mode == api.ResolutionModeDNSRoundRobin {
-		return
-	}
-
 	if s.Endpoint == nil {
-		s.Endpoint = &api.Endpoint{
-			Spec: s.Spec.Endpoint.Copy(),
+		s.Endpoint = &api.Endpoint{}
+	}
+	s.Endpoint.Spec = s.Spec.Endpoint.Copy()
+
+	// If ResolutionMode is DNSRR do not try allocating VIPs, but
+	// free any VIP from previous state.
+	if s.Spec.Endpoint != nil && s.Spec.Endpoint.Mode == api.ResolutionModeDNSRoundRobin {
+		if s.Endpoint != nil {
+			for _, vip := range s.Endpoint.VirtualIPs {
+				if err := na.deallocateVIP(vip); err != nil {
+					// don't bail here, deallocate as many as possible.
+					log.L.WithError(err).
+						WithField("vip.network", vip.NetworkID).
+						WithField("vip.addr", vip.Addr).Error("error deallocating vip")
+				}
+			}
+
+			s.Endpoint.VirtualIPs = nil
 		}
+
+		delete(na.services, s.ID)
+		return
 	}
 
 	// First allocate VIPs for all the pre-populated endpoint attachments
@@ -198,7 +212,6 @@ outer:
 
 		s.Endpoint.VirtualIPs = append(s.Endpoint.VirtualIPs, vip)
 	}
-	s.Endpoint.Spec = s.Spec.Endpoint.Copy()
 
 	na.services[s.ID] = struct{}{}
 	return
@@ -271,11 +284,28 @@ func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 
 // IsServiceAllocated returns if the passed service has it's network resources allocated or not.
 func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
-	if _, ok := na.services[s.ID]; !ok {
-		return false
+	// If endpoint mode is VIP and allocator does not have the
+	// service in VIP allocated set then it is not allocated.
+	if len(s.Spec.Networks) != 0 &&
+		(s.Spec.Endpoint == nil ||
+			s.Spec.Endpoint.Mode == api.ResolutionModeVirtualIP) {
+		if _, ok := na.services[s.ID]; !ok {
+			return false
+		}
 	}
 
-	if s.Spec.Endpoint != nil {
+	// If the endpoint mode is DNSRR and allocator has the service
+	// in VIP allocated set then we return not allocated to make
+	// sure the allocator triggers networkallocator to free up the
+	// resources if any.
+	if s.Spec.Endpoint != nil && s.Spec.Endpoint.Mode == api.ResolutionModeDNSRoundRobin {
+		if _, ok := na.services[s.ID]; ok {
+			return false
+		}
+	}
+
+	if (s.Spec.Endpoint != nil && len(s.Spec.Endpoint.Ports) != 0) ||
+		(s.Endpoint != nil && len(s.Endpoint.Ports) != 0) {
 		return na.portAllocator.isPortsAllocated(s)
 	}
 


### PR DESCRIPTION
A service's endpoint spec can be updated by the user such as changing
the resolution mode from vip to dnsrr or vice-versa or update exposed
ports or completely remove them. The allocator needs to do proper
deallocations and allocations (if any) during those updates. This PR
fixes the allocator logic to handle all these scenarios cleanly.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>