### PR TITLE
[Carry #1517] Support v2 plugins; re-enable scheduler plugin filter

### DIFF
--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -64,9 +64,13 @@ func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
 					} else if typ.Capability == "networkdriver" {
 						plgnTyp = "Network"
 					}
+					plgnName := plgn.Name
+					if plgn.Tag != "" {
+						plgnName += ":" + plgn.Tag
+					}
 					plugins[api.PluginDescription{
 						Type: plgnTyp,
-						Name: plgn.Name,
+						Name: plgnName,
 					}] = struct{}{}
 				}
 			}

--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -145,6 +145,7 @@ func (f *PluginFilter) Check(n *NodeInfo) bool {
 	return true
 }
 
+// pluginExistsOnNode returns true if the (pluginName, pluginType) pair is present in nodePlugins
 func (f *PluginFilter) pluginExistsOnNode(pluginType string, pluginName string, nodePlugins []api.PluginDescription) bool {
 	for _, np := range nodePlugins {
 		if pluginType == np.Type && pluginName == np.Name {

--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -11,12 +11,7 @@ var (
 		// Always check for readiness first.
 		&ReadyFilter{},
 		&ResourceFilter{},
-
-		// TODO(stevvooe): Do not filter based on plugins since they are lazy
-		// loaded in the engine. We can add this back when we can schedule
-		// plugins in the future.
-		// &PluginFilter{},
-
+		&PluginFilter{},
 		&ConstraintFilter{},
 	}
 )

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -1387,7 +1387,6 @@ func watchAssignment(t *testing.T, watch chan events.Event) *api.Task {
 }
 
 func TestSchedulerPluginConstraint(t *testing.T) {
-	t.Skip("plugin filtering disabled since plugins on the engine are lazy loaded")
 	ctx := context.Background()
 
 	// Node1: vol plugin1


### PR DESCRIPTION
This carries #1517:

> Fix #1231. It was disabled in #1224, due to lazy loading by the engine.
> 
> Using the plugins API, it is possible to list installed plugins.
> 
> One issue is that we don't have a way of storing arbitrary plugins in the TaskSpec, from which to match them against the node on which `PluginFilter` is applied. For volumes and networks, this happens via a separate code path that allows for attaching to networks or mounting volumes. This is something we might want to build to support general plugins, and will require proto changes. This PR will work for volume and network v2 plugins.

On top of this, it adds:

- Fixes to the plugin filter to improve safety and consistency
- Don't fail `Describe` if `PluginList` is unimplemented
- Support for tags in plugin names

cc @nishanttotla @aluzzardi @vieux @anusha-ragunathan @tonistiigi