### PR TITLE
vndr: remove nacl from vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -45,7 +45,6 @@ github.com/spf13/cobra 8e91712f174ced10270cf66615e0a9127e7c4de5
 github.com/spf13/pflag 7f60f83a2c81bc3c3c0d5297f61ddfa68da9d3b7
 github.com/stretchr/testify v1.1.4
 golang.org/x/crypto 3fbbcd23f1cb824e69491a5930cfeff09b12f4d2
-golang.org/x/crypto/nacl/secretbox 3fbbcd23f1cb824e69491a5930cfeff09b12f5d2
 golang.org/x/net 024ed629fd292398cfd43c9678a5bf004f7defdc
 golang.org/x/sys 5eaf0df67e70d6997a9fe0ed24383fa1b01638d3
 golang.org/x/time a4bde12657593d5e90d0533a3e4fd95e635124cb


### PR DESCRIPTION
It's subset of crypto and breaks vndr :(
The interface of vndr is not cool in that case, will try to fix it.