### PR TITLE
raft: Avoid closing the wrong connection on an error

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -115,13 +115,19 @@ func (c *Cluster) RemoveMember(id uint64) error {
 
 // ReplaceMemberConnection replaces the member's GRPC connection and GRPC
 // client.
-func (c *Cluster) ReplaceMemberConnection(id uint64, newConn *Member) error {
+func (c *Cluster) ReplaceMemberConnection(id uint64, oldConn *Member, newConn *Member) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	oldMember, ok := c.members[id]
 	if !ok {
 		return ErrIDNotFound
+	}
+
+	if oldConn.Conn != oldMember.Conn {
+		// The connection was already replaced. Don't do it again.
+		newConn.Conn.Close()
+		return nil
 	}
 
 	oldMember.Conn.Close()

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1100,7 +1100,7 @@ func (n *Node) sendToMember(members map[uint64]*membership.Member, m raftpb.Mess
 		if err != nil {
 			n.Config.Logger.Errorf("could connect to member ID %x at %s: %v", m.To, conn.Addr, err)
 		} else {
-			n.cluster.ReplaceMemberConnection(m.To, newConn)
+			n.cluster.ReplaceMemberConnection(m.To, conn, newConn)
 		}
 	} else if m.Type == raftpb.MsgSnap {
 		n.ReportSnapshot(m.To, raft.SnapshotFinish)


### PR DESCRIPTION
ReplaceMemberConnection takes a new GRPC connection for a specific
member as an argument. It sets that member's connection to this new one,
and closes the existing GRPC connection.

The problem is that there may be a concurrent invocation of sendToMember
that's trying to send over the old connection. In this case, it will
also call ReplaceMemberConnection, which now closes the new connection
that it put in place, instead of the one where the error was actually
seen. If calls to sendToMember are likely to overlap, then this produces
a cascade of failures that are hard to recover from. Each invocation
closes the connection that another is using.

Fix this by having ReplaceMemberConnection only replace the connection
if the old connection is the one in the Member record. If it's not,
close the new connection instead. The new connection is still passed in
by the caller to avoid Dialing while holding the lock.

This appears to fix docker's TestApiSwarmLeaderElection on ARM.

cc @abronan @tonistiigi