### PR TITLE
ca: Prevent concurrent certificate renewals

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -53,7 +53,12 @@ const (
 // SecurityConfig is used to represent a node's security configuration. It includes information about
 // the RootCA and ServerTLSCreds/ClientTLSCreds transport authenticators to be used for MTLS
 type SecurityConfig struct {
+	// mu protects against concurrent access to fields inside the structure.
 	mu sync.Mutex
+
+	// renewalMu makes sure only one certificate renewal attempt happens at
+	// a time. It should never be locked after mu is already locked.
+	renewalMu sync.Mutex
 
 	rootCA        *RootCA
 	externalCA    *ExternalCA
@@ -374,6 +379,9 @@ func (rootCA RootCA) CreateSecurityConfig(ctx context.Context, krw *KeyReadWrite
 // RenewTLSConfigNow gets a new TLS cert and key, and updates the security config if provided.  This is similar to
 // RenewTLSConfig, except while that monitors for expiry, and periodically renews, this renews once and is blocking
 func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, r remotes.Remotes) error {
+	s.renewalMu.Lock()
+	defer s.renewalMu.Unlock()
+
 	ctx = log.WithModule(ctx, "tls")
 	log := log.G(ctx).WithFields(logrus.Fields{
 		"node.id":   s.ClientTLSCreds.NodeID(),


### PR DESCRIPTION
`updateKEK` runs `RenewTLSConfigNow` in a goroutine. If a manager is
switched between locked and unlocked mode quickly, some of these
certificate renewal goroutines could run at the same time. They could
potentially also overlap with a scheduled renewal.

This is bad because the `SecurityConfig` may end up using a different key
from the one on disk. The client and server credentials could
potentially get out of sync.

Limit `RenewTLSConfigNow` to one concurrent invocation.

cc @cyli @diogomonica