### PR TITLE
template: support templating of task runtime parameters

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	"github.com/docker/swarmkit/template"
 )
 
 const (
@@ -32,8 +33,7 @@ const (
 // containerConfig converts task properties into docker container compatible
 // components.
 type containerConfig struct {
-	task *api.Task
-
+	task                *api.Task
 	networksAttachments map[string]*api.NetworkAttachment
 }
 
@@ -61,6 +61,14 @@ func (c *containerConfig) setTask(t *api.Task) error {
 	}
 
 	c.task = t
+	preparedSpec, err := template.ExpandContainerSpec(t)
+	if err != nil {
+		return err
+	}
+	c.task.Spec.Runtime = &api.TaskSpec_Container{
+		Container: preparedSpec,
+	}
+
 	return nil
 }
 

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -47,10 +47,6 @@ func newController(client engineapi.APIClient, task *api.Task, secrets exec.Secr
 	}, nil
 }
 
-func (r *controller) Task() (*api.Task, error) {
-	return r.task, nil
-}
-
 // ContainerStatus returns the container-specific status for the task.
 func (r *controller) ContainerStatus(ctx context.Context) (*api.ContainerStatus, error) {
 	ctnr, err := r.adapter.inspect(ctx)

--- a/template/context.go
+++ b/template/context.go
@@ -1,0 +1,72 @@
+package template
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
+)
+
+// Context defines the strict set of values that can be injected into a
+// template expression in SwarmKit data structure.
+type Context struct {
+	Service struct {
+		ID     string
+		Name   string
+		Labels map[string]string
+	}
+
+	Node struct {
+		ID string
+	}
+
+	Task struct {
+		ID   string
+		Name string
+		Slot string
+
+		// NOTE(stevvooe): Why no labels here? Tasks don't actually have labels
+		// (from a user perspective). The labels are part of the container! If
+		// one wants to use labels for templating, use service labels!
+	}
+}
+
+// NewContextFromTask returns a new template context from the data available in
+// task. The provided context can then be used to populate runtime values in a
+// ContainerSpec.
+func NewContextFromTask(t *api.Task) (ctx Context) {
+	ctx.Service.ID = t.ServiceID
+	ctx.Service.Name = t.ServiceAnnotations.Name
+	ctx.Service.Labels = t.ServiceAnnotations.Labels
+
+	ctx.Node.ID = t.NodeID
+
+	ctx.Task.ID = t.ID
+	ctx.Task.Name = naming.Task(t)
+
+	if t.Slot != 0 {
+		ctx.Task.Slot = fmt.Sprint(t.Slot)
+	} else {
+		// fall back to node id for slot when there is no slot
+		ctx.Task.Slot = t.NodeID
+	}
+
+	return
+}
+
+// Expand treats the string s as a template and populates it with values from
+// the context.
+func (ctx *Context) Expand(s string) (string, error) {
+	tmpl, err := newTemplate(s)
+	if err != nil {
+		return s, err
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, ctx); err != nil {
+		return s, err
+	}
+
+	return buf.String(), nil
+}

