### PR TITLE
secrets: enable secret lookup from agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -48,9 +48,11 @@ func New(config *Config) (*Agent, error) {
 		return nil, err
 	}
 
+	worker := newWorker(config.DB, config.Executor)
+
 	a := &Agent{
 		config:   config,
-		worker:   newWorker(config.DB, config.Executor),
+		worker:   worker,
 		sessionq: make(chan sessionOperation),
 		started:  make(chan struct{}),
 		stopped:  make(chan struct{}),

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -26,7 +26,7 @@ func (e *NoopExecutor) Configure(ctx context.Context, node *api.Node) error {
 	return nil
 }
 
-func (e *NoopExecutor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+func (e *NoopExecutor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	return nil, exec.ErrRuntimeUnsupported
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -26,7 +26,7 @@ func (e *NoopExecutor) Configure(ctx context.Context, node *api.Node) error {
 	return nil
 }
 
-func (e *NoopExecutor) Controller(t *api.Task) (exec.Controller, error) {
+func (e *NoopExecutor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
 	return nil, exec.ErrRuntimeUnsupported
 }
 

--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -25,9 +25,10 @@ import (
 type containerAdapter struct {
 	client    engineapi.APIClient
 	container *containerConfig
+	secrets   map[string]*api.Secret
 }
 
-func newContainerAdapter(client engineapi.APIClient, task *api.Task) (*containerAdapter, error) {
+func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets map[string]*api.Secret) (*containerAdapter, error) {
 	ctnr, err := newContainerConfig(task)
 	if err != nil {
 		return nil, err
@@ -36,6 +37,7 @@ func newContainerAdapter(client engineapi.APIClient, task *api.Task) (*container
 	return &containerAdapter{
 		client:    client,
 		container: ctnr,
+		secrets:   secrets,
 	}, nil
 }
 

--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/events"
 	engineapi "github.com/docker/docker/client"
+	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/protobuf/ptypes"
@@ -25,10 +26,10 @@ import (
 type containerAdapter struct {
 	client    engineapi.APIClient
 	container *containerConfig
-	secrets   map[string]*api.Secret
+	secrets   exec.SecretProvider
 }
 
-func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets map[string]*api.Secret) (*containerAdapter, error) {
+func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets exec.SecretProvider) (*containerAdapter, error) {
 	ctnr, err := newContainerConfig(task)
 	if err != nil {
 		return nil, err

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -31,8 +31,8 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // newController returns a docker exec controller for the provided task.
-func newController(client engineapi.APIClient, task *api.Task) (exec.Controller, error) {
-	adapter, err := newContainerAdapter(client, task)
+func newController(client engineapi.APIClient, task *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+	adapter, err := newContainerAdapter(client, task, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -31,7 +31,7 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // newController returns a docker exec controller for the provided task.
-func newController(client engineapi.APIClient, task *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+func newController(client engineapi.APIClient, task *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	adapter, err := newContainerAdapter(client, task, secrets)
 	if err != nil {
 		return nil, err

--- a/agent/exec/container/controller_integration_test.go
+++ b/agent/exec/container/controller_integration_test.go
@@ -54,7 +54,9 @@ func TestControllerFlowIntegration(t *testing.T) {
 		},
 	}
 
-	ctlr, err := newController(client, task)
+	var secrets map[string]*api.Secret
+
+	ctlr, err := newController(client, task, secrets)
 	assert.NoError(t, err)
 	assert.NotNil(t, ctlr)
 	assert.NoError(t, ctlr.Prepare(ctx))

--- a/agent/exec/container/controller_integration_test.go
+++ b/agent/exec/container/controller_integration_test.go
@@ -54,9 +54,7 @@ func TestControllerFlowIntegration(t *testing.T) {
 		},
 	}
 
-	var secrets map[string]*api.Secret
-
-	ctlr, err := newController(client, task, secrets)
+	ctlr, err := newController(client, task, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, ctlr)
 	assert.NoError(t, ctlr.Prepare(ctx))

--- a/agent/exec/container/controller_test.go
+++ b/agent/exec/container/controller_test.go
@@ -292,7 +292,8 @@ func TestControllerRemove(t *testing.T) {
 func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *MockAPIClient, exec.Controller, *containerConfig, func(t *testing.T)) {
 	mocks := gomock.NewController(t)
 	client := NewMockAPIClient(mocks)
-	ctlr, err := newController(client, task)
+	var secrets map[string]*api.Secret
+	ctlr, err := newController(client, task, secrets)
 	assert.NoError(t, err)
 
 	config, err := newContainerConfig(task)

--- a/agent/exec/container/controller_test.go
+++ b/agent/exec/container/controller_test.go
@@ -292,8 +292,7 @@ func TestControllerRemove(t *testing.T) {
 func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *MockAPIClient, exec.Controller, *containerConfig, func(t *testing.T)) {
 	mocks := gomock.NewController(t)
 	client := NewMockAPIClient(mocks)
-	var secrets map[string]*api.Secret
-	ctlr, err := newController(client, task, secrets)
+	ctlr, err := newController(client, task, nil)
 	assert.NoError(t, err)
 
 	config, err := newContainerConfig(task)

--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -86,8 +86,8 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 }
 
 // Controller returns a docker container controller.
-func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
-	ctlr, err := newController(e.client, t)
+func (e *executor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+	ctlr, err := newController(e.client, t, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -86,7 +86,7 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 }
 
 // Controller returns a docker container controller.
-func (e *executor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+func (e *executor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	ctlr, err := newController(e.client, t, secrets)
 	if err != nil {
 		return nil, err

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -59,14 +59,14 @@ type ContainerStatuser interface {
 //
 // Unlike Do, if an error is returned, the status should still be reported. The
 // error merely reports the failure at getting the controller.
-func Resolve(ctx context.Context, task *api.Task, executor Executor) (Controller, *api.TaskStatus, error) {
+func Resolve(ctx context.Context, task *api.Task, secrets map[string]*api.Secret, executor Executor) (Controller, *api.TaskStatus, error) {
 	status := task.Status.Copy()
 
 	defer func() {
 		logStateChange(ctx, task.DesiredState, task.Status.State, status.State)
 	}()
 
-	ctlr, err := executor.Controller(task)
+	ctlr, err := executor.Controller(task, secrets)
 
 	// depending on the tasks state, a failed controller resolution has varying
 	// impact. The following expresses that impact.

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -59,7 +59,7 @@ type ContainerStatuser interface {
 //
 // Unlike Do, if an error is returned, the status should still be reported. The
 // error merely reports the failure at getting the controller.
-func Resolve(ctx context.Context, task *api.Task, secrets map[string]*api.Secret, executor Executor) (Controller, *api.TaskStatus, error) {
+func Resolve(ctx context.Context, task *api.Task, secrets SecretProvider, executor Executor) (Controller, *api.TaskStatus, error) {
 	status := task.Status.Copy()
 
 	defer func() {

--- a/agent/exec/controller_test.go
+++ b/agent/exec/controller_test.go
@@ -21,24 +21,23 @@ func TestResolve(t *testing.T) {
 		ctx      = context.Background()
 		executor = &mockExecutor{}
 		task     = newTestTask(t, api.TaskStateAssigned, api.TaskStateRunning)
-		secrets  map[string]*api.Secret
 	)
 
-	_, status, err := Resolve(ctx, task, secrets, executor)
+	_, status, err := Resolve(ctx, task, nil, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, api.TaskStateAccepted, status.State)
 	assert.Equal(t, "accepted", status.Message)
 
 	task.Status = *status
 	// now, we get no status update.
-	_, status, err = Resolve(ctx, task, secrets, executor)
+	_, status, err = Resolve(ctx, task, nil, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, task.Status, *status)
 
 	// now test an error causing rejection
 	executor.err = errors.New("some error")
 	task = newTestTask(t, api.TaskStateAssigned, api.TaskStateRunning)
-	_, status, err = Resolve(ctx, task, secrets, executor)
+	_, status, err = Resolve(ctx, task, nil, executor)
 	assert.Equal(t, executor.err, err)
 	assert.Equal(t, api.TaskStateRejected, status.State)
 
@@ -47,7 +46,7 @@ func TestResolve(t *testing.T) {
 	// touched.
 	task.Status = *status
 	executor.err = nil
-	_, status, err = Resolve(ctx, task, secrets, executor)
+	_, status, err = Resolve(ctx, task, nil, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, task.Status, *status)
 }
@@ -412,6 +411,6 @@ type mockExecutor struct {
 	err error
 }
 
-func (m *mockExecutor) Controller(t *api.Task, secrets map[string]*api.Secret) (Controller, error) {
+func (m *mockExecutor) Controller(t *api.Task, secrets SecretProvider) (Controller, error) {
 	return nil, m.err
 }

--- a/agent/exec/executor.go
+++ b/agent/exec/executor.go
@@ -15,9 +15,16 @@ type Executor interface {
 	Configure(ctx context.Context, node *api.Node) error
 
 	// Controller provides a controller for the given task.
-	Controller(t *api.Task, secrets map[string]*api.Secret) (Controller, error)
+	Controller(t *api.Task, secrets SecretProvider) (Controller, error)
 
 	// SetNetworkBootstrapKeys passes the symmetric keys from the
 	// manager to the executor.
 	SetNetworkBootstrapKeys([]*api.EncryptionKey) error
+}
+
+// SecretProvider contains secret data necessary for the Controller.
+type SecretProvider interface {
+	// Get returns the the secret with a specific secret ID, if available.
+	// When the secret is not available, the return will be nil.
+	Get(secretID string) *api.Secret
 }

--- a/agent/exec/executor.go
+++ b/agent/exec/executor.go
@@ -15,7 +15,7 @@ type Executor interface {
 	Configure(ctx context.Context, node *api.Node) error
 
 	// Controller provides a controller for the given task.
-	Controller(t *api.Task) (Controller, error)
+	Controller(t *api.Task, secrets map[string]*api.Secret) (Controller, error)
 
 	// SetNetworkBootstrapKeys passes the symmetric keys from the
 	// manager to the executor.

--- a/agent/secrets.go
+++ b/agent/secrets.go
@@ -10,34 +10,37 @@ import (
 // mapped by secret ID
 type secrets struct {
 	mu sync.RWMutex
-	m  map[string]api.Secret
+	m  map[string]*api.Secret
 }
 
 func newSecrets() *secrets {
 	return &secrets{
-		m: make(map[string]api.Secret),
+		m: make(map[string]*api.Secret),
 	}
 }
 
-// Get returns a secret by ID.  If the secret doesn't exist, returns nil.
-func (s *secrets) Get(secretID string) api.Secret {
+// get returns a secret by ID.  If the secret doesn't exist, returns nil.
+func (s *secrets) get(secretID string) *api.Secret {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.m[secretID]
+	if s, ok := s.m[secretID]; ok {
+		return s
+	}
+	return nil
 }
 
-// Add adds one or more secrets to the secret map
-func (s *secrets) Add(secrets ...api.Secret) {
+// add adds one or more secrets to the secret map
+func (s *secrets) add(secrets ...api.Secret) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, secret := range secrets {
-		s.m[secret.ID] = secret
+		s.m[secret.ID] = &secret
 	}
 }
 
-// Remove removes one or more secrets by ID from the secret map.  Succeeds
+// remove removes one or more secrets by ID from the secret map.  Succeeds
 // whether or not the given IDs are in the map.
-func (s *secrets) Remove(secrets []string) {
+func (s *secrets) remove(secrets []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, secret := range secrets {
@@ -45,9 +48,37 @@ func (s *secrets) Remove(secrets []string) {
 	}
 }
 
-// Reset removes all the secrets
-func (s *secrets) Reset() {
+// reset removes all the secrets
+func (s *secrets) reset() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.m = make(map[string]api.Secret)
+	s.m = make(map[string]*api.Secret)
+}
+
+func (s *secrets) filter(secretIDs []string) map[string]*api.Secret {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	filteredSecrets := make(map[string]*api.Secret)
+
+	for _, secretID := range secretIDs {
+		if s, ok := s.m[secretID]; ok {
+			filteredSecrets[secretID] = s.Copy()
+		}
+	}
+
+	return filteredSecrets
+}
+
+// FilterByTask returns only the secrets needed by a specific Task
+func (s *secrets) filterByTask(task *api.Task) map[string]*api.Secret {
+	var secretIDs []string
+
+	container := task.Spec.GetContainer()
+	if container != nil {
+		for _, secretRef := range container.Secrets {
+			secretIDs = append(secretIDs, secretRef.SecretID)
+		}
+	}
+
+	return s.filter(secretIDs)
 }

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -337,7 +337,7 @@ func (w *worker) taskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (
 
 func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (*taskManager, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("task.id", task.ID))
-	secrets := w.secrets.filterByTask(task)
+	secrets := w.secrets.getStoreForTask(task)
 
 	ctlr, status, err := exec.Resolve(ctx, task, secrets, w.executor)
 	if err := w.updateTaskStatus(ctx, tx, task.ID, status); err != nil {

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -278,11 +278,11 @@ func reconcileSecrets(ctx context.Context, w *worker, assignments []*api.Assignm
 
 	// If this was a complete set of secrets, we're going to clear the secrets map and add all of them
 	if fullSnapshot {
-		w.secrets.Reset()
+		w.secrets.reset()
 	} else {
-		w.secrets.Remove(removedSecrets)
+		w.secrets.remove(removedSecrets)
 	}
-	w.secrets.Add(updatedSecrets...)
+	w.secrets.add(updatedSecrets...)
 
 	return nil
 }
@@ -337,8 +337,9 @@ func (w *worker) taskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (
 
 func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (*taskManager, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("task.id", task.ID))
+	secrets := w.secrets.filterByTask(task)
 
-	ctlr, status, err := exec.Resolve(ctx, task, w.executor)
+	ctlr, status, err := exec.Resolve(ctx, task, secrets, w.executor)
 	if err := w.updateTaskStatus(ctx, tx, task.ID, status); err != nil {
 		log.G(ctx).WithError(err).Error("error updating task status after controller resolution")
 	}

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -140,7 +140,7 @@ func TestWorkerAssign(t *testing.T) {
 		assert.Equal(t, testcase.expectedAssigned, assigned)
 		assert.Len(t, worker.secrets.m, len(testcase.expectedSecrets))
 		for _, secret := range testcase.expectedSecrets {
-			assert.NotNil(t, worker.secrets.get(secret.ID))
+			assert.NotNil(t, worker.secrets.Get(secret.ID))
 		}
 	}
 }
@@ -352,7 +352,7 @@ func TestWorkerUpdate(t *testing.T) {
 		assert.Equal(t, testcase.expectedAssigned, assigned)
 		assert.Len(t, worker.secrets.m, len(testcase.expectedSecrets))
 		for _, secret := range testcase.expectedSecrets {
-			assert.NotNil(t, worker.secrets.get(secret.ID))
+			assert.NotNil(t, worker.secrets.Get(secret.ID))
 		}
 	}
 }
@@ -378,6 +378,6 @@ type mockExecutor struct {
 	exec.Executor
 }
 
-func (m *mockExecutor) Controller(task *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+func (m *mockExecutor) Controller(task *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	return &mockTaskController{t: m.t, task: task}, nil
 }

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -140,7 +140,7 @@ func TestWorkerAssign(t *testing.T) {
 		assert.Equal(t, testcase.expectedAssigned, assigned)
 		assert.Len(t, worker.secrets.m, len(testcase.expectedSecrets))
 		for _, secret := range testcase.expectedSecrets {
-			assert.NotNil(t, worker.secrets.Get(secret.ID))
+			assert.NotNil(t, worker.secrets.get(secret.ID))
 		}
 	}
 }
@@ -352,7 +352,7 @@ func TestWorkerUpdate(t *testing.T) {
 		assert.Equal(t, testcase.expectedAssigned, assigned)
 		assert.Len(t, worker.secrets.m, len(testcase.expectedSecrets))
 		for _, secret := range testcase.expectedSecrets {
-			assert.NotNil(t, worker.secrets.Get(secret.ID))
+			assert.NotNil(t, worker.secrets.get(secret.ID))
 		}
 	}
 }
@@ -378,6 +378,6 @@ type mockExecutor struct {
 	exec.Executor
 }
 
-func (m *mockExecutor) Controller(task *api.Task) (exec.Controller, error) {
+func (m *mockExecutor) Controller(task *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
 	return &mockTaskController{t: m.t, task: task}, nil
 }

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -26,7 +26,7 @@ func (e *TestExecutor) SetNetworkBootstrapKeys([]*api.EncryptionKey) error {
 }
 
 // Controller returns TestController.
-func (e *TestExecutor) Controller(t *api.Task) (exec.Controller, error) {
+func (e *TestExecutor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
 	return &TestController{
 		ch: make(chan struct{}),
 	}, nil

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -26,7 +26,7 @@ func (e *TestExecutor) SetNetworkBootstrapKeys([]*api.EncryptionKey) error {
 }
 
 // Controller returns TestController.
-func (e *TestExecutor) Controller(t *api.Task, secrets map[string]*api.Secret) (exec.Controller, error) {
+func (e *TestExecutor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
 	return &TestController{
 		ch: make(chan struct{}),
 	}, nil


### PR DESCRIPTION
This just cherry-picks the commit from https://github.com/diogomonica/swarmkit/pull/1 - I just renamed "name" to "id" since we now do lookups by ID.
 
Enables lookup of the local secret assignment from the agent, which is needed from core side.