### PR TITLE
manager.Run refactoring

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/log"
@@ -230,9 +231,6 @@ func New(config *Config) (*Manager, error) {
 // Run starts all manager sub-systems and the gRPC server at the configured
 // address.
 // The call never returns unless an error occurs or `Stop()` is called.
-//
-// TODO(aluzzardi): /!\ This function is *way* too complex. /!\
-// It needs to be split into smaller manageable functions.
 func (m *Manager) Run(parent context.Context) error {
 	ctx, ctxCancel := context.WithCancel(parent)
 	defer ctxCancel()
@@ -249,191 +247,7 @@ func (m *Manager) Run(parent context.Context) error {
 	leadershipCh, cancel := m.RaftNode.SubscribeLeadership()
 	defer cancel()
 
-	go func() {
-		for leadershipEvent := range leadershipCh {
-			// read out and discard all of the messages when we've stopped
-			// don't acquire the mutex yet. if stopped is closed, we don't need
-			// this stops this loop from starving Run()'s attempt to Lock
-			select {
-			case <-m.stopped:
-				continue
-			default:
-				// do nothing, we're not stopped
-			}
-			// we're not stopping so NOW acquire the mutex
-			m.mu.Lock()
-			newState := leadershipEvent.(raft.LeadershipState)
-
-			if newState == raft.IsLeader {
-				s := m.RaftNode.MemoryStore()
-
-				rootCA := m.config.SecurityConfig.RootCA()
-				nodeID := m.config.SecurityConfig.ClientTLSCreds.NodeID()
-
-				raftCfg := raft.DefaultRaftConfig()
-				raftCfg.ElectionTick = uint32(m.RaftNode.Config.ElectionTick)
-				raftCfg.HeartbeatTick = uint32(m.RaftNode.Config.HeartbeatTick)
-
-				clusterID := m.config.SecurityConfig.ClientTLSCreds.Organization()
-
-				initialCAConfig := ca.DefaultCAConfig()
-				initialCAConfig.ExternalCAs = m.config.ExternalCAs
-
-				s.Update(func(tx store.Tx) error {
-					// Add a default cluster object to the
-					// store. Don't check the error because
-					// we expect this to fail unless this
-					// is a brand new cluster.
-					store.CreateCluster(tx, &api.Cluster{
-						ID: clusterID,
-						Spec: api.ClusterSpec{
-							Annotations: api.Annotations{
-								Name: store.DefaultClusterName,
-							},
-							Orchestration: api.OrchestrationConfig{
-								TaskHistoryRetentionLimit: defaultTaskHistoryRetentionLimit,
-							},
-							Dispatcher: api.DispatcherConfig{
-								HeartbeatPeriod: ptypes.DurationProto(dispatcher.DefaultHeartBeatPeriod),
-							},
-							Raft:     raftCfg,
-							CAConfig: initialCAConfig,
-						},
-						RootCA: api.RootCA{
-							CAKey:      rootCA.Key,
-							CACert:     rootCA.Cert,
-							CACertHash: rootCA.Digest.String(),
-							JoinTokens: api.JoinTokens{
-								Worker:  ca.GenerateJoinToken(rootCA),
-								Manager: ca.GenerateJoinToken(rootCA),
-							},
-						},
-					})
-					// Add Node entry for ourself, if one
-					// doesn't exist already.
-					store.CreateNode(tx, &api.Node{
-						ID: nodeID,
-						Certificate: api.Certificate{
-							CN:   nodeID,
-							Role: api.NodeRoleManager,
-							Status: api.IssuanceStatus{
-								State: api.IssuanceStateIssued,
-							},
-						},
-						Spec: api.NodeSpec{
-							Role:       api.NodeRoleManager,
-							Membership: api.NodeMembershipAccepted,
-						},
-					})
-					return nil
-				})
-
-				// Attempt to rotate the key-encrypting-key of the root CA key-material
-				err := m.rotateRootCAKEK(ctx, clusterID)
-				if err != nil {
-					log.G(ctx).WithError(err).Error("root key-encrypting-key rotation failed")
-				}
-
-				m.replicatedOrchestrator = orchestrator.NewReplicatedOrchestrator(s)
-				m.globalOrchestrator = orchestrator.NewGlobalOrchestrator(s)
-				m.taskReaper = orchestrator.NewTaskReaper(s)
-				m.scheduler = scheduler.New(s)
-				m.keyManager = keymanager.New(m.RaftNode.MemoryStore(), keymanager.DefaultConfig())
-
-				// TODO(stevvooe): Allocate a context that can be used to
-				// shutdown underlying manager processes when leadership is
-				// lost.
-
-				m.allocator, err = allocator.New(s)
-				if err != nil {
-					log.G(ctx).WithError(err).Error("failed to create allocator")
-					// TODO(stevvooe): It doesn't seem correct here to fail
-					// creating the allocator but then use it anyway.
-				}
-
-				if m.keyManager != nil {
-					go func(keyManager *keymanager.KeyManager) {
-						if err := keyManager.Run(ctx); err != nil {
-							log.G(ctx).WithError(err).Error("keymanager failed with an error")
-						}
-					}(m.keyManager)
-				}
-
-				go func(d *dispatcher.Dispatcher) {
-					if err := d.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("Dispatcher exited with an error")
-					}
-				}(m.Dispatcher)
-
-				go func(server *ca.Server) {
-					if err := server.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("CA signer exited with an error")
-					}
-				}(m.caserver)
-
-				// Start all sub-components in separate goroutines.
-				// TODO(aluzzardi): This should have some kind of error handling so that
-				// any component that goes down would bring the entire manager down.
-
-				if m.allocator != nil {
-					go func(allocator *allocator.Allocator) {
-						if err := allocator.Run(ctx); err != nil {
-							log.G(ctx).WithError(err).Error("allocator exited with an error")
-						}
-					}(m.allocator)
-				}
-
-				go func(scheduler *scheduler.Scheduler) {
-					if err := scheduler.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("scheduler exited with an error")
-					}
-				}(m.scheduler)
-
-				go func(taskReaper *orchestrator.TaskReaper) {
-					taskReaper.Run()
-				}(m.taskReaper)
-
-				go func(orchestrator *orchestrator.ReplicatedOrchestrator) {
-					if err := orchestrator.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("replicated orchestrator exited with an error")
-					}
-				}(m.replicatedOrchestrator)
-
-				go func(globalOrchestrator *orchestrator.GlobalOrchestrator) {
-					if err := globalOrchestrator.Run(ctx); err != nil {
-						log.G(ctx).WithError(err).Error("global orchestrator exited with an error")
-					}
-				}(m.globalOrchestrator)
-
-			} else if newState == raft.IsFollower {
-				m.Dispatcher.Stop()
-				m.caserver.Stop()
-
-				if m.allocator != nil {
-					m.allocator.Stop()
-					m.allocator = nil
-				}
-
-				m.replicatedOrchestrator.Stop()
-				m.replicatedOrchestrator = nil
-
-				m.globalOrchestrator.Stop()
-				m.globalOrchestrator = nil
-
-				m.taskReaper.Stop()
-				m.taskReaper = nil
-
-				m.scheduler.Stop()
-				m.scheduler = nil
-
-				if m.keyManager != nil {
-					m.keyManager.Stop()
-					m.keyManager = nil
-				}
-			}
-			m.mu.Unlock()
-		}
-	}()
+	go m.handleLeadershipEvents(ctx, leadershipCh)
 
 	proxyOpts := []grpc.DialOption{
 		grpc.WithTimeout(5 * time.Second),
@@ -498,22 +312,7 @@ func (m *Manager) Run(parent context.Context) error {
 
 	errServe := make(chan error, 2)
 	for proto, l := range m.listeners {
-		go func(proto string, lis net.Listener) {
-			ctx := log.WithLogger(ctx, log.G(ctx).WithFields(
-				logrus.Fields{
-					"proto": lis.Addr().Network(),
-					"addr":  lis.Addr().String()}))
-			if proto == "unix" {
-				log.G(ctx).Info("Listening for local connections")
-				// we need to disallow double closes because UnixListener.Close
-				// can delete unix-socket file of newer listener. grpc calls
-				// Close twice indeed: in Serve and in Stop.
-				errServe <- m.localserver.Serve(&closeOnceListener{Listener: lis})
-			} else {
-				log.G(ctx).Info("Listening for connections")
-				errServe <- m.server.Serve(lis)
-			}
-		}(proto, l)
+		go m.serveListener(ctx, errServe, proto, l)
 	}
 
 	// Set the raft server as serving for the health server
@@ -726,4 +525,229 @@ func (m *Manager) rotateRootCAKEK(ctx context.Context, clusterID string) error {
 		return store.UpdateCluster(tx, cluster)
 	})
 
+}
+
+// handleLeadershipEvents read out and discard all of the messages when the manager is stopped,
+// otherwise it handles the is leader event or is follower event.
+func (m *Manager) handleLeadershipEvents(ctx context.Context, leadershipCh chan events.Event) {
+	for leadershipEvent := range leadershipCh {
+		// read out and discard all of the messages when we've stopped
+		// don't acquire the mutex yet. if stopped is closed, we don't need
+		// this stops this loop from starving Run()'s attempt to Lock
+		select {
+		case <-m.stopped:
+			continue
+		default:
+			// do nothing, we're not stopped
+		}
+		// we're not stopping so NOW acquire the mutex
+		m.mu.Lock()
+		newState := leadershipEvent.(raft.LeadershipState)
+
+		if newState == raft.IsLeader {
+			m.becomeLeader(ctx)
+		} else if newState == raft.IsFollower {
+			m.becomeFollower()
+		}
+		m.mu.Unlock()
+	}
+}
+
+// serveListener serves a listener for local and non local connections.
+func (m *Manager) serveListener(ctx context.Context, errServe chan error, proto string, lis net.Listener) {
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(
+		logrus.Fields{
+			"proto": lis.Addr().Network(),
+			"addr":  lis.Addr().String()}))
+	if proto == "unix" {
+		log.G(ctx).Info("Listening for local connections")
+		// we need to disallow double closes because UnixListener.Close
+		// can delete unix-socket file of newer listener. grpc calls
+		// Close twice indeed: in Serve and in Stop.
+		errServe <- m.localserver.Serve(&closeOnceListener{Listener: lis})
+	} else {
+		log.G(ctx).Info("Listening for connections")
+		errServe <- m.server.Serve(lis)
+	}
+}
+
+// becomeLeader starts the subsystems that are run on the leader.
+func (m *Manager) becomeLeader(ctx context.Context) {
+	s := m.RaftNode.MemoryStore()
+
+	rootCA := m.config.SecurityConfig.RootCA()
+	nodeID := m.config.SecurityConfig.ClientTLSCreds.NodeID()
+
+	raftCfg := raft.DefaultRaftConfig()
+	raftCfg.ElectionTick = uint32(m.RaftNode.Config.ElectionTick)
+	raftCfg.HeartbeatTick = uint32(m.RaftNode.Config.HeartbeatTick)
+
+	clusterID := m.config.SecurityConfig.ClientTLSCreds.Organization()
+
+	initialCAConfig := ca.DefaultCAConfig()
+	initialCAConfig.ExternalCAs = m.config.ExternalCAs
+
+	s.Update(func(tx store.Tx) error {
+		// Add a default cluster object to the
+		// store. Don't check the error because
+		// we expect this to fail unless this
+		// is a brand new cluster.
+		store.CreateCluster(tx, defaultClusterObject(clusterID, initialCAConfig, raftCfg, rootCA))
+		// Add Node entry for ourself, if one
+		// doesn't exist already.
+		store.CreateNode(tx, managerNode(nodeID))
+		return nil
+	})
+
+	// Attempt to rotate the key-encrypting-key of the root CA key-material
+	err := m.rotateRootCAKEK(ctx, clusterID)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("root key-encrypting-key rotation failed")
+	}
+
+	m.replicatedOrchestrator = orchestrator.NewReplicatedOrchestrator(s)
+	m.globalOrchestrator = orchestrator.NewGlobalOrchestrator(s)
+	m.taskReaper = orchestrator.NewTaskReaper(s)
+	m.scheduler = scheduler.New(s)
+	m.keyManager = keymanager.New(m.RaftNode.MemoryStore(), keymanager.DefaultConfig())
+
+	// TODO(stevvooe): Allocate a context that can be used to
+	// shutdown underlying manager processes when leadership is
+	// lost.
+
+	m.allocator, err = allocator.New(s)
+	if err != nil {
+		log.G(ctx).WithError(err).Error("failed to create allocator")
+		// TODO(stevvooe): It doesn't seem correct here to fail
+		// creating the allocator but then use it anyway.
+	}
+
+	if m.keyManager != nil {
+		go func(keyManager *keymanager.KeyManager) {
+			if err := keyManager.Run(ctx); err != nil {
+				log.G(ctx).WithError(err).Error("keymanager failed with an error")
+			}
+		}(m.keyManager)
+	}
+
+	go func(d *dispatcher.Dispatcher) {
+		if err := d.Run(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("Dispatcher exited with an error")
+		}
+	}(m.Dispatcher)
+
+	go func(server *ca.Server) {
+		if err := server.Run(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("CA signer exited with an error")
+		}
+	}(m.caserver)
+
+	// Start all sub-components in separate goroutines.
+	// TODO(aluzzardi): This should have some kind of error handling so that
+	// any component that goes down would bring the entire manager down.
+	if m.allocator != nil {
+		go func(allocator *allocator.Allocator) {
+			if err := allocator.Run(ctx); err != nil {
+				log.G(ctx).WithError(err).Error("allocator exited with an error")
+			}
+		}(m.allocator)
+	}
+
+	go func(scheduler *scheduler.Scheduler) {
+		if err := scheduler.Run(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("scheduler exited with an error")
+		}
+	}(m.scheduler)
+
+	go func(taskReaper *orchestrator.TaskReaper) {
+		taskReaper.Run()
+	}(m.taskReaper)
+
+	go func(orchestrator *orchestrator.ReplicatedOrchestrator) {
+		if err := orchestrator.Run(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("replicated orchestrator exited with an error")
+		}
+	}(m.replicatedOrchestrator)
+
+	go func(globalOrchestrator *orchestrator.GlobalOrchestrator) {
+		if err := globalOrchestrator.Run(ctx); err != nil {
+			log.G(ctx).WithError(err).Error("global orchestrator exited with an error")
+		}
+	}(m.globalOrchestrator)
+
+}
+
+// becomeFollower shuts down the subsystems that are only run by the leader.
+func (m *Manager) becomeFollower() {
+	m.Dispatcher.Stop()
+	m.caserver.Stop()
+
+	if m.allocator != nil {
+		m.allocator.Stop()
+		m.allocator = nil
+	}
+
+	m.replicatedOrchestrator.Stop()
+	m.replicatedOrchestrator = nil
+
+	m.globalOrchestrator.Stop()
+	m.globalOrchestrator = nil
+
+	m.taskReaper.Stop()
+	m.taskReaper = nil
+
+	m.scheduler.Stop()
+	m.scheduler = nil
+
+	if m.keyManager != nil {
+		m.keyManager.Stop()
+		m.keyManager = nil
+	}
+}
+
+// defaultClusterObject creates a default cluster.
+func defaultClusterObject(clusterID string, initialCAConfig api.CAConfig, raftCfg api.RaftConfig, rootCA *ca.RootCA) *api.Cluster {
+	return &api.Cluster{
+		ID: clusterID,
+		Spec: api.ClusterSpec{
+			Annotations: api.Annotations{
+				Name: store.DefaultClusterName,
+			},
+			Orchestration: api.OrchestrationConfig{
+				TaskHistoryRetentionLimit: defaultTaskHistoryRetentionLimit,
+			},
+			Dispatcher: api.DispatcherConfig{
+				HeartbeatPeriod: ptypes.DurationProto(dispatcher.DefaultHeartBeatPeriod),
+			},
+			Raft:     raftCfg,
+			CAConfig: initialCAConfig,
+		},
+		RootCA: api.RootCA{
+			CAKey:      rootCA.Key,
+			CACert:     rootCA.Cert,
+			CACertHash: rootCA.Digest.String(),
+			JoinTokens: api.JoinTokens{
+				Worker:  ca.GenerateJoinToken(rootCA),
+				Manager: ca.GenerateJoinToken(rootCA),
+			},
+		},
+	}
+}
+
+// managerNode create a new node with NodeRoleManager role.
+func managerNode(nodeID string) *api.Node {
+	return &api.Node{
+		ID: nodeID,
+		Certificate: api.Certificate{
+			CN:   nodeID,
+			Role: api.NodeRoleManager,
+			Status: api.IssuanceStatus{
+				State: api.IssuanceStateIssued,
+			},
+		},
+		Spec: api.NodeSpec{
+			Role:       api.NodeRoleManager,
+			Membership: api.NodeMembershipAccepted,
+		},
+	}
 }


### PR DESCRIPTION
This is the first step of a brainless refactoring of the `manager.Run` function.

My work started when I read this comment:

```
// TODO(aluzzardi): /!\ This function is *way* too complex. /!\
// It needs to be split into smaller manageable functions.
func (m *Manager) Run(parent context.Context) error {
```

The Run function still contains a lot of domain logic and it is still too complex,
but a little bit less now.