### PR TITLE
On leader switchover preserve the vxlan id for existing networks

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -573,9 +573,18 @@ func (na *NetworkAllocator) allocateDriverState(n *api.Network) error {
 		return err
 	}
 
-	var options map[string]string
+	options := make(map[string]string)
+	// reconcile the driver specific options from the network spec
+	// and from the operational state retrieved from the store
 	if n.Spec.DriverConfig != nil {
-		options = n.Spec.DriverConfig.Options
+		for k, v := range n.Spec.DriverConfig.Options {
+			options[k] = v
+		}
+	}
+	if n.DriverState != nil {
+		for k, v := range n.DriverState.Options {
+			options[k] = v
+		}
 	}
 
 	// Construct IPAM data for driver consumption.


### PR DESCRIPTION
On a leader change, the new leader restores the state for the existing networks from the store. But the overlay network's vxlan id was getting allocated afresh instead of restoring the current vxlan id allocated for the network.

related to [docker #28493](https://github.com/docker/docker/issues/28493) 

Signed-off-by: Santhosh Manohar <santhosh@docker.com>