### PR TITLE
Refactoring for logrus import Instead of 'log' use original package name logrus

### DIFF
--- a/ca/external.go
+++ b/ca/external.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/cloudflare/cfssl/api"
 	"github.com/cloudflare/cfssl/signer"
 	"github.com/pkg/errors"
@@ -90,7 +90,7 @@ func (eca *ExternalCA) Sign(req signer.SignRequest) (cert []byte, err error) {
 			return eca.rootCA.AppendFirstRootPEM(cert)
 		}
 
-		log.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
+		logrus.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
 	}
 
 	return nil, err
@@ -114,7 +114,7 @@ func makeExternalSignRequest(client *http.Client, url string, csrJSON []byte) (c
 
 	var apiResponse api.Response
 	if err := json.Unmarshal(body, &apiResponse); err != nil {
-		log.Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
+		logrus.Debugf("unable to JSON-parse CFSSL API response body: %s", string(body))
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to parse JSON response")}
 	}
 

--- a/cmd/external-ca-example/main.go
+++ b/cmd/external-ca-example/main.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/identity"
@@ -23,7 +23,7 @@ func main() {
 	// Initialize the Root CA.
 	rootCA, err := ca.CreateAndWriteRootCA("external-ca-example", rootPaths)
 	if err != nil {
-		log.Fatalf("unable to initialize Root CA: %s", err)
+		logrus.Fatalf("unable to initialize Root CA: %s", err)
 	}
 
 	// Create the initial manager node credentials.
@@ -32,7 +32,7 @@ func main() {
 	clusterID := identity.NewID()
 	nodeID := identity.NewID()
 	if _, err := ca.GenerateAndSignNewTLSCert(rootCA, nodeID, ca.ManagerRole, clusterID, nodeConfigPaths.Node); err != nil {
-		log.Fatalf("unable to create initial manager node credentials: %s", err)
+		logrus.Fatalf("unable to create initial manager node credentials: %s", err)
 	}
 
 	// And copy the Root CA certificate into the node config path for its
@@ -41,12 +41,12 @@ func main() {
 
 	server, err := testutils.NewExternalSigningServer(rootCA, "ca")
 	if err != nil {
-		log.Fatalf("unable to start server: %s", err)
+		logrus.Fatalf("unable to start server: %s", err)
 	}
 
 	defer server.Stop()
 
-	log.Infof("Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url %s", server.URL)
+	logrus.Infof("Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url %s", server.URL)
 
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)


### PR DESCRIPTION
Use original pakcage name 'logrus' in the every file. 
Realated PR in other project are like.
https://github.com/docker/docker/pull/24745
https://github.com/docker/libnetwork/pull/1527

Signed-off-by: Daehyeok Mun <daehyeok@gmail.com>