### PR TITLE
dispatcher: Fix long-running TestSession unit test

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -20,7 +20,6 @@ import (
 	raftutils "github.com/docker/swarmkit/manager/state/raft/testutils"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type grpcDispatcher struct {
@@ -730,10 +729,7 @@ func TestSession(t *testing.T) {
 	resp, err := stream.Recv()
 	assert.NoError(t, err)
 	assert.NotEmpty(t, resp.SessionID)
-
-	msg, err := stream.Recv()
-	require.NoError(t, err)
-	assert.Equal(t, 1, len(msg.Managers))
+	assert.Equal(t, 1, len(resp.Managers))
 }
 
 func TestSessionNoCert(t *testing.T) {


### PR DESCRIPTION
This test calls Recv twice, but there doesn't seem to be a good reason.
The second call blocks for awhile until the node heartbeat expires
(because this test isn't sending heartbeats).

Presumably in the past the list of managers was only sent in the second
message, but now it's sent in the first one. So only call Recv once.

Fixes #1406

cc @LK4D4