### PR TITLE
agent/exec: don't log context cancelled errors

### DIFF
--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -147,7 +147,7 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 		if cs, ok := err.(ContainerStatuser); ok {
 			var err error
 			containerStatus, err = cs.ContainerStatus(ctx)
-			if err != nil {
+			if err != nil && !contextDoneError(err) {
 				log.G(ctx).WithError(err).Error("error resolving container status on fatal")
 			}
 		}
@@ -207,7 +207,7 @@ func Do(ctx context.Context, task *api.Task, ctlr Controller) (*api.TaskStatus, 
 
 			var err error
 			containerStatus, err = cctlr.ContainerStatus(ctx)
-			if err != nil {
+			if err != nil && !contextDoneError(err) {
 				log.G(ctx).WithError(err).Error("container status unavailable")
 			}
 
@@ -296,4 +296,9 @@ func logStateChange(ctx context.Context, desired, previous, next api.TaskState) 
 		}
 		log.G(ctx).WithFields(fields).Debug("state changed")
 	}
+}
+
+func contextDoneError(err error) bool {
+	cause := errors.Cause(err)
+	return cause == context.Canceled || cause == context.DeadlineExceeded
 }


### PR DESCRIPTION
Signed-off-by: Stephen J Day <stephen.day@docker.com>

Requires docker/docker#26432 for the full fix but can be merged at leisure.