### PR TITLE
service logs: Support for non-follow mode

### DIFF
--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -69,7 +69,7 @@ func (fn LogPublisherFunc) Publish(ctx context.Context, message api.LogMessage) 
 
 // LogPublisherProvider defines the protocol for receiving a log publisher
 type LogPublisherProvider interface {
-	Publisher(ctx context.Context, subscriptionID string) (LogPublisher, error)
+	Publisher(ctx context.Context, subscriptionID string) (LogPublisher, func(), error)
 }
 
 // ContainerStatuser reports status of a container.

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -16,16 +16,17 @@ import (
 type testPublisherProvider struct {
 }
 
-func (tpp *testPublisherProvider) Publisher(ctx context.Context, subscriptionID string) (exec.LogPublisher, error) {
+func (tpp *testPublisherProvider) Publisher(ctx context.Context, subscriptionID string) (exec.LogPublisher, func(), error) {
 	return exec.LogPublisherFunc(func(ctx context.Context, message api.LogMessage) error {
-		log.G(ctx).WithFields(logrus.Fields{
-			"subscription": subscriptionID,
-			"task.id":      message.Context.TaskID,
-			"node.id":      message.Context.NodeID,
-			"service.id":   message.Context.ServiceID,
-		}).Info(message.Data)
-		return nil
-	}), nil
+			log.G(ctx).WithFields(logrus.Fields{
+				"subscription": subscriptionID,
+				"task.id":      message.Context.TaskID,
+				"node.id":      message.Context.NodeID,
+				"service.id":   message.Context.ServiceID,
+			}).Info(message.Data)
+			return nil
+		}), func() {
+		}, nil
 }
 
 func TestWorkerAssign(t *testing.T) {


### PR DESCRIPTION
Just wanted to get feedback - it lacks tests and may need some cleanup but it works.

This PR adds `Wait` and `Done` to `subscription`, allowing `service logs` to wait for completion when in non-follow mode.

In non follow, the selectors are matched only once - if new tasks come in after that, no match will be attempted.

When a `PublishLogs` session finishes, we assume that subscription is completed for that node.
If a node disconnects (e.g. drops out of `ListenSubscriptions`), we assume all its active subscriptions are completed

/cc @aaronlehmann @stevvooe 