### PR TITLE
Fixes remotes_test.go on 32 bit platforms

### DIFF
--- a/remotes/remotes_test.go
+++ b/remotes/remotes_test.go
@@ -198,8 +198,8 @@ func TestRemotesLargeRanges(t *testing.T) {
 	}
 
 	remotes.Observe(peers[0], 0)
-	remotes.Observe(peers[1], math.MaxInt64)
-	remotes.Observe(peers[2], math.MinInt64)
+	remotes.Observe(peers[1], math.MaxInt32)
+	remotes.Observe(peers[2], math.MinInt32)
 	remotes.Observe(peers[2], remoteWeightMax) // three bounces back!
 
 	seen := make(map[api.Peer]int)


### PR DESCRIPTION
Using MaxInt32 instead of MaxInt64 in TestRemotesLargeRanges. Stops an
overflow on 32 bit systems. Closes #1384

Signed-off-by: Drew Erny <drew.erny@docker.com>