### PR TITLE
raft: Use errors.Wrap

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -32,6 +31,7 @@ import (
 	"github.com/docker/swarmkit/manager/state/watch"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pivotal-golang/clock"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -862,13 +862,13 @@ func (n *Node) getLeaderConn() (*grpc.ClientConn, error) {
 	}
 	l := n.cluster.GetMember(leader)
 	if l == nil {
-		return nil, fmt.Errorf("no leader found")
+		return nil, errors.New("no leader found")
 	}
 	if !n.cluster.Active(leader) {
-		return nil, fmt.Errorf("leader marked as inactive")
+		return nil, errors.New("leader marked as inactive")
 	}
 	if l.Conn == nil {
-		return nil, fmt.Errorf("no connection to leader in member list")
+		return nil, errors.New("no connection to leader in member list")
 	}
 	return l.Conn, nil
 }

--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -1,7 +1,6 @@
 package raft
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,6 +19,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -56,7 +56,7 @@ func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 				return err
 			}
 		} else if err := os.MkdirAll(snapDir, 0700); err != nil {
-			return fmt.Errorf("create snapshot directory error: %v", err)
+			return errors.Wrap(err, "failed to create snapshot directory")
 		}
 	}
 
@@ -103,22 +103,22 @@ func migrateWALs(legacyWALDir, walDir string) error {
 	tmpdirpath := filepath.Clean(walDir) + ".tmp"
 	if fileutil.Exist(tmpdirpath) {
 		if err := os.RemoveAll(tmpdirpath); err != nil {
-			return fmt.Errorf("could not remove temporary wal directory: %v", err)
+			return errors.Wrap(err, "could not remove temporary WAL directory")
 		}
 	}
 	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
-		return fmt.Errorf("could not create temporary wal directory: %v", err)
+		return errors.Wrap(err, "could not create temporary WAL directory")
 	}
 
 	walNames, err := fileutil.ReadDir(legacyWALDir)
 	if err != nil {
-		return fmt.Errorf("could not list WAL directory %s: %v", legacyWALDir, err)
+		return errors.Wrapf(err, "could not list WAL directory %s", legacyWALDir)
 	}
 
 	for _, fname := range walNames {
 		_, err := copyFile(filepath.Join(legacyWALDir, fname), filepath.Join(tmpdirpath, fname), 0600)
 		if err != nil {
-			return fmt.Errorf("error copying WAL file: %v", err)
+			return errors.Wrap(err, "error copying WAL file")
 		}
 	}
 
