### PR TITLE
scheduler: Provide a reason for unschedulable tasks

### DIFF
--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -1,6 +1,10 @@
 package scheduler
 
-import "github.com/docker/swarmkit/api"
+import (
+	"sort"
+
+	"github.com/docker/swarmkit/api"
+)
 
 var (
 	defaultFilters = []Filter{
@@ -20,10 +24,21 @@ var (
 type checklistEntry struct {
 	f       Filter
 	enabled bool
+
+	// failureCount counts the number of nodes that this filter failed
+	// against.
+	failureCount int
 }
+
+type checklistByFailures []checklistEntry
+
+func (c checklistByFailures) Len() int           { return len(c) }
+func (c checklistByFailures) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
+func (c checklistByFailures) Less(i, j int) bool { return c[i].failureCount < c[j].failureCount }
 
 // Pipeline runs a set of filters against nodes.
 type Pipeline struct {
+	// checklist is a slice of filters to run
 	checklist []checklistEntry
 }
 
@@ -41,11 +56,15 @@ func NewPipeline() *Pipeline {
 // Process a node through the filter pipeline.
 // Returns true if all filters pass, false otherwise.
 func (p *Pipeline) Process(n *NodeInfo) bool {
-	for _, entry := range p.checklist {
+	for i, entry := range p.checklist {
 		if entry.enabled && !entry.f.Check(n) {
 			// Immediately stop on first failure.
+			p.checklist[i].failureCount++
 			return false
 		}
+	}
+	for i := range p.checklist {
+		p.checklist[i].failureCount = 0
 	}
 	return true
 }
@@ -55,5 +74,28 @@ func (p *Pipeline) Process(n *NodeInfo) bool {
 func (p *Pipeline) SetTask(t *api.Task) {
 	for i := range p.checklist {
 		p.checklist[i].enabled = p.checklist[i].f.SetTask(t)
+		p.checklist[i].failureCount = 0
 	}
+}
+
+// Explain returns a string explaining why a task could not be scheduled.
+func (p *Pipeline) Explain() string {
+	var explanation string
+
+	// Sort from most failures to least
+
+	sortedByFailures := make([]checklistEntry, len(p.checklist))
+	copy(sortedByFailures, p.checklist)
+	sort.Sort(sort.Reverse(checklistByFailures(sortedByFailures)))
+
+	for _, entry := range sortedByFailures {
+		if entry.failureCount > 0 {
+			if len(explanation) > 0 {
+				explanation += "; "
+			}
+			explanation += entry.f.Explain(entry.failureCount)
+		}
+	}
+
+	return explanation
 }


### PR DESCRIPTION
When a task can't be scheduled on any node, the scheduler fills in the
Status.Message field with a message of the form:

    no suitable node (insufficient resources on 7 nodes; scheduling constraints not satisfied on 4 nodes; 1 node not ready)

Fixes #324

cc @aluzzardi @dongluochen