### PR TITLE
controlapi: Validate that names aren't too long for DNS label

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -64,9 +64,14 @@ func filterMatchLabels(match map[string]string, candidates map[string]string) bo
 func validateAnnotations(m api.Annotations) error {
 	if m.Name == "" {
 		return grpc.Errorf(codes.InvalidArgument, "meta: name must be provided")
-	} else if !isValidName.MatchString(m.Name) {
+	}
+	if !isValidName.MatchString(m.Name) {
 		// if the name doesn't match the regex
 		return grpc.Errorf(codes.InvalidArgument, "name must be valid as a DNS name component")
+	}
+	if len(m.Name) > 63 {
+		// DNS labels are limited to 63 characters
+		return grpc.Errorf(codes.InvalidArgument, "name must be 63 characters or fewer")
 	}
 	return nil
 }

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -184,6 +184,10 @@ func TestValidateServiceSpec(t *testing.T) {
 			spec: createSpec("", "image", 1),
 			c:    codes.InvalidArgument,
 		},
+		{
+			spec: createSpec(strings.Repeat("longname", 8), "image", 1),
+			c:    codes.InvalidArgument,
+		},
 	} {
 		err := validateServiceSpec(bad.spec)
 		assert.Error(t, err)


### PR DESCRIPTION
There is a regexp to validate that service/network names follow the DNS label grammar, but there is no check on the length of these names. For them to be valid labels, they can be at most 63 characters.

Add such a check and test coverage.

This is a narrow fix that just adds the check. As @stevvooe suggested, there's an opportunity to refactor naming into a separate package. Let's do that as a separate PR after this.

Fixes #1576