### PR TITLE
Validate secret for white spaces only data

### DIFF
--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -257,6 +257,11 @@ func validateSecretSpec(spec *api.SecretSpec) error {
 	if len(spec.Data) >= MaxSecretSize || len(spec.Data) < 1 {
 		return grpc.Errorf(codes.InvalidArgument, "secret data must be larger than 0 and less than %d bytes", MaxSecretSize)
 	}
+
+	if len(strings.TrimSpace(string(spec.Data))) == 0 {
+		return grpc.Errorf(codes.InvalidArgument, "secret data must contain non white space bytes")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This fix is related to docker issue:
https://github.com/docker/docker/issues/28927

Currently, secret is validated and the length of the data has to be 0 < len < MaxSecretSize.

However, sometimes data might only contain white spaces (e.g., `" "`, `"\n"`, etc.) and the secret could be created as well.

This fix adds the additional validation so that white spaces only data will not be accepted.

Additional unit tests have been added to cover different invalid data in secret creation.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>