### PR TITLE
Fix duplicated ports allocation with restarted swarm

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -231,7 +231,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 
 	var allocatedServices []*api.Service
 	for _, s := range services {
-		if nc.nwkAllocator.IsServiceAllocated(s) {
+		if nc.nwkAllocator.IsServiceAllocated(s, networkallocator.OnInit) {
 			continue
 		}
 

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -289,8 +289,25 @@ func (na *NetworkAllocator) PortsAllocatedInHostPublishMode(s *api.Service) bool
 	return na.portAllocator.portsAllocatedInHostPublishMode(s)
 }
 
+// ServiceAllocationOpts is struct used for functional options in IsServiceAllocated
+type ServiceAllocationOpts struct {
+	OnInit bool
+}
+
+// OnInit is called for allocator initialization stage
+func OnInit(options *ServiceAllocationOpts) {
+	options.OnInit = true
+}
+
 // IsServiceAllocated returns if the passed service has its network resources allocated or not.
-func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
+// init bool indicates if the func is called during allocator initialization stage.
+func (na *NetworkAllocator) IsServiceAllocated(s *api.Service, flags ...func(*ServiceAllocationOpts)) bool {
+	var options ServiceAllocationOpts
+
+	for _, flag := range flags {
+		flag(&options)
+	}
+
 	// If endpoint mode is VIP and allocator does not have the
 	// service in VIP allocated set then it is not allocated.
 	if (len(s.Spec.Task.Networks) != 0 || len(s.Spec.Networks) != 0) &&
@@ -313,7 +330,7 @@ func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
 
 	if (s.Spec.Endpoint != nil && len(s.Spec.Endpoint.Ports) != 0) ||
 		(s.Endpoint != nil && len(s.Endpoint.Ports) != 0) {
-		return na.portAllocator.isPortsAllocated(s)
+		return na.portAllocator.isPortsAllocatedOnInit(s, options.OnInit)
 	}
 
 	return true

--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -297,6 +297,10 @@ func (pa *portAllocator) portsAllocatedInHostPublishMode(s *api.Service) bool {
 }
 
 func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
+	return pa.isPortsAllocatedOnInit(s, false)
+}
+
+func (pa *portAllocator) isPortsAllocatedOnInit(s *api.Service, onInit bool) bool {
 	// If service has no user-defined endpoint and allocated endpoint,
 	// we assume it is allocated and return true.
 	if s.Endpoint == nil && s.Spec.Endpoint == nil {
@@ -343,6 +347,13 @@ func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
 			continue
 		}
 		if portConfig.PublishedPort == 0 && portStates.delState(portConfig) == nil {
+			return false
+		}
+
+		// If SwarmPort was not defined by user and the func
+		// is called during allocator initialization state then
+		// we are not allocated.
+		if portConfig.PublishedPort == 0 && onInit {
 			return false
 		}
 	}


### PR DESCRIPTION
This fix fixes the issue raised in:
https://github.com/docker/docker/issues/29247

where duplicated ports (`PublishedPort`) is being allocated with restarted swarm nodes.

The reason for the issue was that `isPortsAllocated` relies on portSpace which does not capture the ports in restored services when swarm is restarted.
This fix add a flag in `isPortsAllocated` so that in case the allocator is still in initialization stage, dynamically allocated ports (`PublishedPort`) will always be reallocated.

See docker PR: https://github.com/docker/docker/pull/29277

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>