### PR TITLE
orchestrator: Make global tests more robust; use generic Expect function

### DIFF
--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -77,16 +77,16 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
 
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	observedTask4 := testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, observedTask4.DesiredState, api.TaskStateRunning)
@@ -100,16 +100,16 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask5 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask5.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask5.ServiceAnnotations.Name, "name1")
 
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	observedTask6 := testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, observedTask6.DesiredState, api.TaskStateRunning)
@@ -180,17 +180,17 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
 
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	observedTask4 := testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, observedTask4.DesiredState, api.TaskStateRunning)
@@ -204,11 +204,11 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	select {
 	case <-watch:
@@ -280,11 +280,11 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	select {
 	case <-watch:
@@ -300,10 +300,10 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	select {
 	case <-watch:
@@ -377,13 +377,13 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
@@ -470,13 +470,13 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
@@ -502,18 +502,18 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask5 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask5.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask5.DesiredState, api.TaskStateReady)
 
 	observedTask6 := testutils.WatchTaskUpdate(t, watch) // task gets started after a delay
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask6.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask6.DesiredState, api.TaskStateRunning)
 	assert.Equal(t, observedTask6.ServiceAnnotations.Name, "name1")
@@ -526,10 +526,10 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	select {
 	case <-watch:
@@ -604,13 +604,13 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
@@ -636,19 +636,19 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask5 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask5.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask5.DesiredState, api.TaskStateReady)
 	assert.Equal(t, observedTask5.ServiceAnnotations.Name, "name1")
 
 	observedTask6 := testutils.WatchTaskUpdate(t, watch) // task gets started after a delay
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask6.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask6.DesiredState, api.TaskStateRunning)
 	assert.Equal(t, observedTask6.ServiceAnnotations.Name, "name1")
@@ -661,10 +661,10 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
 	select {
 	case <-watch:
@@ -684,12 +684,12 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 
 	observedTask7 := testutils.WatchTaskCreate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
 	assert.Equal(t, observedTask7.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask7.DesiredState, api.TaskStateReady)
 

--- a/manager/orchestrator/replicated/task_reaper_test.go
+++ b/manager/orchestrator/replicated/task_reaper_test.go
@@ -98,17 +98,17 @@ func TestTaskHistory(t *testing.T) {
 		return nil
 	})
 
-	testutils.ExpectCommit(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectTaskUpdate(t, watch)
-	testutils.ExpectCommit(t, watch)
+	testutils.Expect(t, watch, state.EventCommit{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventUpdateTask{})
+	testutils.Expect(t, watch, state.EventCommit{})
 
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 	observedTask3 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask3.ServiceAnnotations.Name, "name1")
 
-	testutils.ExpectTaskUpdate(t, watch)
+	testutils.Expect(t, watch, state.EventUpdateTask{})
 	observedTask4 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask4.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask4.ServiceAnnotations.Name, "name1")

--- a/manager/state/watch.go
+++ b/manager/state/watch.go
@@ -563,12 +563,17 @@ func Watch(queue *watch.Queue, specifiers ...Event) (eventq chan events.Event, c
 	if len(specifiers) == 0 {
 		return queue.Watch()
 	}
-	return queue.CallbackWatch(events.MatcherFunc(func(event events.Event) bool {
+	return queue.CallbackWatch(Matcher(specifiers...))
+}
+
+// Matcher returns an events.Matcher that matches the specifiers with OR logic.
+func Matcher(specifiers ...Event) events.MatcherFunc {
+	return events.MatcherFunc(func(event events.Event) bool {
 		for _, s := range specifiers {
 			if s.matches(event) {
 				return true
 			}
 		}
 		return false
-	}))
+	})
 }


### PR DESCRIPTION
The global orchestrator tests were pausing 200 ms to wait for some events to pass. It's more reliable to just consume these specific events. This changes them to do that, and also replace testutils.Expect* with a single Expect function. This is nicer than having a separate function for every event type. The Checks in the event structure can be used to match specific event properties.

In the future, I may also convert testutils.Watch* to a similar Watch function.

cc @dongluochen