### PR TITLE
agent: handle errors better

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -339,6 +339,16 @@ func (s *session) sendTaskStatuses(ctx context.Context, updates ...*api.UpdateTa
 	return updates[n:], nil
 }
 
+// sendError is used to send errors to errs channel and trigger session recreation
+func (s *session) sendError(err error) {
+	select {
+	case s.errs <- err:
+	case <-s.closed:
+	}
+}
+
+// close closing session. It should be called only in <-session.errs branch
+// of event loop.
 func (s *session) close() error {
 	s.closeOnce.Do(func() {
 		if s.conn != nil {


### PR DESCRIPTION
* Do not close session anywhere apart from session.errs branch, because
direct session.close() won't trigger backoff increase.
* Do not set sessionq until registration is finished, otherwise tasks
won't wait and report error about session which still in process of
registering.

I will port this to 1.12.2 if it's approved.
ping @stevvooe @aaronlehmann @mrjana 