### PR TITLE
Add ineffective assignment checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
 all: check binaries test ## run fmt, vet, lint, build the binaries and run the tests
 
-check: fmt vet lint ## run fmt, vet, lint
+check: fmt vet lint ineffassign ## run fmt, vet, lint, ineffassign
 
 ci: check binaries checkprotos coverage ## to be used by the CI
 
@@ -38,6 +38,7 @@ setup: ## install dependencies
 	@go get -u github.com/golang/lint/golint
 	#@go get -u github.com/kisielk/errcheck
 	@go get -u github.com/golang/mock/mockgen
+	@go get -u github.com/gordonklaus/ineffassign
 
 generate: bin/protoc-gen-gogoswarm ## generate protobuf
 	@echo "🐳 $@"
@@ -69,6 +70,10 @@ fmt: ## run go fmt
 lint: ## run go lint
 	@echo "🐳 $@"
 	@test -z "$$(golint ./... | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
+
+ineffassign: ## run ineffassign
+	@echo "🐳 $@"
+	@test -z "$$(ineffassign . | grep -v vendor/ | grep -v ".pb.go:" | grep -v ".mock.go" | tee /dev/stderr)"
 
 #errcheck: ## run go errcheck
 #	@echo "🐳 $@"

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -147,11 +147,13 @@ func TestNodeCertificateRenewalsDoNotRequireToken(t *testing.T) {
 	role := api.NodeRoleManager
 	issueRequest := &api.IssueNodeCertificateRequest{CSR: csr, Role: role}
 	issueResponse, err := tc.NodeCAClients[2].IssueNodeCertificate(context.Background(), issueRequest)
+	assert.NoError(t, err)
 	assert.NotNil(t, issueResponse.NodeID)
 	assert.Equal(t, api.NodeMembershipAccepted, issueResponse.NodeMembership)
 
 	statusRequest := &api.NodeCertificateStatusRequest{NodeID: issueResponse.NodeID}
 	statusResponse, err := tc.NodeCAClients[2].NodeCertificateStatus(context.Background(), statusRequest)
+	assert.NoError(t, err)
 	assert.Equal(t, api.IssuanceStateIssued, statusResponse.Status.State)
 	assert.NotNil(t, statusResponse.Certificate.Certificate)
 	assert.Equal(t, role, statusResponse.Certificate.Role)

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -373,6 +373,7 @@ func TestAssignmentsInitialNodeTasks(t *testing.T) {
 		}
 		return nil
 	})
+	assert.NoError(t, err)
 
 	stream, err := gd.Clients[0].Assignments(context.Background(), &api.AssignmentsRequest{SessionID: expectedSessionID})
 	assert.NoError(t, err)
@@ -480,6 +481,7 @@ func TestAssignmentsAddingTasks(t *testing.T) {
 		}
 		return nil
 	})
+	assert.NoError(t, err)
 
 	// Nothing happens until we update.  Updating all the tasks will send updates for all the tasks >= ASSIGNED (10),
 	// and secrets for all the tasks >= ASSIGNED and <= RUNNING (6).
@@ -558,6 +560,8 @@ func TestAssignmentsSecretUpdateAndDeletion(t *testing.T) {
 		}
 		return nil
 	})
+	assert.NoError(t, err)
+
 	stream, err := gd.Clients[0].Assignments(context.Background(), &api.AssignmentsRequest{SessionID: expectedSessionID})
 	assert.NoError(t, err)
 	defer stream.CloseSend()
@@ -967,6 +971,7 @@ func TestSessionNoCert(t *testing.T) {
 	defer gd.Close()
 
 	stream, err := gd.Clients[2].Session(context.Background(), &api.SessionRequest{})
+	assert.NoError(t, err)
 	msg, err := stream.Recv()
 	assert.Nil(t, msg)
 	assert.EqualError(t, err, "rpc error: code = 7 desc = Permission denied: unauthorized peer role: rpc error: code = 7 desc = no client certificates in request")

--- a/manager/orchestrator/restart_test.go
+++ b/manager/orchestrator/restart_test.go
@@ -630,7 +630,6 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	// Fail the second task. Confirm that it gets restarted.
 	updatedTask2 := observedTask2.Copy()
 	updatedTask2.Status = api.TaskStatus{State: api.TaskStateFailed}
-	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask2))
 		return nil
@@ -656,7 +655,6 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	// Fail the first instance again. It should not be restarted.
 	updatedTask1 = observedTask3.Copy()
 	updatedTask1.Status = api.TaskStatus{State: api.TaskStateFailed}
-	before = time.Now()
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.UpdateTask(tx, updatedTask1))
 		return nil


### PR DESCRIPTION
This is a check like lint/vet that fails CI if there are dead stores in the code.