### PR TITLE
raft: fix race in LeaderAddr call

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -814,6 +814,8 @@ func (n *Node) LeaderAddr() (string, error) {
 	if err := WaitForLeader(ctx, n); err != nil {
 		return "", ErrNoClusterLeader
 	}
+	n.stopMu.RLock()
+	defer n.stopMu.RUnlock()
 	if !n.IsMember() {
 		return "", ErrNoRaftMember
 	}


### PR DESCRIPTION
Without mutex lock it's possible that we'll hit State() call during
Stop() and it will hang forever.

ping @aaronlehmann 