### PR TITLE
manager: observe peers immediately from raft

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -598,6 +598,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 			StateDir:       n.config.StateDir,
 			HeartbeatTick:  n.config.HeartbeatTick,
 			ElectionTick:   n.config.ElectionTick,
+			Peers:          n.remotes,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
It's quite important for CA server to get peers update fast. Agent can
be connected to another manager and provide too slow updates for
manager.
Manager and agent mostly duplicate effort of each other, but it looks
harmless.