### PR TITLE
Remove suffix of `.<TaskID>` from the name of `Task`

### DIFF
--- a/api/naming/naming.go
+++ b/api/naming/naming.go
@@ -22,8 +22,8 @@ func Task(t *api.Task) string {
 		slot = t.NodeID
 	}
 
-	// fallback to service.instance.id.
-	return fmt.Sprintf("%s.%s.%s", t.ServiceAnnotations.Name, slot, t.ID)
+	// fallback to service.instance
+	return fmt.Sprintf("%s.%s", t.ServiceAnnotations.Name, slot)
 }
 
 // TODO(stevvooe): Consolidate "Hostname" style validation here.

--- a/api/naming/naming_test.go
+++ b/api/naming/naming_test.go
@@ -23,7 +23,7 @@ func TestTaskNaming(t *testing.T) {
 					Name: "theservice",
 				},
 			},
-			Expected: "theservice.10.taskID",
+			Expected: "theservice.10",
 		},
 		{
 			Name: "Annotations",
@@ -48,7 +48,7 @@ func TestTaskNaming(t *testing.T) {
 					Name: "theservice",
 				},
 			},
-			Expected: "theservice.thenodeID.taskID",
+			Expected: "theservice.thenodeID",
 		},
 	} {
 		t.Run(testcase.Name, func(t *testing.T) {

--- a/template/context_test.go
+++ b/template/context_test.go
@@ -80,7 +80,7 @@ func TestTemplateContext(t *testing.T) {
 					"SERVICE_ID=serviceID",
 					"SERVICE_NAME=serviceName",
 					"TASK_ID=taskID",
-					"TASK_NAME=serviceName.10.taskID",
+					"TASK_NAME=serviceName.10",
 					"NODE_ID=nodeID",
 					"SERVICE_LABELS=ServiceLabelOneKey=service-label-one-value,ServiceLabelTwoKey=service-label-two-value,com.example.ServiceLabelThreeKey=service-label-three-value,",
 				},
@@ -109,7 +109,7 @@ func TestTemplateContext(t *testing.T) {
 			Expected: &api.ContainerSpec{
 				Mounts: []api.Mount{
 					{
-						Source: "bar-nodeID-serviceName.10.taskID",
+						Source: "bar-nodeID-serviceName.10",
 						Target: "foo-serviceID-serviceName",
 					},
 					{


### PR DESCRIPTION
This fix is related to docker PR:
https://github.com/docker/docker/pull/29196

The above PR will remove the suffix of `.<TaskID>` from the name of `Task`.

This fix tries to remove suffix of `.<TaskID>` from the related SwarmKit part.

Technically, the docker PR https://github.com/docker/docker/pull/29196 is only about the "display name" of the task.
We could very well leave the "internal name" of the task alone (keep `.<TaskID>`) if we prefer.

So please fee free to close this PR if keep `.<TaskID>` is preferred. /cc @aluzzardi @stevvooe @aaronlehmann 