### PR TITLE
Revendor etcd to fix locking flakiness

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -101,58 +101,58 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/crc",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/fileutil",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/idutil",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/ioutil",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/pkg/pbutil",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/raft",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/raft/raftpb",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/snap",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/snap/snappb",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/wal",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/wal/walpb",
-			"Comment": "v3.0.0-beta.0-1098-g06e2338",
-			"Rev": "06e2338108fdc694349aed923f4a7e45cf0cec1f"
+			"Comment": "v3.0.0-beta.0-1249-g3a49cbb",
+			"Rev": "3a49cbb769ebd8d1dd25abb1e83386e9883a5707"
 		},
 		{
 			"ImportPath": "github.com/coreos/go-systemd/journal",

--- a/vendor/github.com/coreos/etcd/raft/log.go
+++ b/vendor/github.com/coreos/etcd/raft/log.go
@@ -232,7 +232,7 @@ func (l *raftLog) term(i uint64) (uint64, error) {
 	if err == nil {
 		return t, nil
 	}
-	if err == ErrCompacted {
+	if err == ErrCompacted || err == ErrUnavailable {
 		return 0, err
 	}
 	panic(err) // TODO(bdarnell)
@@ -339,7 +339,7 @@ func (l *raftLog) mustCheckOutOfBounds(lo, hi uint64) error {
 		return ErrCompacted
 	}
 
-	length := l.lastIndex() - fi + 1
+	length := l.lastIndex() + 1 - fi
 	if lo < fi || hi > fi+length {
 		l.logger.Panicf("slice[%d,%d) out of bound [%d,%d]", lo, hi, fi, l.lastIndex())
 	}

--- a/vendor/github.com/coreos/etcd/raft/storage.go
+++ b/vendor/github.com/coreos/etcd/raft/storage.go
@@ -130,6 +130,9 @@ func (ms *MemoryStorage) Term(i uint64) (uint64, error) {
 	if i < offset {
 		return 0, ErrCompacted
 	}
+	if int(i-offset) >= len(ms.ents) {
+		return 0, ErrUnavailable
+	}
 	return ms.ents[i-offset].Term, nil
 }
 

--- a/vendor/github.com/coreos/etcd/raft/util.go
+++ b/vendor/github.com/coreos/etcd/raft/util.go
@@ -48,7 +48,7 @@ func max(a, b uint64) uint64 {
 
 func IsLocalMsg(msgt pb.MessageType) bool {
 	return msgt == pb.MsgHup || msgt == pb.MsgBeat || msgt == pb.MsgUnreachable ||
-		msgt == pb.MsgSnapStatus || msgt == pb.MsgCheckQuorum || msgt == pb.MsgTransferLeader
+		msgt == pb.MsgSnapStatus || msgt == pb.MsgCheckQuorum
 }
 
 func IsResponseMsg(msgt pb.MessageType) bool {

--- a/vendor/github.com/coreos/etcd/wal/wal.go
+++ b/vendor/github.com/coreos/etcd/wal/wal.go
@@ -131,22 +131,7 @@ func Create(dirpath string, metadata []byte) (*WAL, error) {
 		return nil, err
 	}
 
-	// rename of directory with locked files doesn't work on windows; close
-	// the WAL to release the locks so the directory can be renamed
-	w.Close()
-	if err := os.Rename(tmpdirpath, dirpath); err != nil {
-		return nil, err
-	}
-	// reopen and relock
-	newWAL, oerr := Open(dirpath, walpb.Snapshot{})
-	if oerr != nil {
-		return nil, oerr
-	}
-	if _, _, _, err := newWAL.ReadAll(); err != nil {
-		newWAL.Close()
-		return nil, err
-	}
-	return newWAL, nil
+	return w.renameWal(tmpdirpath)
 }
 
 // Open opens the WAL at the given snap.
@@ -301,6 +286,18 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 			state.Reset()
 			return nil, state, nil, err
 		}
+		// decodeRecord() will return io.EOF if it detects a zero record,
+		// but this zero record may be followed by non-zero records from
+		// a torn write. Overwriting some of these non-zero records, but
+		// not all, will cause CRC errors on WAL open. Since the records
+		// were never fully synced to disk in the first place, it's safe
+		// to zero them out to avoid any CRC errors from new writes.
+		if _, err = w.tail().Seek(w.decoder.lastOffset(), os.SEEK_SET); err != nil {
+			return nil, state, nil, err
+		}
+		if err = fileutil.ZeroToEnd(w.tail().File); err != nil {
+			return nil, state, nil, err
+		}
 	}
 
 	err = nil
@@ -319,7 +316,6 @@ func (w *WAL) ReadAll() (metadata []byte, state raftpb.HardState, ents []raftpb.
 
 	if w.tail() != nil {
 		// create encoder (chain crc with the decoder), enable appending
-		_, err = w.tail().Seek(w.decoder.lastOffset(), os.SEEK_SET)
 		w.encoder = newEncoder(w.tail(), w.decoder.lastCRC())
 	}
 	w.decoder = nil

--- a/vendor/github.com/coreos/etcd/wal/wal_unix.go
+++ b/vendor/github.com/coreos/etcd/wal/wal_unix.go
@@ -1,0 +1,38 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package wal
+
+import "os"
+
+func (w *WAL) renameWal(tmpdirpath string) (*WAL, error) {
+	// On non-Windows platforms, hold the lock while renaming. Releasing
+	// the lock and trying to reacquire it quickly can be flaky because
+	// it's possible the process will fork to spawn a process while this is
+	// happening. The fds are set up as close-on-exec by the Go runtime,
+	// but there is a window between the fork and the exec where another
+	// process holds the lock.
+
+	if err := os.RemoveAll(w.dir); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(tmpdirpath, w.dir); err != nil {
+		return nil, err
+	}
+
+	w.fp = newFilePipeline(w.dir, SegmentSizeBytes)
+	return w, nil
+}

--- a/vendor/github.com/coreos/etcd/wal/wal_windows.go
+++ b/vendor/github.com/coreos/etcd/wal/wal_windows.go
@@ -1,0 +1,41 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"os"
+
+	"github.com/coreos/etcd/wal/walpb"
+)
+
+func (w *WAL) renameWal(tmpdirpath string) (*WAL, error) {
+	// rename of directory with locked files doesn't work on
+	// windows; close the WAL to release the locks so the directory
+	// can be renamed
+	w.Close()
+	if err := os.Rename(tmpdirpath, w.dir); err != nil {
+		return nil, err
+	}
+	// reopen and relock
+	newWAL, oerr := Open(w.dir, walpb.Snapshot{})
+	if oerr != nil {
+		return nil, oerr
+	}
+	if _, _, _, err := newWAL.ReadAll(); err != nil {
+		newWAL.Close()
+		return nil, err
+	}
+	return newWAL, nil
+}


### PR DESCRIPTION
This brings in a fix contributed upstream that holds the WAL file lock
during rename on non-Windows platforms. It should address integration
test failures that were caused by a second process holding the lock (due
to inheriting the fd) between fork and exec.

cc @tonistiigi