### PR TITLE
integration: reduce number of nodes in TestServiceCreate

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-const opsTimeout = 32 * time.Second
+const opsTimeout = 64 * time.Second
 
 // Cluster is representation of cluster - connected nodes.
 type testCluster struct {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -143,7 +143,7 @@ func TestClusterCreate(t *testing.T) {
 }
 
 func TestServiceCreate(t *testing.T) {
-	numWorker, numManager := 15, 5
+	numWorker, numManager := 3, 3
 	cl := newCluster(t, numWorker, numManager)
 	defer func() {
 		require.NoError(t, cl.Stop())


### PR DESCRIPTION
It seems like CI sometimes exceeds timeout because of slow disks. And it's not stress-test anyway.