### PR TITLE
agent: bounce session after failed status update

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -364,7 +364,8 @@ func (a *Agent) UpdateTaskStatus(ctx context.Context, taskID string, status *api
 				if err == errTaskUnknown {
 					err = nil // dispatcher no longer cares about this task.
 				} else {
-					log.G(ctx).WithError(err).Error("sending task status update failed")
+					log.G(ctx).WithError(err).Error("closing session after fatal error")
+					session.close()
 				}
 			} else {
 				log.G(ctx).Debug("task status reported")


### PR DESCRIPTION
Previously, failed calls on an agent session to UpdateTaskStatus weren't
causing the agent to fall back into the session creation retry loop.
Without the retry loop, the agent ends up pounding the dispatcher with
status updates that will never drain.

This PR closes the session on a fatal error, ensuring that the agent
will fallback into a retry loop.

Consider backporting this change to 1.12.2.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

cc @aaronlehmann 

Closes #1533