### PR TITLE
[encryption] Fix WAL directory manipulation in windows

### DIFF
--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/wal"
 	"github.com/docker/swarmkit/api"
 	cautils "github.com/docker/swarmkit/ca/testutils"
@@ -319,10 +320,8 @@ func TestRaftLeaderLeave(t *testing.T) {
 	raftutils.WaitForCluster(t, clockSource, newCluster)
 
 	// Node1's state should be cleared
-	_, err = os.Stat(filepath.Join(nodes[1].StateDir, "snap-v3-encrypted"))
-	require.True(t, os.IsNotExist(err))
-	_, err = os.Stat(filepath.Join(nodes[1].StateDir, "wal-v3-encrypted"))
-	require.True(t, os.IsNotExist(err))
+	require.False(t, fileutil.Exist(filepath.Join(nodes[1].StateDir, "snap-v3-encrypted")))
+	require.False(t, fileutil.Exist(filepath.Join(nodes[1].StateDir, "wal-v3-encrypted")))
 	require.Equal(t, raft.EncryptionKeys{}, nodes[1].KeyRotator.GetKeys())
 
 	// Leader should not be 1

--- a/manager/state/raft/storage/storage_test.go
+++ b/manager/state/raft/storage/storage_test.go
@@ -151,9 +151,7 @@ func TestMigrateToV3EncryptedForm(t *testing.T) {
 	writeDataTo := func(suffix string, snapshot raftpb.Snapshot, walFactory WALFactory, snapFactory SnapFactory) []raftpb.Entry {
 		snapDir := filepath.Join(tempdir, "snap"+suffix)
 		walDir := filepath.Join(tempdir, "wal"+suffix)
-		for _, dirpath := range []string{snapDir, walDir} {
-			require.NoError(t, os.MkdirAll(dirpath, 0755))
-		}
+		require.NoError(t, os.MkdirAll(snapDir, 0755))
 		require.NoError(t, snapFactory.New(snapDir).SaveSnap(snapshot))
 
 		_, entries, _ := makeWALData(snapshot.Metadata.Index, snapshot.Metadata.Term)


### PR DESCRIPTION
This fixes bugs introduced in #1598 in windows:

1. the wal directory cannot already exist, or `wal.Create` will not be able to rename
1. when migrating WALs from an older directory, close the temporary writer first.  Otherwise, windows will not be able to rename the temporary directory because the temporary writer has a lock.