### PR TITLE
Vendor go-events

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -270,7 +270,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/go-events",
-			"Rev": "23780caac67d79ef0d523be97b958948c7a91f65"
+			"Rev": "18b43f1bc85d9cdd42c05a6cd2d444c7a200a894"
 		},
 		{
 			"ImportPath": "github.com/docker/go-units",

--- a/vendor/github.com/docker/go-events/broadcast.go
+++ b/vendor/github.com/docker/go-events/broadcast.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -157,4 +158,21 @@ func (b *Broadcaster) run() {
 			return
 		}
 	}
+}
+
+func (b Broadcaster) String() string {
+	// Serialize copy of this broadcaster without the sync.Once, to avoid
+	// a data race.
+
+	b2 := map[string]interface{}{
+		"sinks":   b.sinks,
+		"events":  b.events,
+		"adds":    b.adds,
+		"removes": b.removes,
+
+		"shutdown": b.shutdown,
+		"closed":   b.closed,
+	}
+
+	return fmt.Sprint(b2)
 }

--- a/vendor/github.com/docker/go-events/channel.go
+++ b/vendor/github.com/docker/go-events/channel.go
@@ -1,6 +1,9 @@
 package events
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // Channel provides a sink that can be listened on. The writer and channel
 // listener must operate in separate goroutines.
@@ -45,4 +48,14 @@ func (ch *Channel) Close() error {
 	})
 
 	return nil
+}
+
+func (ch Channel) String() string {
+	// Serialize a copy of the Channel that doesn't contain the sync.Once,
+	// to avoid a data race.
+	ch2 := map[string]interface{}{
+		"C":      ch.C,
+		"closed": ch.closed,
+	}
+	return fmt.Sprint(ch2)
 }

--- a/vendor/github.com/docker/go-events/retry.go
+++ b/vendor/github.com/docker/go-events/retry.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"fmt"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -87,6 +88,17 @@ func (rs *RetryingSink) Close() error {
 	})
 
 	return nil
+}
+
+func (rs RetryingSink) String() string {
+	// Serialize a copy of the RetryingSink without the sync.Once, to avoid
+	// a data race.
+	rs2 := map[string]interface{}{
+		"sink":     rs.sink,
+		"strategy": rs.strategy,
+		"closed":   rs.closed,
+	}
+	return fmt.Sprint(rs2)
 }
 
 // RetryStrategy defines a strategy for retrying event sink writes.


### PR DESCRIPTION
This should hopefully fix race detector errors in CI, now that go-events
does not directly dump objects with synchronization primitives to the
log.

Fixes #1441