### PR TITLE
scheduler: Fix constraint evaluation when assigning more than one task

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -505,7 +505,6 @@ func (s *Scheduler) scheduleTaskGroup(ctx context.Context, taskGroup map[string]
 			nextNode := nodes[(nodeIter+1)%len(nodes)]
 			if nodeLess(&nextNode, &nodeInfo) {
 				nodeIter++
-				continue
 			}
 		} else {
 			// In later passes, we just assign one task at a time


### PR DESCRIPTION
The constraint logic in the HA scheduler has a bug. Constraints get
ignored when assigning more than one task at once to the same node. This
is caused by a bad "continue" that skips the constraint check. Remove
this check, and also add a unit test.

cc @dongluochen