### PR TITLE
replicated orchestrator: Delete tasks on scale down

### DIFF
--- a/manager/orchestrator/drain_test.go
+++ b/manager/orchestrator/drain_test.go
@@ -100,7 +100,9 @@ func TestDrain(t *testing.T) {
 	initialTaskSet := []*api.Task{
 		// Task not assigned to any node
 		{
-			ID: "id0",
+			ID:           "id0",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
@@ -112,7 +114,9 @@ func TestDrain(t *testing.T) {
 		},
 		// Tasks assigned to the nodes defined above
 		{
-			ID: "id1",
+			ID:           "id1",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
@@ -124,7 +128,9 @@ func TestDrain(t *testing.T) {
 			NodeID:    "id1",
 		},
 		{
-			ID: "id2",
+			ID:           "id2",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
@@ -136,7 +142,9 @@ func TestDrain(t *testing.T) {
 			NodeID:    "id2",
 		},
 		{
-			ID: "id3",
+			ID:           "id3",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
@@ -148,7 +156,9 @@ func TestDrain(t *testing.T) {
 			NodeID:    "id3",
 		},
 		{
-			ID: "id4",
+			ID:           "id4",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},
@@ -160,7 +170,9 @@ func TestDrain(t *testing.T) {
 			NodeID:    "id4",
 		},
 		{
-			ID: "id5",
+			ID:           "id5",
+			DesiredState: api.TaskStateRunning,
+			Spec:         initialService.Spec.Task,
 			Status: api.TaskStatus{
 				State: api.TaskStateNew,
 			},

--- a/manager/orchestrator/replicated_test.go
+++ b/manager/orchestrator/replicated_test.go
@@ -153,11 +153,11 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	observedDeletion1 := watchShutdownTask(t, watch)
+	observedDeletion1 := watchTaskDelete(t, watch)
 	assert.Equal(t, observedDeletion1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion1.ServiceAnnotations.Name, "name2")
 
-	observedDeletion2 := watchShutdownTask(t, watch)
+	observedDeletion2 := watchTaskDelete(t, watch)
 	assert.Equal(t, observedDeletion2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedDeletion2.ServiceAnnotations.Name, "name2")
 
@@ -208,7 +208,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{}, state.EventDeleteTask{})
 	defer cancel()
 
 	s1 := &api.Service{
@@ -384,7 +384,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	// be the one the orchestrator chose to shut down because it was not
 	// assigned yet.
 
-	observedShutdown := watchShutdownTask(t, watch)
+	observedShutdown := watchTaskDelete(t, watch)
 	assert.Equal(t, "task7", observedShutdown.ID)
 
 	// Now scale down to 2 instances.
@@ -405,7 +405,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 
 	shutdowns := make(map[string]int)
 	for i := 0; i != 4; i++ {
-		observedShutdown := watchShutdownTask(t, watch)
+		observedShutdown := watchTaskDelete(t, watch)
 		shutdowns[observedShutdown.NodeID]++
 	}
 

--- a/manager/orchestrator/updater_test.go
+++ b/manager/orchestrator/updater_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getRunnableSlotSlice(t *testing.T, s *store.MemoryStore, service *api.Service) []slot {
-	runnable, err := getRunnableSlots(s, service.ID)
+	runnable, _, err := getRunnableAndDeadSlots(s, service.ID)
 	require.NoError(t, err)
 
 	var runnableSlice []slot


### PR DESCRIPTION
When scaling down, we don't want to preserve task history for the slots
that are being removed. These historic tasks are distracting to users
and never get garbage collected.

Make the orchestrator delete these tasks instead of simply shutting them
down.

Always do this for slots that have no runnable tasks on service
reconcilation, so this isn't limited to scale-down operations. This
should properly clean up tasks that were left over by earlier versions.

Fixes #1372

cc @aluzzardi @dongluochen