### PR TITLE
Update certificate renewal to use whole validity period

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -669,25 +669,26 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, r
 	}
 }
 
-// readCertExpiration returns the number of months left for certificate expiration
-func readCertExpiration(paths CertPaths) (time.Duration, error) {
+// readCertValidity returns the certificate issue and expiration time
+func readCertValidity(paths CertPaths) (time.Time, time.Time, error) {
+	var zeroTime time.Time
 	// Read the Cert
 	cert, err := ioutil.ReadFile(paths.Cert)
 	if err != nil {
-		return time.Hour, err
+		return zeroTime, zeroTime, err
 	}
 
 	// Create an x509 certificate out of the contents on disk
 	certBlock, _ := pem.Decode([]byte(cert))
 	if certBlock == nil {
-		return time.Hour, errors.New("failed to decode certificate block")
+		return zeroTime, zeroTime, errors.New("failed to decode certificate block")
 	}
 	X509Cert, err := x509.ParseCertificate(certBlock.Bytes)
 	if err != nil {
-		return time.Hour, err
+		return zeroTime, zeroTime, err
 	}
 
-	return X509Cert.NotAfter.Sub(time.Now()), nil
+	return X509Cert.NotBefore, X509Cert.NotAfter, nil
 
 }
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -336,8 +336,8 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, baseCertDir string, 
 
 			// Since the expiration of the certificate is managed remotely we should update our
 			// retry timer on every iteration of this loop.
-			// Retrieve the time until the certificate expires.
-			expiresIn, err := readCertExpiration(paths.Node)
+			// Retrieve the current certificate expiration information.
+			validFrom, validUntil, err := readCertValidity(paths.Node)
 			if err != nil {
 				// We failed to read the expiration, let's stick with the starting default
 				log.Errorf("failed to read the expiration of the TLS certificate in: %s", paths.Node.Cert)
@@ -345,12 +345,12 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, baseCertDir string, 
 			} else {
 				// If we have an expired certificate, we let's stick with the starting default in
 				// the hope that this is a temporary clock skew.
-				if expiresIn.Minutes() < 0 {
+				if validUntil.Before(time.Now()) {
 					log.WithError(err).Errorf("failed to create a new client TLS config")
 					updates <- CertificateUpdate{Err: errors.New("TLS certificate is expired")}
 				} else {
 					// Random retry time between 50% and 80% of the total time to expiration
-					retry = calculateRandomExpiry(expiresIn)
+					retry = calculateRandomExpiry(validFrom, validUntil)
 				}
 			}
 
@@ -420,18 +420,16 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, baseCertDir string, 
 	return updates
 }
 
-// calculateRandomExpiry returns a random duration between 50% and 80% of the original
-// duration
-func calculateRandomExpiry(expiresIn time.Duration) time.Duration {
-	if expiresIn.Minutes() <= 1 {
-		return time.Second
-	}
+// calculateRandomExpiry returns a random duration between 50% and 80% of the
+// original validity period
+func calculateRandomExpiry(validFrom, validUntil time.Time) time.Duration {
+	duration := validUntil.Sub(validFrom)
 
 	var randomExpiry int
 	// Our lower bound of renewal will be half of the total expiration time
-	minValidity := int(expiresIn.Minutes() * CertLowerRotationRange)
+	minValidity := int(duration.Minutes() * CertLowerRotationRange)
 	// Our upper bound of renewal will be 80% of the total expiration time
-	maxValidity := int(expiresIn.Minutes() * CertUpperRotationRange)
+	maxValidity := int(duration.Minutes() * CertUpperRotationRange)
 	// Let's select a random number of minutes between min and max, and set our retry for that
 	// Using randomly selected rotation allows us to avoid certificate thundering herds.
 	if maxValidity-minValidity < 1 {
@@ -440,7 +438,11 @@ func calculateRandomExpiry(expiresIn time.Duration) time.Duration {
 		randomExpiry = rand.Intn(maxValidity-minValidity) + int(minValidity)
 	}
 
-	return time.Duration(randomExpiry) * time.Minute
+	expiry := validFrom.Add(time.Duration(randomExpiry) * time.Minute).Sub(time.Now())
+	if expiry < 0 {
+		return 0
+	}
+	return expiry
 }
 
 // LoadTLSCreds loads tls credentials from the specified path and verifies that


### PR DESCRIPTION
Change the renewal time detection to always look the full validity period of an old certificate so that restarts don't start to delay the initial renewal time.

cc @diogomonica @aaronlehmann 

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>