### PR TITLE
naming: consolidate task naming into single package

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
 )
 
 const (
@@ -69,13 +70,7 @@ func (c *containerConfig) spec() *api.ContainerSpec {
 }
 
 func (c *containerConfig) name() string {
-	if c.task.Annotations.Name != "" {
-		// if set, use the container Annotations.Name field, set in the orchestrator.
-		return c.task.Annotations.Name
-	}
-
-	// fallback to service.instance.id.
-	return strings.Join([]string{c.task.ServiceAnnotations.Name, fmt.Sprint(c.task.Slot), c.task.ID}, ".")
+	return naming.Task(c.task)
 }
 
 func (c *containerConfig) image() string {
@@ -132,7 +127,7 @@ func (c *containerConfig) labels() map[string]string {
 		system = map[string]string{
 			"task":         "", // mark as cluster task
 			"task.id":      c.task.ID,
-			"task.name":    fmt.Sprintf("%v.%v", c.task.ServiceAnnotations.Name, c.task.Slot),
+			"task.name":    naming.Task(c.task),
 			"node.id":      c.task.NodeID,
 			"service.id":   c.task.ServiceID,
 			"service.name": c.task.ServiceAnnotations.Name,

--- a/api/naming/naming.go
+++ b/api/naming/naming.go
@@ -1,0 +1,29 @@
+// Package naming centralizes the naming of SwarmKit objects.
+package naming
+
+import (
+	"fmt"
+
+	"github.com/docker/swarmkit/api"
+)
+
+// Task returns the task name from Annotations.Name,
+// and, in case Annotations.Name is missing, fallback
+// to construct the name from othere information.
+func Task(t *api.Task) string {
+	if t.Annotations.Name != "" {
+		// if set, use the container Annotations.Name field, set in the orchestrator.
+		return t.Annotations.Name
+	}
+
+	slot := fmt.Sprint(t.Slot)
+	if slot == "" || t.Slot == 0 {
+		// when no slot id is assigned, we assume that this is node-bound task.
+		slot = t.NodeID
+	}
+
+	// fallback to service.instance.id.
+	return fmt.Sprintf("%s.%s.%s", t.ServiceAnnotations.Name, slot, t.ID)
+}
+
+// TODO(stevvooe): Consolidate "Hostname" style validation here.

--- a/api/naming/naming_test.go
+++ b/api/naming/naming_test.go
@@ -1,0 +1,60 @@
+package naming
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTaskNaming(t *testing.T) {
+	for _, testcase := range []struct {
+		Name     string
+		Task     *api.Task
+		Expected string
+	}{
+		{
+			Name: "Basic",
+			Task: &api.Task{
+				ID:     "taskID",
+				Slot:   10,
+				NodeID: "thenodeID",
+				ServiceAnnotations: api.Annotations{
+					Name: "theservice",
+				},
+			},
+			Expected: "theservice.10.taskID",
+		},
+		{
+			Name: "Annotations",
+			Task: &api.Task{
+				ID:     "taskID",
+				NodeID: "thenodeID",
+				Annotations: api.Annotations{
+					Name: "thisisthetaskname",
+				},
+				ServiceAnnotations: api.Annotations{
+					Name: "theservice",
+				},
+			},
+			Expected: "thisisthetaskname",
+		},
+		{
+			Name: "NoSlot",
+			Task: &api.Task{
+				ID:     "taskID",
+				NodeID: "thenodeID",
+				ServiceAnnotations: api.Annotations{
+					Name: "theservice",
+				},
+			},
+			Expected: "theservice.thenodeID.taskID",
+		},
+	} {
+		t.Run(testcase.Name, func(t *testing.T) {
+			t.Parallel()
+			name := Task(testcase.Task)
+			assert.Equal(t, name, testcase.Expected)
+		})
+	}
+}

--- a/manager/controlapi/task.go
+++ b/manager/controlapi/task.go
@@ -2,6 +2,7 @@ package controlapi
 
 import (
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -104,10 +105,10 @@ func (s *Server) ListTasks(ctx context.Context, request *api.ListTasksRequest) (
 	if request.Filters != nil {
 		tasks = filterTasks(tasks,
 			func(e *api.Task) bool {
-				return filterContains(store.TaskName(e), request.Filters.Names)
+				return filterContains(naming.Task(e), request.Filters.Names)
 			},
 			func(e *api.Task) bool {
-				return filterContainsPrefix(store.TaskName(e), request.Filters.NamePrefixes)
+				return filterContainsPrefix(naming.Task(e), request.Filters.NamePrefixes)
 			},
 			func(e *api.Task) bool {
 				return filterContainsPrefix(e.ID, request.Filters.IDPrefixes)

--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 )
 
@@ -50,7 +50,7 @@ func NewTask(cluster *api.Cluster, service *api.Service, slot uint64, nodeID str
 	}
 
 	// Assign name based on task name schema
-	name := store.TaskName(&task)
+	name := naming.Task(&task)
 	task.Annotations = api.Annotations{Name: name}
 
 	return &task

--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 )
@@ -48,10 +47,6 @@ func NewTask(cluster *api.Cluster, service *api.Service, slot uint64, nodeID str
 	if nodeID != "" {
 		task.NodeID = nodeID
 	}
-
-	// Assign name based on task name schema
-	name := naming.Task(&task)
-	task.Annotations = api.Annotations{Name: name}
 
 	return &task
 }

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -1,11 +1,11 @@
 package store
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/manager/state"
 	memdb "github.com/hashicorp/go-memdb"
 )
@@ -110,26 +110,6 @@ func init() {
 			return sa, nil
 		},
 	})
-}
-
-// TaskName returns the task name from Annotations.Name,
-// and, in case Annotations.Name is missing, fallback
-// to construct the name from othere information.
-func TaskName(t *api.Task) string {
-	name := t.Annotations.Name
-	if name == "" {
-		// If Task name is not assigned then calculated name is used like before.
-		// This might be removed in the future.
-		// We use the following scheme for Task name:
-		// Name := <ServiceAnnotations.Name>.<Slot>.<TaskID> (replicated mode)
-		//      := <ServiceAnnotations.Name>.<NodeID>.<TaskID> (global mode)
-		if t.Slot != 0 {
-			name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.Slot, t.ID)
-		} else {
-			name = fmt.Sprintf("%v.%v.%v", t.ServiceAnnotations.Name, t.NodeID, t.ID)
-		}
-	}
-	return name
 }
 
 type taskEntry struct {
@@ -245,7 +225,7 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 		panic("unexpected type passed to FromObject")
 	}
 
-	name := TaskName(t.Task)
+	name := naming.Task(t.Task)
 
 	// Add the null character as a terminator
 	return true, []byte(strings.ToLower(name) + "\x00"), nil


### PR DESCRIPTION
This change consolidates task naming into a single package. The names of
tasks was at risk of diverging over time, since it is a calculated
property. We can further extend this package to do more naming and
validation work.

Signed-off-by: Stephen J Day <stephen.day@docker.com>