### PR TITLE
updater: Don't create a new task when the old one can't be stopped

### DIFF
--- a/manager/orchestrator/restart.go
+++ b/manager/orchestrator/restart.go
@@ -346,7 +346,8 @@ func (r *RestartSupervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask 
 			close(doneCh)
 		}()
 
-		oldTaskTimeout := time.After(r.taskTimeout)
+		oldTaskTimer := time.NewTimer(r.taskTimeout)
+		defer oldTaskTimer.Stop()
 
 		// Wait for the delay to elapse, if one is specified.
 		if delay != 0 {
@@ -357,10 +358,10 @@ func (r *RestartSupervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask 
 			}
 		}
 
-		if waitStop {
+		if waitStop && oldTask != nil {
 			select {
 			case <-watch:
-			case <-oldTaskTimeout:
+			case <-oldTaskTimer.C:
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
This corrects some problems with #1492. That PR avoided tasks getting
stuck in READY by continuing to start the new task if old one couldn't
be stopped. The problem with this is that the old task may have been
restarted due to a failure, which effectively causes that slot to get
updated to the latest version - so there would be two up-to-date tasks
running in that slot. The Docker 1.12 behavior, which is the correct
behavior, is to avoid creating a new task if the old one can't be
stopped.

Also, fix DelayStart to avoid waiting for oldTaskTimeout if no old task
was given.

Finally, change oldTaskTimeout to use a timer which is stopped when the
function returned, instead of a time.After which can leak a long-running
timer.

cc @dongluochen