### PR TITLE
Do not allow service creation on ingress network

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -170,6 +170,24 @@ func validateEndpointSpec(epSpec *api.EndpointSpec) error {
 	return nil
 }
 
+func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error {
+	for _, na := range networks {
+		var network *api.Network
+		s.store.View(func(tx store.ReadTx) {
+			network = store.FindNetwork(tx, na.Target)
+		})
+		if network == nil {
+			continue
+		}
+		if _, ok := network.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
+			return grpc.Errorf(codes.InvalidArgument,
+				"Service cannot be explicitly attached to %q network which is a swarm internal network",
+				network.Spec.Annotations.Name)
+		}
+	}
+	return nil
+}
+
 func validateServiceSpec(spec *api.ServiceSpec) error {
 	if spec == nil {
 		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
@@ -256,6 +274,10 @@ func (s *Server) checkPortConflicts(spec *api.ServiceSpec, serviceID string) err
 // - Returns an error if the creation fails.
 func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRequest) (*api.CreateServiceResponse, error) {
 	if err := validateServiceSpec(request.Spec); err != nil {
+		return nil, err
+	}
+
+	if err := s.validateNetworks(request.Spec.Networks); err != nil {
 		return nil, err
 	}
 

--- a/manager/state/store/networks.go
+++ b/manager/state/store/networks.go
@@ -183,6 +183,22 @@ func FindNetworks(tx ReadTx, by By) ([]*api.Network, error) {
 	return networkList, err
 }
 
+// FindNetwork is a utility function which returns the first
+// network for which the target string matches the ID, or
+// the name or the ID prefix.
+func FindNetwork(tx ReadTx, target string) *api.Network {
+	if n := GetNetwork(tx, target); n != nil {
+		return n
+	}
+	if list, err := FindNetworks(tx, ByName(target)); err == nil && len(list) == 1 {
+		return list[0]
+	}
+	if list, err := FindNetworks(tx, ByIDPrefix(target)); err == nil && len(list) == 1 {
+		return list[0]
+	}
+	return nil
+}
+
 type networkIndexerByID struct{}
 
 func (ni networkIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {


### PR DESCRIPTION
Related to https://github.com/docker/docker/issues/27147

```
$ docker network ls
NETWORK ID          NAME                DRIVER              SCOPE
9303692245a0        bridge              bridge              local
c4f927d72329        docker_gwbridge     bridge              local
1de6d5796506        host                host                local
640eymcv5g3c        ingress             overlay             swarm
7af0bf63afad        none                null                local
$ 
$ docker network inspect ingress | grep Id
        "Id": "640eymcv5g3cabu4jdffrandw",
$ 
$ docker service create --network 640eymcv5g3cabu4jdffrandw busybox top
Error response from daemon: rpc error: code = 3 desc = Service cannot be explicitly attached to "ingress" network which is a swarm internal network
$ 
$ docker service create --network ingress busybox top
Error response from daemon: rpc error: code = 3 desc = Service cannot be explicitly attached to "ingress" network which is a swarm internal network
$ 
$ docker service create --network 640eymcv5g3c busybox top
Error response from daemon: rpc error: code = 3 desc = Service cannot be explicitly attached to "ingress" network which is a swarm internal network
$
```