--- a/template/context_test.go
+++ b/template/context_test.go
@@ -1,0 +1,220 @@
+package template
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplateContext(t *testing.T) {
+	for _, testcase := range []struct {
+		Test     string
+		Task     *api.Task
+		Context  Context
+		Expected *api.ContainerSpec
+		Err      error
+	}{
+		{
+			Test: "Identity",
+			Task: modifyTask(func(t *api.Task) {
+				t.Spec = api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{
+							Env: []string{
+								"NOTOUCH=dont",
+							},
+							Mounts: []api.Mount{
+								{
+									Target: "foo",
+									Source: "bar",
+								},
+							},
+						},
+					},
+				}
+			}),
+			Expected: &api.ContainerSpec{
+				Env: []string{
+					"NOTOUCH=dont",
+				},
+				Mounts: []api.Mount{
+					{
+						Target: "foo",
+						Source: "bar",
+					},
+				},
+			},
+		},
+		{
+			Test: "Env",
+			Task: modifyTask(func(t *api.Task) {
+				t.Spec = api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{
+							Labels: map[string]string{
+								"ContainerLabel": "should-NOT-end-up-as-task",
+							},
+							Env: []string{
+								"MYENV=notemplate",
+								"{{.NotExpanded}}=foo",
+								"SERVICE_ID={{.Service.ID}}",
+								"SERVICE_NAME={{.Service.Name}}",
+								"TASK_ID={{.Task.ID}}",
+								"TASK_NAME={{.Task.Name}}",
+								"NODE_ID={{.Node.ID}}",
+								"SERVICE_LABELS={{range $k, $v := .Service.Labels}}{{$k}}={{$v}},{{end}}",
+							},
+						},
+					},
+				}
+			}),
+			Expected: &api.ContainerSpec{
+				Labels: map[string]string{
+					"ContainerLabel": "should-NOT-end-up-as-task",
+				},
+				Env: []string{
+					"MYENV=notemplate",
+					"{{.NotExpanded}}=foo",
+					"SERVICE_ID=serviceID",
+					"SERVICE_NAME=serviceName",
+					"TASK_ID=taskID",
+					"TASK_NAME=serviceName.10.taskID",
+					"NODE_ID=nodeID",
+					"SERVICE_LABELS=ServiceLabelOneKey=service-label-one-value,ServiceLabelTwoKey=service-label-two-value,com.example.ServiceLabelThreeKey=service-label-three-value,",
+				},
+			},
+		},
+		{
+			Test: "Mount",
+			Task: modifyTask(func(t *api.Task) {
+				t.Spec = api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{
+							Mounts: []api.Mount{
+								{
+									Source: "bar-{{.Node.ID}}-{{.Task.Name}}",
+									Target: "foo-{{.Service.ID}}-{{.Service.Name}}",
+								},
+								{
+									Source: "bar-{{.Node.ID}}-{{.Service.Name}}",
+									Target: "foo-{{.Task.Slot}}-{{.Task.ID}}",
+								},
+							},
+						},
+					},
+				}
+			}),
+			Expected: &api.ContainerSpec{
+				Mounts: []api.Mount{
+					{
+						Source: "bar-nodeID-serviceName.10.taskID",
+						Target: "foo-serviceID-serviceName",
+					},
+					{
+						Source: "bar-nodeID-serviceName",
+						Target: "foo-10-taskID",
+					},
+				},
+			},
+		},
+		{
+			Test: "Hostname",
+			Task: modifyTask(func(t *api.Task) {
+				t.Spec = api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{
+							Hostname: "myhost-{{.Task.Slot}}",
+						},
+					},
+				}
+			}),
+			Expected: &api.ContainerSpec{
+				Hostname: "myhost-10",
+			},
+		},
+	} {
+		t.Run(testcase.Test, func(t *testing.T) {
+			spec, err := ExpandContainerSpec(testcase.Task)
+			if err != nil {
+				if testcase.Err == nil {
+					t.Fatalf("unexpected error: %v", err)
+				} else {
+					if err != testcase.Err {
+						t.Fatalf("unexpected error: %v != %v", err, testcase.Err)
+					}
+				}
+			}
+
+			assert.Equal(t, testcase.Expected, spec)
+
+			for k, v := range testcase.Task.Annotations.Labels {
+				// make sure that that task.annotations.labels didn't make an appearance.
+				visitAllTemplatedFields(spec, func(s string) {
+					if strings.Contains(s, k) || strings.Contains(s, v) {
+						t.Fatalf("string value from task labels found in expanded spec: %q or %q found in %q, on %#v", k, v, s, spec)
+					}
+				})
+			}
+		})
+	}
+}
+
+// modifyTask generates a task with interesting values then calls the function
+// with it. The caller can then modify the task and return the result.
+func modifyTask(fn func(t *api.Task)) *api.Task {
+	t := &api.Task{
+		ID:        "taskID",
+		ServiceID: "serviceID",
+		NodeID:    "nodeID",
+		Slot:      10,
+		Annotations: api.Annotations{
+			Labels: map[string]string{
+				// SUBTLE(stevvooe): Task labels ARE NOT templated. These are
+				// reserved for the system and templated is not really needed.
+				// Non of these values show show up in templates.
+				"TaskLabelOneKey":               "task-label-one-value",
+				"TaskLabelTwoKey":               "task-label-two-value",
+				"com.example.TaskLabelThreeKey": "task-label-three-value",
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name: "serviceName",
+			Labels: map[string]string{
+				"ServiceLabelOneKey":               "service-label-one-value",
+				"ServiceLabelTwoKey":               "service-label-two-value",
+				"com.example.ServiceLabelThreeKey": "service-label-three-value",
+			},
+		},
+	}
+
+	fn(t)
+
+	return t
+}
+
+// visitAllTemplatedFields does just that.
+// TODO(stevvooe): Might be best to make this the actual implementation.
+func visitAllTemplatedFields(spec *api.ContainerSpec, fn func(value string)) {
+	for _, v := range spec.Env {
+		fn(v)
+	}
+
+	for _, mount := range spec.Mounts {
+		fn(mount.Target)
+		fn(mount.Source)
+
+		if mount.VolumeOptions != nil {
+			for _, v := range mount.VolumeOptions.Labels {
+				fn(v)
+			}
+
+			if mount.VolumeOptions.DriverConfig != nil {
+				for _, v := range mount.VolumeOptions.DriverConfig.Options {
+					fn(v)
+				}
+			}
+		}
+	}
+}

--- a/template/expand.go
+++ b/template/expand.go
@@ -1,0 +1,118 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/pkg/errors"
+)
+
+// ExpandContainerSpec expands templated fields in the runtime using the task
+// state. Templating is all evaluated on the agent-side, before execution.
+//
+// Note that these are projected only on runtime values, since active task
+// values are typically manipulated in the manager.
+func ExpandContainerSpec(t *api.Task) (*api.ContainerSpec, error) {
+	container := t.Spec.GetContainer()
+	if container == nil {
+		return nil, errors.Errorf("task missing ContainerSpec to expand")
+	}
+
+	container = container.Copy()
+	ctx := NewContextFromTask(t)
+
+	var err error
+	container.Env, err = expandEnv(ctx, container.Env)
+	if err != nil {
+		return container, errors.Wrap(err, "expanding env failed")
+	}
+
+	// For now, we only allow templating of string-based mount fields
+	container.Mounts, err = expandMounts(ctx, container.Mounts)
+	if err != nil {
+		return container, errors.Wrap(err, "expanding mounts failed")
+	}
+
+	container.Hostname, err = ctx.Expand(container.Hostname)
+	return container, errors.Wrap(err, "expanding hostname failed")
+}
+
+func expandMounts(ctx Context, mounts []api.Mount) ([]api.Mount, error) {
+	if len(mounts) == 0 {
+		return mounts, nil
+	}
+
+	expanded := make([]api.Mount, len(mounts))
+	for i, mount := range mounts {
+		var err error
+		mount.Source, err = ctx.Expand(mount.Source)
+		if err != nil {
+			return mounts, errors.Wrapf(err, "expanding mount source %q", mount.Source)
+		}
+
+		mount.Target, err = ctx.Expand(mount.Target)
+		if err != nil {
+			return mounts, errors.Wrapf(err, "expanding mount target %q", mount.Target)
+		}
+
+		if mount.VolumeOptions != nil {
+			mount.VolumeOptions.Labels, err = expandMap(ctx, mount.VolumeOptions.Labels)
+			if err != nil {
+				return mounts, errors.Wrap(err, "expanding volume labels")
+			}
+
+			if mount.VolumeOptions.DriverConfig != nil {
+				mount.VolumeOptions.DriverConfig.Options, err = expandMap(ctx, mount.VolumeOptions.DriverConfig.Options)
+				if err != nil {
+					return mounts, errors.Wrap(err, "expanding volume driver config")
+				}
+			}
+		}
+
+		expanded[i] = mount
+	}
+
+	return expanded, nil
+}
+
+func expandMap(ctx Context, m map[string]string) (map[string]string, error) {
+	var (
+		n   = make(map[string]string, len(m))
+		err error
+	)
+
+	for k, v := range m {
+		v, err = ctx.Expand(v)
+		if err != nil {
+			return m, errors.Wrapf(err, "expanding map entry %q=%q", k, v)
+		}
+
+		n[k] = v
+	}
+
+	return n, nil
+}
+
+func expandEnv(ctx Context, values []string) ([]string, error) {
+	var result []string
+	for _, value := range values {
+		var (
+			parts = strings.SplitN(value, "=", 2)
+			entry = parts[0]
+		)
+
+		if len(parts) > 1 {
+			expanded, err := ctx.Expand(parts[1])
+			if err != nil {
+				return values, errors.Wrapf(err, "expanding env %q", value)
+			}
+
+			entry = fmt.Sprintf("%s=%s", entry, expanded)
+		}
+
+		result = append(result, entry)
+	}
+
+	return result, nil
+}

--- a/template/template.go
+++ b/template/template.go
@@ -1,0 +1,18 @@
+package template
+
+import (
+	"strings"
+	"text/template"
+)
+
+// funcMap defines functions for our template system.
+var funcMap = template.FuncMap{
+	"join": func(s ...string) string {
+		// first arg is sep, remaining args are strings to join
+		return strings.Join(s[1:], s[0])
+	},
+}
+
+func newTemplate(s string) (*template.Template, error) {
+	return template.New("expansion").Option("missingkey=error").Funcs(funcMap).Parse(s)
+}


### PR DESCRIPTION
To better support common use cases that require injected service and
task information, we now treat ContainerSpec fields as templates. A
common, simplified context is defined that contains commonly needed
values, with access to names, identifiers and labels.

This initial PR focuses on supporting mounts and environment variables.
By supporting these, users will be able to locate mounts based on task
context or service name, unlocking many use cases that were previously
challenging or impossible. Environment variables open up further
possibilities.

Signed-off-by: Stephen J Day stephen.day@docker.com

cc @aluzzardi @mgoelzer @ehazlett @NathanMcCauley @diogomonica 
