### PR TITLE
swarm leave should clean up assignments

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -37,6 +37,8 @@ type Agent struct {
 	started   chan struct{}
 	startOnce sync.Once // start only once
 	ready     chan struct{}
+	leaving   chan struct{}
+	leaveOnce sync.Once
 	stopped   chan struct{} // requests shutdown
 	stopOnce  sync.Once     // only allow stop to be called once
 	closed    chan struct{} // only closed in run
@@ -53,6 +55,7 @@ func New(config *Config) (*Agent, error) {
 		config:   config,
 		sessionq: make(chan sessionOperation),
 		started:  make(chan struct{}),
+		leaving:  make(chan struct{}),
 		stopped:  make(chan struct{}),
 		closed:   make(chan struct{}),
 		ready:    make(chan struct{}),
@@ -76,6 +79,25 @@ func (a *Agent) Start(ctx context.Context) error {
 	})
 
 	return err
+}
+
+// Leave instructs the agent to leave the cluster. This method will shutdown
+// assignment processing and remove all assignments from the node.
+//
+// Tasks are removed asynchronously. After calling Leave, Close can be used to
+// wait until any outstanding task removals are complete.
+func (a *Agent) Leave(ctx context.Context) error {
+	select {
+	case <-a.started:
+	default:
+		return errAgentNotStarted
+	}
+
+	a.leaveOnce.Do(func() {
+		close(a.leaving)
+	})
+
+	return nil
 }
 
 // Stop shuts down the agent, blocking until full shutdown. If the agent is not
@@ -151,6 +173,7 @@ func (a *Agent) run(ctx context.Context) {
 		registered    = session.registered
 		ready         = a.ready // first session ready
 		sessionq      chan sessionOperation
+		leaving       = a.leaving
 		subscriptions = map[string]context.CancelFunc{}
 	)
 
@@ -171,7 +194,21 @@ func (a *Agent) run(ctx context.Context) {
 		select {
 		case operation := <-sessionq:
 			operation.response <- operation.fn(session)
+		case <-leaving:
+			leaving = nil
+
+			// TODO(stevvooe): Signal to the manager that the node is leaving.
+
+			// when leaving we remove all assignments.
+			if err := a.worker.Assign(ctx, nil); err != nil {
+				log.G(ctx).WithError(err).Error("failed removing all assignments")
+			}
 		case msg := <-session.assignments:
+			// if we have left, accept no more assignments
+			if leaving == nil { // leaving when we have left
+				continue
+			}
+
 			switch msg.Type {
 			case api.AssignmentsMessage_COMPLETE:
 				// Need to assign secrets before tasks, because tasks might depend on new secrets

--- a/agent/task.go
+++ b/agent/task.go
@@ -49,6 +49,9 @@ func (tm *taskManager) Update(ctx context.Context, task *api.Task) error {
 }
 
 // Close shuts down the task manager, blocking until it is stopped.
+//
+// Calling this method will result in a complete removal of the controller's
+// resources, blocking until complete.
 func (tm *taskManager) Close() error {
 	select {
 	case <-tm.closed:

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -90,8 +90,6 @@ func TestTaskManager(t *testing.T) {
 				"start":   1,
 				"wait":    1,
 				"prepare": 1,
-				"close":   1,
-				"remove":  1,
 				"update":  2}, ctlr.calls)
 			return
 		case <-ctx.Done():


### PR DESCRIPTION
One of the problem shown in https://github.com/docker/docker/issues/27124 is that overlay networks are not removed when a node leave swarm. The networks are associated with tasks. Node should remove all swarm tasks before leaving. 

On todo list, a more graceful leave would coordinate with manager. It'd inform manager of leaving, let manager drain tasks from the node, then stop the node. It'd require new message from node to manager. And manager putting node into a `leaving` state. 

cc @LK4D4 @stevvooe @mrjana @aaronlehmann. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>