### PR TITLE
make errServe in manager dynamical

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -295,7 +295,7 @@ func (m *Manager) Run(parent context.Context) error {
 	api.RegisterControlServer(m.localserver, localProxyControlAPI)
 	api.RegisterHealthServer(m.localserver, localHealthServer)
 
-	errServe := make(chan error, 2)
+	errServe := make(chan error, len(m.listeners))
 	for proto, l := range m.listeners {
 		go m.serveListener(ctx, errServe, proto, l)
 	}


### PR DESCRIPTION
I found that in manager, when initializing to start listener, hard code to be 2 chan err.
I think it is better to be flexible for errServe to follow length of listeners.

Just a little bit change, feel free to close it if I missed something.
 
Signed-off-by: allencloud <allen.sun@daocloud.io>