### PR TITLE
make ci: disable lint temporarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"
 
 all: check binaries test integration ## run fmt, vet, lint, build the binaries and run the tests
 
-check: fmt vet lint ineffassign ## run fmt, vet, lint, ineffassign
+# lint is disabled temporarily because https://github.com/golang/lint/commit/3390df4df2787994aea98de825b964ac7944b817 failing (#1643)
+check: fmt vet ineffassign ## run fmt, vet, ineffassign
 
 ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
 


### PR DESCRIPTION
lint has been failing due to a recent change in golint  (https://github.com/golang/lint/commit/3390df4df2787994aea98de825b964ac7944b817)

```
 $ make lint
 _ lint
 agent/exec/controller_test.go:347:1: context.Context should be the first parameter of a function
 Makefile:76: recipe for target 'lint' failed
 make: *** [lint] Error 1
````
The prototype of the failing function is: 
```go
checkDo(t *testing.T, ctx context.Context, task *api.Task, ctlr Controller, expected *api.TaskStatus, expectedErr ...error) *api.TaskStatus
```
(https://github.com/docker/swarmkit/blob/3674e9330c0d78076c20849b71b74fb26133439b/agent/exec/controller_test.go#L347)

IMO `checkDo` doesn't have any problem and golint is wrong.
I opened a PR to golint so as to allow `*testing.T` as the first parameter as well. https://github.com/golang/lint/pull/248

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>