### PR TITLE
scheduler: Always initialize maps when nodes are inserted in the nodeset

### DIFF
--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -42,9 +42,6 @@ func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api
 // addTask removes a task from nodeInfo if it's tracked there, and returns true
 // if nodeInfo was modified.
 func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
-	if nodeInfo.Tasks == nil {
-		return false
-	}
 	oldTask, ok := nodeInfo.Tasks[t.ID]
 	if !ok {
 		return false
@@ -66,13 +63,6 @@ func (nodeInfo *NodeInfo) removeTask(t *api.Task) bool {
 // addTask adds or updates a task on nodeInfo, and returns true if nodeInfo was
 // modified.
 func (nodeInfo *NodeInfo) addTask(t *api.Task) bool {
-	if nodeInfo.Tasks == nil {
-		nodeInfo.Tasks = make(map[string]*api.Task)
-	}
-	if nodeInfo.DesiredRunningTasksCountByService == nil {
-		nodeInfo.DesiredRunningTasksCountByService = make(map[string]int)
-	}
-
 	oldTask, ok := nodeInfo.Tasks[t.ID]
 	if ok {
 		if t.DesiredState == api.TaskStateRunning && oldTask.DesiredState != api.TaskStateRunning {

--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -3,6 +3,9 @@ package scheduler
 import (
 	"container/heap"
 	"errors"
+	"time"
+
+	"github.com/docker/swarmkit/api"
 )
 
 var errNodeNotFound = errors.New("node not found in scheduler dataset")
@@ -27,6 +30,16 @@ func (ns *nodeSet) nodeInfo(nodeID string) (NodeInfo, error) {
 // addOrUpdateNode sets the number of tasks for a given node. It adds the node
 // to the set if it wasn't already tracked.
 func (ns *nodeSet) addOrUpdateNode(n NodeInfo) {
+	if n.Tasks == nil {
+		n.Tasks = make(map[string]*api.Task)
+	}
+	if n.DesiredRunningTasksCountByService == nil {
+		n.DesiredRunningTasksCountByService = make(map[string]int)
+	}
+	if n.recentFailures == nil {
+		n.recentFailures = make(map[string][]time.Time)
+	}
+
 	ns.nodes[n.ID] = n
 }
 


### PR DESCRIPTION
There is a possible nil pointer dereference in taskFailed. The map gets
initialized in the constructor, but not all NodeInfo objects are created
with the constructor.

Change addOrUpdateNode to make sure all maps are allocated. Remove
various checks that tried to do this lazily.