### PR TITLE
Use docker's new mounts API instead of Binds

### DIFF
--- a/agent/exec/dockerapi/container.go
+++ b/agent/exec/dockerapi/container.go
@@ -12,6 +12,7 @@ import (
 	enginecontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/filters"
+	enginemount "github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/volume"
 	"github.com/docker/go-connections/nat"
@@ -147,7 +148,6 @@ func (c *containerConfig) config() *enginecontainer.Config {
 		Tty:          c.spec().TTY,
 		OpenStdin:    c.spec().OpenStdin,
 		Image:        c.image(),
-		Volumes:      c.volumes(),
 		ExposedPorts: c.exposedPorts(),
 		Healthcheck:  c.healthcheck(),
 	}
@@ -185,7 +185,7 @@ func (c *containerConfig) healthcheck() *enginecontainer.HealthConfig {
 func (c *containerConfig) hostConfig() *enginecontainer.HostConfig {
 	hc := &enginecontainer.HostConfig{
 		Resources:    c.resources(),
-		Binds:        c.binds(),
+		Mounts:       c.mounts(),
 		Tmpfs:        c.tmpfs(),
 		GroupAdd:     c.spec().Groups,
 		PortBindings: c.portBindings(),
@@ -247,22 +247,6 @@ func (c *containerConfig) labels() map[string]string {
 	return labels
 }
 
-// volumes gets placed into the Volumes field on the containerConfig.
-func (c *containerConfig) volumes() map[string]struct{} {
-	r := make(map[string]struct{})
-	// Volumes *only* creates anonymous volumes. The rest is mixed in with
-	// binds, which aren't actually fucking binds. Basically, any volume that
-	// results in a single component must be added here.
-	//
-	// This is reversed engineered from the behavior of the engine API.
-	for _, mount := range c.spec().Mounts {
-		if mount.Type == api.MountTypeVolume && mount.Source == "" {
-			r[mount.Target] = struct{}{}
-		}
-	}
-	return r
-}
-
 func (c *containerConfig) tmpfs() map[string]string {
 	r := make(map[string]string)
 
@@ -277,19 +261,69 @@ func (c *containerConfig) tmpfs() map[string]string {
 	return r
 }
 
-func (c *containerConfig) binds() []string {
-	var r []string
+func (c *containerConfig) mounts() []enginemount.Mount {
+	var r []enginemount.Mount
 	for _, mount := range c.spec().Mounts {
-		if mount.Type == api.MountTypeBind || (mount.Type == api.MountTypeVolume && mount.Source != "") {
-			spec := fmt.Sprintf("%s:%s", mount.Source, mount.Target)
-			mask := getMountMask(&mount)
-			if mask != "" {
-				spec = fmt.Sprintf("%s:%s", spec, mask)
-			}
-			r = append(r, spec)
-		}
+		r = append(r, convertMount(mount))
 	}
 	return r
+}
+
+func convertMount(m api.Mount) enginemount.Mount {
+	mount := enginemount.Mount{
+		Source:   m.Source,
+		Target:   m.Target,
+		ReadOnly: m.ReadOnly,
+	}
+
+	switch m.Type {
+	case api.MountTypeBind:
+		mount.Type = enginemount.TypeBind
+	case api.MountTypeVolume:
+		mount.Type = enginemount.TypeVolume
+	}
+
+	if m.BindOptions != nil {
+		mount.BindOptions = &enginemount.BindOptions{}
+		switch m.BindOptions.Propagation {
+		case api.MountPropagationRPrivate:
+			mount.BindOptions.Propagation = enginemount.PropagationRPrivate
+		case api.MountPropagationPrivate:
+			mount.BindOptions.Propagation = enginemount.PropagationPrivate
+		case api.MountPropagationRSlave:
+			mount.BindOptions.Propagation = enginemount.PropagationRSlave
+		case api.MountPropagationSlave:
+			mount.BindOptions.Propagation = enginemount.PropagationSlave
+		case api.MountPropagationRShared:
+			mount.BindOptions.Propagation = enginemount.PropagationRShared
+		case api.MountPropagationShared:
+			mount.BindOptions.Propagation = enginemount.PropagationShared
+		}
+	}
+
+	if m.VolumeOptions != nil {
+		mount.VolumeOptions = &enginemount.VolumeOptions{
+			NoCopy: m.VolumeOptions.NoCopy,
+		}
+		if m.VolumeOptions.Labels != nil {
+			mount.VolumeOptions.Labels = make(map[string]string, len(m.VolumeOptions.Labels))
+			for k, v := range m.VolumeOptions.Labels {
+				mount.VolumeOptions.Labels[k] = v
+			}
+		}
+		if m.VolumeOptions.DriverConfig != nil {
+			mount.VolumeOptions.DriverConfig = &enginemount.Driver{
+				Name: m.VolumeOptions.DriverConfig.Name,
+			}
+			if m.VolumeOptions.DriverConfig.Options != nil {
+				mount.VolumeOptions.DriverConfig.Options = make(map[string]string, len(m.VolumeOptions.DriverConfig.Options))
+				for k, v := range m.VolumeOptions.DriverConfig.Options {
+					mount.VolumeOptions.DriverConfig.Options[k] = v
+				}
+			}
+		}
+	}
+	return mount
 }
 
 func getMountMask(m *api.Mount) string {
@@ -299,29 +333,6 @@ func getMountMask(m *api.Mount) string {
 	}
 
 	switch m.Type {
-	case api.MountTypeVolume:
-		if m.VolumeOptions != nil && m.VolumeOptions.NoCopy {
-			maskOpts = append(maskOpts, "nocopy")
-		}
-	case api.MountTypeBind:
-		if m.BindOptions == nil {
-			break
-		}
-
-		switch m.BindOptions.Propagation {
-		case api.MountPropagationPrivate:
-			maskOpts = append(maskOpts, "private")
-		case api.MountPropagationRPrivate:
-			maskOpts = append(maskOpts, "rprivate")
-		case api.MountPropagationShared:
-			maskOpts = append(maskOpts, "shared")
-		case api.MountPropagationRShared:
-			maskOpts = append(maskOpts, "rshared")
-		case api.MountPropagationSlave:
-			maskOpts = append(maskOpts, "slave")
-		case api.MountPropagationRSlave:
-			maskOpts = append(maskOpts, "rslave")
-		}
 	case api.MountTypeTmpfs:
 		if m.TmpfsOptions == nil {
 			break


### PR DESCRIPTION
Closes #1308 -- though this will be handled in the engine itself instead of the agent/exec interface. Not sure if we also want to check this in the agent.
