### PR TITLE
Fix logrus formatting

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -29,9 +29,9 @@ func printTrace() {
 		bufferLen *= 2
 	}
 	buf = buf[:stackSize]
-	logrus.Errorf("===========================STACK TRACE===========================")
+	logrus.Error("===========================STACK TRACE===========================")
 	fmt.Println(string(buf))
-	logrus.Errorf("===========================STACK TRACE END=======================")
+	logrus.Error("===========================STACK TRACE END=======================")
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This fix tries to fix logrus formatting by removing `f` from
`logrus.[Error|Warn|Debug|Fatal|Panic|Info]f` when formatting string
is not present.

Signed-off-by: Daehyeok Mun <daehyeok@gmail.com>