### PR TITLE
Increase timeouts for TestAllocator if a timeout is not expected

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -444,6 +444,19 @@ type mockTester struct{}
 func (m mockTester) Errorf(format string, args ...interface{}) {
 }
 
+// Returns a timeout given whether we should expect a timeout:  In the case where we do expect a timeout,
+// the timeout should be short, because it's not very useful to wait long amounts of time just in case
+// an unexpected event comes in - a short timeout should catch an incorrect event at least often enough
+// to make the test flaky and alert us to the problem. But in the cases where we don't expect a timeout,
+// the timeout should be on the order of serveral seconds, so the test doesn't fail just because it's run
+// on a relatively slow system, or there's a load spike.
+func getWatchTimeout(expectTimeout bool) time.Duration {
+	if expectTimeout {
+		return 350 * time.Millisecond
+	}
+	return 5 * time.Second
+}
+
 func watchNetwork(t *testing.T, watch chan events.Event, expectTimeout bool, fn func(t assert.TestingT, n *api.Network) bool) {
 	for {
 		var network *api.Network
@@ -463,7 +476,7 @@ func watchNetwork(t *testing.T, watch chan events.Event, expectTimeout bool, fn 
 				}
 			}
 
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(getWatchTimeout(expectTimeout)):
 			if !expectTimeout {
 				if network != nil && fn != nil {
 					fn(t, network)
@@ -496,7 +509,7 @@ func watchService(t *testing.T, watch chan events.Event, expectTimeout bool, fn 
 				}
 			}
 
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(getWatchTimeout(expectTimeout)):
 			if !expectTimeout {
 				if service != nil && fn != nil {
 					fn(t, service)
@@ -529,7 +542,7 @@ func watchTask(t *testing.T, s *store.MemoryStore, watch chan events.Event, expe
 				}
 			}
 
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(getWatchTimeout(expectTimeout)):
 			if !expectTimeout {
 				if task != nil && fn != nil {
 					fn(t, s, task)


### PR DESCRIPTION
Addressing some of the potential allocator test flakiness as per @aaronlehmann's comment here:  https://github.com/docker/swarmkit/pull/1470#issuecomment-245048511

> About the allocator tests, I think we should make the sleep depend on expectTimeout. In the case where we do expect a timeout, the timeout should be short, because it's not very useful to wait long amounts of time just in case an unexpected event comes in - a short timeout should catch an incorrect event at least often enough to make the test flaky and alert us to the problem. But in the cases where we don't expect a timeout, the timeout should be on the order of serveral seconds, so the test doesn't fail just because it's run on a relatively slow system, or there's a load spike.