### PR TITLE
[WIP] Refactor: Add a leader structure

### DIFF
--- a/manager/leader.go
+++ b/manager/leader.go
@@ -1,0 +1,42 @@
+package manager
+
+import (
+	"github.com/docker/swarmkit/manager/orchestrator"
+	"github.com/docker/swarmkit/manager/state/raft"
+	"golang.org/x/net/context"
+)
+
+// Leader is the cluster leader for Swarm.
+type Leader struct {
+	globalOrchestrator     *orchestrator.GlobalOrchestrator
+	replicatedOrchestrator *orchestrator.ReplicatedOrchestrator
+	taskReaper             *orchestrator.TaskReaper
+}
+
+// NewLeader creates a new leader
+func NewLeader(raftNode *raft.Node) *Leader {
+
+	leader := &Leader{
+		globalOrchestrator:     orchestrator.NewGlobalOrchestrator(raftNode.MemoryStore()),
+		replicatedOrchestrator: orchestrator.NewReplicatedOrchestrator(raftNode.MemoryStore()),
+		taskReaper:             orchestrator.NewTaskReaper(raftNode.MemoryStore()),
+	}
+
+	return leader
+}
+
+// Start starts leader
+func (l *Leader) Start(ctx context.Context) {
+	l.globalOrchestrator.Start(ctx)
+	l.replicatedOrchestrator.Start(ctx)
+	l.taskReaper.Start(ctx)
+
+	// FIXME(jimmyxian): check error and automatically restart components based on error
+}
+
+// Stop stop leader
+func (l *Leader) Stop(ctx context.Context) {
+	l.globalOrchestrator.Stop(ctx)
+	l.replicatedOrchestrator.Stop(ctx)
+	l.taskReaper.Stop(ctx)
+}

