### PR TITLE
Fix race in ProcessRaftMessage logging

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -897,8 +897,11 @@ func (n *Node) RemoveMember(ctx context.Context, id uint64) error {
 // formatting strings and allocating a logger when it won't be used.
 func (n *Node) processRaftMessageLogger(ctx context.Context, msg *api.ProcessRaftMessageRequest) *logrus.Entry {
 	fields := logrus.Fields{
-		"method":  "(*Node).ProcessRaftMessage",
-		"raft_id": fmt.Sprintf("%x", n.Config.ID),
+		"method": "(*Node).ProcessRaftMessage",
+	}
+
+	if n.IsMember() {
+		fields["raft_id"] = fmt.Sprintf("%x", n.Config.ID)
 	}
 
 	if msg != nil && msg.Message != nil {


### PR DESCRIPTION
Fix silly race in ProcessRaftMessage logging introduced by #1779.

cc @LK4D4 @cyli