### PR TITLE
secrets: decouple secrets from agent package

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -26,7 +26,7 @@ func (e *NoopExecutor) Configure(ctx context.Context, node *api.Node) error {
 	return nil
 }
 
-func (e *NoopExecutor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
+func (e *NoopExecutor) Controller(t *api.Task) (exec.Controller, error) {
 	return nil, exec.ErrRuntimeUnsupported
 }
 

--- a/agent/exec/container/adapter.go
+++ b/agent/exec/container/adapter.go
@@ -26,10 +26,10 @@ import (
 type containerAdapter struct {
 	client    engineapi.APIClient
 	container *containerConfig
-	secrets   exec.SecretProvider
+	secrets   exec.SecretGetter
 }
 
-func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets exec.SecretProvider) (*containerAdapter, error) {
+func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets exec.SecretGetter) (*containerAdapter, error) {
 	ctnr, err := newContainerConfig(task)
 	if err != nil {
 		return nil, err

--- a/agent/exec/container/controller.go
+++ b/agent/exec/container/controller.go
@@ -31,7 +31,7 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // newController returns a docker exec controller for the provided task.
-func newController(client engineapi.APIClient, task *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
+func newController(client engineapi.APIClient, task *api.Task, secrets exec.SecretGetter) (exec.Controller, error) {
 	adapter, err := newContainerAdapter(client, task, secrets)
 	if err != nil {
 		return nil, err

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -59,14 +59,14 @@ type ContainerStatuser interface {
 //
 // Unlike Do, if an error is returned, the status should still be reported. The
 // error merely reports the failure at getting the controller.
-func Resolve(ctx context.Context, task *api.Task, secrets SecretProvider, executor Executor) (Controller, *api.TaskStatus, error) {
+func Resolve(ctx context.Context, task *api.Task, executor Executor) (Controller, *api.TaskStatus, error) {
 	status := task.Status.Copy()
 
 	defer func() {
 		logStateChange(ctx, task.DesiredState, task.Status.State, status.State)
 	}()
 
-	ctlr, err := executor.Controller(task, secrets)
+	ctlr, err := executor.Controller(task)
 
 	// depending on the tasks state, a failed controller resolution has varying
 	// impact. The following expresses that impact.

--- a/agent/exec/controller_test.go
+++ b/agent/exec/controller_test.go
@@ -23,21 +23,21 @@ func TestResolve(t *testing.T) {
 		task     = newTestTask(t, api.TaskStateAssigned, api.TaskStateRunning)
 	)
 
-	_, status, err := Resolve(ctx, task, nil, executor)
+	_, status, err := Resolve(ctx, task, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, api.TaskStateAccepted, status.State)
 	assert.Equal(t, "accepted", status.Message)
 
 	task.Status = *status
 	// now, we get no status update.
-	_, status, err = Resolve(ctx, task, nil, executor)
+	_, status, err = Resolve(ctx, task, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, task.Status, *status)
 
 	// now test an error causing rejection
 	executor.err = errors.New("some error")
 	task = newTestTask(t, api.TaskStateAssigned, api.TaskStateRunning)
-	_, status, err = Resolve(ctx, task, nil, executor)
+	_, status, err = Resolve(ctx, task, executor)
 	assert.Equal(t, executor.err, err)
 	assert.Equal(t, api.TaskStateRejected, status.State)
 
@@ -46,7 +46,7 @@ func TestResolve(t *testing.T) {
 	// touched.
 	task.Status = *status
 	executor.err = nil
-	_, status, err = Resolve(ctx, task, nil, executor)
+	_, status, err = Resolve(ctx, task, executor)
 	assert.NoError(t, err)
 	assert.Equal(t, task.Status, *status)
 }
@@ -411,6 +411,6 @@ type mockExecutor struct {
 	err error
 }
 
-func (m *mockExecutor) Controller(t *api.Task, secrets SecretProvider) (Controller, error) {
+func (m *mockExecutor) Controller(t *api.Task) (Controller, error) {
 	return nil, m.err
 }

--- a/agent/exec/executor.go
+++ b/agent/exec/executor.go
@@ -15,16 +15,31 @@ type Executor interface {
 	Configure(ctx context.Context, node *api.Node) error
 
 	// Controller provides a controller for the given task.
-	Controller(t *api.Task, secrets SecretProvider) (Controller, error)
+	Controller(t *api.Task) (Controller, error)
 
 	// SetNetworkBootstrapKeys passes the symmetric keys from the
 	// manager to the executor.
 	SetNetworkBootstrapKeys([]*api.EncryptionKey) error
 }
 
-// SecretProvider contains secret data necessary for the Controller.
-type SecretProvider interface {
+// SecretsProvider is implemented by objects that can store secrets, typically
+// an executor.
+type SecretsProvider interface {
+	Secrets() SecretsManager
+}
+
+// SecretGetter contains secret data necessary for the Controller.
+type SecretGetter interface {
 	// Get returns the the secret with a specific secret ID, if available.
 	// When the secret is not available, the return will be nil.
 	Get(secretID string) *api.Secret
+}
+
+// SecretsManager is the interface for secret storage and updates.
+type SecretsManager interface {
+	SecretGetter
+
+	Add(secrets ...api.Secret) // add one or more secrets
+	Remove(secrets []string)   // remove the secrets by ID
+	Reset()                    // remove all secrets
 }

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -42,7 +42,6 @@ type worker struct {
 	db        *bolt.DB
 	executor  exec.Executor
 	listeners map[*statusReporterKey]struct{}
-	secrets   *secrets
 
 	taskManagers map[string]*taskManager
 	mu           sync.RWMutex
@@ -54,7 +53,6 @@ func newWorker(db *bolt.DB, executor exec.Executor) *worker {
 		executor:     executor,
 		listeners:    make(map[*statusReporterKey]struct{}),
 		taskManagers: make(map[string]*taskManager),
-		secrets:      newSecrets(),
 	}
 }
 
@@ -255,6 +253,15 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 }
 
 func reconcileSecrets(ctx context.Context, w *worker, assignments []*api.AssignmentChange, fullSnapshot bool) error {
+	var secrets exec.SecretsManager
+	provider, ok := w.executor.(exec.SecretsProvider)
+	if !ok {
+		log.G(ctx).Warn("secrets update ignored; executor does not support secrets")
+		return nil
+	}
+
+	secrets = provider.Secrets()
+
 	var (
 		updatedSecrets []api.Secret
 		removedSecrets []string
@@ -278,11 +285,11 @@ func reconcileSecrets(ctx context.Context, w *worker, assignments []*api.Assignm
 
 	// If this was a complete set of secrets, we're going to clear the secrets map and add all of them
 	if fullSnapshot {
-		w.secrets.reset()
+		secrets.Reset()
 	} else {
-		w.secrets.remove(removedSecrets)
+		secrets.Remove(removedSecrets)
 	}
-	w.secrets.add(updatedSecrets...)
+	secrets.Add(updatedSecrets...)
 
 	return nil
 }
@@ -337,9 +344,8 @@ func (w *worker) taskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (
 
 func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (*taskManager, error) {
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("task.id", task.ID))
-	secrets := w.secrets.getStoreForTask(task)
 
-	ctlr, status, err := exec.Resolve(ctx, task, secrets, w.executor)
+	ctlr, status, err := exec.Resolve(ctx, task, w.executor)
 	if err := w.updateTaskStatus(ctx, tx, task.ID, status); err != nil {
 		log.G(ctx).WithError(err).Error("error updating task status after controller resolution")
 	}

--- a/integration/exec.go
+++ b/integration/exec.go
@@ -26,7 +26,7 @@ func (e *TestExecutor) SetNetworkBootstrapKeys([]*api.EncryptionKey) error {
 }
 
 // Controller returns TestController.
-func (e *TestExecutor) Controller(t *api.Task, secrets exec.SecretProvider) (exec.Controller, error) {
+func (e *TestExecutor) Controller(t *api.Task) (exec.Controller, error) {
 	return &TestController{
 		ch: make(chan struct{}),
 	}, nil


### PR DESCRIPTION
Previous changes tightly coupled the secrets storage with the agent
package. The evidence of this lies in the addition of an argument to
`Executor.Controller`, which typically means something isn't quite
right. Controllers should be resolvable with only the task information.

We now defer the entireity of secret storage to the executor. The
existing map-based implementation is now in a package `secrets` which
can used by executors.

No interface changes are required by upstreams. Secrets support is
declared by executor implementation via the `SecretsProvider` interface.

Signed-off-by: Stephen J Day <stephen.day@docker.com>