### PR TITLE
Check for duplicate mount points in ServiceSpec

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -136,6 +136,15 @@ func validateTask(taskSpec api.TaskSpec) error {
 	if _, err := reference.ParseNamed(container.Image); err != nil {
 		return grpc.Errorf(codes.InvalidArgument, "ContainerSpec: %q is not a valid repository/tag", container.Image)
 	}
+
+	mountMap := make(map[string]bool)
+	for _, mount := range container.Mounts {
+		if _, exists := mountMap[mount.Target]; exists {
+			return grpc.Errorf(codes.InvalidArgument, "ContainerSpec: duplicate mount point: %s", mount.Target)
+		}
+		mountMap[mount.Target] = true
+	}
+
 	return nil
 }
 

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -38,6 +38,25 @@ func createSpec(name, image string, instances uint64) *api.ServiceSpec {
 	}
 }
 
+func createSpecWithDuplicateMounts(name string) *api.ServiceSpec {
+
+	service := createSpec("", "image", 1)
+	mounts := []api.Mount{
+		{
+			Target: "/foo",
+			Source: "/mnt/mount1",
+		},
+		{
+			Target: "/foo",
+			Source: "/mnt/mount2",
+		},
+	}
+
+	service.Task.GetContainer().Mounts = mounts
+
+	return service
+}
+
 func createService(t *testing.T, ts *testServer, name, image string, instances uint64) *api.Service {
 	spec := createSpec(name, image, instances)
 	r, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
@@ -118,6 +137,10 @@ func TestValidateTask(t *testing.T) {
 		},
 		{
 			s: createSpec("", "busybox###", 0).Task,
+			c: codes.InvalidArgument,
+		},
+		{
+			s: createSpecWithDuplicateMounts("test").Task,
 			c: codes.InvalidArgument,
 		},
 	} {


### PR DESCRIPTION
Duplicate mount points are not allowed in serviceSpec.
Validation for same was missing in swarmkit.

Ref: https://github.com/docker/docker/issues/25772

Signed-off-by: Kunal Kushwaha <kushwaha_kunal_v7@lab.ntt.co.jp>