### PR TITLE
correct msg display in allocator

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -165,7 +165,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		nodes, err = store.FindNodes(tx, store.All)
 	})
 	if err != nil {
-		return fmt.Errorf("error listing all services in store while trying to allocate during init: %v", err)
+		return fmt.Errorf("error listing all nodes in store while trying to allocate during init: %v", err)
 	}
 
 	for _, node := range nodes {


### PR DESCRIPTION
In the log message, I found that it is listing nodes while displaying services. I think it may be an error, so I tried to fix this.

Thanks

Signed-off-by: gexinlu <gexinlu.services@gmail.com>