### PR TITLE
return all validation error in spec validation

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -13,6 +13,9 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+// MultiError is a list of errors.
+type MultiError []error
+
 var isValidName = regexp.MustCompile(`^[a-zA-Z0-9](?:[-_]*[A-Za-z0-9]+)*$`)
 
 func buildFilters(by func(string) store.By, values []string) store.By {
@@ -104,4 +107,17 @@ func validateDriver(driver *api.Driver, pg plugingetter.PluginGetter, pluginType
 	}
 
 	return nil
+}
+
+// Error combines multi errors into a single one string.
+func (errList MultiError) Error() string {
+	if len(errList) < 1 {
+		return ""
+	}
+
+	out := make([]string, len(errList))
+	for i := range errList {
+		out[i] = errList[i].Error()
+	}
+	return strings.Join(out, ", ")
 }

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -460,12 +460,20 @@ func TestUpdateNode(t *testing.T) {
 	_, err := ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID: nodeID,
 		Spec: &api.NodeSpec{
+			Annotations: api.Annotations{
+				Name: "node1",
+			},
+			Membership:   api.NodeMembershipPending,
 			Availability: api.NodeAvailabilityDrain,
 		},
 		NodeVersion: &api.Version{},
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	if multiErr, OK := err.(MultiError); OK {
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
+	}
 
 	// Create a node object for the manager
 	assert.NoError(t, nodes[1].MemoryStore().Update(func(tx store.Tx) error {
@@ -485,7 +493,6 @@ func TestUpdateNode(t *testing.T) {
 
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{NodeID: "invalid", Spec: &api.NodeSpec{}, NodeVersion: &api.Version{}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
 
 	r, err := ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: nodeID})
 	assert.NoError(t, err)
@@ -512,7 +519,7 @@ func TestUpdateNode(t *testing.T) {
 		Spec:        spec,
 		NodeVersion: &r.Node.Meta.Version,
 	})
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	r, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: nodeID})
 	assert.NoError(t, err)
@@ -521,11 +528,11 @@ func TestUpdateNode(t *testing.T) {
 	}
 	assert.NotNil(t, r.Node)
 	assert.NotNil(t, r.Node.Spec)
-	assert.Equal(t, api.NodeAvailabilityDrain, r.Node.Spec.Availability)
+	assert.Equal(t, r.Node.Spec.Availability, api.NodeAvailabilityActive)
 
 	version := &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{NodeID: nodeID, Spec: &r.Node.Spec, NodeVersion: version})
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	// Perform an update with the "old" version.
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{NodeID: nodeID, Spec: &r.Node.Spec, NodeVersion: version})
@@ -594,7 +601,14 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 	r, err := ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: nodes[2].SecurityConfig.ClientTLSCreds.NodeID()})
 	assert.NoError(t, err)
 	spec := r.Node.Spec.Copy()
+<<<<<<< HEAD
 	spec.DesiredRole = api.NodeRoleWorker
+=======
+	spec.Role = api.NodeRoleWorker
+	spec.Annotations = api.Annotations{
+		Name: "name1",
+	}
+>>>>>>> return all validation error in spec
 	version := &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      nodes[2].SecurityConfig.ClientTLSCreds.NodeID(),
@@ -627,7 +641,14 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 	r, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: nodes[3].SecurityConfig.ClientTLSCreds.NodeID()})
 	assert.NoError(t, err)
 	spec = r.Node.Spec.Copy()
+<<<<<<< HEAD
 	spec.DesiredRole = api.NodeRoleWorker
+=======
+	spec.Role = api.NodeRoleWorker
+	spec.Annotations = api.Annotations{
+		Name: "name1",
+	}
+>>>>>>> return all validation error in spec
 	version = &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      nodes[3].SecurityConfig.ClientTLSCreds.NodeID(),
@@ -670,7 +691,14 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 	r, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: demoteNode.SecurityConfig.ClientTLSCreds.NodeID()})
 	assert.NoError(t, err)
 	spec = r.Node.Spec.Copy()
+<<<<<<< HEAD
 	spec.DesiredRole = api.NodeRoleWorker
+=======
+	spec.Role = api.NodeRoleWorker
+	spec.Annotations = api.Annotations{
+		Name: "name1",
+	}
+>>>>>>> return all validation error in spec
 	version = &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      demoteNode.SecurityConfig.ClientTLSCreds.NodeID(),
