### PR TITLE
Propagate manager removal error

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -388,26 +388,34 @@ func (m *Manager) Run(parent context.Context) error {
 
 	close(m.started)
 
+	var runErr error
 	go func() {
-		err := m.raftNode.Run(ctx)
-		if err != nil {
-			log.G(ctx).WithError(err).Error("raft node stopped")
+		runErr = m.raftNode.Run(ctx)
+		if runErr != nil {
+			log.G(ctx).WithError(runErr).Error("raft node stopped")
 			m.Stop(ctx)
 		}
 	}()
 
-	if err := raft.WaitForLeader(ctx, m.raftNode); err != nil {
+	returnErr := func(err error) error {
+		if err == context.Canceled && runErr != nil {
+			return runErr
+		}
 		return err
+	}
+
+	if err := raft.WaitForLeader(ctx, m.raftNode); err != nil {
+		return returnErr(err)
 	}
 
 	c, err := raft.WaitForCluster(ctx, m.raftNode)
 	if err != nil {
-		return err
+		return returnErr(err)
 	}
 	raftConfig := c.Spec.Raft
 
 	if err := m.watchForKEKChanges(ctx); err != nil {
-		return err
+		return returnErr(err)
 	}
 
 	if int(raftConfig.ElectionTick) != m.raftNode.Config.ElectionTick {
@@ -426,7 +434,8 @@ func (m *Manager) Run(parent context.Context) error {
 	}
 	m.mu.Unlock()
 	m.Stop(ctx)
-	return err
+
+	return returnErr(err)
 }
 
 const stopTimeout = 8 * time.Second

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager"
 	"github.com/docker/swarmkit/manager/encryption"
+	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/remotes"
 	"github.com/docker/swarmkit/xnet"
 	"github.com/pkg/errors"
@@ -694,7 +695,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		case <-done:
 			// Fail out if m.Run() returns error, otherwise wait for
 			// role change.
-			if runErr != nil {
+			if runErr != nil && runErr != raft.ErrMemberRemoved {
 				err = runErr
 			} else {
 				err = <-roleChanged


### PR DESCRIPTION
Do not stop the node if the manager returned with error `ErrMemberRemoved`.  The new test case does not deterministically trigger the `ErrMemberRemoved` case, but tends to do so after a few runs.

I think this fixes #1782.  Thanks to @tonistiigi for figuring out my test failure!

Currently running tests to see if it addresses https://github.com/docker/docker/issues/28987.