### PR TITLE
raft: use heartbeat for detect nodes reachability

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -33,7 +33,8 @@ type Cluster struct {
 
 	// removed contains the list of removed Members,
 	// those ids cannot be reused
-	removed map[uint64]bool
+	removed        map[uint64]bool
+	heartbeatTicks int
 
 	PeersBroadcast *watch.Queue
 }
@@ -43,18 +44,37 @@ type Member struct {
 	*api.RaftMember
 
 	api.RaftClient
-	Conn *grpc.ClientConn
+	Conn   *grpc.ClientConn
+	tick   int
+	active bool
 }
 
-// NewCluster creates a new Cluster neighbors
-// list for a raft Member
-func NewCluster() *Cluster {
+// NewCluster creates a new Cluster neighbors list for a raft Member.
+// Member marked as inactive if there was no call ReportActive for heartbeatInterval.
+func NewCluster(heartbeatTicks int) *Cluster {
 	// TODO(abronan): generate Cluster ID for federation
 
 	return &Cluster{
 		members:        make(map[uint64]*Member),
 		removed:        make(map[uint64]bool),
+		heartbeatTicks: heartbeatTicks,
 		PeersBroadcast: watch.NewQueue(),
+	}
+}
+
+// Tick increases ticks for all members. After heartbeatTicks node marked as
+// inactive.
+func (c *Cluster) Tick() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, m := range c.members {
+		if !m.active {
+			continue
+		}
+		m.tick++
+		if m.tick > c.heartbeatTicks {
+			m.active = false
+		}
 	}
 }
 
@@ -106,8 +126,11 @@ func (c *Cluster) AddMember(member *Member) error {
 	if c.removed[member.RaftID] {
 		return ErrIDRemoved
 	}
+	member.active = true
+	member.tick = 0
 
 	c.members[member.RaftID] = member
+
 	c.broadcastUpdate()
 	return nil
 }
@@ -117,18 +140,9 @@ func (c *Cluster) AddMember(member *Member) error {
 func (c *Cluster) RemoveMember(id uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	if c.members[id] != nil {
-		conn := c.members[id].Conn
-		if conn != nil {
-			_ = conn.Close()
-		}
-		delete(c.members, id)
-	}
-
 	c.removed[id] = true
-	c.broadcastUpdate()
-	return nil
+
+	return c.clearMember(id)
 }
 
 // ClearMember removes a node from the Cluster Memberlist, but does NOT add it
@@ -137,14 +151,17 @@ func (c *Cluster) ClearMember(id uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.members[id] != nil {
-		conn := c.members[id].Conn
-		if conn != nil {
-			_ = conn.Close()
+	return c.clearMember(id)
+}
+
+func (c *Cluster) clearMember(id uint64) error {
+	m, ok := c.members[id]
+	if ok {
+		if m.Conn != nil {
+			m.Conn.Close()
 		}
 		delete(c.members, id)
 	}
-
 	c.broadcastUpdate()
 	return nil
 }
@@ -171,7 +188,6 @@ func (c *Cluster) ReplaceMemberConnection(id uint64, oldConn *Member, newConn *M
 	newMember := *oldMember
 	newMember.Conn = newConn.Conn
 	newMember.RaftClient = newConn.RaftClient
-
 	c.members[id] = &newMember
 
 	return nil
@@ -196,6 +212,29 @@ func (c *Cluster) Clear() {
 	c.members = make(map[uint64]*Member)
 	c.removed = make(map[uint64]bool)
 	c.mu.Unlock()
+}
+
+// ReportActive reports that member is acive (called ProcessRaftMessage),
+func (c *Cluster) ReportActive(id uint64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	m, ok := c.members[id]
+	if !ok {
+		return
+	}
+	m.tick = 0
+	m.active = true
+}
+
+// Active returns true if node is active.
+func (c *Cluster) Active(id uint64) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	m, ok := c.members[id]
+	if !ok {
+		return false
+	}
+	return m.active
 }
 
 // ValidateConfigurationChange takes a proposed ConfChange and
@@ -248,8 +287,7 @@ func (c *Cluster) CanRemoveMember(from uint64, id uint64) bool {
 			continue
 		}
 
-		connState, err := m.Conn.State()
-		if err == nil && connState == grpc.Ready {
+		if c.Active(m.RaftID) {
 			nreachable++
 		}
 	}

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -42,7 +42,7 @@ func newTestMember(id uint64) *membership.Member {
 }
 
 func newTestCluster(members []*membership.Member, removed []*membership.Member) *membership.Cluster {
-	c := membership.NewCluster()
+	c := membership.NewCluster(3)
 	for _, m := range members {
 		c.AddMember(m)
 	}
@@ -79,22 +79,15 @@ func TestClusterMember(t *testing.T) {
 }
 
 func TestMembers(t *testing.T) {
-	w := map[uint64]*membership.Member{
-		1:  {RaftMember: &api.RaftMember{RaftID: 1}},
-		20: {RaftMember: &api.RaftMember{RaftID: 20}},
-		10: {RaftMember: &api.RaftMember{RaftID: 10}},
-		5:  {RaftMember: &api.RaftMember{RaftID: 5}},
-		50: {RaftMember: &api.RaftMember{RaftID: 50}},
-	}
-
-	cls := membership.NewCluster()
+	cls := membership.NewCluster(1)
+	defer cls.Clear()
 	cls.AddMember(&membership.Member{RaftMember: &api.RaftMember{RaftID: 1}})
 	cls.AddMember(&membership.Member{RaftMember: &api.RaftMember{RaftID: 5}})
 	cls.AddMember(&membership.Member{RaftMember: &api.RaftMember{RaftID: 20}})
 	cls.AddMember(&membership.Member{RaftMember: &api.RaftMember{RaftID: 50}})
 	cls.AddMember(&membership.Member{RaftMember: &api.RaftMember{RaftID: 10}})
 
-	assert.Equal(t, cls.Members(), w)
+	assert.Len(t, cls.Members(), 5)
 }
 
 func TestGetMember(t *testing.T) {


### PR DESCRIPTION
We need this commit for grpc update because there are no State methods
for *grpc.ClientConn in the grpc release.
ping @aaronlehmann 