### PR TITLE
fix panic in portallocator and deallocate endpoints when update with none EndpointSpec

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -564,7 +564,9 @@ func (a *Allocator) allocateNode(ctx context.Context, nc *networkContext, node *
 
 func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *api.Service) error {
 	if s.Spec.Endpoint != nil {
+		// service has user-defined endpoint
 		if s.Endpoint == nil {
+			// service currently has no allocated endpoint, need allocated.
 			s.Endpoint = &api.Endpoint{
 				Spec: s.Spec.Endpoint.Copy(),
 			}
@@ -586,6 +588,12 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 				s.Endpoint.VirtualIPs = append(s.Endpoint.VirtualIPs,
 					&api.Endpoint_VirtualIP{NetworkID: nc.ingressNetwork.ID})
 			}
+		}
+	} else if s.Endpoint != nil {
+		// service has no user-defined endpoints while has already allocated network resources,
+		// need deallocated.
+		if err := nc.nwkAllocator.ServiceDeallocate(s); err != nil {
+			return err
 		}
 	}
 

--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -155,7 +155,18 @@ func (pa *portAllocator) serviceDeallocatePorts(s *api.Service) {
 }
 
 func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
-	if s.Endpoint == nil {
+	// If service has no user-defined endpoint and allocated endpoint,
+	// we assume it is allocated and return true.
+	if s.Endpoint == nil && s.Spec.Endpoint == nil {
+		return true
+	}
+
+	// If service has allocated endpoint while has no user-defined endpoint,
+	// we assume allocated endpoints are redudant, and they need deallocated.
+	// If service has no allocated endpoint while has user-defined endpoint,
+	// we assume it is not allocated.
+	if (s.Endpoint != nil && s.Spec.Endpoint == nil) ||
+		(s.Endpoint == nil && s.Spec.Endpoint != nil) {
 		return false
 	}
 


### PR DESCRIPTION
fixes #1480 

This PR did:
1. in service update request, if there is no endpointSpec in service and there is endpoint in service, it means user no longer wants the allocated endpoint, then swarmkit needs to deallocate this.

Signed-off-by: allencloud <allen.sun@daocloud.io>