### PR TITLE
Fixed bug in secrets assignment, added logging

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -317,6 +317,10 @@ func (s *Server) checkSecretConflicts(spec *api.ServiceSpec) error {
 			return grpc.Errorf(codes.InvalidArgument, "secret references '%s' and '%s' have a conflicting target: '%s'", prevSecretName, secretRef.SecretName, secretRef.Target)
 		}
 
+		if secretRef.SecretID == "" || secretRef.SecretName == "" {
+			return grpc.Errorf(codes.InvalidArgument, "malformed secret reference")
+		}
+
 		existingTargets[secretRef.Target] = secretRef.SecretName
 	}
 


### PR DESCRIPTION
- Fixes a secret assignment bug
- Fixes swarmctl to add SecretID to the SecretReferences
- Adds a validation that all secret references have a name and an ID
- Adds simple logging to the secrets control api

Signed-off-by: Diogo Monica <diogo.monica@gmail.com>