### PR TITLE
Fix IPAM options not passed to RequestPool request

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -746,7 +746,7 @@ func (na *NetworkAllocator) allocatePools(n *api.Network) (map[string]string, er
 	}
 
 	for i, ic := range ipamConfigs {
-		poolID, poolIP, _, err := ipam.RequestPool(asName, ic.Subnet, ic.Range, nil, false)
+		poolID, poolIP, _, err := ipam.RequestPool(asName, ic.Subnet, ic.Range, dOptions, false)
 		if err != nil {
 			// Rollback by releasing all the resources allocated so far.
 			releasePools(ipam, ipamConfigs[:i], pools)


### PR DESCRIPTION
Attempt to fix docker/swarmkit issue https://github.com/docker/swarmkit/issues/1804 where IPAM options are not passed to RequestPool request in network allocator.

This is also related to the docker/swarmkit PR https://github.com/docker/swarmkit/pull/1789 which makes the IPAM options available.