### PR TITLE
ca: rename AgentRole to WorkerRole

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -61,7 +61,7 @@ func TestAgentStartStop(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
-	agentSecurityConfig, err := tc.NewNodeConfig(ca.AgentRole)
+	agentSecurityConfig, err := tc.NewNodeConfig(ca.WorkerRole)
 	assert.NoError(t, err)
 
 	addr := "localhost:4949"
@@ -135,7 +135,7 @@ func agentTestEnv(t *testing.T) (*Agent, func()) {
 	tc := testutils.NewTestCA(t)
 	cleanup = append(cleanup, func() { tc.Stop() })
 
-	agentSecurityConfig, err := tc.NewNodeConfig(ca.AgentRole)
+	agentSecurityConfig, err := tc.NewNodeConfig(ca.WorkerRole)
 	assert.NoError(t, err)
 
 	addr := "localhost:4949"

--- a/agent/node.go
+++ b/agent/node.go
@@ -120,7 +120,7 @@ func NewNode(c *NodeConfig) (*Node, error) {
 
 	n := &Node{
 		remotes:              newPersistentRemotes(stateFile, p...),
-		role:                 ca.AgentRole,
+		role:                 ca.WorkerRole,
 		config:               c,
 		started:              make(chan struct{}),
 		stopped:              make(chan struct{}),
@@ -233,7 +233,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 			case apirole := <-n.roleChangeReq:
 				n.Lock()
 				lastRole := n.role
-				role := ca.AgentRole
+				role := ca.WorkerRole
 				if apirole == api.NodeRoleManager {
 					role = ca.ManagerRole
 				}
@@ -242,7 +242,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 					continue
 				}
 				// switch role to agent immediately to shutdown manager early
-				if role == ca.AgentRole {
+				if role == ca.WorkerRole {
 					n.role = role
 					n.roleCond.Broadcast()
 				}
@@ -635,7 +635,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		roleChanged := make(chan error)
 		waitCtx, waitCancel := context.WithCancel(ctx)
 		go func() {
-			err := n.waitRole(waitCtx, ca.AgentRole)
+			err := n.waitRole(waitCtx, ca.WorkerRole)
 			roleChanged <- err
 		}()
 

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -345,7 +345,7 @@ func TestIssueAndSaveNewCertificates(t *testing.T) {
 	assert.Contains(t, certs[0].DNSNames, "swarm-manager")
 
 	// Test the creation of a worker node cert
-	cert, err = tc.RootCA.IssueAndSaveNewCertificates(tc.Paths.Node, "CN", ca.AgentRole, tc.Organization)
+	cert, err = tc.RootCA.IssueAndSaveNewCertificates(tc.Paths.Node, "CN", ca.WorkerRole, tc.Organization)
 	assert.NoError(t, err)
 	assert.NotNil(t, cert)
 	perms, err = permbits.Stat(tc.Paths.Node.Cert)
@@ -359,7 +359,7 @@ func TestIssueAndSaveNewCertificates(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, certs, 2)
 	assert.Equal(t, "CN", certs[0].Subject.CommonName)
-	assert.Equal(t, ca.AgentRole, certs[0].Subject.OrganizationalUnit[0])
+	assert.Equal(t, ca.WorkerRole, certs[0].Subject.OrganizationalUnit[0])
 	assert.Equal(t, tc.Organization, certs[0].Subject.Organization[0])
 	assert.Equal(t, "swarm-test-CA", certs[1].Subject.CommonName)
 	assert.Contains(t, certs[0].DNSNames, "CN")
@@ -387,7 +387,7 @@ func TestGetRemoteSignedCertificate(t *testing.T) {
 	assert.True(t, time.Now().Add(ca.DefaultNodeCertExpiration).AddDate(0, 0, 1).After(parsedCerts[0].NotAfter))
 	assert.Equal(t, parsedCerts[0].Subject.OrganizationalUnit[0], ca.ManagerRole)
 
-	// Test the expiration for an agent certificate
+	// Test the expiration for an worker certificate
 	certs, err = ca.GetRemoteSignedCertificate(tc.Context, csr, tc.WorkerToken, tc.RootCA.Pool, tc.Remotes, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, certs)
@@ -396,7 +396,7 @@ func TestGetRemoteSignedCertificate(t *testing.T) {
 	assert.Len(t, parsedCerts, 2)
 	assert.True(t, time.Now().Add(ca.DefaultNodeCertExpiration).AddDate(0, 0, -1).Before(parsedCerts[0].NotAfter))
 	assert.True(t, time.Now().Add(ca.DefaultNodeCertExpiration).AddDate(0, 0, 1).After(parsedCerts[0].NotAfter))
-	assert.Equal(t, parsedCerts[0].Subject.OrganizationalUnit[0], ca.AgentRole)
+	assert.Equal(t, parsedCerts[0].Subject.OrganizationalUnit[0], ca.WorkerRole)
 }
 
 func TestGetRemoteSignedCertificateNodeInfo(t *testing.T) {

--- a/ca/config.go
+++ b/ca/config.go
@@ -35,8 +35,8 @@ const (
 	rootCN = "swarm-ca"
 	// ManagerRole represents the Manager node type, and is used for authorization to endpoints
 	ManagerRole = "swarm-manager"
-	// AgentRole represents the Agent node type, and is used for authorization to endpoints
-	AgentRole = "swarm-worker"
+	// WorkerRole represents the Worker node type, and is used for authorization to endpoints
+	WorkerRole = "swarm-worker"
 	// CARole represents the CA node type, and is used for clients attempting to get new certificates issued
 	CARole = "swarm-ca"
 
@@ -272,7 +272,7 @@ func LoadOrCreateSecurityConfig(ctx context.Context, baseCertDir, token, propose
 				return nil, err
 			}
 		}
-		// Create the Server TLS Credentials for this node. These will not be used by agents.
+		// Create the Server TLS Credentials for this node. These will not be used by workers.
 		serverTLSCreds, err = rootCA.NewServerTLSCredentials(tlsKeyPair)
 		if err != nil {
 			return nil, err
@@ -478,7 +478,7 @@ func LoadTLSCreds(rootCA RootCA, paths CertPaths) (*MutableTLSCreds, *MutableTLS
 	}
 
 	// Load the Certificates also as client credentials.
-	// Both Agents and Managers always connect to remote Managers,
+	// Both workers and managers always connect to remote managers,
 	// so ServerName is always set to ManagerRole here.
 	clientTLSCreds, err := rootCA.NewClientTLSCredentials(&keyPair, ManagerRole)
 	if err != nil {
@@ -561,7 +561,7 @@ func ParseRole(apiRole api.NodeRole) (string, error) {
 	case api.NodeRoleManager:
 		return ManagerRole, nil
 	case api.NodeRoleWorker:
-		return AgentRole, nil
+		return WorkerRole, nil
 	default:
 		return "", fmt.Errorf("failed to parse api role: %v", apiRole)
 	}
@@ -572,7 +572,7 @@ func FormatRole(role string) (api.NodeRole, error) {
 	switch strings.ToLower(role) {
 	case strings.ToLower(ManagerRole):
 		return api.NodeRoleManager, nil
-	case strings.ToLower(AgentRole):
+	case strings.ToLower(WorkerRole):
 		return api.NodeRoleWorker, nil
 	default:
 		return 0, fmt.Errorf("failed to parse role: %s", role)

--- a/ca/server.go
+++ b/ca/server.go
@@ -149,14 +149,14 @@ func (s *Server) IssueNodeCertificate(ctx context.Context, request *api.IssueNod
 	}
 	defer s.doneTask()
 
-	// If the remote node is an Agent (either forwarded by a manager, or calling directly),
-	// issue a renew agent certificate entry with the correct ID
-	nodeID, err := AuthorizeForwardedRoleAndOrg(ctx, []string{AgentRole}, []string{ManagerRole}, s.securityConfig.ClientTLSCreds.Organization())
+	// If the remote node is a worker (either forwarded by a manager, or calling directly),
+	// issue a renew worker certificate entry with the correct ID
+	nodeID, err := AuthorizeForwardedRoleAndOrg(ctx, []string{WorkerRole}, []string{ManagerRole}, s.securityConfig.ClientTLSCreds.Organization())
 	if err == nil {
 		return s.issueRenewCertificate(ctx, nodeID, request.CSR)
 	}
 
-	// If the remote node is a Manager (either forwarded by another manager, or calling directly),
+	// If the remote node is a manager (either forwarded by another manager, or calling directly),
 	// issue a renew certificate entry with the correct ID
 	nodeID, err = AuthorizeForwardedRoleAndOrg(ctx, []string{ManagerRole}, []string{ManagerRole}, s.securityConfig.ClientTLSCreds.Organization())
 	if err == nil {

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -78,7 +78,7 @@ func TestIssueNodeCertificateWithInvalidCSR(t *testing.T) {
 	assert.Nil(t, statusResponse.Certificate.Certificate)
 }
 
-func TestIssueNodeCertificateAgentRenewal(t *testing.T) {
+func TestIssueNodeCertificateWorkerRenewal(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
@@ -123,7 +123,7 @@ func TestIssueNodeCertificateManagerRenewal(t *testing.T) {
 	assert.Equal(t, role, statusResponse.Certificate.Role)
 }
 
-func TestIssueNodeCertificateAgentFromDifferentOrgRenewal(t *testing.T) {
+func TestIssueNodeCertificateWorkerFromDifferentOrgRenewal(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -129,7 +129,7 @@ func NewTestCA(t *testing.T) *TestCA {
 	managerDiffOrgConfig, err := genSecurityConfig(s, rootCA, ca.ManagerRole, "swarm-test-org-2", "", External)
 	assert.NoError(t, err)
 
-	agentConfig, err := genSecurityConfig(s, rootCA, ca.AgentRole, organization, "", External)
+	workerConfig, err := genSecurityConfig(s, rootCA, ca.WorkerRole, organization, "", External)
 	assert.NoError(t, err)
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
@@ -137,7 +137,7 @@ func NewTestCA(t *testing.T) *TestCA {
 
 	baseOpts := []grpc.DialOption{grpc.WithTimeout(10 * time.Second)}
 	insecureClientOpts := append(baseOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})))
-	clientOpts := append(baseOpts, grpc.WithTransportCredentials(agentConfig.ClientTLSCreds))
+	clientOpts := append(baseOpts, grpc.WithTransportCredentials(workerConfig.ClientTLSCreds))
 	managerOpts := append(baseOpts, grpc.WithTransportCredentials(managerConfig.ClientTLSCreds))
 	managerDiffOrgOpts := append(baseOpts, grpc.WithTransportCredentials(managerDiffOrgConfig.ClientTLSCreds))
 

--- a/ca/transport_test.go
+++ b/ca/transport_test.go
@@ -45,7 +45,7 @@ func TestLoadNewTLSConfig(t *testing.T) {
 	// Create two different certs and two different TLS configs
 	cert1, err := tc.RootCA.IssueAndSaveNewCertificates(tc.Paths.Node, "CN1", ca.ManagerRole, tc.Organization)
 	assert.NoError(t, err)
-	cert2, err := tc.RootCA.IssueAndSaveNewCertificates(tc.Paths.Node, "CN2", ca.AgentRole, tc.Organization)
+	cert2, err := tc.RootCA.IssueAndSaveNewCertificates(tc.Paths.Node, "CN2", ca.WorkerRole, tc.Organization)
 	assert.NoError(t, err)
 	tlsConfig1, err := ca.NewServerTLSConfig(cert1, tc.RootCA.Pool)
 	assert.NoError(t, err)
@@ -61,6 +61,6 @@ func TestLoadNewTLSConfig(t *testing.T) {
 	// Load the new Config and assert it changed
 	err = creds.LoadNewTLSConfig(tlsConfig2)
 	assert.NoError(t, err)
-	assert.Equal(t, ca.AgentRole, creds.Role())
+	assert.Equal(t, ca.WorkerRole, creds.Role())
 	assert.Equal(t, "CN2", creds.NodeID())
 }

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -80,11 +80,11 @@ func startDispatcher(c *Config) (*grpcDispatcher, error) {
 	}
 
 	tca := testutils.NewTestCA(nil)
-	agentSecurityConfig1, err := tca.NewNodeConfig(ca.AgentRole)
+	agentSecurityConfig1, err := tca.NewNodeConfig(ca.WorkerRole)
 	if err != nil {
 		return nil, err
 	}
-	agentSecurityConfig2, err := tca.NewNodeConfig(ca.AgentRole)
+	agentSecurityConfig2, err := tca.NewNodeConfig(ca.WorkerRole)
 	if err != nil {
 		return nil, err
 	}

--- a/manager/testcluster/manager_cluster_test.go
+++ b/manager/testcluster/manager_cluster_test.go
@@ -63,7 +63,7 @@ func (mc *managersCluster) addAgents(count int) error {
 		addrs = append(addrs, api.Peer{Addr: m.addr})
 	}
 	for i := 0; i < count; i++ {
-		asConfig, err := mc.tc.NewNodeConfig(ca.AgentRole)
+		asConfig, err := mc.tc.NewNodeConfig(ca.WorkerRole)
 		if err != nil {
 			return err
 		}

--- a/manager/testcluster/manager_test.go
+++ b/manager/testcluster/manager_test.go
@@ -67,9 +67,9 @@ func TestManager(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
-	agentSecurityConfig, err := tc.NewNodeConfig(ca.AgentRole)
+	agentSecurityConfig, err := tc.NewNodeConfig(ca.WorkerRole)
 	assert.NoError(t, err)
-	agentDiffOrgSecurityConfig, err := tc.NewNodeConfigOrg(ca.AgentRole, "another-org")
+	agentDiffOrgSecurityConfig, err := tc.NewNodeConfigOrg(ca.WorkerRole, "another-org")
 	assert.NoError(t, err)
 	managerSecurityConfig, err := tc.NewNodeConfig(ca.ManagerRole)
 	assert.NoError(t, err)


### PR DESCRIPTION
This changes the name of the constant to reflect its actual value. It
is purely an internal cosmetic change and won't affect interoperability.

cc @diogomonica