### PR TITLE
raft/membership: remove RaftClient field

### DIFF
--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -53,7 +53,6 @@ type Cluster struct {
 type Member struct {
 	*api.RaftMember
 
-	api.RaftClient
 	Conn         *grpc.ClientConn
 	tick         int
 	active       bool
@@ -211,8 +210,7 @@ func (c *Cluster) clearMember(id uint64) error {
 	return nil
 }
 
-// ReplaceMemberConnection replaces the member's GRPC connection and GRPC
-// client.
+// ReplaceMemberConnection replaces the member's GRPC connection.
 func (c *Cluster) ReplaceMemberConnection(id uint64, oldConn *Member, newConn *Member, newAddr string, force bool) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -236,7 +234,6 @@ func (c *Cluster) ReplaceMemberConnection(id uint64, oldConn *Member, newConn *M
 	newMember.RaftMember = oldMember.RaftMember.Copy()
 	newMember.RaftMember.Addr = newAddr
 	newMember.Conn = newConn.Conn
-	newMember.RaftClient = newConn.RaftClient
 	c.members[id] = &newMember
 
 	return nil

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -952,7 +952,6 @@ func (n *Node) registerNode(node *api.RaftMember) error {
 		// address.
 		if existingMember.Addr != node.Addr {
 			member.RaftMember = node
-			member.RaftClient = existingMember.RaftClient
 			member.Conn = existingMember.Conn
 			n.cluster.AddMember(member)
 		}
@@ -1187,7 +1186,7 @@ func (n *Node) sendToMember(members map[uint64]*membership.Member, m raftpb.Mess
 			return
 		}
 
-		resp, err := queryMember.ResolveAddress(ctx, &api.ResolveAddressRequest{RaftID: m.To})
+		resp, err := api.NewRaftClient(queryMember.Conn).ResolveAddress(ctx, &api.ResolveAddressRequest{RaftID: m.To})
 		if err != nil {
 			log.G(ctx).WithError(err).Errorf("could not resolve address of member ID %x", m.To)
 			return
@@ -1203,7 +1202,7 @@ func (n *Node) sendToMember(members map[uint64]*membership.Member, m raftpb.Mess
 		defer conn.Conn.Close()
 	}
 
-	_, err := conn.ProcessRaftMessage(ctx, &api.ProcessRaftMessageRequest{Message: &m})
+	_, err := api.NewRaftClient(conn.Conn).ProcessRaftMessage(ctx, &api.ProcessRaftMessageRequest{Message: &m})
 	if err != nil {
 		if grpc.ErrorDesc(err) == ErrMemberRemoved.Error() {
 			n.removeRaftFunc()
@@ -1551,8 +1550,7 @@ func (n *Node) ConnectToMember(addr string, timeout time.Duration) (*membership.
 	}
 
 	return &membership.Member{
-		RaftClient: api.NewRaftClient(conn),
-		Conn:       conn,
+		Conn: conn,
 	}, nil
 }
 


### PR DESCRIPTION
There is not much overhead (if any) in creating client each time, but
having embedded RaftClient hurts readability very much IMO.