### PR TITLE
Consolidate arguments in LoadOrCreateSecurityConfig

### DIFF
--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -79,7 +79,13 @@ func TestLoadOrCreateSecurityConfigEmptyDir(t *testing.T) {
 	// Remove all the contents from the temp dir and try again with a new node
 	os.RemoveAll(tc.TempDir)
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
-	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, tc.RootCA, tc.WorkerToken, ca.WorkerRole, tc.Remotes, info, krw)
+	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        tc.RootCA,
+		Token:         tc.WorkerToken,
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: krw,
+	}, info)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
 	assert.NotNil(t, nodeConfig.ClientTLSCreds)
@@ -96,7 +102,13 @@ func TestLoadOrCreateSecurityConfigNoCerts(t *testing.T) {
 	// new certificates that are locally signed
 	os.RemoveAll(tc.Paths.Node.Cert)
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
-	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, tc.RootCA, tc.WorkerToken, ca.WorkerRole, tc.Remotes, nil, krw)
+	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        tc.RootCA,
+		Token:         tc.WorkerToken,
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: krw,
+	}, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
 	assert.NotNil(t, nodeConfig.ClientTLSCreds)
@@ -109,7 +121,13 @@ func TestLoadOrCreateSecurityConfigNoCerts(t *testing.T) {
 	os.RemoveAll(tc.Paths.Node.Cert)
 	rootCA, err := ca.GetLocalRootCA(tc.Paths.RootCA)
 	assert.NoError(t, err)
-	nodeConfig, err = ca.LoadOrCreateSecurityConfig(tc.Context, rootCA, tc.WorkerToken, ca.WorkerRole, tc.Remotes, info, krw)
+	nodeConfig, err = ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        rootCA,
+		Token:         tc.WorkerToken,
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: krw,
+	}, info)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
 	assert.NotNil(t, nodeConfig.ClientTLSCreds)
@@ -128,7 +146,13 @@ some random garbage\n
 -----END CERTIFICATE-----`), 0644)
 
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
-	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, tc.RootCA, "", ca.WorkerRole, tc.Remotes, nil, krw)
+	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        tc.RootCA,
+		Token:         "",
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: krw,
+	}, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
 	assert.NotNil(t, nodeConfig.ClientTLSCreds)
@@ -146,7 +170,13 @@ some random garbage\n
 -----END EC PRIVATE KEY-----`), 0644)
 
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
-	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, tc.RootCA, "", ca.WorkerRole, tc.Remotes, nil, krw)
+	nodeConfig, err := ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        tc.RootCA,
+		Token:         "",
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: krw,
+	}, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, nodeConfig)
 	assert.NotNil(t, nodeConfig.ClientTLSCreds)
@@ -163,8 +193,13 @@ func TestLoadOrCreateSecurityIncorrectPassphrase(t *testing.T) {
 		"nodeID", ca.WorkerRole, tc.Organization)
 	require.NoError(t, err)
 
-	_, err = ca.LoadOrCreateSecurityConfig(tc.Context, tc.RootCA, tc.WorkerToken, ca.WorkerRole, tc.Remotes, nil,
-		ca.NewKeyReadWriter(paths.Node, nil, nil))
+	_, err = ca.LoadOrCreateSecurityConfig(tc.Context, &ca.NodeSecurityConfig{
+		RootCA:        tc.RootCA,
+		Token:         tc.WorkerToken,
+		ProposedRole:  ca.WorkerRole,
+		Remotes:       tc.Remotes,
+		KeyReadWriter: ca.NewKeyReadWriter(paths.Node, nil, nil),
+	}, nil)
 	require.IsType(t, ca.ErrInvalidKEK{}, err)
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -568,8 +568,13 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 
 		// LoadOrCreateSecurityConfig is the point at which a new node joining a cluster will retrieve TLS
 		// certificates and write them to disk
-		securityConfig, err = ca.LoadOrCreateSecurityConfig(
-			ctx, rootCA, n.config.JoinToken, ca.ManagerRole, n.remotes, issueResponseChan, krw)
+		securityConfig, err = ca.LoadOrCreateSecurityConfig(ctx, &ca.NodeSecurityConfig{
+			RootCA:        rootCA,
+			Token:         n.config.JoinToken,
+			ProposedRole:  ca.ManagerRole,
+			Remotes:       n.remotes,
+			KeyReadWriter: krw,
+		}, issueResponseChan)
 		if err != nil {
 			if _, ok := errors.Cause(err).(ca.ErrInvalidKEK); ok {
 				return nil, ErrInvalidUnlockKey


### PR DESCRIPTION
This fix tries to address the issue in #1731 so that the args in LoadOrCreateSecurityConfig could be consolidated, and not a long arg list.

This fix fixes #1731.

cc @aaronlehmann @diogomonica @stevvooe

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>