### PR TITLE
Improve the error message for port collision

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -218,14 +218,14 @@ func (s *Server) checkPortConflicts(spec *api.ServiceSpec) error {
 		if service.Spec.Endpoint != nil {
 			for _, pc := range service.Spec.Endpoint.Ports {
 				if reqPorts[pcToString(pc)] {
-					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service %s", pc.PublishedPort, service.ID)
+					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s)", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
 				}
 			}
 		}
 		if service.Endpoint != nil {
 			for _, pc := range service.Endpoint.Ports {
 				if reqPorts[pcToString(pc)] {
-					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service %s", pc.PublishedPort, service.ID)
+					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s)", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
 				}
 			}
 		}


### PR DESCRIPTION
Currently when there is a collision in port mapping, swarm returns error with service ID:
```
Error response from daemon: rpc error: code = 3 desc = port '80' is already
in use by service cquoc5o30b8c9qlv9x1x1wu4n
```

This might be improved by returning the service name as well, e.g.:
```
Error response from daemon: rpc error: code = 3 desc = port '80' is already
in use by service 'myservice' (cquoc5o30b8c9qlv9x1x1wu4n)
```

This fix adds the service name to the error message.

This fix is related to the comment in:
https://github.com/docker/docker/pull/25428#issuecomment-237841041

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>