### PR TITLE
Fix goroutine leak when manager shuts down

### DIFF
--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -59,6 +59,7 @@ func (tc *TestCA) Stop() {
 	}
 	tc.CAServer.Stop()
 	tc.Server.Stop()
+	tc.MemoryStore.Close()
 }
 
 // NewNodeConfig returns security config for a new node, given a role

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -45,6 +45,7 @@ type testServer struct {
 func (ts *testServer) Stop() {
 	_ = ts.clientConn.Close()
 	ts.grpcServer.Stop()
+	ts.Store.Close()
 }
 
 func newTestServer(t *testing.T) *testServer {

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -127,8 +127,8 @@ func New(cluster Cluster, c *Config) *Dispatcher {
 		nodes:                 newNodeStore(c.HeartbeatPeriod, c.HeartbeatEpsilon, c.GracePeriodMultiplier, c.RateLimitPeriod),
 		store:                 cluster.MemoryStore(),
 		cluster:               cluster,
-		mgrQueue:              watch.NewQueue(16),
-		keyMgrQueue:           watch.NewQueue(16),
+		mgrQueue:              watch.NewQueue(),
+		keyMgrQueue:           watch.NewQueue(),
 		taskUpdates:           make(map[string]*api.TaskStatus),
 		nodeUpdates:           make(map[string]nodeUpdate),
 		processUpdatesTrigger: make(chan struct{}, 1),
@@ -269,6 +269,9 @@ func (d *Dispatcher) Stop() error {
 	// before waiting.
 	d.processUpdatesCond.Broadcast()
 	d.processUpdatesLock.Unlock()
+
+	d.mgrQueue.Close()
+	d.keyMgrQueue.Close()
 
 	return nil
 }

--- a/manager/keymanager/keymanager_test.go
+++ b/manager/keymanager/keymanager_test.go
@@ -35,6 +35,7 @@ func createCluster(t *testing.T, s *store.MemoryStore, id, name string) *api.Clu
 // Verify the key generation and rotation for default subsystems
 func TestKeyManagerDefaultSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
+	defer st.Close()
 	createCluster(t, st, "default", "default")
 
 	k := New(st, DefaultConfig())
@@ -70,6 +71,7 @@ func TestKeyManagerDefaultSubsystem(t *testing.T) {
 // Verify the key generation and rotation for IPsec subsystem
 func TestKeyManagerCustomSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
+	defer st.Close()
 	createCluster(t, st, "default", "default")
 
 	config := &Config{
@@ -115,6 +117,7 @@ func TestKeyManagerCustomSubsystem(t *testing.T) {
 // passed
 func TestKeyManagerInvalidSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
+	defer st.Close()
 	createCluster(t, st, "default", "default")
 
 	config := &Config{

--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -169,6 +169,7 @@ func TestDrain(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Prepopulate service

--- a/manager/orchestrator/global_test.go
+++ b/manager/orchestrator/global_test.go
@@ -74,6 +74,7 @@ func SetupCluster(t *testing.T, store *store.MemoryStore) {
 func TestSetup(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	watch, cancel := state.Watch(store.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()
@@ -89,6 +90,7 @@ func TestSetup(t *testing.T) {
 func TestAddNode(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	SetupCluster(t, store)
 
@@ -107,6 +109,7 @@ func TestAddNode(t *testing.T) {
 func TestDeleteNode(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	SetupCluster(t, store)
 
@@ -125,6 +128,7 @@ func TestDeleteNode(t *testing.T) {
 func TestNodeAvailability(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	SetupCluster(t, store)
 
@@ -156,6 +160,7 @@ func TestNodeAvailability(t *testing.T) {
 func TestAddService(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	SetupCluster(t, store)
 
@@ -174,6 +179,7 @@ func TestAddService(t *testing.T) {
 func TestDeleteService(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	SetupCluster(t, store)
 
@@ -192,6 +198,7 @@ func TestDeleteService(t *testing.T) {
 func TestRemoveTask(t *testing.T) {
 	store := store.NewMemoryStore(nil)
 	assert.NotNil(t, store)
+	defer store.Close()
 
 	watch, cancel := state.Watch(store.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
 	defer cancel()

--- a/manager/orchestrator/replicated_test.go
+++ b/manager/orchestrator/replicated_test.go
@@ -18,6 +18,7 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -202,6 +203,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -16,6 +16,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -118,6 +119,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -218,6 +220,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -312,6 +315,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -401,6 +405,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
@@ -534,6 +539,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()

--- a/manager/orchestrator/task_reaper_test.go
+++ b/manager/orchestrator/task_reaper_test.go
@@ -16,6 +16,7 @@ func TestTaskHistory(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	assert.NoError(t, s.Update(func(tx store.Tx) error {
 		store.CreateCluster(tx, &api.Cluster{

--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -36,6 +36,7 @@ func TestUpdater(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	// Move tasks to their desired state.
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
@@ -149,6 +150,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	// Fail new tasks the updater tries to run
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
@@ -299,6 +301,7 @@ func TestUpdaterStopGracePeriod(t *testing.T) {
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	// Move tasks to their desired state.
 	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -87,6 +87,7 @@ func TestScheduler(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Prepoulate nodes
@@ -367,6 +368,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Add initial task
@@ -451,6 +453,7 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Add initial node and task
@@ -542,6 +545,7 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Add initial node and task
@@ -640,6 +644,7 @@ func TestSchedulerPreexistingDeadTask(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Add initial node and task
@@ -733,6 +738,7 @@ func TestPreassignedTasks(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	err := s.Update(func(tx store.Tx) error {
 		// Prepoulate nodes
@@ -978,6 +984,7 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
+	defer s.Close()
 
 	// Add initial node and task
 	err := s.Update(func(tx store.Tx) error {
@@ -1202,5 +1209,6 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints, worstCas
 
 		scheduler.Stop()
 		cancel()
+		s.Close()
 	}
 }

--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -7,8 +7,8 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/coreos/etcd/raft/raftpb"
-	events "github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state/watch"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -35,7 +35,7 @@ type Cluster struct {
 	// those ids cannot be reused
 	removed map[uint64]bool
 
-	PeersBroadcast *events.Broadcaster
+	PeersBroadcast *watch.Queue
 }
 
 // Member represents a raft Cluster Member
@@ -54,7 +54,7 @@ func NewCluster() *Cluster {
 	return &Cluster{
 		members:        make(map[uint64]*Member),
 		removed:        make(map[uint64]bool),
-		PeersBroadcast: events.NewBroadcaster(),
+		PeersBroadcast: watch.NewQueue(),
 	}
 }
 
@@ -95,7 +95,7 @@ func (c *Cluster) broadcastUpdate() {
 			Addr:   m.Addr,
 		})
 	}
-	c.PeersBroadcast.Write(peers)
+	c.PeersBroadcast.Publish(peers)
 }
 
 // AddMember adds a node to the Cluster Memberlist.

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/manager/state/watch"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pivotal-golang/clock"
 )
@@ -115,7 +116,7 @@ type Node struct {
 	// removeRaftCh notifies about node deletion from raft cluster
 	removeRaftCh        chan struct{}
 	removeRaftFunc      func()
-	leadershipBroadcast *events.Broadcaster
+	leadershipBroadcast *watch.Queue
 
 	// used to coordinate shutdown
 	stopMu sync.RWMutex
@@ -194,7 +195,7 @@ func NewNode(ctx context.Context, opts NewNodeOptions) *Node {
 		StateDir:            opts.StateDir,
 		joinAddr:            opts.JoinAddr,
 		sendTimeout:         2 * time.Second,
-		leadershipBroadcast: events.NewBroadcaster(),
+		leadershipBroadcast: watch.NewQueue(),
 	}
 	n.memoryStore = store.NewMemoryStore(n)
 
@@ -400,7 +401,7 @@ func (n *Node) Run(ctx context.Context) error {
 					n.wait.cancelAll()
 					if atomic.LoadUint32(&n.signalledLeadership) == 1 {
 						atomic.StoreUint32(&n.signalledLeadership, 0)
-						n.leadershipBroadcast.Write(IsFollower)
+						n.leadershipBroadcast.Publish(IsFollower)
 					}
 				} else if !wasLeader && rd.SoftState.RaftState == raft.StateLeader {
 					wasLeader = true
@@ -412,7 +413,7 @@ func (n *Node) Run(ctx context.Context) error {
 				// committed, broadcast our leadership status.
 				if n.caughtUp() {
 					atomic.StoreUint32(&n.signalledLeadership, 1)
-					n.leadershipBroadcast.Write(IsLeader)
+					n.leadershipBroadcast.Publish(IsLeader)
 				}
 			}
 
@@ -452,6 +453,9 @@ func (n *Node) Run(ctx context.Context) error {
 			return ErrMemberRemoved
 		case <-n.stopCh:
 			n.stop()
+			n.leadershipBroadcast.Close()
+			n.cluster.PeersBroadcast.Close()
+			n.memoryStore.Close()
 			return nil
 		}
 	}
@@ -912,14 +916,7 @@ func (n *Node) GetVersion() *api.Version {
 // SubscribePeers subscribes to peer updates in cluster. It sends always full
 // list of peers.
 func (n *Node) SubscribePeers() (q chan events.Event, cancel func()) {
-	ch := events.NewChannel(0)
-	sink := events.Sink(events.NewQueue(ch))
-	n.cluster.PeersBroadcast.Add(sink)
-	return ch.C, func() {
-		n.cluster.PeersBroadcast.Remove(sink)
-		ch.Close()
-		sink.Close()
-	}
+	return n.cluster.PeersBroadcast.Watch()
 }
 
 // GetMemberlist returns the current list of raft members in the cluster.
@@ -1359,14 +1356,7 @@ func (n *Node) ConnectToMember(addr string, timeout time.Duration) (*membership.
 // will be sent in form of raft.LeadershipState. Also cancel func is returned -
 // it should be called when listener is no longer interested in events.
 func (n *Node) SubscribeLeadership() (q chan events.Event, cancel func()) {
-	ch := events.NewChannel(0)
-	sink := events.Sink(events.NewQueue(ch))
-	n.leadershipBroadcast.Add(sink)
-	return ch.C, func() {
-		n.leadershipBroadcast.Remove(sink)
-		ch.Close()
-		sink.Close()
-	}
+	return n.leadershipBroadcast.Watch()
 }
 
 // createConfigChangeEnts creates a series of Raft entries (i.e.

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -96,9 +96,14 @@ func NewMemoryStore(proposer state.Proposer) *MemoryStore {
 
 	return &MemoryStore{
 		memDB:    memDB,
-		queue:    watch.NewQueue(0),
+		queue:    watch.NewQueue(),
 		proposer: proposer,
 	}
+}
+
+// Close closes the memory store and frees its associated resources.
+func (s *MemoryStore) Close() error {
+	return s.queue.Close()
 }
 
 func fromArgs(args ...interface{}) ([]byte, error) {

--- a/manager/state/watch/watch_test.go
+++ b/manager/state/watch/watch_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestWatch(t *testing.T) {
 	// Create a queue
-	q := NewQueue(0)
+	q := NewQueue()
 
 	type testEvent struct {
 		tags []string
@@ -149,7 +149,7 @@ func BenchmarkWatch1000Listeners64Publishers(b *testing.B) {
 }
 
 func benchmarkWatch(b *testing.B, nlisteners, npublishers int, waitForWatchers bool) {
-	q := NewQueue(0)
+	q := NewQueue()
 	var (
 		watchersAttached  sync.WaitGroup
 		watchersRunning   sync.WaitGroup


### PR DESCRIPTION
This was introduced by the change from using a simple channel to a
broadcaster for leadership events.

This was noticed in the stack trace from https://github.com/docker/docker/pull/25833. I don't think this fixes the hang discussed there, though.

cc @tonistiigi @LK4D4