### PR TITLE
Update documentation/comment for checkPortConflicts

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -182,6 +182,9 @@ func validateServiceSpec(spec *api.ServiceSpec) error {
 
 // checkPortConflicts does a best effort to find if the passed in spec has port
 // conflicts with existing services.
+// `serviceID string` is the service ID of the spec in service update. If
+// `serviceID` is not "", then conflicts check will be skipped against this
+// service (the service being updated).
 func (s *Server) checkPortConflicts(spec *api.ServiceSpec, serviceID string) error {
 	if spec.Endpoint == nil {
 		return nil


### PR DESCRIPTION
This fix update the documentation/comment for checkPortConflicts so
that it is clear conflicts check will skip against the service that
is being udpated.

This fix is related to the dicsussion in 1349:
https://github.com/docker/swarmkit/pull/1349#discussion_r74348186

cc @stevvooe 

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>