### PR TITLE
raft: Deduplicate node-level options

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -197,7 +197,7 @@ func New(config *Config) (*Manager, error) {
 		raftCfg.HeartbeatTick = int(config.HeartbeatTick)
 	}
 
-	newNodeOpts := raft.NewNodeOptions{
+	newNodeOpts := raft.NodeOptions{
 		ID:              config.SecurityConfig.ClientTLSCreds.NodeID(),
 		Addr:            tcpAddr,
 		JoinAddr:        config.JoinRaft,

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -591,7 +591,7 @@ func TestRaftUnreachableNode(t *testing.T) {
 
 	ctx := context.Background()
 	// Add a new node
-	nodes[2] = raftutils.NewNode(t, clockSource, tc, raft.NewNodeOptions{JoinAddr: nodes[1].Address})
+	nodes[2] = raftutils.NewNode(t, clockSource, tc, raft.NodeOptions{JoinAddr: nodes[1].Address})
 
 	err := nodes[2].JoinAndStart()
 	require.NoError(t, err, "can't join cluster")
@@ -639,7 +639,7 @@ func TestRaftJoinWithIncorrectAddress(t *testing.T) {
 	defer raftutils.ShutdownNode(nodes[1])
 
 	// Try joining a new node with an incorrect address
-	n := raftutils.NewNode(t, clockSource, tc, raft.NewNodeOptions{JoinAddr: nodes[1].Address, Addr: "1.2.3.4:1234"})
+	n := raftutils.NewNode(t, clockSource, tc, raft.NodeOptions{JoinAddr: nodes[1].Address, Addr: "1.2.3.4:1234"})
 	defer raftutils.CleanupNonRunningNode(n)
 
 	err := n.JoinAndStart()

--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -26,19 +26,19 @@ import (
 var errNoWAL = errors.New("no WAL present")
 
 func (n *Node) legacyWALDir() string {
-	return filepath.Join(n.StateDir, "wal")
+	return filepath.Join(n.opts.StateDir, "wal")
 }
 
 func (n *Node) walDir() string {
-	return filepath.Join(n.StateDir, "wal-v3")
+	return filepath.Join(n.opts.StateDir, "wal-v3")
 }
 
 func (n *Node) legacySnapDir() string {
-	return filepath.Join(n.StateDir, "snap")
+	return filepath.Join(n.opts.StateDir, "snap")
 }
 
 func (n *Node) snapDir() string {
-	return filepath.Join(n.StateDir, "snap-v3")
+	return filepath.Join(n.opts.StateDir, "snap-v3")
 }
 
 func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
@@ -189,7 +189,7 @@ func (n *Node) createWAL(nodeID string) (raft.Peer, error) {
 	raftNode := &api.RaftMember{
 		RaftID: n.Config.ID,
 		NodeID: nodeID,
-		Addr:   n.Address,
+		Addr:   n.opts.Addr,
 	}
 	metadata, err := raftNode.Marshal()
 	if err != nil {
@@ -207,7 +207,7 @@ func (n *Node) createWAL(nodeID string) (raft.Peer, error) {
 // moveWALAndSnap moves away the WAL and snapshot because we were removed
 // from the cluster and will need to recreate them if we are readded.
 func (n *Node) moveWALAndSnap() error {
-	newWALDir, err := ioutil.TempDir(n.StateDir, "wal.")
+	newWALDir, err := ioutil.TempDir(n.opts.StateDir, "wal.")
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (n *Node) moveWALAndSnap() error {
 		return err
 	}
 
-	newSnapDir, err := ioutil.TempDir(n.StateDir, "snap.")
+	newSnapDir, err := ioutil.TempDir(n.opts.StateDir, "snap.")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Node structure has too many fields. One small step in the right
direction is removing fields that are directly copied from the
NewNodeOptions struct, which is also referenced in Node. There is less
potential for error if there is a single source of truth for these
options rather than storing the values in two places.

Rename NewNodeOpts to NodeOpts, since it's really used for more than
NewNode.