### PR TITLE
raft: Stop manager on write error

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -405,7 +405,7 @@ func (n *Node) Run(ctx context.Context) error {
 
 			// Save entries to storage
 			if err := n.saveToStorage(ctx, &raftConfig, rd.HardState, rd.Entries, rd.Snapshot); err != nil {
-				log.G(ctx).WithError(err).Error("failed to save entries to storage")
+				return errors.Wrap(err, "failed to save entries to storage")
 			}
 
 			if len(rd.Messages) != 0 {


### PR DESCRIPTION
If we failed to save some entries to durable storage, we must stop the manager. The existing code just logs an error and continues, but this means the state essentially becomes corrupted and the manager may panic later. It's better to fail immediately.

The code path that involves `Run` returning early is not especially robust, and we've noticed some issues on demotion related to this. Despite this, the alternative of letting `Run` continue in this situation is much worse. We will need to fix the code path where `Run` returns early anyway, because it is used in demotion.

cc @cyli @LK4D4