### PR TITLE
Add indices over tasks and services by referenced network and secret IDs

### DIFF
--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -145,36 +145,20 @@ func (s *Server) GetNetwork(ctx context.Context, request *api.GetNetworkRequest)
 // - Returns `NotFound` if the Network is not found.
 // - Returns an error if the deletion fails.
 func (s *Server) RemoveNetwork(ctx context.Context, request *api.RemoveNetworkRequest) (*api.RemoveNetworkResponse, error) {
-	var (
-		services []*api.Service
-		err      error
-	)
-
 	if request.NetworkID == "" {
 		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
-	s.store.View(func(tx store.ReadTx) {
-		services, err = store.FindServices(tx, store.All)
-	})
-	if err != nil {
-		return nil, grpc.Errorf(codes.Internal, "could not find services using network %s", request.NetworkID)
-	}
-
-	for _, s := range services {
-		specNetworks := s.Spec.Task.Networks
-		if len(specNetworks) == 0 {
-			specNetworks = s.Spec.Networks
+	err := s.store.Update(func(tx store.Tx) error {
+		services, err := store.FindServices(tx, store.ByReferencedNetworkID(request.NetworkID))
+		if err != nil {
+			return grpc.Errorf(codes.Internal, "could not find services using network %s", request.NetworkID)
 		}
 
-		for _, na := range specNetworks {
-			if na.Target == request.NetworkID {
-				return nil, grpc.Errorf(codes.FailedPrecondition, "network %s is in use", request.NetworkID)
-			}
+		if len(services) != 0 {
+			return grpc.Errorf(codes.FailedPrecondition, "network %s is in use by service %s", request.NetworkID, services[0].ID)
 		}
-	}
 
-	err = s.store.Update(func(tx store.Tx) error {
 		nw := store.GetNetwork(tx, request.NetworkID)
 		if _, ok := nw.Spec.Annotations.Labels["com.docker.swarm.internal"]; ok {
 			networkDescription := nw.ID

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -478,6 +478,9 @@ func (g *Orchestrator) addTask(ctx context.Context, batch *store.Batch, service 
 	task := orchestrator.NewTask(g.cluster, service, 0, nodeID)
 
 	err := batch.Update(func(tx store.Tx) error {
+		if store.GetService(tx, service.ID) == nil {
+			return nil
+		}
 		return store.CreateTask(tx, task)
 	})
 	if err != nil {

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -53,6 +53,7 @@ func (r *Orchestrator) handleServiceEvent(ctx context.Context, event events.Even
 		}
 		orchestrator.DeleteServiceTasks(ctx, r.store, v.Service)
 		r.restarts.ClearServiceHistory(v.Service.ID)
+		delete(r.reconcileServices, v.Service.ID)
 	case state.EventCreateService:
 		if !orchestrator.IsReplicatedService(v.Service) {
 			return

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -383,6 +383,10 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 		}
 
 		err = batch.Update(func(tx store.Tx) error {
+			if store.GetService(tx, updated.ServiceID) == nil {
+				return errors.New("service was deleted")
+			}
+
 			if err := store.CreateTask(tx, updated); err != nil {
 				return err
 			}

--- a/manager/state/store/by.go
+++ b/manager/state/store/by.go
@@ -121,3 +121,25 @@ func (b byMembership) isBy() {
 func ByMembership(membership api.NodeSpec_Membership) By {
 	return byMembership(membership)
 }
+
+type byReferencedNetworkID string
+
+func (b byReferencedNetworkID) isBy() {
+}
+
+// ByReferencedNetworkID creates an object to pass to Find to search for a
+// service or task that references a network with the given ID.
+func ByReferencedNetworkID(networkID string) By {
+	return byReferencedNetworkID(networkID)
+}
+
+type byReferencedSecretID string
+
+func (b byReferencedSecretID) isBy() {
+}
+
+// ByReferencedSecretID creates an object to pass to Find to search for a
+// service or task that references a secret with the given ID.
+func ByReferencedSecretID(secretID string) By {
+	return byReferencedSecretID(secretID)
+}

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -29,6 +29,8 @@ const (
 	indexDesiredState = "desiredstate"
 	indexRole         = "role"
 	indexMembership   = "membership"
+	indexNetwork      = "network"
+	indexSecret       = "secret"
 
 	prefix = "_prefix"
 
@@ -620,6 +622,18 @@ func (tx readTx) findIterators(table string, by By, checkType func(By) error) ([
 		return []memdb.ResultIterator{it}, nil
 	case byMembership:
 		it, err := tx.memDBTx.Get(table, indexMembership, strconv.FormatInt(int64(v), 10))
+		if err != nil {
+			return nil, err
+		}
+		return []memdb.ResultIterator{it}, nil
+	case byReferencedNetworkID:
+		it, err := tx.memDBTx.Get(table, indexNetwork, string(v))
+		if err != nil {
+			return nil, err
+		}
+		return []memdb.ResultIterator{it}, nil
+	case byReferencedSecretID:
+		it, err := tx.memDBTx.Get(table, indexSecret, string(v))
 		if err != nil {
 			return nil, err
 		}

--- a/vendor.conf
+++ b/vendor.conf
@@ -32,7 +32,7 @@ github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/golang/mock bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
 github.com/google/certificate-transparency 0f6e3d1d1ba4d03fdaab7cd716f36255c2e48341
 github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
-github.com/hashicorp/go-memdb 98f52f52d7a476958fa9da671354d270c50661a7
+github.com/hashicorp/go-memdb 608dda3b1410a73eaf3ac8b517c9ae7ebab6aa87 https://github.com/floridoo/go-memdb
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
 github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 github.com/mreiferson/go-httpclient 63fe23f7434723dc904c901043af07931f293c47

--- a/vendor/github.com/hashicorp/go-memdb/schema.go
+++ b/vendor/github.com/hashicorp/go-memdb/schema.go
@@ -46,6 +46,9 @@ func (s *TableSchema) Validate() error {
 	if !s.Indexes["id"].Unique {
 		return fmt.Errorf("id index must be unique")
 	}
+	if _, ok := s.Indexes["id"].Indexer.(SingleIndexer); !ok {
+		return fmt.Errorf("id index must be a SingleIndexer")
+	}
 	for name, index := range s.Indexes {
 		if name != index.Name {
 			return fmt.Errorf("index name mis-match for '%s'", name)
@@ -71,6 +74,12 @@ func (s *IndexSchema) Validate() error {
 	}
 	if s.Indexer == nil {
 		return fmt.Errorf("missing index function for '%s'", s.Name)
+	}
+	switch s.Indexer.(type) {
+	case SingleIndexer:
+	case MultiIndexer:
+	default:
+		return fmt.Errorf("indexer for '%s' must be a SingleIndexer or MultiIndexer", s.Name)
 	}
 	return nil
 }

--- a/vendor/github.com/hashicorp/go-memdb/txn.go
+++ b/vendor/github.com/hashicorp/go-memdb/txn.go
@@ -148,7 +148,8 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 
 	// Get the primary ID of the object
 	idSchema := tableSchema.Indexes[id]
-	ok, idVal, err := idSchema.Indexer.FromObject(obj)
+	idIndexer := idSchema.Indexer.(SingleIndexer)
+	ok, idVal, err := idIndexer.FromObject(obj)
 	if err != nil {
 		return fmt.Errorf("failed to build primary index: %v", err)
 	}
@@ -167,7 +168,19 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 		indexTxn := txn.writableIndex(table, name)
 
 		// Determine the new index value
-		ok, val, err := indexSchema.Indexer.FromObject(obj)
+		var (
+			ok   bool
+			vals [][]byte
+			err  error
+		)
+		switch indexer := indexSchema.Indexer.(type) {
+		case SingleIndexer:
+			var val []byte
+			ok, val, err = indexer.FromObject(obj)
+			vals = [][]byte{val}
+		case MultiIndexer:
+			ok, vals, err = indexer.FromObject(obj)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to build index '%s': %v", name, err)
 		}
@@ -176,28 +189,44 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 		// This is done by appending the primary key which must
 		// be unique anyways.
 		if ok && !indexSchema.Unique {
-			val = append(val, idVal...)
+			for i := range vals {
+				vals[i] = append(vals[i], idVal...)
+			}
 		}
 
 		// Handle the update by deleting from the index first
 		if update {
-			okExist, valExist, err := indexSchema.Indexer.FromObject(existing)
+			var (
+				okExist   bool
+				valsExist [][]byte
+				err       error
+			)
+			switch indexer := indexSchema.Indexer.(type) {
+			case SingleIndexer:
+				var valExist []byte
+				okExist, valExist, err = indexer.FromObject(existing)
+				valsExist = [][]byte{valExist}
+			case MultiIndexer:
+				okExist, valsExist, err = indexer.FromObject(existing)
+			}
 			if err != nil {
 				return fmt.Errorf("failed to build index '%s': %v", name, err)
 			}
 			if okExist {
-				// Handle non-unique index by computing a unique index.
-				// This is done by appending the primary key which must
-				// be unique anyways.
-				if !indexSchema.Unique {
-					valExist = append(valExist, idVal...)
-				}
+				for i, valExist := range valsExist {
+					// Handle non-unique index by computing a unique index.
+					// This is done by appending the primary key which must
+					// be unique anyways.
+					if !indexSchema.Unique {
+						valExist = append(valExist, idVal...)
+					}
 
-				// If we are writing to the same index with the same value,
-				// we can avoid the delete as the insert will overwrite the
-				// value anyways.
-				if !bytes.Equal(valExist, val) {
-					indexTxn.Delete(valExist)
+					// If we are writing to the same index with the same value,
+					// we can avoid the delete as the insert will overwrite the
+					// value anyways.
+					if i >= len(vals) || !bytes.Equal(valExist, vals[i]) {
+						indexTxn.Delete(valExist)
+					}
 				}
 			}
 		}
@@ -213,7 +242,9 @@ func (txn *Txn) Insert(table string, obj interface{}) error {
 		}
 
 		// Update the value of the index
-		indexTxn.Insert(val, obj)
+		for _, val := range vals {
+			indexTxn.Insert(val, obj)
+		}
 	}
 	return nil
 }
@@ -233,7 +264,8 @@ func (txn *Txn) Delete(table string, obj interface{}) error {
 
 	// Get the primary ID of the object
 	idSchema := tableSchema.Indexes[id]
-	ok, idVal, err := idSchema.Indexer.FromObject(obj)
+	idIndexer := idSchema.Indexer.(SingleIndexer)
+	ok, idVal, err := idIndexer.FromObject(obj)
 	if err != nil {
 		return fmt.Errorf("failed to build primary index: %v", err)
 	}
@@ -253,7 +285,19 @@ func (txn *Txn) Delete(table string, obj interface{}) error {
 		indexTxn := txn.writableIndex(table, name)
 
 		// Handle the update by deleting from the index first
-		ok, val, err := indexSchema.Indexer.FromObject(existing)
+		var (
+			ok   bool
+			vals [][]byte
+			err  error
+		)
+		switch indexer := indexSchema.Indexer.(type) {
+		case SingleIndexer:
+			var val []byte
+			ok, val, err = indexer.FromObject(existing)
+			vals = [][]byte{val}
+		case MultiIndexer:
+			ok, vals, err = indexer.FromObject(existing)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to build index '%s': %v", name, err)
 		}
@@ -261,10 +305,12 @@ func (txn *Txn) Delete(table string, obj interface{}) error {
 			// Handle non-unique index by computing a unique index.
 			// This is done by appending the primary key which must
 			// be unique anyways.
-			if !indexSchema.Unique {
-				val = append(val, idVal...)
+			for _, val := range vals {
+				if !indexSchema.Unique {
+					val = append(val, idVal...)
+				}
+				indexTxn.Delete(val)
 			}
-			indexTxn.Delete(val)
 		}
 	}
 	return nil
@@ -332,39 +378,6 @@ func (txn *Txn) First(table, index string, args ...interface{}) (interface{}, er
 	iter.SeekPrefix(val)
 	_, value, _ := iter.Next()
 	return value, nil
-}
-
-// LongestPrefix is used to fetch the longest prefix match for the given
-// constraints on the index. Note that this will not work with the memdb
-// StringFieldIndex because it adds null terminators which prevent the
-// algorithm from correctly finding a match (it will get to right before the
-// null and fail to find a leaf node). This should only be used where the prefix
-// given is capable of matching indexed entries directly, which typically only
-// applies to a custom indexer. See the unit test for an example.
-func (txn *Txn) LongestPrefix(table, index string, args ...interface{}) (interface{}, error) {
-	// Enforce that this only works on prefix indexes.
-	if !strings.HasSuffix(index, "_prefix") {
-		return nil, fmt.Errorf("must use '%s_prefix' on index", index)
-	}
-
-	// Get the index value.
-	indexSchema, val, err := txn.getIndexValue(table, index, args...)
-	if err != nil {
-		return nil, err
-	}
-
-	// This algorithm only makes sense against a unique index, otherwise the
-	// index keys will have the IDs appended to them.
-	if !indexSchema.Unique {
-		return nil, fmt.Errorf("index '%s' is not unique", index)
-	}
-
-	// Find the longest prefix match with the given index.
-	indexTxn := txn.readableIndex(table, indexSchema.Name)
-	if _, value, ok := indexTxn.Root().LongestPrefix(val); ok {
-		return value, nil
-	}
-	return nil, nil
 }
 
 // getIndexValue is used to get the IndexSchema and the value


### PR DESCRIPTION
Previously, it was not possible to have indices which could have more
than one value per object. This vendors a fork of go-memdb that adds
this feature, from a PR that has been pending for more than eight
months. It then adds indices over tasks and services for the network and
secret IDs referenced by the tasks and services. Network deletion is
updated to use the new index instead of listing all services.

cc @aluzzardi @mrjana @diogomonica @mavenugo