### PR TITLE
add detail information when removeTasksFromNode batch failed

### DIFF
--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -205,7 +205,7 @@ func (g *Orchestrator) removeTasksFromNode(ctx context.Context, node *api.Node) 
 		return nil
 	})
 	if err != nil {
-		log.G(ctx).WithError(err).Errorf("global orchestrator: removeTasksFromNode failed")
+		log.G(ctx).WithError(err).Errorf("global orchestrator: removeTasksFromNode failed batching tasks")
 	}
 }
 


### PR DESCRIPTION
add detail information when removeTasksFromNode batch failed, so as to differ from other exception.