### PR TITLE
logbroker: Fix race on subscription.message.Close

### DIFF
--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -152,7 +152,8 @@ func (lb *LogBroker) unregisterSubscription(subscription *subscription) {
 	defer lb.mu.Unlock()
 
 	delete(lb.registeredSubscriptions, subscription.message.ID)
-	subscription.message.Close = true
+
+	subscription.Close()
 	lb.subscriptionQueue.Publish(subscription)
 }
 
@@ -321,7 +322,7 @@ func (lb *LogBroker) ListenSubscriptions(request *api.ListenSubscriptionsRequest
 		case v := <-subscriptionCh:
 			subscription := v.(*subscription)
 
-			if subscription.message.Close {
+			if subscription.Closed() {
 				log.WithField("subscription.id", subscription.message.ID).Debug("subscription closed")
 				delete(activeSubscriptions, subscription.message.ID)
 			} else {

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -137,6 +137,18 @@ func (s *subscription) Err() error {
 	return fmt.Errorf("warning: incomplete log stream. some logs could not be retrieved for the following reasons: %s", strings.Join(messages, ", "))
 }
 
+func (s *subscription) Close() {
+	s.mu.Lock()
+	s.message.Close = true
+	s.mu.Unlock()
+}
+
+func (s *subscription) Closed() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.message.Close
+}
+
 func (s *subscription) match() {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Encountered a data race while running the unit tests on the 1.13.x
branch. The `Close` field is set without locking. Make sure it is only set
and checked with the subscription's lock held.

I also considered creating a copy of the subscription before setting
`Close` to true and sending it over the queue, but this seems a bit more
straightforward.

cc @aluzzardi