### PR TITLE
raft: use separate timeout for health api calls

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -659,6 +659,12 @@ func (n *Node) checkHealth(ctx context.Context, addr string, timeout time.Durati
 		return err
 	}
 
+	if timeout != 0 {
+		tctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		ctx = tctx
+	}
+
 	client := api.NewHealthClient(conn)
 	defer conn.Close()
 


### PR DESCRIPTION
It seems like in new grpc timeouts for dial are not applied to calls.

This is last piece for grpc update.
ping @aaronlehmann 