### PR TITLE
[cmd] tool to decrypt or downgrade raft logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PACKAGES=$(shell go list ./... | grep -v /vendor/)
 INTEGRATION_PACKAGE=${PROJECT_ROOT}/integration
 
 # Project binaries.
-COMMANDS=swarmd swarmctl swarm-bench protoc-gen-gogoswarm
+COMMANDS=swarmd swarmctl swarm-bench swarm-rafttool protoc-gen-gogoswarm
 BINARIES=$(addprefix bin/,$(COMMANDS))
 
 GO_LDFLAGS=-ldflags "-X `go list ./version`.Version=$(VERSION)"

--- a/cmd/swarm-rafttool/common.go
+++ b/cmd/swarm-rafttool/common.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/net/context"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/etcd/wal/walpb"
+	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/manager"
+	"github.com/docker/swarmkit/manager/encryption"
+	"github.com/docker/swarmkit/manager/state/raft/storage"
+)
+
+func certPaths(swarmdir string) *ca.SecurityConfigPaths {
+	return ca.NewConfigPaths(filepath.Join(swarmdir, "certificates"))
+}
+
+func getDEKData(krw *ca.KeyReadWriter) (manager.RaftDEKData, error) {
+	h, _ := krw.GetCurrentState()
+	dekData, ok := h.(manager.RaftDEKData)
+	if !ok {
+		return manager.RaftDEKData{}, errors.New("cannot read raft dek headers in TLS key")
+	}
+
+	if dekData.CurrentDEK == nil {
+		return manager.RaftDEKData{}, errors.New("no raft DEKs available")
+	}
+
+	return dekData, nil
+}
+
+func getKRW(swarmdir, unlockKey string) (*ca.KeyReadWriter, error) {
+	var (
+		kek []byte
+		err error
+	)
+	if unlockKey != "" {
+		kek, err = encryption.ParseHumanReadableKey(unlockKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+	krw := ca.NewKeyReadWriter(certPaths(swarmdir).Node, kek, manager.RaftDEKData{})
+	_, _, err = krw.Read() // loads all the key data into the KRW object
+	if err != nil {
+		return nil, err
+	}
+	return krw, nil
+}
+
+func moveDirAside(dirname string) error {
+	if fileutil.Exist(dirname) {
+		tempdir, err := ioutil.TempDir(filepath.Dir(dirname), filepath.Base(dirname))
+		if err != nil {
+			return err
+		}
+		return os.Rename(dirname, tempdir)
+	}
+	return nil
+}
+
+func decryptRaftData(swarmdir, outdir, unlockKey string) error {
+	krw, err := getKRW(swarmdir, unlockKey)
+	if err != nil {
+		return err
+	}
+	deks, err := getDEKData(krw)
+	if err != nil {
+		return err
+	}
+
+	_, d := encryption.Defaults(deks.CurrentDEK)
+	if deks.PendingDEK == nil {
+		_, d2 := encryption.Defaults(deks.PendingDEK)
+		d = storage.MultiDecrypter{d, d2}
+	}
+
+	snapDir := filepath.Join(outdir, "snap-decrypted")
+	if err := moveDirAside(snapDir); err != nil {
+		return err
+	}
+	if err := storage.MigrateSnapshot(
+		filepath.Join(swarmdir, "raft", "snap-v3-encrypted"), snapDir,
+		storage.NewSnapFactory(encryption.NoopCrypter, d), storage.OriginalSnap); err != nil {
+		return err
+	}
+
+	var walsnap walpb.Snapshot
+	snap, err := storage.OriginalSnap.New(snapDir).Load()
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if snap != nil {
+		walsnap.Index = snap.Metadata.Index
+		walsnap.Term = snap.Metadata.Term
+	}
+
+	walDir := filepath.Join(outdir, "wal-decrypted")
+	if err := moveDirAside(walDir); err != nil {
+		return err
+	}
+	return storage.MigrateWALs(context.Background(),
+		filepath.Join(swarmdir, "raft", "wal-v3-encrypted"), walDir,
+		storage.NewWALFactory(encryption.NoopCrypter, d), storage.OriginalWAL, walsnap)
+}

--- a/cmd/swarm-rafttool/common_test.go
+++ b/cmd/swarm-rafttool/common_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coreos/etcd/pkg/fileutil"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/coreos/etcd/wal/walpb"
+	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/manager"
+	"github.com/docker/swarmkit/manager/encryption"
+	"github.com/docker/swarmkit/manager/state/raft"
+	"github.com/docker/swarmkit/manager/state/raft/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFakeRaftData writes the given snapshot and some generated WAL data to given "snap" and "wal" directories
+func writeFakeRaftData(t *testing.T, stateDir string, snapshot *raftpb.Snapshot, wf storage.WALFactory, sf storage.SnapFactory) {
+	snapDir := filepath.Join(stateDir, "raft", "snap-v3-encrypted")
+	walDir := filepath.Join(stateDir, "raft", "wal-v3-encrypted")
+	require.NoError(t, os.MkdirAll(snapDir, 0755))
+
+	wsn := walpb.Snapshot{}
+	if snapshot != nil {
+		require.NoError(t, sf.New(snapDir).SaveSnap(*snapshot))
+
+		wsn.Index = snapshot.Metadata.Index
+		wsn.Term = snapshot.Metadata.Term
+	}
+
+	var entries []raftpb.Entry
+	for i := wsn.Index + 1; i < wsn.Index+6; i++ {
+		entries = append(entries, raftpb.Entry{
+			Term:  wsn.Term + 1,
+			Index: i,
+			Data:  []byte(fmt.Sprintf("v3Entry %d", i)),
+		})
+	}
+
+	walWriter, err := wf.Create(walDir, []byte("v3metadata"))
+	require.NoError(t, err)
+	require.NoError(t, walWriter.SaveSnapshot(wsn))
+	require.NoError(t, walWriter.Save(raftpb.HardState{}, entries))
+	require.NoError(t, walWriter.Close())
+}
+
+func TestDecrypt(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "rafttool")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	kek := []byte("kek")
+	dek := []byte("dek")
+	unlockKey := encryption.HumanReadableKey(kek)
+
+	// write a key to disk, else we won't be able to decrypt anything
+	paths := certPaths(tempdir)
+	krw := ca.NewKeyReadWriter(paths.Node, kek,
+		manager.RaftDEKData{EncryptionKeys: raft.EncryptionKeys{CurrentDEK: dek}})
+	cert, key, err := testutils.CreateRootCertAndKey("not really a root, just need cert and key")
+	require.NoError(t, err)
+	require.NoError(t, krw.Write(cert, key, nil))
+
+	// create the encrypted v3 directory
+	origSnapshot := raftpb.Snapshot{
+		Data: []byte("snapshot"),
+		Metadata: raftpb.SnapshotMetadata{
+			Index: 1,
+			Term:  1,
+		},
+	}
+	e, d := encryption.Defaults(dek)
+	writeFakeRaftData(t, tempdir, &origSnapshot, storage.NewWALFactory(e, d), storage.NewSnapFactory(e, d))
+
+	outdir := filepath.Join(tempdir, "outdir")
+	// if we use the wrong unlock key, we can't actually decrypt anything.  The output directory won't get created.
+	err = decryptRaftData(tempdir, outdir, "")
+	require.IsType(t, ca.ErrInvalidKEK{}, err)
+	require.False(t, fileutil.Exist(outdir))
+
+	// Using the right unlock key, we produce data that is unencrypted
+	require.NoError(t, decryptRaftData(tempdir, outdir, unlockKey))
+	require.True(t, fileutil.Exist(outdir))
+
+	// The snapshot directory is readable by the regular snapshotter
+	snapshot, err := storage.OriginalSnap.New(filepath.Join(outdir, "snap-decrypted")).Load()
+	require.NoError(t, err)
+	require.NotNil(t, snapshot)
+	require.Equal(t, origSnapshot, *snapshot)
+
+	// The wals are readable by the regular wal
+	walreader, err := storage.OriginalWAL.Open(filepath.Join(outdir, "wal-decrypted"), walpb.Snapshot{Index: 1, Term: 1})
+	require.NoError(t, err)
+	metadata, _, entries, err := walreader.ReadAll()
+	require.NoError(t, err)
+	require.Equal(t, []byte("v3metadata"), metadata)
+	require.Len(t, entries, 5)
+}

--- a/cmd/swarm-rafttool/main.go
+++ b/cmd/swarm-rafttool/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	mainCmd = &cobra.Command{
+		Use:   os.Args[0],
+		Short: "Tool to translate and decrypt the raft logs of a swarm manager",
+	}
+
+	decryptCmd = &cobra.Command{
+		Use:   "decrypt <output directory>",
+		Short: "Decrypt a swarm manager's raft logs to an optional directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("%s command does not take any arguments", os.Args[0])
+			}
+
+			outDir, err := cmd.Flags().GetString("output-dir")
+			if err != nil {
+				return err
+			}
+
+			stateDir, err := cmd.Flags().GetString("state-dir")
+			if err != nil {
+				return err
+			}
+
+			unlockKey, err := cmd.Flags().GetString("unlock-key")
+			if err != nil {
+				return err
+			}
+
+			return decryptRaftData(stateDir, outDir, unlockKey)
+		},
+	}
+)
+
+func init() {
+	mainCmd.PersistentFlags().StringP("state-dir", "d", "./swarmkitstate", "State directory")
+	mainCmd.PersistentFlags().String("unlock-key", "", "Unlock key, if raft logs are encrypted")
+	decryptCmd.Flags().StringP("output-dir", "o", "plaintext_raft", "Output directory for decrypted raft logs")
+	mainCmd.AddCommand(
+		decryptCmd,
+	)
+}
+
+func main() {
+	if _, err := mainCmd.ExecuteC(); err != nil {
+		os.Exit(-1)
+	}
+}


### PR DESCRIPTION
So we can view bits of information.  Currently this is just cluster data - not sure what else would be useful - creating a new directory with decrypted raft data for the user to debug?

Possibly this could be a docker image?  This PR is more of a discussion on what tooling we can provide for debugging.  Alternately we can kill this and create a tool that's not part of swarmkit.