### PR TITLE
Update the comment for `Hosts` field in `ContainerSpec`

### DIFF
--- a/agent/exec/container/container.go
+++ b/agent/exec/container/container.go
@@ -188,10 +188,17 @@ func (c *containerConfig) hostConfig() *enginecontainer.HostConfig {
 		PortBindings: c.portBindings(),
 	}
 
+	// The format of extra hosts on swarmkit is specified in:
+	// http://man7.org/linux/man-pages/man5/hosts.5.html
+	//    IP_address canonical_hostname [aliases...]
+	// However, the format of ExtraHosts in HostConfig is
+	//    <host>:<ip>
+	// We need to do the conversion here
+	// (Alias is ignored for now)
 	for _, entry := range c.spec().Hosts {
-		index := strings.IndexAny(entry, ":= ")
-		if 0 < index && (index+1) < len(entry) {
-			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", entry[:index], entry[index+1:]))
+		parts := strings.Fields(entry)
+		if len(parts) > 1 {
+			hc.ExtraHosts = append(hc.ExtraHosts, fmt.Sprintf("%s:%s", parts[1], parts[0]))
 		}
 	}
 

--- a/agent/exec/container/container_test.go
+++ b/agent/exec/container/container_test.go
@@ -98,9 +98,9 @@ func TestExtraHosts(t *testing.T) {
 			Spec: api.TaskSpec{Runtime: &api.TaskSpec_Container{
 				Container: &api.ContainerSpec{
 					Hosts: []string{
-						"example.com:1.2.3.4",
-						"example.org=5.6.7.8",
-						"mylocal 127.0.0.1",
+						"1.2.3.4 example.com",
+						"5.6.7.8 example.org",
+						"127.0.0.1 mylocal",
 					},
 				},
 			}},

--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -491,10 +491,12 @@ type ContainerSpec struct {
 	// that associates IP addresses with hostnames.
 	// Detailed documentation is available in:
 	// http://man7.org/linux/man-pages/man5/hosts.5.html
-	// The format of the Hosts here could be:
-	// <hostname>:<ip> (separated by `:`)
-	// <hostname>=<ip> (separated by `=`)
-	// <hostname> <ip> (separated by ` `)
+	//   IP_address canonical_hostname [aliases...]
+	//
+	// The format of the Hosts in swarmkit follows the same as
+	// above.
+	// This is different from `docker run --add-host <hostname>:<ip>`
+	// where format is `<hostname>:<ip>`
 	Hosts []string `protobuf:"bytes,17,rep,name=hosts" json:"hosts,omitempty"`
 	// DNSConfig allows one to specify DNS related configuration in resolv.conf
 	DNSConfig *ContainerSpec_DNSConfig `protobuf:"bytes,15,opt,name=dns_config,json=dnsConfig" json:"dns_config,omitempty"`

--- a/api/specs.proto
+++ b/api/specs.proto
@@ -212,10 +212,12 @@ message ContainerSpec {
 	// that associates IP addresses with hostnames.
 	// Detailed documentation is available in:
 	// http://man7.org/linux/man-pages/man5/hosts.5.html
-	// The format of the Hosts here could be:
-	// <hostname>:<ip> (separated by `:`)
-	// <hostname>=<ip> (separated by `=`)
-	// <hostname> <ip> (separated by ` `)
+	//   IP_address canonical_hostname [aliases...]
+	//
+	// The format of the Hosts in swarmkit follows the same as
+	// above.
+	// This is different from `docker run --add-host <hostname>:<ip>`
+	// where format is `<hostname>:<ip>`
 	repeated string hosts = 17;
 
 	// DNSConfig specifies DNS related configurations in resolver configuration file (resolv.conf)


### PR DESCRIPTION
This fix is a followup for `Hosts` field in `ContainerSpec`, from the comment in:
https://github.com/docker/swarmkit/pull/1729#pullrequestreview-8044827
and from docker PR:
https://github.com/docker/docker/pull/28031

In the docker PR, it has been specified that `Hosts` in `ContainerSpec` should only follow the standard format:
```
IP_address canonical_hostname [aliases...]
```
The docker PR 28031 already takes the above into consideration so no implementation updates needed.

This fix corrects the comment in the specification of `Hosts`.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>