### PR TITLE
raft: rethink context usage

### DIFF
--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -302,9 +302,9 @@ func TestListManagerNodes(t *testing.T) {
 
 	// Stops 2 nodes
 	nodes[4].Server.Stop()
-	nodes[4].Shutdown()
+	nodes[4].ShutdownRaft()
 	nodes[5].Server.Stop()
-	nodes[5].Shutdown()
+	nodes[5].ShutdownRaft()
 
 	// Node 4 and Node 5 should be listed as Unreachable
 	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
@@ -356,7 +356,7 @@ func TestListManagerNodes(t *testing.T) {
 
 	// Stop node 1 (leader)
 	nodes[1].Server.Stop()
-	nodes[1].Shutdown()
+	nodes[1].ShutdownRaft()
 
 	newCluster := map[uint64]*raftutils.TestNode{
 		2: nodes[2],
@@ -389,7 +389,7 @@ func TestListManagerNodes(t *testing.T) {
 	}))
 
 	// Restart node 1
-	nodes[1].Shutdown()
+	nodes[1].ShutdownRaft()
 	nodes[1] = raftutils.RestartNode(t, clockSource, nodes[1], false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
@@ -544,7 +544,7 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 
 	// Stop Node 3 (1 node out of 3)
 	nodes[3].Server.Stop()
-	nodes[3].Shutdown()
+	nodes[3].ShutdownRaft()
 
 	// Node 3 should be listed as Unreachable
 	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -256,9 +256,9 @@ func TestCanRemoveMember(t *testing.T) {
 
 	// Stop node 2 and node 3 (2 nodes out of 3)
 	nodes[2].Server.Stop()
-	nodes[2].Shutdown()
+	nodes[2].ShutdownRaft()
 	nodes[3].Server.Stop()
-	nodes[3].Shutdown()
+	nodes[3].ShutdownRaft()
 
 	// Node 2 and Node 3 should be listed as Unreachable
 	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {
@@ -307,7 +307,7 @@ func TestCanRemoveMember(t *testing.T) {
 
 	// Stop Node 3 (1 node out of 3)
 	nodes[3].Server.Stop()
-	nodes[3].Shutdown()
+	nodes[3].ShutdownRaft()
 
 	// Node 3 should be listed as Unreachable
 	assert.NoError(t, raftutils.PollFunc(clockSource, func() error {

--- a/manager/state/raft/storage_test.go
+++ b/manager/state/raft/storage_test.go
@@ -147,7 +147,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 
 	// Take down node 3
 	nodes[3].Server.Stop()
-	nodes[3].Shutdown()
+	nodes[3].ShutdownRaft()
 
 	// Propose a 4th value before the snapshot
 	values[3], err = raftutils.ProposeValue(t, nodes[1], DefaultProposalTime, nodeIDs[3])
@@ -236,7 +236,7 @@ func TestRaftSnapshotRestart(t *testing.T) {
 
 	// Restart node 3 again. It should load the snapshot.
 	nodes[3].Server.Stop()
-	nodes[3].Shutdown()
+	nodes[3].ShutdownRaft()
 	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], false)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
@@ -339,7 +339,7 @@ func TestGCWAL(t *testing.T) {
 	// Restart the whole cluster
 	for _, node := range nodes {
 		node.Server.Stop()
-		node.Shutdown()
+		node.ShutdownRaft()
 	}
 
 	raftutils.AdvanceTicks(clockSource, 5)
@@ -449,7 +449,7 @@ func TestMigrateWAL(t *testing.T) {
 	raftutils.CheckValuesOnNodes(t, clockSource, nodes, []string{"id1"}, []*api.Node{value})
 
 	nodes[1].Server.Stop()
-	nodes[1].Shutdown()
+	nodes[1].ShutdownRaft()
 
 	// Move WAL directory so it looks like it was created by an old version
 	require.NoError(t, os.Rename(filepath.Join(nodes[1].StateDir, "wal-v3"), filepath.Join(nodes[1].StateDir, "wal")))


### PR DESCRIPTION
* Remove Ctx field from struct, use `stopped` channed as stop signal
instead.
* Add WithContext method which returns child context which also cancelled
on close of `stopped` channel.
* All top level functions use WithContext (Run, RemoveNode, grpc
handlers).
This is sorta intersects with #1580 
ping @aaronlehmann 
