### PR TITLE
raft: Migrate WAL files to new directory

### DIFF
--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -25,27 +25,56 @@ import (
 
 var errNoWAL = errors.New("no WAL present")
 
-func (n *Node) walDir() string {
+func (n *Node) legacyWALDir() string {
 	return filepath.Join(n.StateDir, "wal")
 }
 
-func (n *Node) snapDir() string {
+func (n *Node) walDir() string {
+	return filepath.Join(n.StateDir, "wal-v3")
+}
+
+func (n *Node) legacySnapDir() string {
 	return filepath.Join(n.StateDir, "snap")
+}
+
+func (n *Node) snapDir() string {
+	return filepath.Join(n.StateDir, "snap-v3")
 }
 
 func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 	walDir := n.walDir()
 	snapDir := n.snapDir()
 
-	if err := os.MkdirAll(snapDir, 0700); err != nil {
-		return fmt.Errorf("create snapshot directory error: %v", err)
+	if !fileutil.Exist(snapDir) {
+		// If snapshots created by the etcd-v2 code exist, hard link
+		// them at the new path. This prevents etc-v2 creating
+		// snapshots that are visible to us, but out of sync with our
+		// WALs, after a downgrade.
+		legacySnapDir := n.legacySnapDir()
+		if fileutil.Exist(legacySnapDir) {
+			if err := migrateSnapshots(legacySnapDir, snapDir); err != nil {
+				return err
+			}
+		} else if err := os.MkdirAll(snapDir, 0700); err != nil {
+			return fmt.Errorf("create snapshot directory error: %v", err)
+		}
 	}
 
 	// Create a snapshotter
 	n.snapshotter = snap.New(snapDir)
 
 	if !wal.Exist(walDir) {
-		return errNoWAL
+		// If wals created by the etcd-v2 wal code exist, copy them to
+		// the new path to avoid adding backwards-incompatible entries
+		// to those files.
+		legacyWALDir := n.legacyWALDir()
+		if !wal.Exist(legacyWALDir) {
+			return errNoWAL
+		}
+
+		if err := migrateWALs(legacyWALDir, walDir); err != nil {
+			return err
+		}
 	}
 
 	// Load snapshot data
@@ -67,6 +96,93 @@ func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 	}
 
 	return nil
+}
+
+func migrateWALs(legacyWALDir, walDir string) error {
+	// keep temporary wal directory so WAL initialization appears atomic
+	tmpdirpath := filepath.Clean(walDir) + ".tmp"
+	if fileutil.Exist(tmpdirpath) {
+		if err := os.RemoveAll(tmpdirpath); err != nil {
+			return fmt.Errorf("could not remove temporary wal directory: %v", err)
+		}
+	}
+	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
+		return fmt.Errorf("could not create temporary wal directory: %v", err)
+	}
+
+	walNames, err := fileutil.ReadDir(legacyWALDir)
+	if err != nil {
+		return fmt.Errorf("could not list WAL directory %s: %v", legacyWALDir, err)
+	}
+
+	for _, fname := range walNames {
+		_, err := copyFile(filepath.Join(legacyWALDir, fname), filepath.Join(tmpdirpath, fname), 0600)
+		if err != nil {
+			return fmt.Errorf("error copying WAL file: %v", err)
+		}
+	}
+
+	if err := os.Rename(tmpdirpath, walDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func migrateSnapshots(legacySnapDir, snapDir string) error {
+	// use temporary snaphot directory so initialization appears atomic
+	tmpdirpath := filepath.Clean(snapDir) + ".tmp"
+	if fileutil.Exist(tmpdirpath) {
+		if err := os.RemoveAll(tmpdirpath); err != nil {
+			return fmt.Errorf("could not remove temporary snapshot directory: %v", err)
+		}
+	}
+	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
+		return fmt.Errorf("could not create temporary snapshot directory: %v", err)
+	}
+
+	snapshotNames, err := fileutil.ReadDir(legacySnapDir)
+	if err != nil {
+		return fmt.Errorf("could not list snapshot directory %s: %v", legacySnapDir, err)
+	}
+
+	for _, fname := range snapshotNames {
+		err := os.Link(filepath.Join(legacySnapDir, fname), filepath.Join(tmpdirpath, fname))
+		if err != nil {
+			return fmt.Errorf("error linking snapshot file: %v", err)
+		}
+	}
+
+	if err := os.Rename(tmpdirpath, snapDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copyFile copies from src to dst until either EOF is reached
+// on src or an error occurs. It verifies src exists and removes
+// the dst if it exists.
+func copyFile(src, dst string, perm os.FileMode) (int64, error) {
+	cleanSrc := filepath.Clean(src)
+	cleanDst := filepath.Clean(dst)
+	if cleanSrc == cleanDst {
+		return 0, nil
+	}
+	sf, err := os.Open(cleanSrc)
+	if err != nil {
+		return 0, err
+	}
+	defer sf.Close()
+	if err := os.Remove(cleanDst); err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+	df, err := os.OpenFile(cleanDst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return 0, err
+	}
+	defer df.Close()
+	return io.Copy(df, sf)
 }
 
 func (n *Node) createWAL(nodeID string) (raft.Peer, error) {


### PR DESCRIPTION
The currently vendored version of etcd/wal produces files that are
incompatible with the version of this package that 1.12 vendored. When
reading files created by this version, the WAL decoder in 1.12 will
panic.

To avoid causing crashes in downgrade scenarios, copy existing WAL files
to a new path that Docker 1.12 doesn't read from. The old files will be
preserved in case there is a downgrade. The downgraded version would
read the old state and catch up through raft.


Fixes #1475

cc @icecrime @aluzzardi @dongluochen @LK4D4