### PR TITLE
Update service name validation regex error message

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -66,7 +66,7 @@ func validateAnnotations(m api.Annotations) error {
 		return grpc.Errorf(codes.InvalidArgument, "meta: name must be provided")
 	} else if !isValidName.MatchString(m.Name) {
 		// if the name doesn't match the regex
-		return grpc.Errorf(codes.InvalidArgument, "invalid name, only [a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9] are allowed")
+		return grpc.Errorf(codes.InvalidArgument, "name must be valid as a DNS name component")
 	}
 	return nil
 }


### PR DESCRIPTION
The regex string in the error message was out of sync with the actual
regex being used to validate a service name.

The actual regex (`isValidName`) being used is here: https://github.com/tombee/swarmkit/blob/fa4be1382a605f7ff645e734b7754f95803ed1ff/manager/controlapi/common.go#L13

Signed-off-by: Tom Barlow <tomwbarlow@gmail.com>