### PR TITLE
Honor Network and IPAM plugin

### DIFF
--- a/manager/allocator/networkallocator/drivers_ipam.go
+++ b/manager/allocator/networkallocator/drivers_ipam.go
@@ -1,0 +1,23 @@
+package networkallocator
+
+import (
+	"github.com/docker/libnetwork/drvregistry"
+	"github.com/docker/libnetwork/ipamapi"
+	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
+	nullIpam "github.com/docker/libnetwork/ipams/null"
+	remoteIpam "github.com/docker/libnetwork/ipams/remote"
+)
+
+func initIPAMDrivers(r *drvregistry.DrvRegistry) error {
+	for _, fn := range [](func(ipamapi.Callback, interface{}, interface{}) error){
+		builtinIpam.Init,
+		remoteIpam.Init,
+		nullIpam.Init,
+	} {
+		if err := fn(r, nil, nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/manager/allocator/networkallocator/drivers_linux.go
+++ b/manager/allocator/networkallocator/drivers_linux.go
@@ -1,0 +1,13 @@
+package networkallocator
+
+import (
+	"github.com/docker/libnetwork/drivers/overlay/ovmanager"
+	"github.com/docker/libnetwork/drivers/remote"
+)
+
+func getInitializers() []initializer {
+	return []initializer{
+		{remote.Init, "remote"},
+		{ovmanager.Init, "overlay"},
+	}
+}

--- a/manager/allocator/networkallocator/drivers_unsupported.go
+++ b/manager/allocator/networkallocator/drivers_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package networkallocator
+
+func getInitializers() []initializer {
+	return nil
+}

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -60,10 +58,6 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 		return err
 	}
 
-	if ipam.Driver != nil && ipam.Driver.Name != ipamapi.DefaultIPAM {
-		return grpc.Errorf(codes.InvalidArgument, "invalid IPAM specified")
-	}
-
 	for _, ipamConf := range ipam.Configs {
 		if err := validateIPAMConfiguration(ipamConf); err != nil {
 			return err
@@ -84,10 +78,6 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 
 	if err := validateDriver(spec.DriverConfig); err != nil {
 		return err
-	}
-
-	if spec.DriverConfig != nil && spec.DriverConfig.Name != networkallocator.DefaultDriver {
-		return grpc.Errorf(codes.InvalidArgument, "invalid driver specified")
 	}
 
 	if err := validateIPAM(spec.IPAM); err != nil {

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -144,34 +144,6 @@ func TestValidateIPAMConfiguration(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestValidateIPAM(t *testing.T) {
-	assert.NoError(t, validateIPAM(nil))
-	ipam := &api.IPAMOptions{
-		Driver: &api.Driver{
-			Name: "external",
-		},
-	}
-
-	err := validateIPAM(ipam)
-	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
-}
-
-func TestValidateNetworkSpec(t *testing.T) {
-	err := validateNetworkSpec(nil)
-	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
-
-	spec := createNetworkSpec("invalid_driver")
-	spec.DriverConfig = &api.Driver{
-		Name: "external",
-	}
-
-	err = validateNetworkSpec(spec)
-	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
-}
-
 func TestCreateNetwork(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Stop()

--- a/vendor.conf
+++ b/vendor.conf
@@ -19,7 +19,7 @@ github.com/docker/go-connections 34b5052da6b11e27f5f2e357b38b571ddddd3928
 github.com/docker/go-events 37d35add5005832485c0225ec870121b78fcff1c
 github.com/docker/go-units 954fed01cc617c55d838fa2230073f2cb17386c8
 github.com/docker/libkv 9fd56606e928ff1f309808f5d5a0b7a2ef73f9a8
-github.com/docker/libnetwork 7b26d7e3009f57409cbd15b5cd42e240c1a13510
+github.com/docker/libnetwork 7b74403be4241aea5b01b56adab5eab82a80698b
 github.com/opencontainers/runc 8e8d01d38d7b4fb0a35bf89b72bc3e18c98882d7
 
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/vendor/github.com/docker/libnetwork/drivers/remote/api/api.go
+++ b/vendor/github.com/docker/libnetwork/drivers/remote/api/api.go
@@ -1,0 +1,220 @@
+/*
+Package api represents all requests and responses suitable for conversation
+with a remote driver.
+*/
+package api
+
+import (
+	"net"
+
+	"github.com/docker/libnetwork/discoverapi"
+	"github.com/docker/libnetwork/driverapi"
+)
+
+// Response is the basic response structure used in all responses.
+type Response struct {
+	Err string
+}
+
+// GetError returns the error from the response, if any.
+func (r *Response) GetError() string {
+	return r.Err
+}
+
+// GetCapabilityResponse is the response of GetCapability request
+type GetCapabilityResponse struct {
+	Response
+	Scope string
+}
+
+// AllocateNetworkRequest requests allocation of new network by manager
+type AllocateNetworkRequest struct {
+	// A network ID that remote plugins are expected to store for future
+	// reference.
+	NetworkID string
+
+	// A free form map->object interface for communication of options.
+	Options map[string]string
+
+	// IPAMData contains the address pool information for this network
+	IPv4Data, IPv6Data []driverapi.IPAMData
+}
+
+// AllocateNetworkResponse is the response to the AllocateNetworkRequest.
+type AllocateNetworkResponse struct {
+	Response
+	// A free form plugin specific string->string object to be sent in
+	// CreateNetworkRequest call in the libnetwork agents
+	Options map[string]string
+}
+
+// FreeNetworkRequest is the request to free allocated network in the manager
+type FreeNetworkRequest struct {
+	// The ID of the network to be freed.
+	NetworkID string
+}
+
+// FreeNetworkResponse is the response to a request for freeing a network.
+type FreeNetworkResponse struct {
+	Response
+}
+
+// CreateNetworkRequest requests a new network.
+type CreateNetworkRequest struct {
+	// A network ID that remote plugins are expected to store for future
+	// reference.
+	NetworkID string
+
+	// A free form map->object interface for communication of options.
+	Options map[string]interface{}
+
+	// IPAMData contains the address pool information for this network
+	IPv4Data, IPv6Data []driverapi.IPAMData
+}
+
+// CreateNetworkResponse is the response to the CreateNetworkRequest.
+type CreateNetworkResponse struct {
+	Response
+}
+
+// DeleteNetworkRequest is the request to delete an existing network.
+type DeleteNetworkRequest struct {
+	// The ID of the network to delete.
+	NetworkID string
+}
+
+// DeleteNetworkResponse is the response to a request for deleting a network.
+type DeleteNetworkResponse struct {
+	Response
+}
+
+// CreateEndpointRequest is the request to create an endpoint within a network.
+type CreateEndpointRequest struct {
+	// Provided at create time, this will be the network id referenced.
+	NetworkID string
+	// The ID of the endpoint for later reference.
+	EndpointID string
+	Interface  *EndpointInterface
+	Options    map[string]interface{}
+}
+
+// EndpointInterface represents an interface endpoint.
+type EndpointInterface struct {
+	Address     string
+	AddressIPv6 string
+	MacAddress  string
+}
+
+// CreateEndpointResponse is the response to the CreateEndpoint action.
+type CreateEndpointResponse struct {
+	Response
+	Interface *EndpointInterface
+}
+
+// Interface is the representation of a linux interface.
+type Interface struct {
+	Address     *net.IPNet
+	AddressIPv6 *net.IPNet
+	MacAddress  net.HardwareAddr
+}
+
+// DeleteEndpointRequest describes the API for deleting an endpoint.
+type DeleteEndpointRequest struct {
+	NetworkID  string
+	EndpointID string
+}
+
+// DeleteEndpointResponse is the response to the DeleteEndpoint action.
+type DeleteEndpointResponse struct {
+	Response
+}
+
+// EndpointInfoRequest retrieves information about the endpoint from the network driver.
+type EndpointInfoRequest struct {
+	NetworkID  string
+	EndpointID string
+}
+
+// EndpointInfoResponse is the response to an EndpointInfoRequest.
+type EndpointInfoResponse struct {
+	Response
+	Value map[string]interface{}
+}
+
+// JoinRequest describes the API for joining an endpoint to a sandbox.
+type JoinRequest struct {
+	NetworkID  string
+	EndpointID string
+	SandboxKey string
+	Options    map[string]interface{}
+}
+
+// InterfaceName is the struct represetation of a pair of devices with source
+// and destination, for the purposes of putting an endpoint into a container.
+type InterfaceName struct {
+	SrcName   string
+	DstName   string
+	DstPrefix string
+}
+
+// StaticRoute is the plain JSON representation of a static route.
+type StaticRoute struct {
+	Destination string
+	RouteType   int
+	NextHop     string
+}
+
+// JoinResponse is the response to a JoinRequest.
+type JoinResponse struct {
+	Response
+	InterfaceName         *InterfaceName
+	Gateway               string
+	GatewayIPv6           string
+	StaticRoutes          []StaticRoute
+	DisableGatewayService bool
+}
+
+// LeaveRequest describes the API for detaching an endpoint from a sandbox.
+type LeaveRequest struct {
+	NetworkID  string
+	EndpointID string
+}
+
+// LeaveResponse is the answer to LeaveRequest.
+type LeaveResponse struct {
+	Response
+}
+
+// ProgramExternalConnectivityRequest describes the API for programming the external connectivity for the given endpoint.
+type ProgramExternalConnectivityRequest struct {
+	NetworkID  string
+	EndpointID string
+	Options    map[string]interface{}
+}
+
+// ProgramExternalConnectivityResponse is the answer to ProgramExternalConnectivityRequest.
+type ProgramExternalConnectivityResponse struct {
+	Response
+}
+
+// RevokeExternalConnectivityRequest describes the API for revoking the external connectivity for the given endpoint.
+type RevokeExternalConnectivityRequest struct {
+	NetworkID  string
+	EndpointID string
+}
+
+// RevokeExternalConnectivityResponse is the answer to RevokeExternalConnectivityRequest.
+type RevokeExternalConnectivityResponse struct {
+	Response
+}
+
+// DiscoveryNotification represents a discovery notification
+type DiscoveryNotification struct {
+	DiscoveryType discoverapi.DiscoveryType
+	DiscoveryData interface{}
+}
+
+// DiscoveryResponse is used by libnetwork to log any plugin error processing the discovery notifications
+type DiscoveryResponse struct {
+	Response
+}

--- a/vendor/github.com/docker/libnetwork/drivers/remote/driver.go
+++ b/vendor/github.com/docker/libnetwork/drivers/remote/driver.go
@@ -1,0 +1,382 @@
+package remote
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/plugins"
+	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/discoverapi"
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/drivers/remote/api"
+	"github.com/docker/libnetwork/types"
+)
+
+type driver struct {
+	endpoint    *plugins.Client
+	networkType string
+}
+
+type maybeError interface {
+	GetError() string
+}
+
+func newDriver(name string, client *plugins.Client) driverapi.Driver {
+	return &driver{networkType: name, endpoint: client}
+}
+
+// Init makes sure a remote driver is registered when a network driver
+// plugin is activated.
+func Init(dc driverapi.DriverCallback, config map[string]interface{}) error {
+	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
+	handleFunc := plugins.Handle
+	if pg := dc.GetPluginGetter(); pg != nil {
+		handleFunc = pg.Handle
+	}
+	handleFunc(driverapi.NetworkPluginEndpointType, func(name string, client *plugins.Client) {
+		// negotiate driver capability with client
+		d := newDriver(name, client)
+		c, err := d.(*driver).getCapabilities()
+		if err != nil {
+			log.Errorf("error getting capability for %s due to %v", name, err)
+			return
+		}
+		if err = dc.RegisterDriver(name, d, *c); err != nil {
+			log.Errorf("error registering driver for %s due to %v", name, err)
+		}
+	})
+	return nil
+}
+
+// Get capability from client
+func (d *driver) getCapabilities() (*driverapi.Capability, error) {
+	var capResp api.GetCapabilityResponse
+	if err := d.call("GetCapabilities", nil, &capResp); err != nil {
+		return nil, err
+	}
+
+	c := &driverapi.Capability{}
+	switch capResp.Scope {
+	case "global":
+		c.DataScope = datastore.GlobalScope
+	case "local":
+		c.DataScope = datastore.LocalScope
+	default:
+		return nil, fmt.Errorf("invalid capability: expecting 'local' or 'global', got %s", capResp.Scope)
+	}
+
+	return c, nil
+}
+
+// Config is not implemented for remote drivers, since it is assumed
+// to be supplied to the remote process out-of-band (e.g., as command
+// line arguments).
+func (d *driver) Config(option map[string]interface{}) error {
+	return &driverapi.ErrNotImplemented{}
+}
+
+func (d *driver) call(methodName string, arg interface{}, retVal maybeError) error {
+	method := driverapi.NetworkPluginEndpointType + "." + methodName
+	err := d.endpoint.Call(method, arg, retVal)
+	if err != nil {
+		return err
+	}
+	if e := retVal.GetError(); e != "" {
+		return fmt.Errorf("remote: %s", e)
+	}
+	return nil
+}
+
+func (d *driver) NetworkAllocate(id string, options map[string]string, ipV4Data, ipV6Data []driverapi.IPAMData) (map[string]string, error) {
+	create := &api.AllocateNetworkRequest{
+		NetworkID: id,
+		Options:   options,
+		IPv4Data:  ipV4Data,
+		IPv6Data:  ipV6Data,
+	}
+	retVal := api.AllocateNetworkResponse{}
+	err := d.call("AllocateNetwork", create, &retVal)
+	return retVal.Options, err
+}
+
+func (d *driver) NetworkFree(id string) error {
+	fr := &api.FreeNetworkRequest{NetworkID: id}
+	return d.call("FreeNetwork", fr, &api.FreeNetworkResponse{})
+}
+
+func (d *driver) EventNotify(etype driverapi.EventType, nid, tableName, key string, value []byte) {
+}
+
+func (d *driver) CreateNetwork(id string, options map[string]interface{}, nInfo driverapi.NetworkInfo, ipV4Data, ipV6Data []driverapi.IPAMData) error {
+	create := &api.CreateNetworkRequest{
+		NetworkID: id,
+		Options:   options,
+		IPv4Data:  ipV4Data,
+		IPv6Data:  ipV6Data,
+	}
+	return d.call("CreateNetwork", create, &api.CreateNetworkResponse{})
+}
+
+func (d *driver) DeleteNetwork(nid string) error {
+	delete := &api.DeleteNetworkRequest{NetworkID: nid}
+	return d.call("DeleteNetwork", delete, &api.DeleteNetworkResponse{})
+}
+
+func (d *driver) CreateEndpoint(nid, eid string, ifInfo driverapi.InterfaceInfo, epOptions map[string]interface{}) error {
+	if ifInfo == nil {
+		return fmt.Errorf("must not be called with nil InterfaceInfo")
+	}
+
+	reqIface := &api.EndpointInterface{}
+	if ifInfo.Address() != nil {
+		reqIface.Address = ifInfo.Address().String()
+	}
+	if ifInfo.AddressIPv6() != nil {
+		reqIface.AddressIPv6 = ifInfo.AddressIPv6().String()
+	}
+	if ifInfo.MacAddress() != nil {
+		reqIface.MacAddress = ifInfo.MacAddress().String()
+	}
+
+	create := &api.CreateEndpointRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+		Interface:  reqIface,
+		Options:    epOptions,
+	}
+	var res api.CreateEndpointResponse
+	if err := d.call("CreateEndpoint", create, &res); err != nil {
+		return err
+	}
+
+	inIface, err := parseInterface(res)
+	if err != nil {
+		return err
+	}
+	if inIface == nil {
+		// Remote driver did not set any field
+		return nil
+	}
+
+	if inIface.MacAddress != nil {
+		if err := ifInfo.SetMacAddress(inIface.MacAddress); err != nil {
+			return errorWithRollback(fmt.Sprintf("driver modified interface MAC address: %v", err), d.DeleteEndpoint(nid, eid))
+		}
+	}
+	if inIface.Address != nil {
+		if err := ifInfo.SetIPAddress(inIface.Address); err != nil {
+			return errorWithRollback(fmt.Sprintf("driver modified interface address: %v", err), d.DeleteEndpoint(nid, eid))
+		}
+	}
+	if inIface.AddressIPv6 != nil {
+		if err := ifInfo.SetIPAddress(inIface.AddressIPv6); err != nil {
+			return errorWithRollback(fmt.Sprintf("driver modified interface address: %v", err), d.DeleteEndpoint(nid, eid))
+		}
+	}
+
+	return nil
+}
+
+func errorWithRollback(msg string, err error) error {
+	rollback := "rolled back"
+	if err != nil {
+		rollback = "failed to roll back: " + err.Error()
+	}
+	return fmt.Errorf("%s; %s", msg, rollback)
+}
+
+func (d *driver) DeleteEndpoint(nid, eid string) error {
+	delete := &api.DeleteEndpointRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+	}
+	return d.call("DeleteEndpoint", delete, &api.DeleteEndpointResponse{})
+}
+
+func (d *driver) EndpointOperInfo(nid, eid string) (map[string]interface{}, error) {
+	info := &api.EndpointInfoRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+	}
+	var res api.EndpointInfoResponse
+	if err := d.call("EndpointOperInfo", info, &res); err != nil {
+		return nil, err
+	}
+	return res.Value, nil
+}
+
+// Join method is invoked when a Sandbox is attached to an endpoint.
+func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo, options map[string]interface{}) error {
+	join := &api.JoinRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+		SandboxKey: sboxKey,
+		Options:    options,
+	}
+	var (
+		res api.JoinResponse
+		err error
+	)
+	if err = d.call("Join", join, &res); err != nil {
+		return err
+	}
+
+	ifaceName := res.InterfaceName
+	if iface := jinfo.InterfaceName(); iface != nil && ifaceName != nil {
+		if err := iface.SetNames(ifaceName.SrcName, ifaceName.DstPrefix); err != nil {
+			return errorWithRollback(fmt.Sprintf("failed to set interface name: %s", err), d.Leave(nid, eid))
+		}
+	}
+
+	var addr net.IP
+	if res.Gateway != "" {
+		if addr = net.ParseIP(res.Gateway); addr == nil {
+			return fmt.Errorf(`unable to parse Gateway "%s"`, res.Gateway)
+		}
+		if jinfo.SetGateway(addr) != nil {
+			return errorWithRollback(fmt.Sprintf("failed to set gateway: %v", addr), d.Leave(nid, eid))
+		}
+	}
+	if res.GatewayIPv6 != "" {
+		if addr = net.ParseIP(res.GatewayIPv6); addr == nil {
+			return fmt.Errorf(`unable to parse GatewayIPv6 "%s"`, res.GatewayIPv6)
+		}
+		if jinfo.SetGatewayIPv6(addr) != nil {
+			return errorWithRollback(fmt.Sprintf("failed to set gateway IPv6: %v", addr), d.Leave(nid, eid))
+		}
+	}
+	if len(res.StaticRoutes) > 0 {
+		routes, err := parseStaticRoutes(res)
+		if err != nil {
+			return err
+		}
+		for _, route := range routes {
+			if jinfo.AddStaticRoute(route.Destination, route.RouteType, route.NextHop) != nil {
+				return errorWithRollback(fmt.Sprintf("failed to set static route: %v", route), d.Leave(nid, eid))
+			}
+		}
+	}
+	if res.DisableGatewayService {
+		jinfo.DisableGatewayService()
+	}
+	return nil
+}
+
+// Leave method is invoked when a Sandbox detaches from an endpoint.
+func (d *driver) Leave(nid, eid string) error {
+	leave := &api.LeaveRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+	}
+	return d.call("Leave", leave, &api.LeaveResponse{})
+}
+
+// ProgramExternalConnectivity is invoked to program the rules to allow external connectivity for the endpoint.
+func (d *driver) ProgramExternalConnectivity(nid, eid string, options map[string]interface{}) error {
+	data := &api.ProgramExternalConnectivityRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+		Options:    options,
+	}
+	err := d.call("ProgramExternalConnectivity", data, &api.ProgramExternalConnectivityResponse{})
+	if err != nil && plugins.IsNotFound(err) {
+		// It is not mandatory yet to support this method
+		return nil
+	}
+	return err
+}
+
+// RevokeExternalConnectivity method is invoked to remove any external connectivity programming related to the endpoint.
+func (d *driver) RevokeExternalConnectivity(nid, eid string) error {
+	data := &api.RevokeExternalConnectivityRequest{
+		NetworkID:  nid,
+		EndpointID: eid,
+	}
+	err := d.call("RevokeExternalConnectivity", data, &api.RevokeExternalConnectivityResponse{})
+	if err != nil && plugins.IsNotFound(err) {
+		// It is not mandatory yet to support this method
+		return nil
+	}
+	return err
+}
+
+func (d *driver) Type() string {
+	return d.networkType
+}
+
+// DiscoverNew is a notification for a new discovery event, such as a new node joining a cluster
+func (d *driver) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	if dType != discoverapi.NodeDiscovery {
+		return nil
+	}
+	notif := &api.DiscoveryNotification{
+		DiscoveryType: dType,
+		DiscoveryData: data,
+	}
+	return d.call("DiscoverNew", notif, &api.DiscoveryResponse{})
+}
+
+// DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
+func (d *driver) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
+	if dType != discoverapi.NodeDiscovery {
+		return nil
+	}
+	notif := &api.DiscoveryNotification{
+		DiscoveryType: dType,
+		DiscoveryData: data,
+	}
+	return d.call("DiscoverDelete", notif, &api.DiscoveryResponse{})
+}
+
+func parseStaticRoutes(r api.JoinResponse) ([]*types.StaticRoute, error) {
+	var routes = make([]*types.StaticRoute, len(r.StaticRoutes))
+	for i, inRoute := range r.StaticRoutes {
+		var err error
+		outRoute := &types.StaticRoute{RouteType: inRoute.RouteType}
+
+		if inRoute.Destination != "" {
+			if outRoute.Destination, err = types.ParseCIDR(inRoute.Destination); err != nil {
+				return nil, err
+			}
+		}
+
+		if inRoute.NextHop != "" {
+			outRoute.NextHop = net.ParseIP(inRoute.NextHop)
+			if outRoute.NextHop == nil {
+				return nil, fmt.Errorf("failed to parse nexthop IP %s", inRoute.NextHop)
+			}
+		}
+
+		routes[i] = outRoute
+	}
+	return routes, nil
+}
+
+// parseInterfaces validates all the parameters of an Interface and returns them.
+func parseInterface(r api.CreateEndpointResponse) (*api.Interface, error) {
+	var outIf *api.Interface
+
+	inIf := r.Interface
+	if inIf != nil {
+		var err error
+		outIf = &api.Interface{}
+		if inIf.Address != "" {
+			if outIf.Address, err = types.ParseCIDR(inIf.Address); err != nil {
+				return nil, err
+			}
+		}
+		if inIf.AddressIPv6 != "" {
+			if outIf.AddressIPv6, err = types.ParseCIDR(inIf.AddressIPv6); err != nil {
+				return nil, err
+			}
+		}
+		if inIf.MacAddress != "" {
+			if outIf.MacAddress, err = net.ParseMAC(inIf.MacAddress); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return outIf, nil
+}

--- a/vendor/github.com/docker/libnetwork/ipams/remote/api/api.go
+++ b/vendor/github.com/docker/libnetwork/ipams/remote/api/api.go
@@ -1,0 +1,94 @@
+// Package api defines the data structure to be used in the request/response
+// messages between libnetwork and the remote ipam plugin
+package api
+
+import "github.com/docker/libnetwork/ipamapi"
+
+// Response is the basic response structure used in all responses
+type Response struct {
+	Error string
+}
+
+// IsSuccess returns wheter the plugin response is successful
+func (r *Response) IsSuccess() bool {
+	return r.Error == ""
+}
+
+// GetError returns the error from the response, if any.
+func (r *Response) GetError() string {
+	return r.Error
+}
+
+// GetCapabilityResponse is the response of GetCapability request
+type GetCapabilityResponse struct {
+	Response
+	RequiresMACAddress    bool
+	RequiresRequestReplay bool
+}
+
+// ToCapability converts the capability response into the internal ipam driver capability structure
+func (capRes GetCapabilityResponse) ToCapability() *ipamapi.Capability {
+	return &ipamapi.Capability{
+		RequiresMACAddress:    capRes.RequiresMACAddress,
+		RequiresRequestReplay: capRes.RequiresRequestReplay,
+	}
+}
+
+// GetAddressSpacesResponse is the response to the ``get default address spaces`` request message
+type GetAddressSpacesResponse struct {
+	Response
+	LocalDefaultAddressSpace  string
+	GlobalDefaultAddressSpace string
+}
+
+// RequestPoolRequest represents the expected data in a ``request address pool`` request message
+type RequestPoolRequest struct {
+	AddressSpace string
+	Pool         string
+	SubPool      string
+	Options      map[string]string
+	V6           bool
+}
+
+// RequestPoolResponse represents the response message to a ``request address pool`` request
+type RequestPoolResponse struct {
+	Response
+	PoolID string
+	Pool   string // CIDR format
+	Data   map[string]string
+}
+
+// ReleasePoolRequest represents the expected data in a ``release address pool`` request message
+type ReleasePoolRequest struct {
+	PoolID string
+}
+
+// ReleasePoolResponse represents the response message to a ``release address pool`` request
+type ReleasePoolResponse struct {
+	Response
+}
+
+// RequestAddressRequest represents the expected data in a ``request address`` request message
+type RequestAddressRequest struct {
+	PoolID  string
+	Address string
+	Options map[string]string
+}
+
+// RequestAddressResponse represents the expected data in the response message to a ``request address`` request
+type RequestAddressResponse struct {
+	Response
+	Address string // in CIDR format
+	Data    map[string]string
+}
+
+// ReleaseAddressRequest represents the expected data in a ``release address`` request message
+type ReleaseAddressRequest struct {
+	PoolID  string
+	Address string
+}
+
+// ReleaseAddressResponse represents the response message to a ``release address`` request
+type ReleaseAddressResponse struct {
+	Response
+}

--- a/vendor/github.com/docker/libnetwork/ipams/remote/remote.go
+++ b/vendor/github.com/docker/libnetwork/ipams/remote/remote.go
@@ -1,0 +1,145 @@
+package remote
+
+import (
+	"fmt"
+	"net"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/plugins"
+	"github.com/docker/libnetwork/discoverapi"
+	"github.com/docker/libnetwork/ipamapi"
+	"github.com/docker/libnetwork/ipams/remote/api"
+	"github.com/docker/libnetwork/types"
+)
+
+type allocator struct {
+	endpoint *plugins.Client
+	name     string
+}
+
+// PluginResponse is the interface for the plugin request responses
+type PluginResponse interface {
+	IsSuccess() bool
+	GetError() string
+}
+
+func newAllocator(name string, client *plugins.Client) ipamapi.Ipam {
+	a := &allocator{name: name, endpoint: client}
+	return a
+}
+
+// Init registers a remote ipam when its plugin is activated
+func Init(cb ipamapi.Callback, l, g interface{}) error {
+
+	// Unit test code is unaware of a true PluginStore. So we fall back to v1 plugins.
+	handleFunc := plugins.Handle
+	if pg := cb.GetPluginGetter(); pg != nil {
+		handleFunc = pg.Handle
+	}
+	handleFunc(ipamapi.PluginEndpointType, func(name string, client *plugins.Client) {
+		a := newAllocator(name, client)
+		if cps, err := a.(*allocator).getCapabilities(); err == nil {
+			if err := cb.RegisterIpamDriverWithCapabilities(name, a, cps); err != nil {
+				log.Errorf("error registering remote ipam driver %s due to %v", name, err)
+			}
+		} else {
+			log.Infof("remote ipam driver %s does not support capabilities", name)
+			log.Debug(err)
+			if err := cb.RegisterIpamDriver(name, a); err != nil {
+				log.Errorf("error registering remote ipam driver %s due to %v", name, err)
+			}
+		}
+	})
+	return nil
+}
+
+func (a *allocator) call(methodName string, arg interface{}, retVal PluginResponse) error {
+	method := ipamapi.PluginEndpointType + "." + methodName
+	err := a.endpoint.Call(method, arg, retVal)
+	if err != nil {
+		return err
+	}
+	if !retVal.IsSuccess() {
+		return fmt.Errorf("remote: %s", retVal.GetError())
+	}
+	return nil
+}
+
+func (a *allocator) getCapabilities() (*ipamapi.Capability, error) {
+	var res api.GetCapabilityResponse
+	if err := a.call("GetCapabilities", nil, &res); err != nil {
+		return nil, err
+	}
+	return res.ToCapability(), nil
+}
+
+// GetDefaultAddressSpaces returns the local and global default address spaces
+func (a *allocator) GetDefaultAddressSpaces() (string, string, error) {
+	res := &api.GetAddressSpacesResponse{}
+	if err := a.call("GetDefaultAddressSpaces", nil, res); err != nil {
+		return "", "", err
+	}
+	return res.LocalDefaultAddressSpace, res.GlobalDefaultAddressSpace, nil
+}
+
+// RequestPool requests an address pool in the specified address space
+func (a *allocator) RequestPool(addressSpace, pool, subPool string, options map[string]string, v6 bool) (string, *net.IPNet, map[string]string, error) {
+	req := &api.RequestPoolRequest{AddressSpace: addressSpace, Pool: pool, SubPool: subPool, Options: options, V6: v6}
+	res := &api.RequestPoolResponse{}
+	if err := a.call("RequestPool", req, res); err != nil {
+		return "", nil, nil, err
+	}
+	retPool, err := types.ParseCIDR(res.Pool)
+	return res.PoolID, retPool, res.Data, err
+}
+
+// ReleasePool removes an address pool from the specified address space
+func (a *allocator) ReleasePool(poolID string) error {
+	req := &api.ReleasePoolRequest{PoolID: poolID}
+	res := &api.ReleasePoolResponse{}
+	return a.call("ReleasePool", req, res)
+}
+
+// RequestAddress requests an address from the address pool
+func (a *allocator) RequestAddress(poolID string, address net.IP, options map[string]string) (*net.IPNet, map[string]string, error) {
+	var (
+		prefAddress string
+		retAddress  *net.IPNet
+		err         error
+	)
+	if address != nil {
+		prefAddress = address.String()
+	}
+	req := &api.RequestAddressRequest{PoolID: poolID, Address: prefAddress, Options: options}
+	res := &api.RequestAddressResponse{}
+	if err := a.call("RequestAddress", req, res); err != nil {
+		return nil, nil, err
+	}
+	if res.Address != "" {
+		retAddress, err = types.ParseCIDR(res.Address)
+	} else {
+		return nil, nil, ipamapi.ErrNoIPReturned
+	}
+	return retAddress, res.Data, err
+}
+
+// ReleaseAddress releases the address from the specified address pool
+func (a *allocator) ReleaseAddress(poolID string, address net.IP) error {
+	var relAddress string
+	if address != nil {
+		relAddress = address.String()
+	}
+	req := &api.ReleaseAddressRequest{PoolID: poolID, Address: relAddress}
+	res := &api.ReleaseAddressResponse{}
+	return a.call("ReleaseAddress", req, res)
+}
+
+// DiscoverNew is a notification for a new discovery event, such as a new global datastore
+func (a *allocator) DiscoverNew(dType discoverapi.DiscoveryType, data interface{}) error {
+	return nil
+}
+
+// DiscoverDelete is a notification for a discovery delete event, such as a node leaving a cluster
+func (a *allocator) DiscoverDelete(dType discoverapi.DiscoveryType, data interface{}) error {
+	return nil
+}


### PR DESCRIPTION
In Docker 1.12, swarmkit is hard-coded only to accept `overlay` network driver and builtin ipam driver. That practically eliminates all other global network and IPAM plugins.

This PR enables the network and ipam plugins be used with swarmkit as well.