### PR TITLE
orchestrator: Reconcile instances, not tasks

### DIFF
--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -104,6 +104,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 1,
 			ServiceAnnotations: api.Annotations{
 				Name: "name0",
 			},
@@ -115,6 +116,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 2,
 			ServiceAnnotations: api.Annotations{
 				Name: "name1",
 			},
@@ -126,6 +128,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 3,
 			ServiceAnnotations: api.Annotations{
 				Name: "name2",
 			},
@@ -137,6 +140,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 4,
 			ServiceAnnotations: api.Annotations{
 				Name: "name3",
 			},
@@ -148,6 +152,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 5,
 			ServiceAnnotations: api.Annotations{
 				Name: "name4",
 			},
@@ -159,6 +164,7 @@ func TestDrain(t *testing.T) {
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
+			Slot: 6,
 			ServiceAnnotations: api.Annotations{
 				Name: "name5",
 			},

--- a/manager/orchestrator/replicated.go
+++ b/manager/orchestrator/replicated.go
@@ -110,7 +110,7 @@ func (r *ReplicatedOrchestrator) tick(ctx context.Context) {
 	r.tickServices(ctx)
 }
 
-func newTask(cluster *api.Cluster, service *api.Service, instance uint64) *api.Task {
+func newTask(cluster *api.Cluster, service *api.Service, slot uint64) *api.Task {
 	var logDriver *api.Driver
 	if service.Spec.Task.LogDriver != nil {
 		// use the log driver specific to the task, if we have it.
@@ -128,7 +128,7 @@ func newTask(cluster *api.Cluster, service *api.Service, instance uint64) *api.T
 		ServiceAnnotations: service.Spec.Annotations,
 		Spec:               service.Spec.Task,
 		ServiceID:          service.ID,
-		Slot:               instance,
+		Slot:               slot,
 		Status: api.TaskStatus{
 			State:     api.TaskStateNew,
 			Timestamp: ptypes.MustTimestampProto(time.Now()),

--- a/manager/orchestrator/replicated_test.go
+++ b/manager/orchestrator/replicated_test.go
@@ -276,6 +276,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 		tasks := []*api.Task{
 			{
 				ID:           "task1",
+				Slot:         1,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateStarting,
@@ -288,6 +289,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task2",
+				Slot:         2,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateRunning,
@@ -300,6 +302,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task3",
+				Slot:         3,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateRunning,
@@ -312,6 +315,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task4",
+				Slot:         4,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateRunning,
@@ -324,6 +328,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task5",
+				Slot:         5,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateRunning,
@@ -336,6 +341,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task6",
+				Slot:         6,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateRunning,
@@ -348,6 +354,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 			},
 			{
 				ID:           "task7",
+				Slot:         7,
 				DesiredState: api.TaskStateRunning,
 				Status: api.TaskStatus{
 					State: api.TaskStateNew,

--- a/manager/orchestrator/slot.go
+++ b/manager/orchestrator/slot.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"github.com/docker/swarmkit/api"
+)
+
+// slot is a list of the running tasks occupying a certain slot. Generally this
+// will only be one task, but some rolling update situations involve
+// temporarily having two running tasks in the same slot. Note that this use of
+// "slot" is more generic than the Slot number for replicated services - a node
+// is also considered a slot for global services.
+type slot []*api.Task
+
+type slotsByRunningState []slot
+
+func (is slotsByRunningState) Len() int      { return len(is) }
+func (is slotsByRunningState) Swap(i, j int) { is[i], is[j] = is[j], is[i] }
+
+func (is slotsByRunningState) Less(i, j int) bool {
+	iRunning := false
+	jRunning := false
+
+	for _, ii := range is[i] {
+		if ii.Status.State == api.TaskStateRunning {
+			iRunning = true
+			break
+		}
+	}
+	for _, ij := range is[j] {
+		if ij.Status.State == api.TaskStateRunning {
+			jRunning = true
+			break
+		}
+	}
+
+	return iRunning && !jRunning
+}
+
+type slotWithIndex struct {
+	slot slot
+
+	// index is a counter that counts this task as the nth instance of
+	// the service on its node. This is used for sorting the tasks so that
+	// when scaling down we leave tasks more evenly balanced.
+	index int
+}
+
+type slotsByIndex []slotWithIndex
+
+func (is slotsByIndex) Len() int      { return len(is) }
+func (is slotsByIndex) Swap(i, j int) { is[i], is[j] = is[j], is[i] }
+
+func (is slotsByIndex) Less(i, j int) bool {
+	if is[i].index < 0 && is[j].index >= 0 {
+		return false
+	}
+	if is[j].index < 0 && is[i].index >= 0 {
+		return true
+	}
+	return is[i].index < is[j].index
+}


### PR DESCRIPTION
This commit prepares for an upcoming change that will allow a
configurable rollout strategy (either shut down the old task before
starting the new one, or start the new one before shutting down the old
one). The issue that was blocking having a rollout strategy with an
overlap between the lifetime of the new and old tasks was that
service-level reconciliation couldn't properly handle situations where
there was more than one active task per slot or node. This change
attempts to solve this by moving to *instance-level* reconciliation.

Before, the orchestrator counted tasks. With this change, it counts
instances (slots or nodes) that are satisfied with at least one task
that has a desired state > `NEW` and <= `RUNNING`.

When service-level reconciliation calls the updater, it passes
`[][]*api.Task` instead of a flat `[]*api.Task`. The first dimension is the
instance (slot or node grouping), and the next dimension contains the
set of tasks for that instance. This allows the updater to handle
situations like partial updates. For example, if slot 5 has two running
tasks, and only one matches the current service spec, the updater can
recognize that this is a partial update, and remove the dirty task. In
this model, the orchestrator doesn't need to know anything about what's
going on with the individual tasks. It just has scale up and down as
appropriate, and let the updater reconcile state below the instance
level.

I explored a few alternative approaches as well, and ran into a lot of
complexity because the orchestrator invariably had to recognize partial
update situations, and take action to remediate them (making sure not to
fight with a current update in progress). I find this model more elegant
because the orchestrator only needs to call Update, as it did before,
and the updater handles all logic related to updates. But I'm interested
in feedback and I'm willing to explore more alternatives.


cc @dongluochen @aluzzardi