### PR TITLE
Change Task Name to `<ServiceAnnotations.Name>.<NodeID>.<TaskID>` in global mode

### DIFF
--- a/manager/controlapi/task.go
+++ b/manager/controlapi/task.go
@@ -1,8 +1,6 @@
 package controlapi
 
 import (
-	"fmt"
-
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
@@ -106,22 +104,10 @@ func (s *Server) ListTasks(ctx context.Context, request *api.ListTasksRequest) (
 	if request.Filters != nil {
 		tasks = filterTasks(tasks,
 			func(e *api.Task) bool {
-				name := e.Annotations.Name
-				if name == "" {
-					// If Task name is not assigned then calculated name is used like before.
-					// This might be removed in the future.
-					name = fmt.Sprintf("%v.%v.%v", e.ServiceAnnotations.Name, e.Slot, e.ID)
-				}
-				return filterContains(name, request.Filters.Names)
+				return filterContains(store.TaskName(e), request.Filters.Names)
 			},
 			func(e *api.Task) bool {
-				name := e.Annotations.Name
-				if name == "" {
-					// If Task name is not assigned then calculated name is used like before
-					// This might be removed in the future.
-					name = fmt.Sprintf("%v.%v.%v", e.ServiceAnnotations.Name, e.Slot, e.ID)
-				}
-				return filterContainsPrefix(name, request.Filters.NamePrefixes)
+				return filterContainsPrefix(store.TaskName(e), request.Filters.NamePrefixes)
 			},
 			func(e *api.Task) bool {
 				return filterContainsPrefix(e.ID, request.Filters.IDPrefixes)

--- a/manager/orchestrator/global.go
+++ b/manager/orchestrator/global.go
@@ -373,8 +373,7 @@ func (g *GlobalOrchestrator) removeTask(ctx context.Context, batch *store.Batch,
 }
 
 func (g *GlobalOrchestrator) addTask(ctx context.Context, batch *store.Batch, service *api.Service, nodeID string) {
-	task := newTask(g.cluster, service, 0)
-	task.NodeID = nodeID
+	task := newTask(g.cluster, service, 0, nodeID)
 
 	err := batch.Update(func(tx store.Tx) error {
 		return store.CreateTask(tx, task)

--- a/manager/orchestrator/restart.go
+++ b/manager/orchestrator/restart.go
@@ -133,10 +133,9 @@ func (r *RestartSupervisor) Restart(ctx context.Context, tx store.Tx, cluster *a
 	var restartTask *api.Task
 
 	if isReplicatedService(service) {
-		restartTask = newTask(cluster, service, t.Slot)
+		restartTask = newTask(cluster, service, t.Slot, "")
 	} else if isGlobalService(service) {
-		restartTask = newTask(cluster, service, 0)
-		restartTask.NodeID = t.NodeID
+		restartTask = newTask(cluster, service, 0, t.NodeID)
 	} else {
 		log.G(ctx).Error("service not supported by restart supervisor")
 		return nil

--- a/manager/orchestrator/services.go
+++ b/manager/orchestrator/services.go
@@ -179,7 +179,7 @@ func (r *ReplicatedOrchestrator) addTasks(ctx context.Context, batch *store.Batc
 		}
 
 		err := batch.Update(func(tx store.Tx) error {
-			return store.CreateTask(tx, newTask(r.cluster, service, slot))
+			return store.CreateTask(tx, newTask(r.cluster, service, slot, ""))
 		})
 		if err != nil {
 			log.G(ctx).Errorf("Failed to create task: %v", err)

--- a/manager/orchestrator/updater.go
+++ b/manager/orchestrator/updater.go
@@ -331,11 +331,11 @@ func (u *Updater) worker(ctx context.Context, queue <-chan slot) {
 				log.G(ctx).WithError(err).Error("update failed")
 			}
 		} else {
-			updated := newTask(u.cluster, u.newService, slot[0].Slot)
-			updated.DesiredState = api.TaskStateReady
+			updated := newTask(u.cluster, u.newService, slot[0].Slot, "")
 			if isGlobalService(u.newService) {
-				updated.NodeID = slot[0].NodeID
+				updated = newTask(u.cluster, u.newService, slot[0].Slot, slot[0].NodeID)
 			}
+			updated.DesiredState = api.TaskStateReady
 
 			if err := u.updateTask(ctx, slot, updated); err != nil {
 				log.G(ctx).WithError(err).WithField("task.id", updated.ID).Error("update failed")

--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -93,7 +93,7 @@ func TestUpdater(t *testing.T) {
 		assert.NoError(t, store.CreateCluster(tx, cluster))
 		assert.NoError(t, store.CreateService(tx, service))
 		for i := 0; i < instances; i++ {
-			assert.NoError(t, store.CreateTask(tx, newTask(cluster, service, uint64(i))))
+			assert.NoError(t, store.CreateTask(tx, newTask(cluster, service, uint64(i), "")))
 		}
 		return nil
 	})
@@ -230,7 +230,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 		assert.NoError(t, store.CreateCluster(tx, cluster))
 		assert.NoError(t, store.CreateService(tx, service))
 		for i := 0; i < instances; i++ {
-			assert.NoError(t, store.CreateTask(tx, newTask(cluster, service, uint64(i))))
+			assert.NoError(t, store.CreateTask(tx, newTask(cluster, service, uint64(i), "")))
 		}
 		return nil
 	})
@@ -374,7 +374,7 @@ func TestUpdaterStopGracePeriod(t *testing.T) {
 	err := s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.CreateService(tx, service))
 		for i := uint64(0); i < instances; i++ {
-			task := newTask(nil, service, uint64(i))
+			task := newTask(nil, service, uint64(i), "")
 			task.Status.State = api.TaskStateRunning
 			assert.NoError(t, store.CreateTask(tx, task))
 		}

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -112,6 +112,26 @@ func init() {
 	})
 }
 
+// TaskName returns the task name from Annotations.Name,
+// and, in case Annotations.Name is missing, fallback
+// to construct the name from othere information.
+func TaskName(t *api.Task) string {
+	name := t.Annotations.Name
+	if name == "" {
+		// If Task name is not assigned then calculated name is used like before.
+		// This might be removed in the future.
+		// We use the following scheme for Task name:
+		// Name := <ServiceAnnotations.Name>.<Slot>.<TaskID> (replicated mode)
+		//      := <ServiceAnnotations.Name>.<NodeID>.<TaskID> (global mode)
+		if t.Slot != 0 {
+			name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.Slot, t.ID)
+		} else {
+			name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.NodeID, t.ID)
+		}
+	}
+	return name
+}
+
 type taskEntry struct {
 	*api.Task
 }
@@ -225,12 +245,7 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 		panic("unexpected type passed to FromObject")
 	}
 
-	name := t.Annotations.Name
-	if name == "" {
-		// If Task name is not assigned then calculated name is used like before.
-		// This might be removed in the future.
-		name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.Slot, t.Task.ID)
-	}
+	name := TaskName(t.Task)
 
 	// Add the null character as a terminator
 	return true, []byte(strings.ToLower(name) + "\x00"), nil


### PR DESCRIPTION
This fix is based on the discussion in:
https://github.com/docker/docker/pull/24850#issuecomment-243518250

Previously Task Name has been defined as `<ServiceAnnotations.Name>.<Slot>.<TaskID>` in both replicated and global mode. That means in global mode, the Task Name is `<ServiceAnnotations.Name>.0.<TaskID>` which does not carry any information in `0`.

In this fix, the Task Name has been changed to `<ServiceAnnotations.Name>.<NodeID>.<TaskID>` in global mode.

This fix is related to:
https://github.com/docker/docker/pull/24850

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>