### PR TITLE
fix ACL for named pipe

### DIFF
--- a/xnet/xnet_windows.go
+++ b/xnet/xnet_windows.go
@@ -11,8 +11,17 @@ import (
 
 // ListenLocal opens a local socket for control communication
 func ListenLocal(socket string) (net.Listener, error) {
+	// set up ACL for the named pipe
+	// allow Administrators and SYSTEM
+	sddl := "D:P(A;;GA;;;BA)(A;;GA;;;SY)"
+	c := winio.PipeConfig{
+		SecurityDescriptor: sddl,
+		MessageMode:        true,  // Use message mode so that CloseWrite() is supported
+		InputBufferSize:    65536, // Use 64KB buffers to improve performance
+		OutputBufferSize:   65536,
+	}
 	// on windows, our socket is actually a named pipe
-	return winio.ListenPipe(socket, nil)
+	return winio.ListenPipe(socket, &c)
 }
 
 // DialTimeoutLocal is a DialTimeout function for local sockets


### PR DESCRIPTION
This is an amendment to the named pipe changed merged last. It includes a more restrictive ACL for the named pipe we create. This change was recommended in the review of docker/docker#27838 by @jhowardmsft. 

(@jhowardmsft if you would take a look and make sure this looks right to you, that would be really, really helpful. I tried reading up by my understanding of Windows ACLs is still VERY basic) 