### PR TITLE
raft: use CheckQuorum option

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -317,6 +317,7 @@ func DefaultNodeConfig() *raft.Config {
 		MaxSizePerMsg:   math.MaxUint16,
 		MaxInflightMsgs: 256,
 		Logger:          log.L,
+		CheckQuorum:     true,
 	}
 }
 


### PR DESCRIPTION
Leader steps down as follower when quorum is lost. This option enabled
by default in etcd as well.