--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -190,11 +190,9 @@ func TestDrain(t *testing.T) {
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	// id2 and id5 should be killed immediately
 	deletion1 := watchShutdownTask(t, watch)

--- a/manager/orchestrator/errors.go
+++ b/manager/orchestrator/errors.go
@@ -1,0 +1,16 @@
+package orchestrator
+
+import (
+	"errors"
+)
+
+var (
+	errReplicatedOrchestratorStarted    = errors.New("ReplicatedOrchestrator: already started")
+	errReplicatedOrchestratorNotStarted = errors.New("ReplicatedOrchestrator: not started")
+
+	errGlobalOrchestratorStarted    = errors.New("GlobalOrchestrator: already started")
+	errGlobalOrchestratorNotStarted = errors.New("GlobalOrchestrator: not started")
+
+	errTaskReaperStarted    = errors.New("TaskReaper: already started")
+	errTaskReaperNotStarted = errors.New("TaskReaper: not started")
+)

--- a/manager/orchestrator/global_test.go
+++ b/manager/orchestrator/global_test.go
@@ -63,9 +63,8 @@ func SetupCluster(t *testing.T, store *store.MemoryStore) {
 	ctx := context.Background()
 	// Start the global orchestrator.
 	global := NewGlobalOrchestrator(store)
-	go func() {
-		assert.NoError(t, global.Run(ctx))
-	}()
+
+	assert.NoError(t, global.Start(ctx))
 
 	addService(t, store, service1)
 	addNode(t, store, node1)

--- a/manager/orchestrator/replicated.go
+++ b/manager/orchestrator/replicated.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -21,6 +22,10 @@ type ReplicatedOrchestrator struct {
 	reconcileServices map[string]*api.Service
 	restartTasks      map[string]struct{}
 
+	started   chan struct{}
+	startOnce sync.Once // start only once
+	stopOnce  sync.Once // only allow stop to be called once
+
 	// stopChan signals to the state machine to stop running.
 	stopChan chan struct{}
 	// doneChan is closed when the state machine terminates.
@@ -38,6 +43,7 @@ func NewReplicatedOrchestrator(store *store.MemoryStore) *ReplicatedOrchestrator
 	updater := NewUpdateSupervisor(store, restartSupervisor)
 	return &ReplicatedOrchestrator{
 		store:             store,
+		started:           make(chan struct{}),
 		stopChan:          make(chan struct{}),
 		doneChan:          make(chan struct{}),
 		reconcileServices: make(map[string]*api.Service),
@@ -47,8 +53,21 @@ func NewReplicatedOrchestrator(store *store.MemoryStore) *ReplicatedOrchestrator
 	}
 }
 
-// Run contains the orchestrator event loop. It runs until Stop is called.
-func (r *ReplicatedOrchestrator) Run(ctx context.Context) error {
+// Start starts replicated orchestrator
+func (r *ReplicatedOrchestrator) Start(ctx context.Context) error {
+	err := errReplicatedOrchestratorStarted
+
+	r.startOnce.Do(func() {
+		close(r.started)
+		go r.run(ctx)
+		err = nil
+	})
+
+	return err
+}
+
+// run contains the orchestrator event loop. It runs until Stop is called.
+func (r *ReplicatedOrchestrator) run(ctx context.Context) error {
 	defer close(r.doneChan)
 
 	// Watch changes to services and tasks
@@ -90,14 +109,35 @@ func (r *ReplicatedOrchestrator) Run(ctx context.Context) error {
 			case state.EventUpdateCluster:
 				r.cluster = v.Cluster
 			}
+		case <-ctx.Done():
+			return nil
 		case <-r.stopChan:
 			return nil
 		}
 	}
 }
 
-// Stop stops the orchestrator.
-func (r *ReplicatedOrchestrator) Stop() {
+// Stop stops the ReplicatedOrchestrator
+func (r *ReplicatedOrchestrator) Stop(ctx context.Context) error {
+	select {
+	case <-r.started:
+	default:
+		return errReplicatedOrchestratorNotStarted
+	}
+
+	r.stopOnce.Do(func() {
+		r.stop()
+	})
+
+	select {
+	case <-r.doneChan:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *ReplicatedOrchestrator) stop() {
 	close(r.stopChan)
 	<-r.doneChan
 	r.updater.CancelAll()

--- a/manager/orchestrator/replicated_test.go
+++ b/manager/orchestrator/replicated_test.go
@@ -20,7 +20,7 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -53,9 +53,7 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -204,7 +202,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
 	defer cancel()
@@ -367,9 +365,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	// Replicas was set to 6, but we started with 7 tasks. task7 should
 	// be the one the orchestrator chose to shut down because it was not

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -18,7 +18,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -55,9 +55,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -120,7 +118,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -157,9 +155,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -220,7 +216,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -256,9 +252,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -314,7 +308,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -351,9 +345,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -403,7 +395,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -441,9 +433,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
@@ -536,7 +526,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	assert.NotNil(t, s)
 
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -571,10 +561,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
+	assert.NoError(t, orchestrator.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)

--- a/manager/orchestrator/task_reaper_test.go
+++ b/manager/orchestrator/task_reaper_test.go
@@ -33,9 +33,9 @@ func TestTaskHistory(t *testing.T) {
 	}))
 
 	taskReaper := NewTaskReaper(s)
-	defer taskReaper.Stop()
+	defer taskReaper.Stop(ctx)
 	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
+	defer orchestrator.Stop(ctx)
 
 	watch, cancel := state.Watch(s.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -69,10 +69,8 @@ func TestTaskHistory(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Start the orchestrator.
-	go func() {
-		assert.NoError(t, orchestrator.Run(ctx))
-	}()
-	go taskReaper.Run()
+	assert.NoError(t, orchestrator.Start(ctx))
+	assert.NoError(t, taskReaper.Start(ctx))
 
 	observedTask1 := watchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)


### PR DESCRIPTION
Add a leader structure and move the following components into leader:
- [X] replicatedOrchestrator
- [X] globalOrchestrator
- [X] taskReaper
- [ ] scheduler
- [ ] allocator
- [ ] keyManager
- [ ] caserver
- [ ] Dispatcher

Signed-off-by: Xian Chaobo xianchaobo@huawei.com
