### PR TITLE
ca: Fix flaky test, clean up test code

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -394,7 +394,7 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, baseCertDir string, 
 // calculateRandomExpiry returns a random duration between 50% and 80% of the original
 // duration
 func calculateRandomExpiry(expiresIn time.Duration) time.Duration {
-	if expiresIn.Minutes() < 1 {
+	if expiresIn.Minutes() <= 1 {
 		return time.Second
 	}
 


### PR DESCRIPTION
Several tests created certs that expire in 1 minute, and then waited up
to 2 seconds for them to be renewed. But the logic for renewing a cert
only renews it quickly if the cert is expiring in *less than* one
minute. Since CFSSL rounds NotBefore/NotAfter to the nearest minute, we
could end up with a cert that expires in slightly more than one minute,
and it would take some random fraction of that minute to get renewed.

Change the renewal logic to renew certs after a second if they expire
in <= 1 minute, not < 1 minute.

Clean up the related tests (remove an unnecessary for/select loop).

cc @diogomonica