### PR TITLE
agent/exec/container: filter out useless error

### DIFF
--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -200,12 +200,15 @@ func (c *containerAdapter) events(ctx context.Context) (<-chan events.Message, <
 		for {
 			var event events.Message
 			if err := dec.Decode(&event); err != nil {
-				// TODO(stevvooe): This error handling isn't quite right.
-				if err == io.EOF {
+				// TODO(stevvooe): This error handling isn't quite right. We
+				// can refactor this to use
+				// https://github.com/docker/docker/pull/25853 and this will a
+				// lot more simplified.
+				if err == io.EOF || strings.Contains(err.Error(), "request canceled") {
 					return
 				}
 
-				log.G(ctx).Errorf("error decoding event: %v", err)
+				log.G(ctx).WithError(err).Errorf("error decoding event")
 				return
 			}
 


### PR DESCRIPTION
During the normal course of operation, http requests may get canceled.
While listening the events API, this error was being reported when
decoding events. This should really just be shutdown with no log message
in this case.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

@diogomonica @aaronlehmann PTAL