### PR TITLE
agent: do not call Fatalf in goroutine

### DIFF
--- a/agent/reporter_test.go
+++ b/agent/reporter_test.go
@@ -74,7 +74,7 @@ func TestReporter(t *testing.T) {
 			// simulate pounding this with a bunch of goroutines
 			go func() {
 				if err := reporter.UpdateTaskStatus(ctx, taskID, status); err != nil {
-					t.Fatalf("sending should not fail: %v", err)
+					assert.NoError(t, err, "sending should not fail")
 				}
 			}()
 


### PR DESCRIPTION
According to Go documentation functions with FailNow should be
called in same goroutine with test.