### PR TITLE
remove field client in struct container controller

### DIFF
--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-// containerController conducts remote operations for a container. All calls
+// containerAdapter conducts remote operations for a container. All calls
 // are mostly naked calls to the client API, seeded with information from
 // containerConfig.
 type containerAdapter struct {
@@ -241,7 +241,7 @@ func (c *containerAdapter) remove(ctx context.Context) error {
 	})
 }
 
-func (c *containerAdapter) createVolumes(ctx context.Context, client engineapi.APIClient) error {
+func (c *containerAdapter) createVolumes(ctx context.Context) error {
 	// Create plugin volumes that are embedded inside a Mount
 	for _, mount := range c.container.spec().Mounts {
 		if mount.Type != api.MountTypeVolume {
@@ -258,7 +258,7 @@ func (c *containerAdapter) createVolumes(ctx context.Context, client engineapi.A
 		}
 
 		req := c.container.volumeCreateRequest(&mount)
-		if _, err := client.VolumeCreate(ctx, *req); err != nil {
+		if _, err := c.client.VolumeCreate(ctx, *req); err != nil {
 			// TODO(amitshukla): Today, volume create through the engine api does not return an error
 			// when the named volume with the same parameters already exists.
 			// It returns an error if the driver name is different - that is a valid error

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -18,7 +18,6 @@ import (
 // Most operations against docker's API are done through the container name,
 // which is unique to the task.
 type controller struct {
-	client  engineapi.APIClient
 	task    *api.Task
 	adapter *containerAdapter
 	closed  chan struct{}
@@ -39,7 +38,6 @@ func newController(client engineapi.APIClient, task *api.Task) (exec.Controller,
 	}
 
 	return &controller{
-		client:  client,
 		task:    task,
 		adapter: adapter,
 		closed:  make(chan struct{}),
@@ -86,7 +84,7 @@ func (r *controller) Prepare(ctx context.Context) error {
 	}
 
 	// Make sure all the volumes that the task needs are created.
-	if err := r.adapter.createVolumes(ctx, r.client); err != nil {
+	if err := r.adapter.createVolumes(ctx); err != nil {
 		return err
 	}
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -527,7 +527,7 @@ func (m *Manager) rotateRootCAKEK(ctx context.Context, clusterID string) error {
 
 }
 
-// handleLeadershipEvents read out and discard all of the messages when the manager is stopped,
+// handleLeadershipEvents reads out and discards all of the messages when the manager is stopped,
 // otherwise it handles the is leader event or is follower event.
 func (m *Manager) handleLeadershipEvents(ctx context.Context, leadershipCh chan events.Event) {
 	for leadershipEvent := range leadershipCh {
@@ -734,7 +734,7 @@ func defaultClusterObject(clusterID string, initialCAConfig api.CAConfig, raftCf
 	}
 }
 
-// managerNode create a new node with NodeRoleManager role.
+// managerNode creates a new node with NodeRoleManager role.
 func managerNode(nodeID string) *api.Node {
 	return &api.Node{
 		ID: nodeID,


### PR DESCRIPTION
I found that in the struct controller in agent/exec/container, client is no need, because it will be stored in adapter field.

What I did:
1. remove field client in struct controller in agent/exec/container;
2. remove parameter in createVolumes;
3. fix some typos.

Signed-off-by: allencloud <allen.sun@daocloud.io>