### PR TITLE
[doc] update description about the task slot

### DIFF
--- a/design/task_model.md
+++ b/design/task_model.md
@@ -169,6 +169,14 @@ satisfied by at least one running task, not the detailed makeup of those slots.
 The updater takes care of making sure that each slot converges to having a
 single running task.
 
+Also, for application availability, multiple tasks can share the single slot
+number when a network partition occurs between nodes. If a node is split from
+manager nodes, the tasks that were running on the node will be recreated on
+another node.  However, the tasks on the split node can still continue
+running. So the old tasks and the new ones can share identical slot
+numbers. These tasks may be considered "orphaned" by the manager, after some
+time. Upon recovering the split, these tasks will be killed.
+
 Global tasks do not have slot numbers, but the concept is similar. Each node in
 the system should have a single running task associated with it. If this is not
 the case, the orchestrator and updater work together to create or destroy tasks


### PR DESCRIPTION
This PR updates `design/task_model.md` for clarifying that multiple containers can share the single slot number because of a network partition between nodes.

Note that people may abuse the `{{.Task.Slot}}` template string without knowledge about this behavior. (https://github.com/docker/swarmkit/pull/1650, https://github.com/docker/docker/pull/28025)

The PR for the  "introspection mount" is related to this behavior as well. (https://github.com/docker/docker/pull/26331, https://github.com/docker/swarmkit/pull/1642)

- - - -

Below is the repro for the behavior I mentioned in this PR.
IMO we don't need to include this repro in `design/task_model.md` it self.

### Repro

Consider that we have 1 manager node (`dm01`) and 2 worker nodes (`dm02` and `dm03`).

```console
dm01$ docker node ls
ID                           HOSTNAME  STATUS  AVAILABILITY  MANAGER STATUS
kohz31yrlbkk9xplcmvyjvhew *  dm01      Ready   Active        Leader
midxgj1vyg6bwmmsa9l27dfkx    dm03      Ready   Active        
zgq4jimlom374s98nspy6flb3    dm02      Ready   Active
```

#### Step 1.

Start a service with 3 replicas. We use the `{{.Task.Slot}}` template string for injecting the slot numbers into containers.

```console
dm01$ docker service create --hostname 'slot-{{.Task.Slot}}' --replicas 3 --name foo busybox top
wt3vzqd5szjytzpwrfr6gf786
```

Consider that now the container for the slot 1 is running on `dm01`, 2 is on `dm03`, and 3 is on `dm02`.

```console
dm01$ docker service ps foo
NAME                IMAGE    NODE  DESIRED STATE  CURRENT STATE                   ERROR
foo.1.4tuobs6y6bf1  busybox  dm01  Running        Running 1 second ago            
foo.2.52fda7b7ohpv  busybox  dm03  Running        Running less than a second ago  
foo.3.dbikhhbeo6mp  busybox  dm02  Running        Running 1 second ago
```

#### Step 2. 
 
Split `dm02` from `dm01`, but keep `dm02` itself still running.

```console
dm01$ sudo iptables -I INPUT -s $(docker node inspect -f '{{.Status.Addr}}' dm02) -j DROP
```

Then, a new container for the slot 3 will be automatically created and started on another node. e.g. `dm01`.

```console
dm01$ docker service ps foo
NAME                IMAGE    NODE  DESIRED STATE  CURRENT STATE               ERROR
foo.1.4tuobs6y6bf1  busybox  dm01  Running        Running 5 minutes ago       
foo.2.52fda7b7ohpv  busybox  dm03  Running        Running 5 minutes ago       
foo.3.l7i6r4a3t0vf  busybox  dm01  Running        Running about a minute ago
dm01$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
ca1ade6ab083        busybox:latest      "top"               10 minutes ago      Up 10 minutes                           foo.3.l7i6r4a3t0vfxqd79xdfe84h0
8554d36a2832        busybox:latest      "top"               13 minutes ago      Up 13 minutes                           foo.1.4tuobs6y6bf1j7ojnjmjzt62d
dm01$ docker exec foo.3.l7i6r4a3t0vfxqd79xdfe84h0 hostname
slot-3
```

However, the old container for the slot 3 is still running on `dm02`, which is split from `dm01`.
```console
dm02$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
1347974c00d4        busybox:latest      "top"               4 minutes ago       Up 4 minutes                            foo.3.dbikhhbeo6mplqs2vb3v2v78w
dm02$ docker exec foo.3.dbikhhbeo6mplqs2vb3v2v78w hostname
slot-3
```

Now we have two containers running simultaneously with the common slot number. :penguin: 

- - -

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>