### PR TITLE
allocator: Use errors.Wrap

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -91,7 +92,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		}
 	})
 	if err != nil {
-		return fmt.Errorf("failed to find ingress network during init: %v", err)
+		return errors.Wrap(err, "failed to find ingress network during init")
 	}
 
 	// If ingress network is not found, create one right away
@@ -105,7 +106,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to create ingress network: %v", err)
+			return errors.Wrap(err, "failed to create ingress network")
 		}
 
 		a.store.View(func(tx store.ReadTx) {
@@ -115,7 +116,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 			}
 		})
 		if err != nil {
-			return fmt.Errorf("failed to find ingress network after creating it: %v", err)
+			return errors.Wrap(err, "failed to find ingress network after creating it")
 		}
 
 	}
@@ -125,7 +126,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 	// network.
 	if !na.IsAllocated(nc.ingressNetwork) {
 		if err := a.allocateNetwork(ctx, nc, nc.ingressNetwork); err != nil {
-			log.G(ctx).Errorf("failed allocating ingress network during init: %v", err)
+			log.G(ctx).WithError(err).Error("failed allocating ingress network during init")
 		}
 
 		// Update store after allocation
@@ -136,7 +137,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 
 			return nil
 		}); err != nil {
-			return fmt.Errorf("failed to create ingress network: %v", err)
+			return errors.Wrap(err, "failed to create ingress network")
 		}
 	}
 
@@ -146,7 +147,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		networks, err = store.FindNetworks(tx, store.All)
 	})
 	if err != nil {
-		return fmt.Errorf("error listing all networks in store while trying to allocate during init: %v", err)
+		return errors.Wrap(err, "error listing all networks in store while trying to allocate during init")
 	}
 
 	for _, n := range networks {
@@ -155,7 +156,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		}
 
 		if err := a.allocateNetwork(ctx, nc, n); err != nil {
-			log.G(ctx).Errorf("failed allocating network %s during init: %v", n.ID, err)
+			log.G(ctx).WithError(err).Errorf("failed allocating network %s during init", n.ID)
 		}
 	}
 
@@ -165,7 +166,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		nodes, err = store.FindNodes(tx, store.All)
 	})
 	if err != nil {
-		return fmt.Errorf("error listing all nodes in store while trying to allocate during init: %v", err)
+		return errors.Wrap(err, "error listing all nodes in store while trying to allocate during init")
 	}
 
 	for _, node := range nodes {
@@ -179,7 +180,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 
 		node.Attachment.Network = nc.ingressNetwork.Copy()
 		if err := a.allocateNode(ctx, nc, node); err != nil {
-			log.G(ctx).Errorf("Failed to allocate network resources for node %s during init: %v", node.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed to allocate network resources for node %s during init", node.ID)
 		}
 	}
 
@@ -189,7 +190,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		services, err = store.FindServices(tx, store.All)
 	})
 	if err != nil {
-		return fmt.Errorf("error listing all services in store while trying to allocate during init: %v", err)
+		return errors.Wrap(err, "error listing all services in store while trying to allocate during init")
 	}
 
 	for _, s := range services {
@@ -198,7 +199,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		}
 
 		if err := a.allocateService(ctx, nc, s); err != nil {
-			log.G(ctx).Errorf("failed allocating service %s during init: %v", s.ID, err)
+			log.G(ctx).WithError(err).Errorf("failed allocating service %s during init", s.ID)
 		}
 	}
 
