### PR TITLE
Dynamically update node inventory

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -15,6 +15,7 @@ import (
 const (
 	initialSessionFailureBackoff = 100 * time.Millisecond
 	maxSessionFailureBackoff     = 8 * time.Second
+	nodeUpdatePeriod             = 20 * time.Second
 )
 
 // Agent implements the primary node functionality for a member of a swarm
@@ -134,9 +135,18 @@ func (a *Agent) run(ctx context.Context) {
 	log.G(ctx).Debugf("(*Agent).run")
 	defer log.G(ctx).Debugf("(*Agent).run exited")
 
+	// get the node description
+	nodeDescription, err := a.nodeDescriptionWithHostname(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).WithField("agent", a.config.Executor).Errorf("agent: node description unavailable")
+	}
+	// nodeUpdateTicker is used to periodically check for updates to node description
+	nodeUpdateTicker := time.NewTicker(nodeUpdatePeriod)
+	defer nodeUpdateTicker.Stop()
+
 	var (
 		backoff    time.Duration
-		session    = newSession(ctx, a, backoff, "") // start the initial session
+		session    = newSession(ctx, a, backoff, "", nodeDescription) // start the initial session
 		registered = session.registered
 		ready      = a.ready // first session ready
 		sessionq   chan sessionOperation
@@ -197,10 +207,41 @@ func (a *Agent) run(ctx context.Context) {
 			log.G(ctx).Debugf("agent: rebuild session")
 
 			// select a session registration delay from backoff range.
-			delay := time.Duration(rand.Int63n(int64(backoff)))
-			session = newSession(ctx, a, delay, session.sessionID)
+			delay := time.Duration(0)
+			if backoff > 0 {
+				delay = time.Duration(rand.Int63n(int64(backoff)))
+			}
+			session = newSession(ctx, a, delay, session.sessionID, nodeDescription)
 			registered = session.registered
 			sessionq = a.sessionq
+		case <-nodeUpdateTicker.C:
+			// skip this case if the registration isn't finished
+			if registered != nil {
+				continue
+			}
+			// get the current node description
+			newNodeDescription, err := a.nodeDescriptionWithHostname(ctx)
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("agent", a.config.Executor).Errorf("agent: updated node description unavailable")
+			}
+
+			// if newNodeDescription is nil, it will cause a panic when
+			// trying to create a session. Typically this can happen
+			// if the engine goes down
+			if newNodeDescription == nil {
+				continue
+			}
+
+			// if the node description has changed, update it to the new one
+			// and close the session. The old session will be stopped and a
+			// new one will be created with the updated description
+			if !reflect.DeepEqual(nodeDescription, newNodeDescription) {
+				nodeDescription = newNodeDescription
+				// close the session
+				if err := session.close(); err != nil {
+					log.G(ctx).WithError(err).Error("agent: closing session for node update failed")
+				}
+			}
 		case <-a.stopped:
 			// TODO(stevvooe): Wait on shutdown and cleanup. May need to pump
 			// this loop a few times.
@@ -335,6 +376,17 @@ func (a *Agent) UpdateTaskStatus(ctx context.Context, taskID string, status *api
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// nodeDescriptionWithHostname retrieves node description, and overrides hostname if available
+func (a *Agent) nodeDescriptionWithHostname(ctx context.Context) (*api.NodeDescription, error) {
+	desc, err := a.config.Executor.Describe(ctx)
+
+	// Override hostname
+	if a.config.Hostname != "" && desc != nil {
+		desc.Hostname = a.config.Hostname
+	}
+	return desc, err
 }
 
 // nodesEqual returns true if the node states are functionaly equal, ignoring status,

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -238,6 +238,7 @@ func (a *Agent) run(ctx context.Context) {
 			if !reflect.DeepEqual(nodeDescription, newNodeDescription) {
 				nodeDescription = newNodeDescription
 				// close the session
+				log.G(ctx).Info("agent: found node update")
 				if err := session.close(); err != nil {
 					log.G(ctx).WithError(err).Error("agent: closing session for node update failed")
 				}


### PR DESCRIPTION
This PR makes the node inventory dynamic i.e. changes to node info are passed to the dispatcher. A ticker checks the node info periodically (currently every 20 seconds) and closes the session if changes are found, so that a new one can be created with an updated node description, and the same session id.

I'm trying to test this change thoroughly since it can likely cause race conditions in the main agent loop. The update period will likely have to be tuned to make sure that it doesn't interfere with the agent's backoff mechanism.

The underlying assumption is that node updates aren't super frequent.

Follow up to #1174 after it had to be reverted due to unstable behavior. #1230 was meant to fix some of that.

Fix #279 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>