### PR TITLE
dispatcher: make peers updates better

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
@@ -50,8 +51,22 @@ type testCluster struct {
 func (t *testCluster) GetMemberlist() map[uint64]*api.RaftMember {
 	return map[uint64]*api.RaftMember{
 		1: {
-			Addr: t.addr,
+			NodeID: "1",
+			Addr:   t.addr,
 		},
+	}
+}
+
+func (t *testCluster) SubscribePeers() (chan events.Event, func()) {
+	ch := make(chan events.Event, 1)
+	ch <- []*api.Peer{
+		{
+			Addr:   t.addr,
+			NodeID: "1",
+		},
+	}
+	return ch, func() {
+		close(ch)
 	}
 }
 

--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/coreos/etcd/raft/raftpb"
+	events "github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/gogo/protobuf/proto"
 )
@@ -33,6 +34,8 @@ type Cluster struct {
 	// removed contains the list of removed Members,
 	// those ids cannot be reused
 	removed map[uint64]bool
+
+	PeersBroadcast *events.Broadcaster
 }
 
 // Member represents a raft Cluster Member
@@ -49,8 +52,9 @@ func NewCluster() *Cluster {
 	// TODO(abronan): generate Cluster ID for federation
 
 	return &Cluster{
-		members: make(map[uint64]*Member),
-		removed: make(map[uint64]bool),
+		members:        make(map[uint64]*Member),
+		removed:        make(map[uint64]bool),
+		PeersBroadcast: events.NewBroadcaster(),
 	}
 }
 
@@ -83,6 +87,17 @@ func (c *Cluster) GetMember(id uint64) *Member {
 	return c.members[id]
 }
 
+func (c *Cluster) broadcastUpdate() {
+	peers := make([]*api.Peer, 0, len(c.members))
+	for _, m := range c.members {
+		peers = append(peers, &api.Peer{
+			NodeID: m.NodeID,
+			Addr:   m.Addr,
+		})
+	}
+	c.PeersBroadcast.Write(peers)
+}
+
 // AddMember adds a node to the Cluster Memberlist.
 func (c *Cluster) AddMember(member *Member) error {
 	c.mu.Lock()
@@ -93,6 +108,7 @@ func (c *Cluster) AddMember(member *Member) error {
 	}
 
 	c.members[member.RaftID] = member
+	c.broadcastUpdate()
 	return nil
 }
 
@@ -110,6 +126,7 @@ func (c *Cluster) RemoveMember(id uint64) error {
 	}
 
 	c.removed[id] = true
+	c.broadcastUpdate()
 	return nil
 }
 

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -907,6 +907,19 @@ func (n *Node) GetVersion() *api.Version {
 	return &api.Version{Index: status.Commit}
 }
 
+// SubscribePeers subscribes to peer updates in cluster. It sends always full
+// list of peers.
+func (n *Node) SubscribePeers() (q chan events.Event, cancel func()) {
+	ch := events.NewChannel(0)
+	sink := events.Sink(events.NewQueue(ch))
+	n.cluster.PeersBroadcast.Add(sink)
+	return ch.C, func() {
+		n.cluster.PeersBroadcast.Remove(sink)
+		ch.Close()
+		sink.Close()
+	}
+}
+
 // GetMemberlist returns the current list of raft members in the cluster.
 func (n *Node) GetMemberlist() map[uint64]*api.RaftMember {
 	memberlist := make(map[uint64]*api.RaftMember)


### PR DESCRIPTION
Now they update almost immediately on membership list change. This
change is free and I think makes dispatcher code more consistent.