### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+Note: If your bug report relates to Docker's swarm mode, please file it against
+the docker repository instead: https://github.com/docker/docker/issues/new
+
+In general, if you experienced a bug using commands that start with `docker`,
+the report probably belongs in the docker repository. The swarmkit repository
+should only be used for specific low-level issue reports related to swarmkit's
+internals.
+
+For more information about reporting issues on the Docker project, see
+https://github.com/docker/docker/blob/master/CONTRIBUTING.md#reporting-other-issues
+-->


### PR DESCRIPTION
Add an issue template directing users to the docker/docker repository
for bug reports related to engine's swarm mode.

cc @aluzzardi @mgoelzer @thaJeztah