### PR TITLE
allocator: Fix unit tests on Mac

### DIFF
--- a/manager/allocator/networkallocator/drivers_darwin.go
+++ b/manager/allocator/networkallocator/drivers_darwin.go
@@ -1,0 +1,13 @@
+package networkallocator
+
+import (
+	"github.com/docker/libnetwork/drivers/overlay/ovmanager"
+	"github.com/docker/libnetwork/drivers/remote"
+)
+
+func getInitializers() []initializer {
+	return []initializer{
+		{remote.Init, "remote"},
+		{ovmanager.Init, "overlay"},
+	}
+}

--- a/manager/allocator/networkallocator/drivers_unsupported.go
+++ b/manager/allocator/networkallocator/drivers_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!darwin
 
 package networkallocator
 


### PR DESCRIPTION
Enable the drivers on Darwin as well as Linux.

cc @mavenugo @mrjana