### PR TITLE
raft: Fix resource leaks in code and tests

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -168,6 +168,12 @@ func (c *Cluster) IsIDRemoved(id uint64) bool {
 // Clear resets the list of active Members and removed Members.
 func (c *Cluster) Clear() {
 	c.mu.Lock()
+	for _, member := range c.members {
+		if member.Conn != nil {
+			member.Conn.Close()
+		}
+	}
+
 	c.members = make(map[uint64]*Member)
 	c.removed = make(map[uint64]bool)
 	c.mu.Unlock()

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -641,7 +641,7 @@ func TestRaftJoinWithIncorrectAddress(t *testing.T) {
 
 	// Try joining a new node with an incorrect address
 	n := raftutils.NewNode(t, clockSource, tc, raft.NewNodeOptions{JoinAddr: nodes[1].Address, Addr: "1.2.3.4:1234"})
-	defer os.RemoveAll(n.StateDir)
+	defer raftutils.CleanupNonRunningNode(n)
 
 	err := n.JoinAndStart()
 	assert.NotNil(t, err)


### PR DESCRIPTION
I found that the tests were leaking a lot of goroutines for various
reasons. This was a mix of problems in the test and problems in the raft
code.

Actual problems:

- `Cluster.Clear()` did not close active connections, so it would leak
  these connections.

- Resources were not being released when `JoinAndStart` fails, or when the
  node shuts down because it has left the cluster.

- Errors from `ReplaceMemberConnection` were not handled. This could
  caused connections to be leaked in some cases.

Test problems:

- `TestRaftJoinWithIncorrectAddress` did not close the listener for the
  node it attempts to join.

- `WrappedListener` could leak a goroutine if it receives an incoming
  connection and there are no more calls to Accept to hand the
  connection off to. Increase the channel buffering to prevent this from
  happening.

cc @abronan @LK4D4