### PR TITLE
Remove tasks that no longer satisfy constraints

### DIFF
--- a/manager/orchestrator/constraint_enforcer.go
+++ b/manager/orchestrator/constraint_enforcer.go
@@ -1,0 +1,157 @@
+package orchestrator
+
+import (
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/constraint"
+	"github.com/docker/swarmkit/manager/state"
+	"github.com/docker/swarmkit/manager/state/store"
+)
+
+// ConstraintEnforcer watches for updates to nodes and shuts down tasks that no
+// longer satisfy scheduling constraints or resource limits.
+type ConstraintEnforcer struct {
+	store    *store.MemoryStore
+	stopChan chan struct{}
+	doneChan chan struct{}
+}
+
+// NewConstraintEnforcer creates a new ConstraintEnforcer.
+func NewConstraintEnforcer(store *store.MemoryStore) *ConstraintEnforcer {
+	return &ConstraintEnforcer{
+		store:    store,
+		stopChan: make(chan struct{}),
+		doneChan: make(chan struct{}),
+	}
+}
+
+// Run is the ConstraintEnforcer's main loop.
+func (ce *ConstraintEnforcer) Run() {
+	defer close(ce.doneChan)
+
+	watcher, cancelWatch := state.Watch(ce.store.WatchQueue(), state.EventUpdateNode{})
+	defer cancelWatch()
+
+	var (
+		nodes []*api.Node
+		err   error
+	)
+	ce.store.View(func(readTx store.ReadTx) {
+		nodes, err = store.FindNodes(readTx, store.All)
+	})
+	if err != nil {
+		log.L.WithError(err).Error("failed to check nodes for noncompliant tasks")
+	} else {
+		for _, node := range nodes {
+			ce.shutdownNoncompliantTasks(node)
+		}
+	}
+
+	for {
+		select {
+		case event := <-watcher:
+			node := event.(state.EventUpdateNode).Node
+			ce.shutdownNoncompliantTasks(node)
+		case <-ce.stopChan:
+			return
+		}
+	}
+}
+
+func (ce *ConstraintEnforcer) shutdownNoncompliantTasks(node *api.Node) {
+	// If the availability is "drain", the orchestrator will
+	// shut down all tasks.
+	// If the availability is "pause", we shouldn't touch
+	// the tasks on this node.
+	if node.Spec.Availability != api.NodeAvailabilityActive {
+		return
+	}
+
+	var (
+		tasks []*api.Task
+		err   error
+	)
+
+	ce.store.View(func(tx store.ReadTx) {
+		tasks, err = store.FindTasks(tx, store.ByNodeID(node.ID))
+	})
+
+	if err != nil {
+		log.L.WithError(err).Errorf("failed to list tasks for node ID %s", node.ID)
+	}
+
+	var availableMemoryBytes, availableNanoCPUs int64
+	if node.Description != nil && node.Description.Resources != nil {
+		availableMemoryBytes = node.Description.Resources.MemoryBytes
+		availableNanoCPUs = node.Description.Resources.NanoCPUs
+	}
+
+	removeTasks := make(map[string]*api.Task)
+
+	// TODO(aaronl): The set of tasks removed will be
+	// nondeterministic because it depends on the order of
+	// the slice returned from FindTasks. We could do
+	// a separate pass over the tasks for each type of
+	// resource, and sort by the size of the reservation
+	// to remove the most resource-intensive tasks.
+	for _, t := range tasks {
+		if t.DesiredState < api.TaskStateAssigned || t.DesiredState > api.TaskStateRunning {
+			continue
+		}
+
+		// Ensure that the task still meets scheduling
+		// constraints.
+		if t.Spec.Placement != nil && len(t.Spec.Placement.Constraints) != 0 {
+			constraints, _ := constraint.Parse(t.Spec.Placement.Constraints)
+			if !constraint.NodeMatches(constraints, node) {
+				removeTasks[t.ID] = t
+				continue
+			}
+		}
+
+		// Ensure that the task assigned to the node
+		// still satisfies the resource limits.
+		if t.Spec.Resources != nil && t.Spec.Resources.Reservations != nil {
+			if t.Spec.Resources.Reservations.MemoryBytes > availableMemoryBytes {
+				removeTasks[t.ID] = t
+				continue
+			}
+			if t.Spec.Resources.Reservations.NanoCPUs > availableNanoCPUs {
+				removeTasks[t.ID] = t
+				continue
+			}
+			availableMemoryBytes -= t.Spec.Resources.Reservations.MemoryBytes
+			availableNanoCPUs -= t.Spec.Resources.Reservations.NanoCPUs
+		}
+	}
+
+	if len(removeTasks) != 0 {
+		_, err := ce.store.Batch(func(batch *store.Batch) error {
+			for _, t := range removeTasks {
+				err := batch.Update(func(tx store.Tx) error {
+					t = store.GetTask(tx, t.ID)
+					if t == nil || t.DesiredState > api.TaskStateRunning {
+						return nil
+					}
+
+					t.DesiredState = api.TaskStateShutdown
+					return store.UpdateTask(tx, t)
+				})
+				if err != nil {
+					log.L.WithError(err).Errorf("failed to shut down task %s", t.ID)
+				}
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.L.WithError(err).Errorf("failed to shut down tasks")
+		}
+	}
+}
+
+// Stop stops the ConstraintEnforcer and waits for the main loop to exit.
+func (ce *ConstraintEnforcer) Stop() {
+	close(ce.stopChan)
+	<-ce.doneChan
+}

--- a/manager/orchestrator/constraint_enforcer_test.go
+++ b/manager/orchestrator/constraint_enforcer_test.go
@@ -1,0 +1,166 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstraintEnforcer(t *testing.T) {
+	nodes := []*api.Node{
+		{
+			ID: "id1",
+			Spec: api.NodeSpec{
+				Annotations: api.Annotations{
+					Name: "name1",
+				},
+				Role:         api.NodeRoleWorker,
+				Availability: api.NodeAvailabilityActive,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_READY,
+			},
+		},
+		{
+			ID: "id2",
+			Spec: api.NodeSpec{
+				Annotations: api.Annotations{
+					Name: "name2",
+				},
+				Availability: api.NodeAvailabilityActive,
+			},
+			Status: api.NodeStatus{
+				State: api.NodeStatus_READY,
+			},
+			Description: &api.NodeDescription{
+				Resources: &api.Resources{
+					NanoCPUs:    1e9,
+					MemoryBytes: 1e9,
+				},
+			},
+		},
+	}
+
+	tasks := []*api.Task{
+		{
+			ID:           "id0",
+			DesiredState: api.TaskStateRunning,
+			Spec: api.TaskSpec{
+				Placement: &api.Placement{
+					Constraints: []string{"node.role == manager"},
+				},
+			},
+			Status: api.TaskStatus{
+				State: api.TaskStateNew,
+			},
+			NodeID: "id1",
+		},
+		{
+			ID:           "id1",
+			DesiredState: api.TaskStateRunning,
+			Status: api.TaskStatus{
+				State: api.TaskStateNew,
+			},
+			NodeID: "id1",
+		},
+		{
+			ID:           "id2",
+			DesiredState: api.TaskStateRunning,
+			Spec: api.TaskSpec{
+				Placement: &api.Placement{
+					Constraints: []string{"node.role == worker"},
+				},
+			},
+			Status: api.TaskStatus{
+				State: api.TaskStateRunning,
+			},
+			NodeID: "id1",
+		},
+		{
+			ID:           "id3",
+			DesiredState: api.TaskStateNew,
+			Status: api.TaskStatus{
+				State: api.TaskStateNew,
+			},
+			NodeID: "id2",
+		},
+		{
+			ID:           "id4",
+			DesiredState: api.TaskStateReady,
+			Spec: api.TaskSpec{
+				Resources: &api.ResourceRequirements{
+					Reservations: &api.Resources{
+						MemoryBytes: 9e8,
+					},
+				},
+			},
+			Status: api.TaskStatus{
+				State: api.TaskStateAllocated,
+			},
+			NodeID: "id2",
+		},
+	}
+
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	err := s.Update(func(tx store.Tx) error {
+		// Prepoulate nodes
+		for _, n := range nodes {
+			assert.NoError(t, store.CreateNode(tx, n))
+		}
+
+		// Prepopulate tasks
+		for _, task := range tasks {
+			assert.NoError(t, store.CreateTask(tx, task))
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventUpdateTask{})
+	defer cancel()
+
+	constraintEnforcer := NewConstraintEnforcer(s)
+	defer constraintEnforcer.Stop()
+
+	go constraintEnforcer.Run()
+
+	// id0 should be killed immediately
+	shutdown1 := watchShutdownTask(t, watch)
+	assert.Equal(t, "id0", shutdown1.ID)
+
+	// Change node id1 to a manager
+	err = s.Update(func(tx store.Tx) error {
+		node := store.GetNode(tx, "id1")
+		if node == nil {
+			t.Fatal("could not get node id1")
+		}
+		node.Spec.Role = api.NodeRoleManager
+		assert.NoError(t, store.UpdateNode(tx, node))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	shutdown2 := watchShutdownTask(t, watch)
+	assert.Equal(t, "id2", shutdown2.ID)
+
+	// Change resources on node id2
+	err = s.Update(func(tx store.Tx) error {
+		node := store.GetNode(tx, "id2")
+		if node == nil {
+			t.Fatal("could not get node id2")
+		}
+		node.Description.Resources.MemoryBytes = 5e8
+		assert.NoError(t, store.UpdateNode(tx, node))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	shutdown3 := watchShutdownTask(t, watch)
+	assert.Equal(t, "id4", shutdown3.ID)
+}

--- a/manager/orchestrator/global.go
+++ b/manager/orchestrator/global.go
@@ -374,11 +374,13 @@ func (g *GlobalOrchestrator) reconcileServicesOneNode(ctx context.Context, servi
 				continue
 			}
 
-			meetsConstraints := constraint.NodeMatches(service.constraints, node)
+			if !constraint.NodeMatches(service.constraints, node) {
+				continue
+			}
 
 			// if restart policy considers this node has finished its task
 			// it should remove all running tasks
-			if completed[serviceID] || !meetsConstraints {
+			if completed[serviceID] {
 				g.removeTasks(ctx, batch, tasks[serviceID])
 				continue
 			}


### PR DESCRIPTION
If a node is updated in a way that makes its tasks no longer satisfy constraints or resource requirements, shut down the affected tasks.

This is not done in the scheduler because the scheduler should not be shutting down tasks. DesiredState is a field owned by the orchestrator, and should not be written by other components.

Instead, introduce a ConstraintEnforcer inside the orchestrator package. It waits for node updates, and checks that the tasks on the node still satisfy constraints and resource requirements.

Change the scheduler to atomically check that nodes where tasks are assigned haven't changed during the time the scheduling decision was made, since this could cause a new task to be assigned to node that was just updated in a way that makes it incompatible with the task.

Fixes #1009

I'll add tests to this after it passes design review.

cc @dongluochen @aluzzardi