### PR TITLE
integration: Don't wait for dispatcher heartbeats to timeout

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -178,7 +178,7 @@ func TestNodeOps(t *testing.T) {
 			break
 		}
 	}
-	require.NoError(t, cl.RemoveNode(worker.node.NodeID()))
+	require.NoError(t, cl.RemoveNode(worker.node.NodeID(), false))
 	// agents 1, managers 2
 	numWorker--
 	// long wait for heartbeat expiration


### PR DESCRIPTION
Make graceful node removal optional. For existing tests, remove nodes
forcefully. This makes the integration tests run about 20s faster.

cc @LK4D4 @cyli