### PR TITLE
Revert "rewrite part of NewNode to handle all kinds of err"

### DIFF
--- a/agent/node.go
+++ b/agent/node.go
@@ -108,16 +108,11 @@ func NewNode(c *NodeConfig) (*Node, error) {
 	}
 	stateFile := filepath.Join(c.StateDir, stateFilename)
 	dt, err := ioutil.ReadFile(stateFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = errors.Wrap(err, "local state file does not exist")
-		}
+	var p []api.Peer
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
-
-	var p []api.Peer
-
-	if len(dt) > 0 {
+	if err == nil {
 		if err := json.Unmarshal(dt, &p); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This reverts commit ab756e027570ffb531220cb2b8dc3c1cfa788ba5.

The original PR was based on a misunderstanding of the code. It treats a
nonexistent state file as a fatal error, but this is meant to be
ignored.

This revert is necessary to make node initialization work again. See https://github.com/docker/swarmkit/pull/1087#issuecomment-249774565

cc @allencloud @LK4D4 @stevvooe @dperny