### PR TITLE
raft: Prevent the same manager from joining raft twice

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -999,6 +999,11 @@ func (n *Node) ProcessRaftMessage(ctx context.Context, msg *api.ProcessRaftMessa
 	defer n.stopMu.RUnlock()
 
 	if n.IsMember() {
+		if msg.Message.To != n.Config.ID {
+			n.processRaftMessageLogger(ctx, msg).Errorf("received message intended for raft_id %x", msg.Message.To)
+			return &api.ProcessRaftMessageResponse{}, nil
+		}
+
 		if err := n.raftNode.Step(ctx, *msg.Message); err != nil {
 			n.processRaftMessageLogger(ctx, msg).WithError(err).Debug("raft Step failed")
 		}


### PR DESCRIPTION
If a manager's raft state is lost or corrupted, it may try to join the
Raft cluster as a fresh member. This must be avoided, because it will
influence the quorum of the Raft cluster, which can prevent leader
elections from succeeding.

Add a check to `Join` that prevents a node with the same identity from
joining twice.

cc @cyli @LK4D4