### PR TITLE
agent: Handle managers that don't implement LogBroker

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -226,6 +226,16 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 
 	client := api.NewLogBrokerClient(s.conn)
 	subscriptions, err := client.ListenSubscriptions(ctx, &api.ListenSubscriptionsRequest{})
+	if grpc.Code(err) == codes.Unimplemented {
+		log.Warning("manager does not support log subscriptions")
+		// Don't return, because returning would bounce the session
+		select {
+		case <-s.closed:
+			return errSessionClosed
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the manager is too old to support the LogBroker service, the agent
should not bounce the session.

See https://github.com/docker/docker/issues/28496

cc @aluzzardi @stevvooe