### PR TITLE
Add functions for updating node description with existing session

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -787,6 +787,11 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 		}
 	} else {
 		sessionID = r.SessionID
+		// we're not creating a new session, but update the description
+		err := d.nodes.SetDescriptionWithSession(nodeID, r.SessionID, r.Description)
+		if err != nil {
+			return err
+		}
 	}
 
 	fields := logrus.Fields{


### PR DESCRIPTION
Currently, we don't register a new session if a session id exists (after #1230). This means that if a node description is updated, there's no way to update it in the node store, because registration handles that part.

This PR adds functionality for fixing the above, and unblocks #1374. This is a proposal for feedback, to see if it is acceptable to do it this way. This is not the most efficient way (particularly the `SetDescriptionWithSession` function is acquiring a lock again after `GetWithSession`), but we can fix that if this is the right way to go.

WDYT @stevvooe?

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>