@@ -703,7 +731,14 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 	r, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: lastNode.SecurityConfig.ClientTLSCreds.NodeID()})
 	assert.NoError(t, err)
 	spec = r.Node.Spec.Copy()
+<<<<<<< HEAD
 	spec.DesiredRole = api.NodeRoleWorker
+=======
+	spec.Role = api.NodeRoleWorker
+	spec.Annotations = api.Annotations{
+		Name: "name1",
+	}
+>>>>>>> return all validation error in spec
 	version = &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      lastNode.SecurityConfig.ClientTLSCreds.NodeID(),
@@ -718,6 +753,9 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 	assert.NoError(t, err)
 	spec = r.Node.Spec.Copy()
 	spec.Availability = api.NodeAvailabilityDrain
+	spec.Annotations = api.Annotations{
+		Name: "name1",
+	}
 	version = &r.Node.Meta.Version
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      lastNode.SecurityConfig.ClientTLSCreds.NodeID(),

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -25,35 +25,41 @@ var (
 	errModeChangeNotAllowed      = errors.New("service mode change is not allowed")
 )
 
-func validateResources(r *api.Resources) error {
+func validateResources(r *api.Resources) (me MultiError) {
 	if r == nil {
 		return nil
 	}
 
 	if r.NanoCPUs != 0 && r.NanoCPUs < 1e6 {
-		return grpc.Errorf(codes.InvalidArgument, "invalid cpu value %g: Must be at least %g", float64(r.NanoCPUs)/1e9, 1e6/1e9)
+		err := grpc.Errorf(codes.InvalidArgument, "invalid cpu value %g: must be at least %g", float64(r.NanoCPUs)/1e9, 1e6/1e9)
+		me = append(me, err)
 	}
 
 	if r.MemoryBytes != 0 && r.MemoryBytes < 4*1024*1024 {
-		return grpc.Errorf(codes.InvalidArgument, "invalid memory value %d: Must be at least 4MiB", r.MemoryBytes)
+		err := grpc.Errorf(codes.InvalidArgument, "invalid memory value %d: must be at least 4MiB", r.MemoryBytes)
+		me = append(me, err)
 	}
-	return nil
+
+	return
 }
 
-func validateResourceRequirements(r *api.ResourceRequirements) error {
+func validateResourceRequirements(r *api.ResourceRequirements) (me MultiError) {
 	if r == nil {
 		return nil
 	}
-	if err := validateResources(r.Limits); err != nil {
-		return err
+
+	if mError := validateResources(r.Limits); err != nil {
+		me = append(me, mError...)
 	}
-	if err := validateResources(r.Reservations); err != nil {
-		return err
+
+	if mError := validateResources(r.Reservations); err != nil {
+		me = append(me, mError...)
 	}
-	return nil
+
+	return
 }
 
-func validateRestartPolicy(rp *api.RestartPolicy) error {
+func validateRestartPolicy(rp *api.RestartPolicy) (me MultiError) {
 	if rp == nil {
 		return nil
 	}
@@ -61,49 +67,56 @@ func validateRestartPolicy(rp *api.RestartPolicy) error {
 	if rp.Delay != nil {
 		delay, err := gogotypes.DurationFromProto(rp.Delay)
 		if err != nil {
-			return err
-		}
-		if delay < 0 {
-			return grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-delay cannot be negative")
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-delay parse error: %v", err))
+		} else if delay < 0 {
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-delay cannot be negative"))
 		}
 	}
 
 	if rp.Window != nil {
 		win, err := gogotypes.DurationFromProto(rp.Window)
 		if err != nil {
-			return err
-		}
-		if win < 0 {
-			return grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-window cannot be negative")
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-window parse error: %v", err))
+		} else if win < 0 {
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: restart-window cannot be negative"))
 		}
 	}
 
-	return nil
+	if rp.Condition != api.RestartOnNone && rp.Condition != api.RestartOnFailure && rp.Condition != api.RestartOnAny {
+		me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: unimplemented restart-condition in task spec"))
+	}
+
+	return
 }
 
-func validatePlacement(placement *api.Placement) error {
+func validatePlacement(placement *api.Placement) (me MultiError) {
 	if placement == nil {
 		return nil
 	}
-	_, err := constraint.Parse(placement.Constraints)
-	return err
+
+	if _, err := constraint.Parse(placement.Constraints); err != nil {
+		me = append(me, err)
+	}
+
+	return
 }
 
-func validateUpdate(uc *api.UpdateConfig) error {
+func validateUpdate(uc *api.UpdateConfig) (me MultiError) {
 	if uc == nil {
 		return nil
 	}
 
 	if uc.Delay < 0 {
-		return grpc.Errorf(codes.InvalidArgument, "TaskSpec: update-delay cannot be negative")
+		me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: update-delay cannot be negative"))
 	}
 
-	return nil
+	return
 }
 
-func validateContainerSpec(container *api.ContainerSpec) error {
+func validateContainerSpec(container *api.ContainerSpec) (me MultiError) {
 	if container == nil {
-		return grpc.Errorf(codes.InvalidArgument, "ContainerSpec: missing in service spec")
+		me = append(me, grpc.Errorf(codes.InvalidArgument, "ContainerSpec: missing in service spec"))
+		return
 	}
 
 	if container.Image == "" {
@@ -117,34 +130,31 @@ func validateContainerSpec(container *api.ContainerSpec) error {
 	mountMap := make(map[string]bool)
 	for _, mount := range container.Mounts {
 		if _, exists := mountMap[mount.Target]; exists {
-			return grpc.Errorf(codes.InvalidArgument, "ContainerSpec: duplicate mount point: %s", mount.Target)
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "ContainerSpec: duplicate mount point: %s", mount.Target))
 		}
 		mountMap[mount.Target] = true
 	}
 
-	return nil
+	return
 }
 
-func validateTask(taskSpec api.TaskSpec) error {
-	if err := validateResourceRequirements(taskSpec.Resources); err != nil {
-		return err
+func validateTask(taskSpec api.TaskSpec) (me MultiError) {
+	if mError := validateResourceRequirements(taskSpec.Resources); err != nil {
+		me = append(me, mError...)
 	}
 
-	if err := validateRestartPolicy(taskSpec.Restart); err != nil {
-		return err
+	if mError := validateRestartPolicy(taskSpec.Restart); err != nil {
+		me = append(me, mError...)
 	}
 
-	if err := validatePlacement(taskSpec.Placement); err != nil {
-		return err
+	if mError := validatePlacement(taskSpec.Placement); err != nil {
+		me = append(me, mError...)
 	}
 
 	if taskSpec.GetRuntime() == nil {
-		return grpc.Errorf(codes.InvalidArgument, "TaskSpec: missing runtime")
-	}
-
-	_, ok := taskSpec.GetRuntime().(*api.TaskSpec_Container)
-	if !ok {
-		return grpc.Errorf(codes.Unimplemented, "RuntimeSpec: unimplemented runtime in service spec")
+		me = append(me, grpc.Errorf(codes.InvalidArgument, "TaskSpec: missing runtime"))
+	} else if _, ok := taskSpec.GetRuntime().(*api.TaskSpec_Container); !ok {
+		me = append(me, grpc.Errorf(codes.Unimplemented, "RuntimeSpec: unimplemented runtime in service spec"))
 	}
 
 	// Building a empty/dummy Task to validate the templating and
@@ -166,16 +176,42 @@ func validateTask(taskSpec api.TaskSpec) error {
 		LogDriver: taskSpec.LogDriver,
 	})
 	if err != nil {
-		return grpc.Errorf(codes.InvalidArgument, err.Error())
+		me = append(me, grpc.Errorf(codes.InvalidArgument, err.Error()))
+		return
 	}
-	if err := validateContainerSpec(preparedSpec); err != nil {
-		return err
+	if mError := validateContainerSpec(preparedSpec); err != nil {
+		me = append(me, mError...)
+	}
+	container := taskSpec.GetContainer()
+	if container == nil {
+		me = append(me, grpc.Errorf(codes.InvalidArgument, "ContainerSpec: missing in service spec"))
+		return
 	}
 
-	return nil
+	if container.Image == "" {
+		err := grpc.Errorf(codes.InvalidArgument, "ContainerSpec: image reference must be provided")
+		me = append(me, err)
+		return
+	}
+
+	if _, err := reference.ParseNamed(container.Image); err != nil {
+		err := grpc.Errorf(codes.InvalidArgument, "ContainerSpec: %q is not a valid repository/tag", container.Image)
+		me = append(me, err)
+	}
+
+	mountMap := make(map[string]bool)
+	for _, mount := range container.Mounts {
+		if _, exists := mountMap[mount.Target]; exists {
+			err := grpc.Errorf(codes.InvalidArgument, "ContainerSpec: duplicate mount point: %s", mount.Target)
+			me = append(me, err)
+		}
+		mountMap[mount.Target] = true
+	}
+
+	return
 }
 
-func validateEndpointSpec(epSpec *api.EndpointSpec) error {
+func validateEndpointSpec(epSpec *api.EndpointSpec) (me MultiError) {
 	// Endpoint spec is optional
 	if epSpec == nil {
 		return nil
@@ -196,7 +232,7 @@ func validateEndpointSpec(epSpec *api.EndpointSpec) error {
 		// for the backend network and hence we accept that configuration.
 
 		if epSpec.Mode == api.ResolutionModeDNSRoundRobin && port.PublishMode == api.PublishModeIngress {
-			return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: port published with ingress mode can't be used with dnsrr mode")
+			me = append(me, grpc.Errorf(codes.InvalidArgument, "EndpointSpec: port published with ingress mode can't be used with dnsrr mode"))
 		}
 
 		// If published port is not specified, it does not conflict
@@ -207,13 +243,14 @@ func validateEndpointSpec(epSpec *api.EndpointSpec) error {
 
 		portSpec := portSpec{publishedPort: port.PublishedPort, protocol: port.Protocol}
 		if _, ok := portSet[portSpec]; ok {
-			return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: duplicate published ports provided")
+			err := grpc.Errorf(codes.InvalidArgument, "EndpointSpec: duplicate published ports provided")
+			me = append(me, err)
 		}
 
 		portSet[portSpec] = struct{}{}
 	}
 
-	return nil
+	return
 }
 
 // validateSecretRefsSpec finds if the secrets passed in spec are valid and have no
@@ -257,7 +294,8 @@ func validateSecretRefsSpec(spec *api.ServiceSpec) error {
 
 	return nil
 }
-func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error {
+
+func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) (me MultiError) {
 	for _, na := range networks {
 		var network *api.Network
 		s.store.View(func(tx store.ReadTx) {
@@ -267,12 +305,13 @@ func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error
 			continue
 		}
 		if _, ok := network.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
-			return grpc.Errorf(codes.InvalidArgument,
+			err := grpc.Errorf(codes.InvalidArgument,
 				"Service cannot be explicitly attached to %q network which is a swarm internal network",
 				network.Spec.Annotations.Name)
+			me = append(me, err)
 		}
 	}
-	return nil
+	return
 }
 
 func validateMode(s *api.ServiceSpec) error {
@@ -290,31 +329,33 @@ func validateMode(s *api.ServiceSpec) error {
 	return nil
 }
 
-func validateServiceSpec(spec *api.ServiceSpec) error {
+func validateServiceSpec(spec *api.ServiceSpec) (me MultiError) {
 	if spec == nil {
-		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		me = append(me, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error()))
+		return
 	}
+
 	if err := validateAnnotations(spec.Annotations); err != nil {
-		return err
+		me = append(me, err)
 	}
 	if err := validateTask(spec.Task); err != nil {
-		return err
+		me = append(me, err...)
 	}
 	if err := validateUpdate(spec.Update); err != nil {
-		return err
+		me = append(me, err...)
 	}
 	if err := validateEndpointSpec(spec.Endpoint); err != nil {
-		return err
+		me = append(me, err...)
 	}
 	if err := validateMode(spec); err != nil {
-		return err
+		me = append(me, err)
 	}
 	// Check to see if the Secret Reference portion of the spec is valid
 	if err := validateSecretRefsSpec(spec); err != nil {
 		return err
 	}
 
-	return nil
+	return
 }
 
 // checkPortConflicts does a best effort to find if the passed in spec has port

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -114,9 +114,12 @@ func TestValidateResources(t *testing.T) {
 	}
 
 	for _, b := range bad {
-		err := validateResources(b)
-		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		multiErr := validateResources(b)
+		assert.Error(t, multiErr)
+
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
 	}
 
 	for _, g := range good {
@@ -134,9 +137,11 @@ func TestValidateResourceRequirements(t *testing.T) {
 		{Reservations: &api.Resources{NanoCPUs: 1e9}},
 	}
 	for _, b := range bad {
-		err := validateResourceRequirements(b)
-		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		multiErr := validateResourceRequirements(b)
+		assert.Error(t, multiErr)
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
 	}
 
 	for _, g := range good {
@@ -210,9 +215,11 @@ func TestValidateTask(t *testing.T) {
 			c: codes.InvalidArgument,
 		},
 	} {
-		err := validateTask(bad.s)
-		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err))
+		multiErr := validateTask(bad.s)
+		assert.Error(t, multiErr)
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
 	}
 
 	for _, good := range []api.TaskSpec{
@@ -258,7 +265,6 @@ func TestValidateServiceSpec(t *testing.T) {
 	} {
 		err := validateServiceSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err), grpc.ErrorDesc(err))
 	}
 
 	for _, good := range []*api.ServiceSpec{
@@ -289,9 +295,11 @@ func TestValidateRestartPolicy(t *testing.T) {
 	}
 
 	for _, b := range bad {
-		err := validateRestartPolicy(b)
-		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		multiErr := validateRestartPolicy(b)
+		assert.Error(t, multiErr)
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
 	}
 
 	for _, g := range good {
@@ -310,9 +318,11 @@ func TestValidateUpdate(t *testing.T) {
 	}
 
 	for _, b := range bad {
-		err := validateUpdate(b)
-		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		multiErr := validateUpdate(b)
+		assert.Error(t, multiErr)
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
 	}
 
 	for _, g := range good {
@@ -325,7 +335,11 @@ func TestCreateService(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	if multiErr, ok := err.(MultiError); ok {
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
+	}
 
 	spec := createSpec("name", "image", 1)
 	r, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
@@ -347,7 +361,11 @@ func TestCreateService(t *testing.T) {
 	}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	if multiErr, ok := err.(MultiError); ok {
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
+	}
 
 	// test no port conflicts when no publish port is specified
 	spec3 := createSpec("name4", "image", 1)
@@ -489,7 +507,11 @@ func TestUpdateService(t *testing.T) {
 
 	_, err := ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	if multiErr, ok := err.(MultiError); ok {
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
+	}
 
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: "invalid", Spec: &service.Spec, ServiceVersion: &api.Version{}})
 	assert.Error(t, err)
@@ -498,7 +520,11 @@ func TestUpdateService(t *testing.T) {
 	// No update options.
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	if multiErr, ok := err.(MultiError); ok {
+		for _, singleErr := range multiErr {
+			assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+		}
+	}
 
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec, ServiceVersion: &service.Meta.Version})
 	assert.NoError(t, err)
@@ -727,6 +753,7 @@ func TestValidateEndpointSpec(t *testing.T) {
 		},
 	}
 
+<<<<<<< HEAD
 	// duplicated published port but different protocols, valid
 	endPointSpec4 := &api.EndpointSpec{
 		Mode: api.ResolutionModeVirtualIP,
@@ -771,10 +798,18 @@ func TestValidateEndpointSpec(t *testing.T) {
 	err := validateEndpointSpec(endPointSpec1)
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+=======
+	multiErr := validateEndpointSpec(endPointSpec1)
+	assert.Error(t, multiErr)
+	for _, singleErr := range multiErr {
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+	}
+>>>>>>> return all validation error in spec
 
-	err = validateEndpointSpec(endPointSpec2)
-	assert.NoError(t, err)
+	multiErr = validateEndpointSpec(endPointSpec2)
+	assert.NoError(t, multiErr)
 
+<<<<<<< HEAD
 	err = validateEndpointSpec(endPointSpec3)
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
@@ -784,6 +819,13 @@ func TestValidateEndpointSpec(t *testing.T) {
 
 	err = validateEndpointSpec(endPointSpec5)
 	assert.NoError(t, err)
+=======
+	multiErr = validateEndpointSpec(endPointSpec3)
+	assert.Error(t, multiErr)
+	for _, singleErr := range multiErr {
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(singleErr))
+	}
+>>>>>>> return all validation error in spec
 }
 
 func TestServiceEndpointSpecUpdate(t *testing.T) {


### PR DESCRIPTION
When creating a service or a network, swarmkit will validate ServiceSpec and NetworkSpec. Currently, if the validation ran into an error, the validation process returns this error immediately. I think this does not make sense somewhat. I think swarmkit should take the spec validation as a whole one, returns all the validation err in total.

If there are many error in a Spec, currently swarmkit  only reports one error. Then user corrects this, swarmkit reports the next error.  This process will take users a lot of time.

Reporting all the validation error is a better way to avoid the situation above.

This PR did:
1. return all validation error in networkspec, nodespec, servicespec validation;
2. add more validation in serviceSpec;
3. change function test files.

Signed-off-by: allencloud allen.sun@daocloud.io
