### PR TITLE
Update go-events to fix race

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -270,7 +270,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/go-events",
-			"Rev": "75bd8e1de6126833daf8df682aa10f17cea7e011"
+			"Rev": "23780caac67d79ef0d523be97b958948c7a91f65"
 		},
 		{
 			"ImportPath": "github.com/docker/go-units",

--- a/vendor/github.com/docker/go-events/LICENSE
+++ b/vendor/github.com/docker/go-events/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/vendor/github.com/docker/go-events/README.md
+++ b/vendor/github.com/docker/go-events/README.md
@@ -110,3 +110,8 @@ Application behavior can be controlled by how `Write` behaves. The examples
 above are designed to queue the message and return as quickly as possible.
 Other implementations may block until the event is committed to durable
 storage.
+
+## Copyright and license
+
+Copyright © 2016 Docker, Inc. go-events is licensed under the Apache License,
+Version 2.0. See [LICENSE](LICENSE) for the full license text.

--- a/vendor/github.com/docker/go-events/broadcast.go
+++ b/vendor/github.com/docker/go-events/broadcast.go
@@ -1,6 +1,10 @@
 package events
 
-import "github.com/Sirupsen/logrus"
+import (
+	"sync"
+
+	"github.com/Sirupsen/logrus"
+)
 
 // Broadcaster sends events to multiple, reliable Sinks. The goal of this
 // component is to dispatch events to configured endpoints. Reliability can be
@@ -10,7 +14,10 @@ type Broadcaster struct {
 	events  chan Event
 	adds    chan configureRequest
 	removes chan configureRequest
-	closed  chan chan struct{}
+
+	shutdown chan struct{}
+	closed   chan struct{}
+	once     sync.Once
 }
 
 // NewBroadcaster appends one or more sinks to the list of sinks. The
@@ -19,11 +26,12 @@ type Broadcaster struct {
 // its own. Use of EventQueue and RetryingSink should be used here.
 func NewBroadcaster(sinks ...Sink) *Broadcaster {
 	b := Broadcaster{
-		sinks:   sinks,
-		events:  make(chan Event),
-		adds:    make(chan configureRequest),
-		removes: make(chan configureRequest),
-		closed:  make(chan chan struct{}),
+		sinks:    sinks,
+		events:   make(chan Event),
+		adds:     make(chan configureRequest),
+		removes:  make(chan configureRequest),
+		shutdown: make(chan struct{}),
+		closed:   make(chan struct{}),
 	}
 
 	// Start the broadcaster
@@ -82,24 +90,19 @@ func (b *Broadcaster) configure(ch chan configureRequest, sink Sink) error {
 // Close the broadcaster, ensuring that all messages are flushed to the
 // underlying sink before returning.
 func (b *Broadcaster) Close() error {
-	select {
-	case <-b.closed:
-		// already closed
-		return ErrSinkClosed
-	default:
-		// do a little chan handoff dance to synchronize closing
-		closed := make(chan struct{})
-		b.closed <- closed
-		close(b.closed)
-		<-closed
-		return nil
-	}
+	b.once.Do(func() {
+		close(b.shutdown)
+	})
+
+	<-b.closed
+	return nil
 }
 
 // run is the main broadcast loop, started when the broadcaster is created.
 // Under normal conditions, it waits for events on the event channel. After
 // Close is called, this goroutine will exit.
 func (b *Broadcaster) run() {
+	defer close(b.closed)
 	remove := func(target Sink) {
 		for i, sink := range b.sinks {
 			if sink == target {
@@ -143,7 +146,7 @@ func (b *Broadcaster) run() {
 		case request := <-b.removes:
 			remove(request.sink)
 			request.response <- nil
-		case closing := <-b.closed:
+		case <-b.shutdown:
 			// close all the underlying sinks
 			for _, sink := range b.sinks {
 				if err := sink.Close(); err != nil && err != ErrSinkClosed {
@@ -151,7 +154,6 @@ func (b *Broadcaster) run() {
 						Errorf("broadcaster: closing sink failed")
 				}
 			}
-			closing <- struct{}{}
 			return
 		}
 	}

--- a/vendor/github.com/docker/go-events/filter.go
+++ b/vendor/github.com/docker/go-events/filter.go
@@ -44,7 +44,7 @@ func (f *Filter) Write(event Event) error {
 func (f *Filter) Close() error {
 	// TODO(stevvooe): Not all sinks should have Close.
 	if f.closed {
-		return ErrSinkClosed
+		return nil
 	}
 
 	f.closed = true

--- a/vendor/github.com/docker/go-events/queue.go
+++ b/vendor/github.com/docker/go-events/queue.go
@@ -52,7 +52,7 @@ func (eq *Queue) Close() error {
 	defer eq.mu.Unlock()
 
 	if eq.closed {
-		return ErrSinkClosed
+		return nil
 	}
 
 	// set closed flag

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -18,6 +18,7 @@ type RetryingSink struct {
 	sink     Sink
 	strategy RetryStrategy
 	closed   chan struct{}
+	once     sync.Once
 }
 
 // NewRetryingSink returns a sink that will retry writes to a sink, backing
@@ -81,13 +82,11 @@ retry:
 
 // Close closes the sink and the underlying sink.
 func (rs *RetryingSink) Close() error {
-	select {
-	case <-rs.closed:
-		return ErrSinkClosed
-	default:
+	rs.once.Do(func() {
 		close(rs.closed)
-		return rs.sink.Close()
-	}
+	})
+
+	return nil
 }
 
 // RetryStrategy defines a strategy for retrying event sink writes.


### PR DESCRIPTION
This fixes a race when closing the broadcaster that can cause a hang. In
the old version, the Write and configure functions can receive from the
"closed" channel, which causes "run" to try to write to a nil channel.

cc @LK4D4 @stevvooe