@@ -134,22 +134,22 @@ func migrateSnapshots(legacySnapDir, snapDir string) error {
 	tmpdirpath := filepath.Clean(snapDir) + ".tmp"
 	if fileutil.Exist(tmpdirpath) {
 		if err := os.RemoveAll(tmpdirpath); err != nil {
-			return fmt.Errorf("could not remove temporary snapshot directory: %v", err)
+			return errors.Wrap(err, "could not remove temporary snapshot directory")
 		}
 	}
 	if err := fileutil.CreateDirAll(tmpdirpath); err != nil {
-		return fmt.Errorf("could not create temporary snapshot directory: %v", err)
+		return errors.Wrap(err, "could not create temporary snapshot directory")
 	}
 
 	snapshotNames, err := fileutil.ReadDir(legacySnapDir)
 	if err != nil {
-		return fmt.Errorf("could not list snapshot directory %s: %v", legacySnapDir, err)
+		return errors.Wrapf(err, "could not list snapshot directory %s", legacySnapDir)
 	}
 
 	for _, fname := range snapshotNames {
 		err := os.Link(filepath.Join(legacySnapDir, fname), filepath.Join(tmpdirpath, fname))
 		if err != nil {
-			return fmt.Errorf("error linking snapshot file: %v", err)
+			return errors.Wrap(err, "error linking snapshot file")
 		}
 	}
 
@@ -193,11 +193,11 @@ func (n *Node) createWAL(nodeID string) (raft.Peer, error) {
 	}
 	metadata, err := raftNode.Marshal()
 	if err != nil {
-		return raft.Peer{}, fmt.Errorf("error marshalling raft node: %v", err)
+		return raft.Peer{}, errors.Wrap(err, "error marshalling raft node")
 	}
 	n.wal, err = wal.Create(n.walDir(), metadata)
 	if err != nil {
-		return raft.Peer{}, fmt.Errorf("create WAL error: %v", err)
+		return raft.Peer{}, errors.Wrap(err, "failed to create WAL")
 	}
 
 	n.cluster.AddMember(&membership.Member{RaftMember: raftNode})
@@ -244,7 +244,7 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 	repaired := false
 	for {
 		if n.wal, err = wal.Open(n.walDir(), walsnap); err != nil {
-			return fmt.Errorf("open WAL error: %v", err)
+			return errors.Wrap(err, "failed to open WAL")
 		}
 		if metadata, st, ents, err = n.wal.ReadAll(); err != nil {
 			if err := n.wal.Close(); err != nil {
@@ -252,12 +252,12 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 			}
 			// we can only repair ErrUnexpectedEOF and we never repair twice.
 			if repaired || err != io.ErrUnexpectedEOF {
-				return fmt.Errorf("read WAL error (%v) and cannot be repaired", err)
+				return errors.Wrap(err, "irreparable WAL error")
 			}
 			if !wal.Repair(n.walDir()) {
-				return fmt.Errorf("WAL error (%v) cannot be repaired", err)
+				return errors.Wrap(err, "WAL error cannot be repaired")
 			}
-			log.G(ctx).Infof("repaired WAL error (%v)", err)
+			log.G(ctx).WithError(err).Info("repaired WAL error")
 			repaired = true
 			continue
 		}
@@ -267,14 +267,14 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 	defer func() {
 		if err != nil {
 			if walErr := n.wal.Close(); walErr != nil {
-				n.Config.Logger.Errorf("error closing raft WAL: %v", walErr)
+				log.G(ctx).WithError(walErr).Error("error closing raft WAL")
 			}
 		}
 	}()
 
 	var raftNode api.RaftMember
 	if err := raftNode.Unmarshal(metadata); err != nil {
-		return fmt.Errorf("error unmarshalling WAL metadata: %v", err)
+		return errors.Wrap(err, "failed to unmarshal WAL metadata")
 	}
 	n.Config.ID = raftNode.RaftID
 
@@ -286,7 +286,7 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 		if ent.Index <= st.Commit && ent.Type == raftpb.EntryConfChange {
 			var cc raftpb.ConfChange
 			if err := cc.Unmarshal(ent.Data); err != nil {
-				return fmt.Errorf("error unmarshalling config change: %v", err)
+				return errors.Wrap(err, "failed to unmarshal config change")
 			}
 			if cc.Type == raftpb.ConfChangeRemoveNode {
 				n.cluster.RemoveMember(cc.NodeID)
@@ -298,7 +298,7 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 		// discard the previously uncommitted entries
 		for i, ent := range ents {
 			if ent.Index > st.Commit {
-				log.G(context.Background()).Infof("discarding %d uncommitted WAL entries ", len(ents)-i)
+				log.G(ctx).Infof("discarding %d uncommitted WAL entries ", len(ents)-i)
 				ents = ents[:i]
 				break
 			}
@@ -316,7 +316,7 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 			if ccEnt.Type == raftpb.EntryConfChange {
 				var cc raftpb.ConfChange
 				if err := cc.Unmarshal(ccEnt.Data); err != nil {
-					return fmt.Errorf("error unmarshalling force-new-cluster config change: %v", err)
+					return errors.Wrap(err, "error unmarshalling force-new-cluster config change")
 				}
 				if cc.Type == raftpb.ConfChangeRemoveNode {
 					n.cluster.RemoveMember(cc.NodeID)
@@ -328,7 +328,7 @@ func (n *Node) readWAL(ctx context.Context, snapshot *raftpb.Snapshot, forceNewC
 		// force commit newly appended entries
 		err := n.wal.Save(st, toAppEnts)
 		if err != nil {
-			log.G(context.Background()).Fatalf("%v", err)
+			log.G(ctx).WithError(err).Fatalf("failed to save WAL while forcing new cluster")
 		}
 		if len(toAppEnts) != 0 {
 			st.Commit = toAppEnts[len(toAppEnts)-1].Index
@@ -427,7 +427,7 @@ func (n *Node) saveSnapshot(snapshot raftpb.Snapshot, keepOldSnapshots uint64) e
 	var snapTerm, snapIndex uint64
 	_, err = fmt.Sscanf(oldestSnapshot, "%016x-%016x.snap", &snapTerm, &snapIndex)
 	if err != nil {
-		return fmt.Errorf("malformed snapshot filename %s: %v", oldestSnapshot, err)
+		return errors.Wrapf(err, "malformed snapshot filename %s", oldestSnapshot)
 	}
 
 	// List the WALs
@@ -453,7 +453,7 @@ func (n *Node) saveSnapshot(snapshot raftpb.Snapshot, keepOldSnapshots uint64) e
 		var walSeq, walIndex uint64
 		_, err = fmt.Sscanf(walName, "%016x-%016x.wal", &walSeq, &walIndex)
 		if err != nil {
-			return fmt.Errorf("could not parse WAL name %s: %v", walName, err)
+			return errors.Wrapf(err, "could not parse WAL name %s", walName)
 		}
 
 		if walIndex >= snapIndex {
@@ -473,12 +473,12 @@ func (n *Node) saveSnapshot(snapshot raftpb.Snapshot, keepOldSnapshots uint64) e
 		walPath := filepath.Join(n.walDir(), wals[i])
 		l, err := fileutil.TryLockFile(walPath, os.O_WRONLY, fileutil.PrivateFileMode)
 		if err != nil {
-			return fmt.Errorf("could not lock old WAL file %s for removal: %v", wals[i], err)
+			return errors.Wrapf(err, "could not lock old WAL file %s for removal", wals[i])
 		}
 		err = os.Remove(walPath)
 		l.Close()
 		if err != nil {
-			return fmt.Errorf("error removing old WAL file %s: %v", wals[i], err)
+			return errors.Wrapf(err, "error removing old WAL file %s", wals[i])
 		}
 	}
 


### PR DESCRIPTION
Wrap errors with github.com/pkg/errors instead of using fmt.Errorf.

cc @stevvooe