### PR TITLE
Clarify that NetworkAttachment target is an ID

### DIFF
--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -1053,8 +1053,8 @@ func _TaskStatus_OneofSizer(msg proto.Message) (n int) {
 // instructing Swarm on how this service should work on the particular
 // network.
 type NetworkAttachmentConfig struct {
-	// Target specifies the target network for attachment. This value may be a
-	// network name or identifier. Only identifiers are supported at this time.
+	// Target specifies the target network for attachment. This value must be a
+	// network ID.
 	Target string `protobuf:"bytes,1,opt,name=target,proto3" json:"target,omitempty"`
 	// Aliases specifies a list of discoverable alternate names for the service on this Target.
 	Aliases []string `protobuf:"bytes,2,rep,name=aliases" json:"aliases,omitempty"`

--- a/api/types.proto
+++ b/api/types.proto
@@ -447,8 +447,8 @@ message TaskStatus {
 // instructing Swarm on how this service should work on the particular
 // network.
 message NetworkAttachmentConfig {
-	// Target specifies the target network for attachment. This value may be a
-	// network name or identifier. Only identifiers are supported at this time.
+	// Target specifies the target network for attachment. This value must be a
+	// network ID.
 	string target = 1;
 	// Aliases specifies a list of discoverable alternate names for the service on this Target.
 	repeated string aliases = 2;

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -174,7 +174,7 @@ func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error
 	for _, na := range networks {
 		var network *api.Network
 		s.store.View(func(tx store.ReadTx) {
-			network = store.FindNetwork(tx, na.Target)
+			network = store.GetNetwork(tx, na.Target)
 		})
 		if network == nil {
 			continue

--- a/manager/state/store/networks.go
+++ b/manager/state/store/networks.go
@@ -183,22 +183,6 @@ func FindNetworks(tx ReadTx, by By) ([]*api.Network, error) {
 	return networkList, err
 }
 
-// FindNetwork is a utility function which returns the first
-// network for which the target string matches the ID, or
-// the name or the ID prefix.
-func FindNetwork(tx ReadTx, target string) *api.Network {
-	if n := GetNetwork(tx, target); n != nil {
-		return n
-	}
-	if list, err := FindNetworks(tx, ByName(target)); err == nil && len(list) == 1 {
-		return list[0]
-	}
-	if list, err := FindNetworks(tx, ByIDPrefix(target)); err == nil && len(list) == 1 {
-		return list[0]
-	}
-	return nil
-}
-
 type networkIndexerByID struct{}
 
 func (ni networkIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {


### PR DESCRIPTION
PR #1600 added a FindNetwork function to the store package to resolve a
NetworkAttachment's target by ID, name, or name prefix. I think this is
based on a misleading comment in the NetworkAttachment definition saying
that the target can be a name or an ID. In fact, it's always an ID, and
existing code passes it directly to GetNetwork.

Clarify the comment and remove FindNetwork.

cc @aboch @mrjana @aluzzardi