### PR TITLE
Refactor LoadOrCreateSecurityConfig

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -153,7 +153,7 @@ func (rca *RootCA) IssueAndSaveNewCertificates(kw KeyWriter, cn, ou, org string)
 
 // RequestAndSaveNewCertificates gets new certificates issued, either by signing them locally if a signer is
 // available, or by requesting them from the remote server at remoteAddr.
-func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWriter, token string, r remotes.Remotes, transport credentials.TransportCredentials, nodeInfo chan<- api.IssueNodeCertificateResponse) (*tls.Certificate, error) {
+func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWriter, config CertificateRequestConfig) (*tls.Certificate, error) {
 	// Create a new key/pair and CSR
 	csr, key, err := GenerateNewCSR()
 	if err != nil {
@@ -165,7 +165,7 @@ func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWrit
 	// responding properly (for example, it may have just been demoted).
 	var signedCert []byte
 	for i := 0; i != 5; i++ {
-		signedCert, err = GetRemoteSignedCertificate(ctx, csr, token, rca.Pool, r, transport, nodeInfo)
+		signedCert, err = GetRemoteSignedCertificate(ctx, csr, rca.Pool, config)
 		if err == nil {
 			break
 		}
@@ -202,7 +202,7 @@ func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWrit
 
 	var kekUpdate *KEKData
 	for i := 0; i < 5; i++ {
-		kekUpdate, err = rca.getKEKUpdate(ctx, X509Cert, tlsKeyPair, r)
+		kekUpdate, err = rca.getKEKUpdate(ctx, X509Cert, tlsKeyPair, config.Remotes)
 		if err == nil {
 			break
 		}
@@ -545,10 +545,12 @@ func CreateRootCA(rootCN string, paths CertPaths) (RootCA, error) {
 
 // GetRemoteSignedCertificate submits a CSR to a remote CA server address,
 // and that is part of a CA identified by a specific certificate pool.
-func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, rootCAPool *x509.CertPool, r remotes.Remotes, creds credentials.TransportCredentials, nodeInfo chan<- api.IssueNodeCertificateResponse) ([]byte, error) {
+func GetRemoteSignedCertificate(ctx context.Context, csr []byte, rootCAPool *x509.CertPool, config CertificateRequestConfig) ([]byte, error) {
 	if rootCAPool == nil {
 		return nil, errors.New("valid root CA pool required")
 	}
+
+	creds := config.Credentials
 
 	if creds == nil {
 		// This is our only non-MTLS request, and it happens when we are boostraping our TLS certs
@@ -556,7 +558,7 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, r
 		creds = credentials.NewTLS(&tls.Config{ServerName: CARole, RootCAs: rootCAPool})
 	}
 
-	conn, peer, err := getGRPCConnection(creds, r)
+	conn, peer, err := getGRPCConnection(creds, config.Remotes)
 	if err != nil {
 		return nil, err
 	}
@@ -566,16 +568,11 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, r
 	caClient := api.NewNodeCAClient(conn)
 
 	// Send the Request and retrieve the request token
-	issueRequest := &api.IssueNodeCertificateRequest{CSR: csr, Token: token}
+	issueRequest := &api.IssueNodeCertificateRequest{CSR: csr, Token: config.Token}
 	issueResponse, err := caClient.IssueNodeCertificate(ctx, issueRequest)
 	if err != nil {
-		r.Observe(peer, -remotes.DefaultObservationWeight)
+		config.Remotes.Observe(peer, -remotes.DefaultObservationWeight)
 		return nil, err
-	}
-
-	// Send back the NodeID on the nodeInfo, so the caller can know what ID was assigned by the CA
-	if nodeInfo != nil {
-		nodeInfo <- *issueResponse
 	}
 
 	statusRequest := &api.NodeCertificateStatusRequest{NodeID: issueResponse.NodeID}
@@ -592,7 +589,7 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, r
 		defer cancel()
 		statusResponse, err := caClient.NodeCertificateStatus(ctx, statusRequest)
 		if err != nil {
-			r.Observe(peer, -remotes.DefaultObservationWeight)
+			config.Remotes.Observe(peer, -remotes.DefaultObservationWeight)
 			return nil, err
 		}
 
@@ -608,7 +605,7 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, token string, r
 			// retry until the certificate gets updated per our
 			// current request.
 			if bytes.Equal(statusResponse.Certificate.CSR, csr) {
-				r.Observe(peer, remotes.DefaultObservationWeight)
+				config.Remotes.Observe(peer, remotes.DefaultObservationWeight)
 				return statusResponse.Certificate.Certificate, nil
 			}
 		}

--- a/ca/config.go
+++ b/ca/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/remotes"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/credentials"
 
 	"golang.org/x/net/context"
 )
@@ -234,89 +235,138 @@ func DownloadRootCA(ctx context.Context, paths CertPaths, token string, r remote
 	return rootCA, nil
 }
 
-// LoadOrCreateSecurityConfig encapsulates the security logic behind joining a cluster.
-// Every node requires at least a set of TLS certificates with which to join the cluster with.
-// In the case of a manager, these certificates will be used both for client and server credentials.
-func LoadOrCreateSecurityConfig(ctx context.Context, rootCA RootCA, token, proposedRole string, remotes remotes.Remotes, nodeInfo chan<- api.IssueNodeCertificateResponse, krw *KeyReadWriter) (*SecurityConfig, error) {
+// LoadSecurityConfig loads TLS credentials from disk, or returns an error if
+// these credentials do not exist or are unusable.
+func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter) (*SecurityConfig, error) {
 	ctx = log.WithModule(ctx, "tls")
 
 	// At this point we've successfully loaded the CA details from disk, or
 	// successfully downloaded them remotely. The next step is to try to
 	// load our certificates.
-	clientTLSCreds, serverTLSCreds, err := LoadTLSCreds(rootCA, krw)
+
+	// Read both the Cert and Key from disk
+	cert, key, err := krw.Read()
 	if err != nil {
-		if _, ok := errors.Cause(err).(ErrInvalidKEK); ok {
-			return nil, err
-		}
+		return nil, err
+	}
 
-		log.G(ctx).WithError(err).Debugf("no node credentials found in: %s", krw.Target())
+	// Create an x509 certificate out of the contents on disk
+	certBlock, _ := pem.Decode([]byte(cert))
+	if certBlock == nil {
+		return nil, errors.New("failed to parse certificate PEM")
+	}
 
-		var (
-			tlsKeyPair *tls.Certificate
-			err        error
-		)
+	// Create an X509Cert so we can .Verify()
+	X509Cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
 
-		if rootCA.CanSign() {
-			// Create a new random ID for this certificate
-			cn := identity.NewID()
-			org := identity.NewID()
+	// Include our root pool
+	opts := x509.VerifyOptions{
+		Roots: rootCA.Pool,
+	}
 
-			if nodeInfo != nil {
-				nodeInfo <- api.IssueNodeCertificateResponse{
-					NodeID:         cn,
-					NodeMembership: api.NodeMembershipAccepted,
-				}
-			}
-			tlsKeyPair, err = rootCA.IssueAndSaveNewCertificates(krw, cn, proposedRole, org)
-			if err != nil {
-				log.G(ctx).WithFields(logrus.Fields{
-					"node.id":   cn,
-					"node.role": proposedRole,
-				}).WithError(err).Errorf("failed to issue and save new certificate")
-				return nil, err
-			}
+	// Check to see if this certificate was signed by our CA, and isn't expired
+	if _, err := X509Cert.Verify(opts); err != nil {
+		return nil, err
+	}
 
+	// Now that we know this certificate is valid, create a TLS Certificate for our
+	// credentials
+	keyPair, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the Certificates as server credentials
+	serverTLSCreds, err := rootCA.NewServerTLSCredentials(&keyPair)
+	if err != nil {
+		return nil, err
+	}
+
+	// Load the Certificates also as client credentials.
+	// Both workers and managers always connect to remote managers,
+	// so ServerName is always set to ManagerRole here.
+	clientTLSCreds, err := rootCA.NewClientTLSCredentials(&keyPair, ManagerRole)
+	if err != nil {
+		return nil, err
+	}
+
+	log.G(ctx).WithFields(logrus.Fields{
+		"node.id":   clientTLSCreds.NodeID(),
+		"node.role": clientTLSCreds.Role(),
+	}).Debug("loaded node credentials")
+
+	return NewSecurityConfig(&rootCA, krw, clientTLSCreds, serverTLSCreds), nil
+}
+
+// CertificateRequestConfig contains the information needed to request a
+// certificate from a remote CA.
+type CertificateRequestConfig struct {
+	// Token is the join token that authenticates us with the CA.
+	Token string
+	// Remotes is the set of remote CAs.
+	Remotes remotes.Remotes
+	// Credentials provides transport credentials for communicating with the
+	// remote server.
+	Credentials credentials.TransportCredentials
+}
+
+// CreateSecurityConfig creates a new key and cert for this node, either locally
+// or via a remote CA.
+func (rootCA RootCA) CreateSecurityConfig(ctx context.Context, krw *KeyReadWriter, config CertificateRequestConfig) (*SecurityConfig, error) {
+	ctx = log.WithModule(ctx, "tls")
+
+	var (
+		tlsKeyPair *tls.Certificate
+		err        error
+	)
+
+	if rootCA.CanSign() {
+		// Create a new random ID for this certificate
+		cn := identity.NewID()
+		org := identity.NewID()
+
+		proposedRole := ManagerRole
+		tlsKeyPair, err = rootCA.IssueAndSaveNewCertificates(krw, cn, proposedRole, org)
+		if err != nil {
 			log.G(ctx).WithFields(logrus.Fields{
 				"node.id":   cn,
 				"node.role": proposedRole,
-			}).Debug("issued new TLS certificate")
-		} else {
-			// There was an error loading our Credentials, let's get a new certificate issued
-			// Last argument is nil because at this point we don't have any valid TLS creds
-			tlsKeyPair, err = rootCA.RequestAndSaveNewCertificates(ctx, krw, token, remotes, nil, nodeInfo)
-			if err != nil {
-				log.G(ctx).WithError(err).Error("failed to request save new certificate")
-				return nil, err
-			}
-		}
-		// Create the Server TLS Credentials for this node. These will not be used by workers.
-		serverTLSCreds, err = rootCA.NewServerTLSCredentials(tlsKeyPair)
-		if err != nil {
+			}).WithError(err).Errorf("failed to issue and save new certificate")
 			return nil, err
 		}
 
-		// Create a TLSConfig to be used when this node connects as a client to another remote node.
-		// We're using ManagerRole as remote serverName for TLS host verification
-		clientTLSCreds, err = rootCA.NewClientTLSCredentials(tlsKeyPair, ManagerRole)
+		log.G(ctx).WithFields(logrus.Fields{
+			"node.id":   cn,
+			"node.role": proposedRole,
+		}).Debug("issued new TLS certificate")
+	} else {
+		// Request certificate issuance from a remote CA.
+		// Last argument is nil because at this point we don't have any valid TLS creds
+		tlsKeyPair, err = rootCA.RequestAndSaveNewCertificates(ctx, krw, config)
 		if err != nil {
+			log.G(ctx).WithError(err).Error("failed to request save new certificate")
 			return nil, err
 		}
-		log.G(ctx).WithFields(logrus.Fields{
-			"node.id":   clientTLSCreds.NodeID(),
-			"node.role": clientTLSCreds.Role(),
-		}).Debugf("new node credentials generated: %s", krw.Target())
-	} else {
-		if nodeInfo != nil {
-			nodeInfo <- api.IssueNodeCertificateResponse{
-				NodeID:         clientTLSCreds.NodeID(),
-				NodeMembership: api.NodeMembershipAccepted,
-			}
-		}
-		log.G(ctx).WithFields(logrus.Fields{
-			"node.id":   clientTLSCreds.NodeID(),
-			"node.role": clientTLSCreds.Role(),
-		}).Debug("loaded node credentials")
 	}
+	// Create the Server TLS Credentials for this node. These will not be used by workers.
+	serverTLSCreds, err := rootCA.NewServerTLSCredentials(tlsKeyPair)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a TLSConfig to be used when this node connects as a client to another remote node.
+	// We're using ManagerRole as remote serverName for TLS host verification
+	clientTLSCreds, err := rootCA.NewClientTLSCredentials(tlsKeyPair, ManagerRole)
+	if err != nil {
+		return nil, err
+	}
+	log.G(ctx).WithFields(logrus.Fields{
+		"node.id":   clientTLSCreds.NodeID(),
+		"node.role": clientTLSCreds.Role(),
+	}).Debugf("new node credentials generated: %s", krw.Target())
 
 	return NewSecurityConfig(&rootCA, krw, clientTLSCreds, serverTLSCreds), nil
 }
@@ -334,10 +384,10 @@ func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, r remotes.Remotes
 	rootCA := s.RootCA()
 	tlsKeyPair, err := rootCA.RequestAndSaveNewCertificates(ctx,
 		s.KeyWriter(),
-		"",
-		r,
-		s.ClientTLSCreds,
-		nil)
+		CertificateRequestConfig{
+			Remotes:     r,
+			Credentials: s.ClientTLSCreds,
+		})
 	if err != nil {
 		log.WithError(err).Errorf("failed to renew the certificate")
 		return err
@@ -463,61 +513,6 @@ func calculateRandomExpiry(validFrom, validUntil time.Time) time.Duration {
 	return expiry
 }
 
-// LoadTLSCreds loads tls credentials from the specified path and verifies that
-// thay are valid for the RootCA.
-func LoadTLSCreds(rootCA RootCA, kr KeyReader) (*MutableTLSCreds, *MutableTLSCreds, error) {
-	// Read both the Cert and Key from disk
-	cert, key, err := kr.Read()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create an x509 certificate out of the contents on disk
-	certBlock, _ := pem.Decode([]byte(cert))
-	if certBlock == nil {
-		return nil, nil, errors.New("failed to parse certificate PEM")
-	}
-
-	// Create an X509Cert so we can .Verify()
-	X509Cert, err := x509.ParseCertificate(certBlock.Bytes)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Include our root pool
-	opts := x509.VerifyOptions{
-		Roots: rootCA.Pool,
-	}
-
-	// Check to see if this certificate was signed by our CA, and isn't expired
-	if _, err := X509Cert.Verify(opts); err != nil {
-		return nil, nil, err
-	}
-
-	// Now that we know this certificate is valid, create a TLS Certificate for our
-	// credentials
-	keyPair, err := tls.X509KeyPair(cert, key)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Load the Certificates as server credentials
-	serverTLSCreds, err := rootCA.NewServerTLSCredentials(&keyPair)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Load the Certificates also as client credentials.
-	// Both workers and managers always connect to remote managers,
-	// so ServerName is always set to ManagerRole here.
-	clientTLSCreds, err := rootCA.NewClientTLSCredentials(&keyPair, ManagerRole)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return clientTLSCreds, serverTLSCreds, nil
-}
-
 // NewServerTLSConfig returns a tls.Config configured for a TLS Server, given a tls.Certificate
 // and the PEM-encoded root CA Certificate
 func NewServerTLSConfig(cert *tls.Certificate, rootCAPool *x509.CertPool) (*tls.Config, error) {
@@ -554,8 +549,8 @@ func NewClientTLSConfig(cert *tls.Certificate, rootCAPool *x509.CertPool, server
 
 // NewClientTLSCredentials returns GRPC credentials for a TLS GRPC client, given a tls.Certificate
 // a PEM-Encoded root CA Certificate, and the name of the remote server the client wants to connect to.
-func (rca *RootCA) NewClientTLSCredentials(cert *tls.Certificate, serverName string) (*MutableTLSCreds, error) {
-	tlsConfig, err := NewClientTLSConfig(cert, rca.Pool, serverName)
+func (rootCA *RootCA) NewClientTLSCredentials(cert *tls.Certificate, serverName string) (*MutableTLSCreds, error) {
+	tlsConfig, err := NewClientTLSConfig(cert, rootCA.Pool, serverName)
 	if err != nil {
 		return nil, err
 	}
@@ -567,8 +562,8 @@ func (rca *RootCA) NewClientTLSCredentials(cert *tls.Certificate, serverName str
 
 // NewServerTLSCredentials returns GRPC credentials for a TLS GRPC client, given a tls.Certificate
 // a PEM-Encoded root CA Certificate, and the name of the remote server the client wants to connect to.
-func (rca *RootCA) NewServerTLSCredentials(cert *tls.Certificate) (*MutableTLSCreds, error) {
-	tlsConfig, err := NewServerTLSConfig(cert, rca.Pool)
+func (rootCA *RootCA) NewServerTLSCredentials(cert *tls.Certificate) (*MutableTLSCreds, error) {
+	tlsConfig, err := NewServerTLSConfig(cert, rootCA.Pool)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -100,26 +100,24 @@ type Config struct {
 // cluster. Node handles workloads and may also run as a manager.
 type Node struct {
 	sync.RWMutex
-	config               *Config
-	remotes              *persistentRemotes
-	role                 string
-	roleCond             *sync.Cond
-	conn                 *grpc.ClientConn
-	connCond             *sync.Cond
-	nodeID               string
-	nodeMembership       api.NodeSpec_Membership
-	started              chan struct{}
-	startOnce            sync.Once
-	stopped              chan struct{}
-	stopOnce             sync.Once
-	ready                chan struct{} // closed when agent has completed registration and manager(if enabled) is ready to receive control requests
-	certificateRequested chan struct{} // closed when certificate issue request has been sent by node
-	closed               chan struct{}
-	err                  error
-	agent                *agent.Agent
-	manager              *manager.Manager
-	notifyNodeChange     chan *api.Node // used to send role updates from the dispatcher api on promotion/demotion
-	unlockKey            []byte
+	config           *Config
+	remotes          *persistentRemotes
+	role             string
+	roleCond         *sync.Cond
+	conn             *grpc.ClientConn
+	connCond         *sync.Cond
+	nodeID           string
+	started          chan struct{}
+	startOnce        sync.Once
+	stopped          chan struct{}
+	stopOnce         sync.Once
+	ready            chan struct{} // closed when agent has completed registration and manager(if enabled) is ready to receive control requests
+	closed           chan struct{}
+	err              error
+	agent            *agent.Agent
+	manager          *manager.Manager
+	notifyNodeChange chan *api.Node // used to send role updates from the dispatcher api on promotion/demotion
+	unlockKey        []byte
 }
 
 // RemoteAPIAddr returns address on which remote manager api listens.
@@ -155,16 +153,15 @@ func New(c *Config) (*Node, error) {
 	}
 
 	n := &Node{
-		remotes:              newPersistentRemotes(stateFile, p...),
-		role:                 ca.WorkerRole,
-		config:               c,
-		started:              make(chan struct{}),
-		stopped:              make(chan struct{}),
-		closed:               make(chan struct{}),
-		ready:                make(chan struct{}),
-		certificateRequested: make(chan struct{}),
-		notifyNodeChange:     make(chan *api.Node, 1),
-		unlockKey:            c.UnlockKey,
+		remotes:          newPersistentRemotes(stateFile, p...),
+		role:             ca.WorkerRole,
+		config:           c,
+		started:          make(chan struct{}),
+		stopped:          make(chan struct{}),
+		closed:           make(chan struct{}),
+		ready:            make(chan struct{}),
+		notifyNodeChange: make(chan *api.Node, 1),
+		unlockKey:        c.UnlockKey,
 	}
 
 	if n.config.JoinAddr != "" || n.config.ForceNewCluster {
@@ -403,13 +400,6 @@ func (n *Node) Ready() <-chan struct{} {
 	return n.ready
 }
 
-// CertificateRequested returns a channel that is closed after node has
-// requested a certificate. After this call a caller can expect calls to
-// NodeID() and `NodeMembership()` to succeed.
-func (n *Node) CertificateRequested() <-chan struct{} {
-	return n.certificateRequested
-}
-
 func (n *Node) setControlSocket(conn *grpc.ClientConn) {
 	n.Lock()
 	if n.conn != nil {
@@ -461,13 +451,6 @@ func (n *Node) NodeID() string {
 	return n.nodeID
 }
 
-// NodeMembership returns current node's membership. May be empty if not set.
-func (n *Node) NodeMembership() api.NodeSpec_Membership {
-	n.RLock()
-	defer n.RUnlock()
-	return n.nodeMembership
-}
-
 // Manager returns manager instance started by node. May be nil.
 func (n *Node) Manager() *manager.Manager {
 	n.RLock()
@@ -507,18 +490,14 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		return nil, err
 	}
 	if err == nil {
-		clientTLSCreds, serverTLSCreds, err := ca.LoadTLSCreds(rootCA, krw)
-		_, ok := errors.Cause(err).(ca.ErrInvalidKEK)
-		switch {
-		case err == nil:
-			securityConfig = ca.NewSecurityConfig(&rootCA, krw, clientTLSCreds, serverTLSCreds)
-			log.G(ctx).Debug("loaded CA and TLS certificates")
-		case ok:
-			return nil, ErrInvalidUnlockKey
-		case os.IsNotExist(err):
-			break
-		default:
-			return nil, errors.Wrapf(err, "error while loading TLS certificate in %s", paths.Node.Cert)
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw)
+		if err != nil {
+			_, isInvalidKEK := errors.Cause(err).(ca.ErrInvalidKEK)
+			if isInvalidKEK {
+				return nil, ErrInvalidUnlockKey
+			} else if !os.IsNotExist(err) {
+				return nil, errors.Wrapf(err, "error while loading TLS certificate in %s", paths.Node.Cert)
+			}
 		}
 	}
 
@@ -544,44 +523,36 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		}
 
 		// Obtain new certs and setup TLS certificates renewal for this node:
-		// - We call LoadOrCreateSecurityConfig which blocks until a valid certificate has been issued
-		// - We retrieve the nodeID from LoadOrCreateSecurityConfig through the info channel. This allows
-		// us to display the ID before the certificate gets issued (for potential approval).
-		// - We wait for LoadOrCreateSecurityConfig to finish since we need a certificate to operate.
-		// - Given a valid certificate, spin a renewal go-routine that will ensure that certificates stay
-		// up to date.
-		issueResponseChan := make(chan api.IssueNodeCertificateResponse, 1)
-		go func() {
-			select {
-			case <-ctx.Done():
-			case resp := <-issueResponseChan:
-				log.G(log.WithModule(ctx, "tls")).WithFields(logrus.Fields{
-					"node.id": resp.NodeID,
-				}).Debugf("loaded TLS certificate")
-				n.Lock()
-				n.nodeID = resp.NodeID
-				n.nodeMembership = resp.NodeMembership
-				n.Unlock()
-				close(n.certificateRequested)
-			}
-		}()
+		// - If certificates weren't present on disk, we call CreateSecurityConfig, which blocks
+		//   until a valid certificate has been issued.
+		// - We wait for CreateSecurityConfig to finish since we need a certificate to operate.
 
-		// LoadOrCreateSecurityConfig is the point at which a new node joining a cluster will retrieve TLS
-		// certificates and write them to disk
-		securityConfig, err = ca.LoadOrCreateSecurityConfig(
-			ctx, rootCA, n.config.JoinToken, ca.ManagerRole, n.remotes, issueResponseChan, krw)
-		if err != nil {
+		// Attempt to load certificate from disk
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw)
+		if err == nil {
+			log.G(ctx).WithFields(logrus.Fields{
+				"node.id": securityConfig.ClientTLSCreds.NodeID(),
+			}).Debugf("loaded TLS certificate")
+		} else {
 			if _, ok := errors.Cause(err).(ca.ErrInvalidKEK); ok {
 				return nil, ErrInvalidUnlockKey
 			}
-			return nil, err
+			log.G(ctx).WithError(err).Debugf("no node credentials found in: %s", krw.Target())
+
+			securityConfig, err = rootCA.CreateSecurityConfig(ctx, krw, ca.CertificateRequestConfig{
+				Token:   n.config.JoinToken,
+				Remotes: n.remotes,
+			})
+
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	n.Lock()
 	n.role = securityConfig.ClientTLSCreds.Role()
 	n.nodeID = securityConfig.ClientTLSCreds.NodeID()
-	n.nodeMembership = api.NodeMembershipAccepted
 	n.roleCond.Broadcast()
 	n.Unlock()
 


### PR DESCRIPTION
This is an alternative proposal to #1751 
Fixes #1731

- Split `LoadOrCreateSecurityConfig` into `LoadSecurityConfig` and `RootCA.CreateSecurityConfig`. The latter is a method on `RootCA` because the `RootCA` object issues the certificate.
- Create a `CertificateRequestConfig` struct that configures a certificate request. It includes things such as the remote CA addresses and the token needed to authenticate with them. Use this in `CreateSecurityConfig` and some of its downstream methods.
- Only use the `NodeInfo` channel when an actual remote certificate request is taking place. It's not necessary in the case where the certificate is loaded from disk or issued locally, because `n.nodeID` and `n.nodeMembership` will be set right inside `loadSecurityConfig`.
- Remove unused `CertificateRequested` method in node and associated channel.

cc @yongtang @stevvooe @diogomonica @cyli