### PR TITLE
Allowing GetSecret to return the secret data

### DIFF
--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -48,7 +48,6 @@ func (s *Server) GetSecret(ctx context.Context, request *api.GetSecretRequest) (
 		return nil, grpc.Errorf(codes.NotFound, "secret %s not found", request.SecretID)
 	}
 
-	secret.Spec.Data = nil // clean the actual secret data so it's never returned
 	return &api.GetSecretResponse{Secret: secret}, nil
 }
 

--- a/manager/controlapi/secret_test.go
+++ b/manager/controlapi/secret_test.go
@@ -160,10 +160,6 @@ func TestGetSecret(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotNil(t, resp.Secret)
-
-	// the data should be empty/omitted
-	assert.NotEqual(t, secret, resp.Secret)
-	secret.Spec.Data = nil
 	assert.Equal(t, secret, resp.Secret)
 }
 


### PR DESCRIPTION
Allowing GetSecret to return the secret data. Intentionally leaving ListSecrets with redaction enabled.

/cc @cyli @aaronlehmann 

Signed-off-by: Diogo Monica <diogo.monica@gmail.com>