### PR TITLE
manager: Fix advertise address regression

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -131,11 +131,13 @@ func New(config *Config) (*Manager, error) {
 	// externally-reachable address.
 	tcpAddr := config.AdvertiseAddr
 
+	var tcpAddrPort string
 	if tcpAddr == "" {
 		// Otherwise, we know we are joining an existing swarm. Use a
 		// wildcard address to trigger remote autodetection of our
 		// address.
-		_, tcpAddrPort, err := net.SplitHostPort(config.ProtoAddr["tcp"])
+		var err error
+		_, tcpAddrPort, err = net.SplitHostPort(config.ProtoAddr["tcp"])
 		if err != nil {
 			return nil, fmt.Errorf("missing or invalid listen address %s", config.ProtoAddr["tcp"])
 		}
@@ -189,7 +191,7 @@ func New(config *Config) (*Manager, error) {
 			} else if err != nil {
 				return nil, err
 			}
-			if proto == "tcp" {
+			if proto == "tcp" && tcpAddrPort == "0" {
 				// in case of 0 port
 				tcpAddr = l.Addr().String()
 			}


### PR DESCRIPTION
The advertise address was being forced to the same value as the listen
address, by some code added to `(*Manager).New` for integration testing.
This code was overwriting `tcpAddr` (which is supposed to contain the
advertise address) with the bound address of the listening socket. The
idea was to support passing a :0 address into the manager, through node
(so a listener can't be bound beforehand). Fix this to only override
`tcpAddr` if a 0 port was actually given.

cc @LK4D4 @dperny @aluzzardi