### PR TITLE
Run more tests in parallel

### DIFF
--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -415,6 +415,8 @@ func TestGetRemoteSignedCertificateNodeInfo(t *testing.T) {
 }
 
 func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -215,6 +215,8 @@ some random garbage\n
 }
 
 func TestRenewTLSConfigAgent(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
@@ -264,6 +266,8 @@ func TestRenewTLSConfigAgent(t *testing.T) {
 }
 
 func TestRenewTLSConfigManager(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
@@ -315,6 +319,8 @@ func TestRenewTLSConfigManager(t *testing.T) {
 }
 
 func TestRenewTLSConfigWithNoNode(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
@@ -371,6 +377,8 @@ func TestRenewTLSConfigWithNoNode(t *testing.T) {
 }
 
 func TestForceRenewTLSConfig(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -172,6 +172,8 @@ func TestNodeCertificateRenewalsDoNotRequireToken(t *testing.T) {
 }
 
 func TestNewNodeCertificateRequiresToken(t *testing.T) {
+	t.Parallel()
+
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -233,6 +233,8 @@ func getMap(t *testing.T, nodes []*api.Node) map[uint64]*api.ManagerStatus {
 }
 
 func TestListManagerNodes(t *testing.T) {
+	t.Parallel()
+
 	tc := cautils.NewTestCA(nil)
 	defer tc.Stop()
 	ts := newTestServer(t)
@@ -690,9 +692,11 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 }
 
 func TestUpdateNodeDemote(t *testing.T) {
+	t.Parallel()
 	testUpdateNodeDemote(false, t)
 }
 
 func TestUpdateNodeDemoteLeader(t *testing.T) {
+	t.Parallel()
 	testUpdateNodeDemote(true, t)
 }

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -187,6 +187,8 @@ func TestRegisterTwice(t *testing.T) {
 }
 
 func TestRegisterExceedRateLimit(t *testing.T) {
+	t.Parallel()
+
 	gd, err := startDispatcher(DefaultConfig())
 	assert.NoError(t, err)
 	defer gd.Close()
@@ -284,6 +286,8 @@ func TestHeartbeatNoCert(t *testing.T) {
 }
 
 func TestHeartbeatTimeout(t *testing.T) {
+	t.Parallel()
+
 	cfg := DefaultConfig()
 	cfg.HeartbeatPeriod = 100 * time.Millisecond
 	cfg.HeartbeatEpsilon = 0
@@ -328,6 +332,8 @@ func TestHeartbeatUnregistered(t *testing.T) {
 }
 
 func TestTasks(t *testing.T) {
+	t.Parallel()
+
 	gd, err := startDispatcher(DefaultConfig())
 	assert.NoError(t, err)
 	defer gd.Close()
@@ -424,6 +430,8 @@ func TestTasks(t *testing.T) {
 }
 
 func TestTasksStatusChange(t *testing.T) {
+	t.Parallel()
+
 	gd, err := startDispatcher(DefaultConfig())
 	assert.NoError(t, err)
 	defer gd.Close()
@@ -745,6 +753,8 @@ func TestSessionNoCert(t *testing.T) {
 }
 
 func TestNodesCount(t *testing.T) {
+	t.Parallel()
+
 	cfg := DefaultConfig()
 	cfg.HeartbeatPeriod = 100 * time.Millisecond
 	cfg.HeartbeatEpsilon = 0

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -402,6 +402,8 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 }
 
 func TestOrchestratorRestartMaxAttempts(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
@@ -536,6 +538,8 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 }
 
 func TestOrchestratorRestartWindow(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)

--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -147,6 +147,8 @@ func TestUpdater(t *testing.T) {
 }
 
 func TestUpdaterFailureAction(t *testing.T) {
+	t.Parallel()
+
 	ctx := context.Background()
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)


### PR DESCRIPTION
Add t.Parallel() to more tests that involve sleeps or polling.

before:
```
ok      github.com/docker/swarmkit/manager/controlapi   9.348s
ok      github.com/docker/swarmkit/manager/orchestrator 5.852s
ok      github.com/docker/swarmkit/manager/dispatcher   4.538s
ok      github.com/docker/swarmkit/ca   6.807s
```

after:
```
ok      github.com/docker/swarmkit/manager/controlapi   7.566s
ok      github.com/docker/swarmkit/manager/orchestrator 3.960s
ok      github.com/docker/swarmkit/manager/dispatcher   2.680s
ok      github.com/docker/swarmkit/ca   1.637s
```