### PR TITLE
Add cyli to maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,6 +10,7 @@
 			"aaronlehmann",
 			"aluzzardi",
 			"amitshukla",
+			"cyli",
 			"diogomonica",
 			"dongluochen",
 			"lk4d4",
@@ -65,6 +66,11 @@
 	Name = "Amit Shukla"
 	Email = "amit.shukla@docker.com"
 	GitHub = "amitshukla"
+
+	[people.cyli]
+	Name = "Ying Li"
+	Email = "ying.li@docker.com"
+	GitHub = "cyli"
 
 	[people.diogomonica]
 	Name = "Diogo Monica"


### PR DESCRIPTION
@cyli led the development of secrets (#1511, #1544, #1567) and at-rest encryption (#1598). These features not only involved a formidable engineering effort, but also patience with repeated design changes requested by maintainers, and hard work behind the scenes tracking down esoteric test failures. All work has gone a long way in making SwarmKit better designed, better abstracted, and better tested.

Welcome @cyli!