### PR TITLE
all: remove picker usage

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
-	"github.com/docker/swarmkit/picker"
+	"github.com/docker/swarmkit/remotes"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 )
@@ -43,7 +43,7 @@ func TestAgent(t *testing.T) {
 	//
 	// 	Connection: Manages the RPC connection and the available managers. Must
 	// 	follow lazy grpc style but also expose primitives to force reset, which
-	// 	is currently exposed through picker.
+	// 	is currently exposed through remotes.
 	//
 	//	Session: Manages the lifecycle of an agent from Register to a failure.
 	//	Currently, this is implemented as Agent.session but we'd prefer to
@@ -65,7 +65,7 @@ func TestAgentStartStop(t *testing.T) {
 	assert.NoError(t, err)
 
 	addr := "localhost:4949"
-	remotes := picker.NewRemotes(api.Peer{Addr: addr})
+	remotes := remotes.NewRemotes(api.Peer{Addr: addr})
 
 	db, cleanup := storageTestEnv(t)
 	defer cleanup()
@@ -139,7 +139,7 @@ func agentTestEnv(t *testing.T) (*Agent, func()) {
 	assert.NoError(t, err)
 
 	addr := "localhost:4949"
-	remotes := picker.NewRemotes(api.Peer{Addr: addr})
+	remotes := remotes.NewRemotes(api.Peer{Addr: addr})
 
 	db, cleanupStorage := storageTestEnv(t)
 	cleanup = append(cleanup, func() { cleanupStorage() })

--- a/agent/config.go
+++ b/agent/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/picker"
+	"github.com/docker/swarmkit/remotes"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -17,7 +17,7 @@ type Config struct {
 
 	// Managers provides the manager backend used by the agent. It will be
 	// updated with managers weights as observed by the agent.
-	Managers picker.Remotes
+	Managers remotes.Remotes
 
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor

--- a/agent/session.go
+++ b/agent/session.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"github.com/docker/swarmkit/picker"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	"github.com/docker/swarmkit/remotes"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -307,7 +307,7 @@ func (s *session) close() error {
 		return errSessionClosed
 	default:
 		if s.conn != nil {
-			s.agent.config.Managers.ObserveIfExists(api.Peer{Addr: s.addr}, -picker.DefaultObservationWeight)
+			s.agent.config.Managers.ObserveIfExists(api.Peer{Addr: s.addr}, -remotes.DefaultObservationWeight)
 			s.conn.Close()
 		}
 		close(s.closed)

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/docker/swarmkit/manager/state/store"
-	"github.com/docker/swarmkit/picker"
+	"github.com/docker/swarmkit/remotes"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -43,9 +43,9 @@ type TestCA struct {
 	NodeCAClients         []api.NodeCAClient
 	CAClients             []api.CAClient
 	Conns                 []*grpc.ClientConn
-	Picker                *picker.Picker
 	WorkerToken           string
 	ManagerToken          string
+	Remotes               remotes.Remotes
 }
 
 // Stop cleansup after TestCA
@@ -170,9 +170,7 @@ func NewTestCA(t *testing.T) *TestCA {
 
 	// Wait for caServer to be ready to serve
 	<-caServer.Ready()
-
-	remotes := picker.NewRemotes(api.Peer{Addr: l.Addr().String()})
-	picker := picker.NewPicker(remotes, l.Addr().String())
+	remotes := remotes.NewRemotes(api.Peer{Addr: l.Addr().String()})
 
 	caClients := []api.CAClient{api.NewCAClient(conn1), api.NewCAClient(conn2), api.NewCAClient(conn3)}
 	nodeCAClients := []api.NodeCAClient{api.NewNodeCAClient(conn1), api.NewNodeCAClient(conn2), api.NewNodeCAClient(conn3), api.NewNodeCAClient(conn4)}
@@ -182,7 +180,6 @@ func NewTestCA(t *testing.T) *TestCA {
 		RootCA:                rootCA,
 		ExternalSigningServer: externalSigningServer,
 		MemoryStore:           s,
-		Picker:                picker,
 		TempDir:               tempBaseDir,
 		Organization:          organization,
 		Paths:                 paths,
@@ -193,6 +190,7 @@ func NewTestCA(t *testing.T) *TestCA {
 		CAServer:              caServer,
 		WorkerToken:           workerToken,
 		ManagerToken:          managerToken,
+		Remotes:               remotes,
 	}
 }
 

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -19,8 +19,8 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/manager/state/watch"
-	"github.com/docker/swarmkit/picker"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	"github.com/docker/swarmkit/remotes"
 	"golang.org/x/net/context"
 )
 
@@ -153,7 +153,7 @@ func getWeightedPeers(cluster Cluster) []*api.WeightedPeer {
 			// TODO(stevvooe): Calculate weight of manager selection based on
 			// cluster-level observations, such as number of connections and
 			// load.
-			Weight: picker.DefaultObservationWeight,
+			Weight: remotes.DefaultObservationWeight,
 		})
 	}
 	return mgrs
@@ -209,7 +209,7 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 		for _, p := range peers {
 			mgrs = append(mgrs, &api.WeightedPeer{
 				Peer:   p,
-				Weight: picker.DefaultObservationWeight,
+				Weight: remotes.DefaultObservationWeight,
 			})
 		}
 		d.mu.Lock()

--- a/manager/testcluster/manager_cluster_test.go
+++ b/manager/testcluster/manager_cluster_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/swarmkit/manager"
 	"github.com/docker/swarmkit/manager/state/raft/testutils"
 	"github.com/docker/swarmkit/manager/state/store"
-	"github.com/docker/swarmkit/picker"
+	"github.com/docker/swarmkit/remotes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,7 +68,7 @@ func (mc *managersCluster) addAgents(count int) error {
 			return err
 		}
 
-		managers := picker.NewRemotes(addrs...)
+		managers := remotes.NewRemotes(addrs...)
 		id := strconv.Itoa(rand.Int())
 		a, err := agent.New(&agent.Config{
 			Hostname:    "hostname_" + id,

--- a/remotes/remotes_test.go
+++ b/remotes/remotes_test.go
@@ -1,4 +1,4 @@
-package picker
+package remotes
 
 import (
 	"math"


### PR DESCRIPTION
Also, renamed picker package to remotes. There is still one picker for
controlapi, I'm going to rewrite it.

I sorta went mad with renaming and it was too late to stop, so commit is mess :(