### PR TITLE
Allow dynamic updates of hostname

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -494,8 +494,8 @@ func (a *Agent) Publisher(ctx context.Context, subscriptionID string) (exec.LogP
 func (a *Agent) nodeDescriptionWithHostname(ctx context.Context) (*api.NodeDescription, error) {
 	desc, err := a.config.Executor.Describe(ctx)
 
-	// Override hostname
-	if a.config.Hostname != "" && desc != nil {
+	// Only override hostname if it is not received from the call to Describe
+	if desc != nil && desc.Hostname == "" {
 		desc.Hostname = a.config.Hostname
 	}
 	return desc, err


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/27173

Currently, we override the hostname received from the Docker Engine if it is already in the config. This leads to old hostnames being reported on `docker node ls` or `docker node inspect`, as reported in the above issue.

This PR fixes that. The side-effect of this change is that the `--hostname` flag in SwarmKit will not work anymore, since it will be overridden by the hostname provided by the Engine.

cc @aluzzardi @aaronlehmann @nathanleclaire 

Signed-off-by: Nishant Totla nishanttotla@gmail.com
