### PR TITLE
validate duplicate published port in ServiceSpec

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -149,13 +149,13 @@ func validateEndpointSpec(epSpec *api.EndpointSpec) error {
 		return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: ports can't be used with dnsrr mode")
 	}
 
-	portSet := make(map[api.PortConfig]struct{})
+	portSet := make(map[uint32]struct{})
 	for _, port := range epSpec.Ports {
-		if _, ok := portSet[*port]; ok {
-			return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: duplicate ports provided")
+		if _, ok := portSet[port.PublishedPort]; ok {
+			return grpc.Errorf(codes.InvalidArgument, "EndpointSpec: duplicate published ports provided")
 		}
 
-		portSet[*port] = struct{}{}
+		portSet[port.PublishedPort] = struct{}{}
 	}
 
 	return nil


### PR DESCRIPTION
fixed #1494 

Currently, swarmkit checks the whole `*port` to avoid duplication.

This PR makes swarmkit to check the published port of `PortConfig`.

Signed-off-by: allencloud <allen.sun@daocloud.io>