### PR TITLE
Remove old snapshots when completing a raft DEK key rotation

### DIFF
--- a/manager/state/raft/storage/storage.go
+++ b/manager/state/raft/storage/storage.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -358,7 +357,7 @@ func (e *EncryptedRaftLogger) Close(ctx context.Context) {
 	e.snapshotter = nil
 }
 
-// Clear closes the existing WAL and moves away the WAL and snapshot.
+// Clear closes the existing WAL and removes the WAL and snapshot.
 func (e *EncryptedRaftLogger) Clear(ctx context.Context) error {
 	e.encoderMu.Lock()
 	defer e.encoderMu.Unlock()
@@ -370,23 +369,7 @@ func (e *EncryptedRaftLogger) Clear(ctx context.Context) error {
 	}
 	e.snapshotter = nil
 
-	newWALDir, err := ioutil.TempDir(e.StateDir, "wal.")
-	if err != nil {
-		return err
-	}
-	os.RemoveAll(newWALDir)
-	if err = os.Rename(e.walDir(), newWALDir); err != nil {
-		return err
-	}
-
-	newSnapDir, err := ioutil.TempDir(e.StateDir, "snap.")
-	if err != nil {
-		return err
-	}
-	os.RemoveAll(newSnapDir)
-	if err := os.Rename(e.snapDir(), newSnapDir); err != nil {
-		return err
-	}
-
+	os.RemoveAll(e.walDir())
+	os.RemoveAll(e.snapDir())
 	return nil
 }


### PR DESCRIPTION
When completing a raft DEK key rotation, (which only happens when a snapshot is completed using the new DEK key, and the snapshot's index must be >= the index of the last WAL written with the old
key), remove the previous snapshots and WALs, since the old DEK will no longer be available and
they can't be decrypted anymore anyway.

Also, when a manager is removed from the cluster, the raft DEK will be removed and the TLS key
rotated to be that of a worker.  Since the DEK won't be available anyway, just remove the old
wal and snapshot directories instead of backing them up.

Signed-off-by: cyli <ying.li@docker.com>

cc @aaronlehmann @diogomonica 