### PR TITLE
manager: Clean up address configuration

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -117,10 +117,10 @@ func (n *Node) RemoteAPIAddr() (string, error) {
 		return "", errors.Errorf("node is not manager")
 	}
 	addr := n.manager.Addr()
-	if addr == nil {
+	if addr == "" {
 		return "", errors.Errorf("manager addr is not set")
 	}
-	return addr.String(), nil
+	return addr, nil
 }
 
 // New returns new Node instance.
@@ -555,8 +555,6 @@ func (n *Node) initManagerConnection(ctx context.Context, ready chan<- struct{})
 	opts := []grpc.DialOption{}
 	insecureCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
 	opts = append(opts, grpc.WithTransportCredentials(insecureCreds))
-	// Using listen address instead of advertised address because this is a
-	// local connection.
 	addr := n.config.ListenControlAPI
 	opts = append(opts, grpc.WithDialer(
 		func(addr string, timeout time.Duration) (net.Conn, error) {
@@ -624,11 +622,11 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		remoteAddr, _ := n.remotes.Select(n.NodeID())
 		m, err := manager.New(&manager.Config{
 			ForceNewCluster: n.config.ForceNewCluster,
-			ProtoAddr: map[string]string{
-				"tcp":  n.config.ListenRemoteAPI,
-				"unix": n.config.ListenControlAPI,
+			RemoteAPI: manager.RemoteAddrs{
+				ListenAddr:    n.config.ListenRemoteAPI,
+				AdvertiseAddr: n.config.AdvertiseRemoteAPI,
 			},
-			AdvertiseAddr:  n.config.AdvertiseRemoteAPI,
+			ControlAPI:     n.config.ListenControlAPI,
 			SecurityConfig: securityConfig,
 			ExternalCAs:    n.config.ExternalCAs,
 			JoinRaft:       remoteAddr.Addr,


### PR DESCRIPTION
Previously, we had a ProtoAddr map and a ProtoListener map. These maps
were awkward because keying on the protocol doesn't really make sense.

Replace these with RemoteAPI and ControlAPI fields. RemoteAPI is a
struct that contains a listening address and an optional advertise
address. ControlAPI is just an address string, because the concept of
advertise address does not apply to the control API.

Remove the capability to pass in listeners. This was only used by a
single unit test. The concept can't extend to node, because node may
start the manager multiple times, and a listener can't be reused.
Change the unit test to pass in an address with a 0 port and let the
manager bind.

cc @dperny @LK4D4 @aluzzardi