@@ -208,7 +209,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 		tasks, err = store.FindTasks(tx, store.All)
 	})
 	if err != nil {
-		return fmt.Errorf("error listing all tasks in store while trying to allocate during init: %v", err)
+		return errors.Wrap(err, "error listing all tasks in store while trying to allocate during init")
 	}
 
 	if _, err := a.store.Batch(func(batch *store.Batch) error {
@@ -247,7 +248,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 						updateTaskStatus(storeT, api.TaskStateAllocated, "allocated")
 
 						if err := store.UpdateTask(tx, storeT); err != nil {
-							return fmt.Errorf("failed updating state in store transaction for task %s: %v", storeT.ID, err)
+							return errors.Wrapf(err, "failed updating state in store transaction for task %s", storeT.ID)
 						}
 
 						return nil
@@ -263,7 +264,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) error {
 				return err
 			})
 			if err != nil {
-				log.G(ctx).Errorf("failed allocating task %s during init: %v", t.ID, err)
+				log.G(ctx).WithError(err).Errorf("failed allocating task %s during init", t.ID)
 				nc.unallocatedTasks[t.ID] = t
 			}
 		}
@@ -288,7 +289,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		}
 
 		if err := a.allocateNetwork(ctx, nc, n); err != nil {
-			log.G(ctx).Errorf("Failed allocation for network %s: %v", n.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed allocation for network %s", n.ID)
 			break
 		}
 	case state.EventDeleteNetwork:
@@ -299,7 +300,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		// thing that needs to happen is free the network
 		// resources.
 		if err := nc.nwkAllocator.Deallocate(n); err != nil {
-			log.G(ctx).Errorf("Failed during network free for network %s: %v", n.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed during network free for network %s", n.ID)
 		}
 	case state.EventCreateService:
 		s := v.Service.Copy()
@@ -309,7 +310,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		}
 
 		if err := a.allocateService(ctx, nc, s); err != nil {
-			log.G(ctx).Errorf("Failed allocation for service %s: %v", s.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed allocation for service %s", s.ID)
 			break
 		}
 	case state.EventUpdateService:
@@ -320,14 +321,14 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		}
 
 		if err := a.allocateService(ctx, nc, s); err != nil {
-			log.G(ctx).Errorf("Failed allocation during update of service %s: %v", s.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed allocation during update of service %s", s.ID)
 			break
 		}
 	case state.EventDeleteService:
 		s := v.Service.Copy()
 
 		if err := nc.nwkAllocator.ServiceDeallocate(s); err != nil {
-			log.G(ctx).Errorf("Failed deallocation during delete of service %s: %v", s.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed deallocation during delete of service %s", s.ID)
 		}
 
 		// Remove it from unallocatedServices just in case
@@ -364,7 +365,7 @@ func (a *Allocator) doNodeAlloc(ctx context.Context, nc *networkContext, ev even
 	if isDelete {
 		if nc.nwkAllocator.IsNodeAllocated(node) {
 			if err := nc.nwkAllocator.DeallocateNode(node); err != nil {
-				log.G(ctx).Errorf("Failed freeing network resources for node %s: %v", node.ID, err)
+				log.G(ctx).WithError(err).Errorf("Failed freeing network resources for node %s", node.ID)
 			}
 		}
 		return
@@ -377,7 +378,7 @@ func (a *Allocator) doNodeAlloc(ctx context.Context, nc *networkContext, ev even
 
 		node.Attachment.Network = nc.ingressNetwork.Copy()
 		if err := a.allocateNode(ctx, nc, node); err != nil {
-			log.G(ctx).Errorf("Failed to allocate network resources for node %s: %v", node.ID, err)
+			log.G(ctx).WithError(err).Errorf("Failed to allocate network resources for node %s", node.ID)
 		}
 	}
 }
@@ -485,7 +486,7 @@ func (a *Allocator) doTaskAlloc(ctx context.Context, nc *networkContext, ev even
 	if taskDead(t) || isDelete {
 		if nc.nwkAllocator.IsTaskAllocated(t) {
 			if err := nc.nwkAllocator.DeallocateTask(t); err != nil {
-				log.G(ctx).Errorf("Failed freeing network resources for task %s: %v", t.ID, err)
+				log.G(ctx).WithError(err).Errorf("Failed freeing network resources for task %s", t.ID)
 			}
 		}
 
@@ -538,7 +539,7 @@ func (a *Allocator) allocateNode(ctx context.Context, nc *networkContext, node *
 		for {
 			err := store.UpdateNode(tx, node)
 			if err != nil && err != store.ErrSequenceConflict {
-				return fmt.Errorf("failed updating state in store transaction for node %s: %v", node.ID, err)
+				return errors.Wrapf(err, "failed updating state in store transaction for node %s", node.ID)
 			}
 
 			if err == store.ErrSequenceConflict {
@@ -553,7 +554,7 @@ func (a *Allocator) allocateNode(ctx context.Context, nc *networkContext, node *
 		return nil
 	}); err != nil {
 		if err := nc.nwkAllocator.DeallocateNode(node); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed rolling back allocation of node %s: %v", node.ID, err)
+			log.G(ctx).WithError(err).Errorf("failed rolling back allocation of node %s", node.ID)
 		}
 
 		return err
@@ -623,7 +624,7 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 			err := store.UpdateService(tx, s)
 
 			if err != nil && err != store.ErrSequenceConflict {
-				return fmt.Errorf("failed updating state in store transaction for service %s: %v", s.ID, err)
+				return errors.Wrapf(err, "failed updating state in store transaction for service %s", s.ID)
 			}
 
 			if err == store.ErrSequenceConflict {
@@ -638,7 +639,7 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 		return nil
 	}); err != nil {
 		if err := nc.nwkAllocator.ServiceDeallocate(s); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed rolling back allocation of service %s: %v", s.ID, err)
+			log.G(ctx).WithError(err).Errorf("failed rolling back allocation of service %s", s.ID)
 		}
 
 		return err
@@ -650,12 +651,12 @@ func (a *Allocator) allocateService(ctx context.Context, nc *networkContext, s *
 func (a *Allocator) allocateNetwork(ctx context.Context, nc *networkContext, n *api.Network) error {
 	if err := nc.nwkAllocator.Allocate(n); err != nil {
 		nc.unallocatedNetworks[n.ID] = n
-		return fmt.Errorf("failed during network allocation for network %s: %v", n.ID, err)
+		return errors.Wrapf(err, "failed during network allocation for network %s", n.ID)
 	}
 
 	if err := a.store.Update(func(tx store.Tx) error {
 		if err := store.UpdateNetwork(tx, n); err != nil {
-			return fmt.Errorf("failed updating state in store transaction for network %s: %v", n.ID, err)
+			return errors.Wrapf(err, "failed updating state in store transaction for network %s", n.ID)
 		}
 		return nil
 	}); err != nil {
@@ -710,7 +711,7 @@ func (a *Allocator) allocateTask(ctx context.Context, nc *networkContext, tx sto
 		}
 
 		if err := nc.nwkAllocator.AllocateTask(t); err != nil {
-			return nil, fmt.Errorf("failed during networktask allocation for task %s: %v", t.ID, err)
+			return nil, errors.Wrapf(err, "failed during networktask allocation for task %s", t.ID)
 		}
 		if nc.nwkAllocator.IsTaskAllocated(t) {
 			taskUpdateNetworks(storeT, t.Networks)
@@ -730,7 +731,7 @@ func (a *Allocator) allocateTask(ctx context.Context, nc *networkContext, tx sto
 
 	if taskUpdated {
 		if err := store.UpdateTask(tx, storeT); err != nil {
-			return nil, fmt.Errorf("failed updating state in store transaction for task %s: %v", storeT.ID, err)
+			return nil, errors.Wrapf(err, "failed updating state in store transaction for task %s", storeT.ID)
 		}
 	}
 
@@ -834,7 +835,7 @@ func (a *Allocator) procUnallocatedTasksNetwork(ctx context.Context, nc *network
 
 		retryCnt++
 		if retryCnt >= 3 {
-			log.G(ctx).Errorf("failed to complete batch update of allocated tasks after 3 retries")
+			log.G(ctx).Error("failed to complete batch update of allocated tasks after 3 retries")
 			break
 		}
 	}


### PR DESCRIPTION
Wrap errors with github.com/pkg/errors instead of using fmt.Errorf.

cc @stevvooe