### PR TITLE
node: handle transient NotFound error on health check

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -295,18 +295,21 @@ func (m *Manager) Run(parent context.Context) error {
 	api.RegisterControlServer(m.localserver, localProxyControlAPI)
 	api.RegisterHealthServer(m.localserver, localHealthServer)
 
+	healthServer.SetServingStatus("Raft", api.HealthCheckResponse_NOT_SERVING)
+	localHealthServer.SetServingStatus("ControlAPI", api.HealthCheckResponse_NOT_SERVING)
+
 	errServe := make(chan error, len(m.listeners))
 	for proto, l := range m.listeners {
 		go m.serveListener(ctx, errServe, proto, l)
 	}
 
-	// Set the raft server as serving for the health server
-	healthServer.SetServingStatus("Raft", api.HealthCheckResponse_SERVING)
-
 	defer func() {
 		m.server.Stop()
 		m.localserver.Stop()
 	}()
+
+	// Set the raft server as serving for the health server
+	healthServer.SetServingStatus("Raft", api.HealthCheckResponse_SERVING)
 
 	if err := m.RaftNode.JoinAndStart(); err != nil {
 		return fmt.Errorf("can't initialize raft node: %v", err)


### PR DESCRIPTION
Otherwise, initManagerConnection just exits if SetServingStatus is not called.