### PR TITLE
all: Avoid unnecessary "append" loops

### DIFF
--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -831,16 +831,12 @@ func (m *ListNodesRequest_Filters) Copy() *ListNodesRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -852,23 +848,17 @@ func (m *ListNodesRequest_Filters) Copy() *ListNodesRequest_Filters {
 
 	if m.Memberships != nil {
 		o.Memberships = make([]NodeSpec_Membership, 0, len(m.Memberships))
-		for _, v := range m.Memberships {
-			o.Memberships = append(o.Memberships, v)
-		}
+		o.Memberships = append(o.Memberships, m.Memberships...)
 	}
 
 	if m.Roles != nil {
 		o.Roles = make([]NodeRole, 0, len(m.Roles))
-		for _, v := range m.Roles {
-			o.Roles = append(o.Roles, v)
-		}
+		o.Roles = append(o.Roles, m.Roles...)
 	}
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o
@@ -1007,16 +997,12 @@ func (m *ListTasksRequest_Filters) Copy() *ListTasksRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -1028,30 +1014,22 @@ func (m *ListTasksRequest_Filters) Copy() *ListTasksRequest_Filters {
 
 	if m.ServiceIDs != nil {
 		o.ServiceIDs = make([]string, 0, len(m.ServiceIDs))
-		for _, v := range m.ServiceIDs {
-			o.ServiceIDs = append(o.ServiceIDs, v)
-		}
+		o.ServiceIDs = append(o.ServiceIDs, m.ServiceIDs...)
 	}
 
 	if m.NodeIDs != nil {
 		o.NodeIDs = make([]string, 0, len(m.NodeIDs))
-		for _, v := range m.NodeIDs {
-			o.NodeIDs = append(o.NodeIDs, v)
-		}
+		o.NodeIDs = append(o.NodeIDs, m.NodeIDs...)
 	}
 
 	if m.DesiredStates != nil {
 		o.DesiredStates = make([]TaskState, 0, len(m.DesiredStates))
-		for _, v := range m.DesiredStates {
-			o.DesiredStates = append(o.DesiredStates, v)
-		}
+		o.DesiredStates = append(o.DesiredStates, m.DesiredStates...)
 	}
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o
@@ -1191,16 +1169,12 @@ func (m *ListServicesRequest_Filters) Copy() *ListServicesRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -1212,9 +1186,7 @@ func (m *ListServicesRequest_Filters) Copy() *ListServicesRequest_Filters {
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o
@@ -1330,16 +1302,12 @@ func (m *ListNetworksRequest_Filters) Copy() *ListNetworksRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -1351,9 +1319,7 @@ func (m *ListNetworksRequest_Filters) Copy() *ListNetworksRequest_Filters {
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o
@@ -1421,16 +1387,12 @@ func (m *ListClustersRequest_Filters) Copy() *ListClustersRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -1442,9 +1404,7 @@ func (m *ListClustersRequest_Filters) Copy() *ListClustersRequest_Filters {
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o
@@ -1552,16 +1512,12 @@ func (m *ListSecretsRequest_Filters) Copy() *ListSecretsRequest_Filters {
 
 	if m.Names != nil {
 		o.Names = make([]string, 0, len(m.Names))
-		for _, v := range m.Names {
-			o.Names = append(o.Names, v)
-		}
+		o.Names = append(o.Names, m.Names...)
 	}
 
 	if m.IDPrefixes != nil {
 		o.IDPrefixes = make([]string, 0, len(m.IDPrefixes))
-		for _, v := range m.IDPrefixes {
-			o.IDPrefixes = append(o.IDPrefixes, v)
-		}
+		o.IDPrefixes = append(o.IDPrefixes, m.IDPrefixes...)
 	}
 
 	if m.Labels != nil {
@@ -1573,9 +1529,7 @@ func (m *ListSecretsRequest_Filters) Copy() *ListSecretsRequest_Filters {
 
 	if m.NamePrefixes != nil {
 		o.NamePrefixes = make([]string, 0, len(m.NamePrefixes))
-		for _, v := range m.NamePrefixes {
-			o.NamePrefixes = append(o.NamePrefixes, v)
-		}
+		o.NamePrefixes = append(o.NamePrefixes, m.NamePrefixes...)
 	}
 
 	return o

--- a/api/objects.pb.go
+++ b/api/objects.pb.go
@@ -401,16 +401,12 @@ func (m *NetworkAttachment) Copy() *NetworkAttachment {
 
 	if m.Addresses != nil {
 		o.Addresses = make([]string, 0, len(m.Addresses))
-		for _, v := range m.Addresses {
-			o.Addresses = append(o.Addresses, v)
-		}
+		o.Addresses = append(o.Addresses, m.Addresses...)
 	}
 
 	if m.Aliases != nil {
 		o.Aliases = make([]string, 0, len(m.Aliases))
-		for _, v := range m.Aliases {
-			o.Aliases = append(o.Aliases, v)
-		}
+		o.Aliases = append(o.Aliases, m.Aliases...)
 	}
 
 	return o

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -528,9 +528,7 @@ func (m *JoinResponse) Copy() *JoinResponse {
 
 	if m.RemovedMembers != nil {
 		o.RemovedMembers = make([]uint64, 0, len(m.RemovedMembers))
-		for _, v := range m.RemovedMembers {
-			o.RemovedMembers = append(o.RemovedMembers, v)
-		}
+		o.RemovedMembers = append(o.RemovedMembers, m.RemovedMembers...)
 	}
 
 	return o

--- a/api/snapshot.pb.go
+++ b/api/snapshot.pb.go
@@ -151,9 +151,7 @@ func (m *ClusterSnapshot) Copy() *ClusterSnapshot {
 
 	if m.Removed != nil {
 		o.Removed = make([]uint64, 0, len(m.Removed))
-		for _, v := range m.Removed {
-			o.Removed = append(o.Removed, v)
-		}
+		o.Removed = append(o.Removed, m.Removed...)
 	}
 
 	return o

--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -732,30 +732,22 @@ func (m *ContainerSpec) Copy() *ContainerSpec {
 
 	if m.Command != nil {
 		o.Command = make([]string, 0, len(m.Command))
-		for _, v := range m.Command {
-			o.Command = append(o.Command, v)
-		}
+		o.Command = append(o.Command, m.Command...)
 	}
 
 	if m.Args != nil {
 		o.Args = make([]string, 0, len(m.Args))
-		for _, v := range m.Args {
-			o.Args = append(o.Args, v)
-		}
+		o.Args = append(o.Args, m.Args...)
 	}
 
 	if m.Env != nil {
 		o.Env = make([]string, 0, len(m.Env))
-		for _, v := range m.Env {
-			o.Env = append(o.Env, v)
-		}
+		o.Env = append(o.Env, m.Env...)
 	}
 
 	if m.Groups != nil {
 		o.Groups = make([]string, 0, len(m.Groups))
-		for _, v := range m.Groups {
-			o.Groups = append(o.Groups, v)
-		}
+		o.Groups = append(o.Groups, m.Groups...)
 	}
 
 	if m.Mounts != nil {

--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -1779,16 +1779,12 @@ func (m *NetworkAttachmentConfig) Copy() *NetworkAttachmentConfig {
 
 	if m.Aliases != nil {
 		o.Aliases = make([]string, 0, len(m.Aliases))
-		for _, v := range m.Aliases {
-			o.Aliases = append(o.Aliases, v)
-		}
+		o.Aliases = append(o.Aliases, m.Aliases...)
 	}
 
 	if m.Addresses != nil {
 		o.Addresses = make([]string, 0, len(m.Addresses))
-		for _, v := range m.Addresses {
-			o.Addresses = append(o.Addresses, v)
-		}
+		o.Addresses = append(o.Addresses, m.Addresses...)
 	}
 
 	return o
@@ -2052,9 +2048,7 @@ func (m *Placement) Copy() *Placement {
 
 	if m.Constraints != nil {
 		o.Constraints = make([]string, 0, len(m.Constraints))
-		for _, v := range m.Constraints {
-			o.Constraints = append(o.Constraints, v)
-		}
+		o.Constraints = append(o.Constraints, m.Constraints...)
 	}
 
 	return o

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -445,19 +445,15 @@ func (a *Allocator) taskCreateNetworkAttachments(t *api.Task, s *api.Service) {
 
 		for _, na := range specNetworks {
 			n := store.GetNetwork(tx, na.Target)
-			if n != nil {
-				var aliases []string
-				var addresses []string
-
-				for _, a := range na.Aliases {
-					aliases = append(aliases, a)
-				}
-				for _, a := range na.Addresses {
-					addresses = append(addresses, a)
-				}
-
-				networks = append(networks, &api.NetworkAttachment{Network: n, Aliases: aliases, Addresses: addresses})
+			if n == nil {
+				continue
 			}
+
+			attachment := api.NetworkAttachment{Network: n}
+			attachment.Aliases = append(attachment.Aliases, na.Aliases...)
+			attachment.Addresses = append(attachment.Addresses, na.Addresses...)
+
+			networks = append(networks, &attachment)
 		}
 	})
 

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -518,7 +518,7 @@ func (na *NetworkAllocator) allocateNetworkIPs(nAttach *api.NetworkAttachment) e
 	}
 
 	addresses := nAttach.Addresses
-	if addresses == nil {
+	if len(addresses) == 0 {
 		addresses = []string{""}
 	}
 

--- a/protobuf/plugin/deepcopy/deepcopy.go
+++ b/protobuf/plugin/deepcopy/deepcopy.go
@@ -156,13 +156,13 @@ func (d *deepCopyGen) genRepeatedWriter(m *generator.Descriptor, f *descriptor.F
 	repeatedFunc := func() {
 		d.gen.P("\tif m.", fName, " != nil {")
 		d.gen.P("\t\to.", fName, " = make(", typename, ", 0, len(m.", fName, "))")
-		d.gen.P("\t\tfor _, v := range m.", fName, " {")
 		if isMessage {
+			d.gen.P("\t\tfor _, v := range m.", fName, " {")
 			d.gen.P("\t\t\to.", fName, " = append(o.", fName, ", ", notNullablePrefix, "v.Copy())")
+			d.gen.P("\t\t}")
 		} else {
-			d.gen.P("\t\t\to.", fName, " = append(o.", fName, ", v)")
+			d.gen.P("\t\to.", fName, " = append(o.", fName, ", m.", fName, "...)")
 		}
-		d.gen.P("\t\t}")
 		d.gen.P("\t}")
 		d.gen.P()
 	}

--- a/protobuf/plugin/deepcopy/test/deepcopy.pb.go
+++ b/protobuf/plugin/deepcopy/test/deepcopy.pb.go
@@ -205,107 +205,77 @@ func (m *RepeatedScalar) Copy() *RepeatedScalar {
 
 	if m.Field1 != nil {
 		o.Field1 = make([]float64, 0, len(m.Field1))
-		for _, v := range m.Field1 {
-			o.Field1 = append(o.Field1, v)
-		}
+		o.Field1 = append(o.Field1, m.Field1...)
 	}
 
 	if m.Field2 != nil {
 		o.Field2 = make([]float32, 0, len(m.Field2))
-		for _, v := range m.Field2 {
-			o.Field2 = append(o.Field2, v)
-		}
+		o.Field2 = append(o.Field2, m.Field2...)
 	}
 
 	if m.Field3 != nil {
 		o.Field3 = make([]int32, 0, len(m.Field3))
-		for _, v := range m.Field3 {
-			o.Field3 = append(o.Field3, v)
-		}
+		o.Field3 = append(o.Field3, m.Field3...)
 	}
 
 	if m.Field4 != nil {
 		o.Field4 = make([]int64, 0, len(m.Field4))
-		for _, v := range m.Field4 {
-			o.Field4 = append(o.Field4, v)
-		}
+		o.Field4 = append(o.Field4, m.Field4...)
 	}
 
 	if m.Field5 != nil {
 		o.Field5 = make([]uint32, 0, len(m.Field5))
-		for _, v := range m.Field5 {
-			o.Field5 = append(o.Field5, v)
-		}
+		o.Field5 = append(o.Field5, m.Field5...)
 	}
 
 	if m.Field6 != nil {
 		o.Field6 = make([]uint64, 0, len(m.Field6))
-		for _, v := range m.Field6 {
-			o.Field6 = append(o.Field6, v)
-		}
+		o.Field6 = append(o.Field6, m.Field6...)
 	}
 
 	if m.Field7 != nil {
 		o.Field7 = make([]int32, 0, len(m.Field7))
-		for _, v := range m.Field7 {
-			o.Field7 = append(o.Field7, v)
-		}
+		o.Field7 = append(o.Field7, m.Field7...)
 	}
 
 	if m.Field8 != nil {
 		o.Field8 = make([]int64, 0, len(m.Field8))
-		for _, v := range m.Field8 {
-			o.Field8 = append(o.Field8, v)
-		}
+		o.Field8 = append(o.Field8, m.Field8...)
 	}
 
 	if m.Field9 != nil {
 		o.Field9 = make([]uint32, 0, len(m.Field9))
-		for _, v := range m.Field9 {
-			o.Field9 = append(o.Field9, v)
-		}
+		o.Field9 = append(o.Field9, m.Field9...)
 	}
 
 	if m.Field10 != nil {
 		o.Field10 = make([]int32, 0, len(m.Field10))
-		for _, v := range m.Field10 {
-			o.Field10 = append(o.Field10, v)
-		}
+		o.Field10 = append(o.Field10, m.Field10...)
 	}
 
 	if m.Field11 != nil {
 		o.Field11 = make([]uint64, 0, len(m.Field11))
-		for _, v := range m.Field11 {
-			o.Field11 = append(o.Field11, v)
-		}
+		o.Field11 = append(o.Field11, m.Field11...)
 	}
 
 	if m.Field12 != nil {
 		o.Field12 = make([]int64, 0, len(m.Field12))
-		for _, v := range m.Field12 {
-			o.Field12 = append(o.Field12, v)
-		}
+		o.Field12 = append(o.Field12, m.Field12...)
 	}
 
 	if m.Field13 != nil {
 		o.Field13 = make([]bool, 0, len(m.Field13))
-		for _, v := range m.Field13 {
-			o.Field13 = append(o.Field13, v)
-		}
+		o.Field13 = append(o.Field13, m.Field13...)
 	}
 
 	if m.Field14 != nil {
 		o.Field14 = make([]string, 0, len(m.Field14))
-		for _, v := range m.Field14 {
-			o.Field14 = append(o.Field14, v)
-		}
+		o.Field14 = append(o.Field14, m.Field14...)
 	}
 
 	if m.Field15 != nil {
 		o.Field15 = make([][]byte, 0, len(m.Field15))
-		for _, v := range m.Field15 {
-			o.Field15 = append(o.Field15, v)
-		}
+		o.Field15 = append(o.Field15, m.Field15...)
 	}
 
 	return o
@@ -320,93 +290,67 @@ func (m *RepeatedScalarPacked) Copy() *RepeatedScalarPacked {
 
 	if m.Field1 != nil {
 		o.Field1 = make([]float64, 0, len(m.Field1))
-		for _, v := range m.Field1 {
-			o.Field1 = append(o.Field1, v)
-		}
+		o.Field1 = append(o.Field1, m.Field1...)
 	}
 
 	if m.Field2 != nil {
 		o.Field2 = make([]float32, 0, len(m.Field2))
-		for _, v := range m.Field2 {
-			o.Field2 = append(o.Field2, v)
-		}
+		o.Field2 = append(o.Field2, m.Field2...)
 	}
 
 	if m.Field3 != nil {
 		o.Field3 = make([]int32, 0, len(m.Field3))
-		for _, v := range m.Field3 {
-			o.Field3 = append(o.Field3, v)
-		}
+		o.Field3 = append(o.Field3, m.Field3...)
 	}
 
 	if m.Field4 != nil {
 		o.Field4 = make([]int64, 0, len(m.Field4))
-		for _, v := range m.Field4 {
-			o.Field4 = append(o.Field4, v)
-		}
+		o.Field4 = append(o.Field4, m.Field4...)
 	}
 
 	if m.Field5 != nil {
 		o.Field5 = make([]uint32, 0, len(m.Field5))
-		for _, v := range m.Field5 {
-			o.Field5 = append(o.Field5, v)
-		}
+		o.Field5 = append(o.Field5, m.Field5...)
 	}
 
 	if m.Field6 != nil {
 		o.Field6 = make([]uint64, 0, len(m.Field6))
-		for _, v := range m.Field6 {
-			o.Field6 = append(o.Field6, v)
-		}
+		o.Field6 = append(o.Field6, m.Field6...)
 	}
 
 	if m.Field7 != nil {
 		o.Field7 = make([]int32, 0, len(m.Field7))
-		for _, v := range m.Field7 {
-			o.Field7 = append(o.Field7, v)
-		}
+		o.Field7 = append(o.Field7, m.Field7...)
 	}
 
 	if m.Field8 != nil {
 		o.Field8 = make([]int64, 0, len(m.Field8))
-		for _, v := range m.Field8 {
-			o.Field8 = append(o.Field8, v)
-		}
+		o.Field8 = append(o.Field8, m.Field8...)
 	}
 
 	if m.Field9 != nil {
 		o.Field9 = make([]uint32, 0, len(m.Field9))
-		for _, v := range m.Field9 {
-			o.Field9 = append(o.Field9, v)
-		}
+		o.Field9 = append(o.Field9, m.Field9...)
 	}
 
 	if m.Field10 != nil {
 		o.Field10 = make([]int32, 0, len(m.Field10))
-		for _, v := range m.Field10 {
-			o.Field10 = append(o.Field10, v)
-		}
+		o.Field10 = append(o.Field10, m.Field10...)
 	}
 
 	if m.Field11 != nil {
 		o.Field11 = make([]uint64, 0, len(m.Field11))
-		for _, v := range m.Field11 {
-			o.Field11 = append(o.Field11, v)
-		}
+		o.Field11 = append(o.Field11, m.Field11...)
 	}
 
 	if m.Field12 != nil {
 		o.Field12 = make([]int64, 0, len(m.Field12))
-		for _, v := range m.Field12 {
-			o.Field12 = append(o.Field12, v)
-		}
+		o.Field12 = append(o.Field12, m.Field12...)
 	}
 
 	if m.Field13 != nil {
 		o.Field13 = make([]bool, 0, len(m.Field13))
-		for _, v := range m.Field13 {
-			o.Field13 = append(o.Field13, v)
-		}
+		o.Field13 = append(o.Field13, m.Field13...)
 	}
 
 	return o


### PR DESCRIPTION
In cases where append(a, b...) can be used, don't replicate the same
functionality with a for loop.

Modify the deepcopy plugin to generate code that uses the former syntax.

Fix an instance in allocator. Also change a slice == nil check to
len(slice) == 0, which caused some fun to debug problems.

@stevvooe @mrjana