### PR TITLE
fix PublishedPort allocate logic

### DIFF
--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -209,18 +209,19 @@ func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
 
 func (ps *portSpace) allocate(p *api.PortConfig) (err error) {
 	if p.PublishedPort != 0 {
+
+		defer func() {
+			if err != nil {
+				ps.dynamicPortSpace.Release(uint64(p.PublishedPort))
+			}
+		}()
+
 		// If it falls in the dynamic port range check out
 		// from dynamic port space first.
 		if p.PublishedPort >= dynamicPortStart && p.PublishedPort <= dynamicPortEnd {
 			if err = ps.dynamicPortSpace.GetSpecificID(uint64(p.PublishedPort)); err != nil {
 				return err
 			}
-
-			defer func() {
-				if err != nil {
-					ps.dynamicPortSpace.Release(uint64(p.PublishedPort))
-				}
-			}()
 		}
 
 		return ps.masterPortSpace.GetSpecificID(uint64(p.PublishedPort))
@@ -231,6 +232,7 @@ func (ps *portSpace) allocate(p *api.PortConfig) (err error) {
 	if err != nil {
 		return
 	}
+
 	defer func() {
 		if err != nil {
 			ps.dynamicPortSpace.Release(uint64(swarmPort))


### PR DESCRIPTION
In the code if p.PulishedPort does not meed condition `p.PublishedPort >= dynamicPortStart && p.PublishedPort <= dynamicPortEnd`, when `GetSpecificID` fails, I think swarmkit still needs to `Release` it.

This pr did:
1. move `defer func()` outer to release more cases.

Signed-off-by: allencloud <allen.sun@daocloud.io>