### PR TITLE
raft: Make TestRaftSnapshotRestart more robust

### DIFF
--- a/manager/state/raft/storage_test.go
+++ b/manager/state/raft/storage_test.go
@@ -222,7 +222,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 
 	// Propose yet another value, to make sure the rejoined node is still
 	// receiving new logs
-	values[5], err = raftutils.ProposeValue(t, nodes[1], DefaultProposalTime, nodeIDs[5])
+	values[5], err = raftutils.ProposeValue(t, raftutils.Leader(nodes), DefaultProposalTime, nodeIDs[5])
 	require.NoError(t, err)
 
 	// All nodes should have all the data
@@ -239,7 +239,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 	raftutils.CheckValuesOnNodes(t, clockSource, nodes, nodeIDs[:6], values[:6])
 
 	// Propose again. Just to check consensus after this latest restart.
-	values[6], err = raftutils.ProposeValue(t, nodes[1], DefaultProposalTime, nodeIDs[6])
+	values[6], err = raftutils.ProposeValue(t, raftutils.Leader(nodes), DefaultProposalTime, nodeIDs[6])
 	require.NoError(t, err)
 	raftutils.CheckValuesOnNodes(t, clockSource, nodes, nodeIDs, values)
 }


### PR DESCRIPTION
Generally, restarting a follower node will not cause a leader election.
But our test advances the fake clock as part of its polling, and on a
slow machine this can make enough time pass from raft's point of view to
trigger an election.

Don't assume that node 1 will still be the leader after the restart.

cc @abronan @tonistiigi