### PR TITLE
raft: make Leader method return error

### DIFF
--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -34,6 +34,13 @@ type TestNode struct {
 	SecurityConfig *ca.SecurityConfig
 }
 
+// Leader is wrapper around real Leader method to suppress error.
+// TODO: tests should use Leader method directly.
+func (n *TestNode) Leader() uint64 {
+	id, _ := n.Node.Leader()
+	return id
+}
+
 // AdvanceTicks advances the raft state machine fake clock
 func AdvanceTicks(clockSource *fakeclock.FakeClock, ticks int) {
 	// A FakeClock timer won't fire multiple times if time is advanced

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -35,19 +35,19 @@ func Register(server *grpc.Server, node *Node) {
 // WaitForLeader waits until node observe some leader in cluster. It returns
 // error if ctx was cancelled before leader appeared.
 func WaitForLeader(ctx context.Context, n *Node) error {
-	l := n.Leader()
-	if l != 0 {
+	_, err := n.Leader()
+	if err == nil {
 		return nil
 	}
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
-	for l == 0 {
+	for err != nil {
 		select {
 		case <-ticker.C:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-		l = n.Leader()
+		_, err = n.Leader()
 	}
 	return nil
 }


### PR DESCRIPTION
It's important to know when the node is not a member of the cluster.
Also, it fixes race in accessing n.Config.ID, which might be accessed only when node is member.