### PR TITLE
Make port allocator not depend on order of ports

### DIFF
--- a/manager/allocator/networkallocator/portallocator_test.go
+++ b/manager/allocator/networkallocator/portallocator_test.go
@@ -119,6 +119,58 @@ func TestReconcilePortConfigs(t *testing.T) {
 				},
 			},
 		},
+		{
+			input: &api.Service{
+				Spec: api.ServiceSpec{
+					Endpoint: &api.EndpointSpec{
+						Ports: []*api.PortConfig{
+							{
+								Name:          "test1",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    10000,
+								PublishedPort: 0,
+							},
+							{
+								Name:          "test2",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    10001,
+								PublishedPort: 0,
+							},
+						},
+					},
+				},
+				Endpoint: &api.Endpoint{
+					Ports: []*api.PortConfig{
+						{
+							Name:          "test2",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    10001,
+							PublishedPort: 10001,
+						},
+						{
+							Name:          "test1",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    10000,
+							PublishedPort: 10000,
+						},
+					},
+				},
+			},
+			expect: []*api.PortConfig{
+				{
+					Name:          "test1",
+					Protocol:      api.ProtocolTCP,
+					TargetPort:    10000,
+					PublishedPort: 10000,
+				},
+				{
+					Name:          "test2",
+					Protocol:      api.ProtocolTCP,
+					TargetPort:    10001,
+					PublishedPort: 10001,
+				},
+			},
+		},
 	}
 
 	for _, singleTest := range portConfigsBinds {
@@ -433,6 +485,60 @@ func TestIsPortsAllocated(t *testing.T) {
 				},
 				Endpoint: &api.Endpoint{
 					Ports: []*api.PortConfig{
+						{
+							Name:          "test1",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    10000,
+							PublishedPort: 10000,
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			// Endpoint and Spec.Endpoint are the same except the ports are in different order
+			input: &api.Service{
+				Spec: api.ServiceSpec{
+					Endpoint: &api.EndpointSpec{
+						Ports: []*api.PortConfig{
+							{
+								Name:          "test1",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    10000,
+								PublishedPort: 0,
+							},
+							{
+								Name:          "test2",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    10001,
+								PublishedPort: 0,
+							},
+							{
+								Name:          "test3",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    10002,
+								PublishedPort: 0,
+								PublishMode:   api.PublishModeHost,
+							},
+						},
+					},
+				},
+				Endpoint: &api.Endpoint{
+					Ports: []*api.PortConfig{
+						{
+							Name:          "test2",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    10001,
+							PublishedPort: 10001,
+						},
+						{
+							Name:          "test3",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    10002,
+							PublishedPort: 0,
+							PublishMode:   api.PublishModeHost,
+						},
 						{
 							Name:          "test1",
 							Protocol:      api.ProtocolTCP,


### PR DESCRIPTION
Currently the port allocator depends on the order of the ports in the
Spec and the Endpoint to be the same to determine if it is allocated or
while reconciling ports. This results in unnecessary false negatives
while testing for allocated and go through unnecessary
allocations. Fixed this by treating the list of ports as a set and check
if the same set of ports are available in the Endpoint as in Spec.

Signed-off-by: Jana Radhakrishnan <mrjana@docker.com>