### PR TITLE
Improve error message for removing pre-defined (e.g., `ingress`) network

### DIFF
--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/docker/libnetwork/ipamapi"
@@ -186,7 +187,11 @@ func (s *Server) RemoveNetwork(ctx context.Context, request *api.RemoveNetworkRe
 	err = s.store.Update(func(tx store.Tx) error {
 		nw := store.GetNetwork(tx, request.NetworkID)
 		if _, ok := nw.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
-			return grpc.Errorf(codes.PermissionDenied, "%s is a pre-defined network and cannot be removed", request.NetworkID)
+			networkDescription := nw.ID
+			if nw.Spec.Annotations.Name != "" {
+				networkDescription = fmt.Sprintf("%s (%s)", nw.Spec.Annotations.Name, nw.ID)
+			}
+			return grpc.Errorf(codes.PermissionDenied, "%s is a pre-defined network and cannot be removed", networkDescription)
 		}
 		return store.DeleteNetwork(tx, request.NetworkID)
 	})


### PR DESCRIPTION
This fix tries to address the issue raised in:
https://github.com/docker/docker/issues/24538
where the error message is unclear when removing pre-defined networks:
```
docker network rm ingress
Error response from daemon: rpc error: code = 7 desc = 4vlxuzpk8bxdsxpyvkxluol5g is a pre-defined network and cannot be removed
```

This fix improve the error message so that if network's name is specified
in the `RemoveNetwork`, then error message will contain the name and the ID
(instead of just an ID).
```
docker network rm ingress
Error response from daemon: rpc error: code = 7 desc = ingress (4vlxuzpk8bxdsxpyvkxluol5g) is a pre-defined network and cannot be removed
```

The unit test has been updated to cover the changes.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>