### PR TITLE
raft: Add grace period to sendToMember

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -950,13 +950,13 @@ func (n *Node) ProcessRaftMessage(ctx context.Context, msg *api.ProcessRaftMessa
 		defer cancel()
 
 		if err := member.HealthCheck(healthCtx); err != nil {
-			n.processRaftMessageLogger(ctx, msg).Debug("member which sent vote request failed health check")
+			n.processRaftMessageLogger(ctx, msg).WithError(err).Debug("member which sent vote request failed health check")
 			return &api.ProcessRaftMessageResponse{}, nil
 		}
 	}
 
 	if msg.Message.Type == raftpb.MsgProp {
-		// We don't accepted forwarded proposals. Our
+		// We don't accept forwarded proposals. Our
 		// current architecture depends on only the leader
 		// making proposals, so in-flight proposals can be
 		// guaranteed not to conflict.
@@ -1296,25 +1296,32 @@ func (n *Node) sendToMember(ctx context.Context, members map[uint64]*membership.
 	defer n.asyncTasks.Done()
 	defer close(thisSend)
 
-	ctx, cancel := context.WithTimeout(ctx, n.opts.SendTimeout)
-	defer cancel()
-
 	if lastSend != nil {
+		waitCtx, waitCancel := context.WithTimeout(ctx, n.opts.SendTimeout)
+		defer waitCancel()
+
 		select {
 		case <-lastSend:
-		case <-ctx.Done():
+		case <-waitCtx.Done():
 			return
 		}
+
+		select {
+		case <-waitCtx.Done():
+			return
+		default:
+		}
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, n.opts.SendTimeout)
+	defer cancel()
 
 	if n.cluster.IsIDRemoved(m.To) {
 		// Should not send to removed members
 		return
 	}
 
-	var (
-		conn *membership.Member
-	)
+	var conn *membership.Member
 	if toMember, ok := members[m.To]; ok {
 		conn = toMember
 	} else {


### PR DESCRIPTION
This function was recently changed to synchronize sends to the same
member, so that sending goroutines wouldn't impact each other by closing
the connection on an error.

To prevent the number of waiting goroutines from growing without bound,
`SendTimeout` was applied to both waiting for the last sender to finish,
and doing the actual I/O.

This may have unwanted consequences if two sends to the same member are
started around the same time and the first times out. The second will
only have a tiny amount of time to complete after waiting. It will
probably time out too, and bounce the connection as a result. So the
connection may be closed and reopened more than necessary, and this may
impact health checks, which reuse the same connections.

Change this function to reset the timeout after it finishes waiting.

I think this may help with long election loops seen in Docker Engine's
`TestSwarmLockUnlockCluster`. The logs from these runs showed "member
which sent vote request failed health check", which is unexpected, and
probably means a connection was being wrongly closed from underneath
`ProcessRaftMessage`. In case this change doesn't solve the problem, I've
added more detailed error logging that will show how the health check
failed.

cc @cyli @LK4D4