### PR TITLE
orchestrator should fix tasks before start

### DIFF
--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -504,7 +504,7 @@ func (g *Orchestrator) removeTasks(ctx context.Context, batch *store.Batch, task
 }
 
 func isTaskRunning(t *api.Task) bool {
-	return t != nil && t.DesiredState <= api.TaskStateRunning && t.Status.State <= api.TaskStateRunning
+	return t != nil && t.DesiredState <= api.TaskStateRunning
 }
 
 func isTaskCompleted(t *api.Task, restartPolicy api.RestartPolicy_RestartCondition) bool {

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/swarmkit/manager/constraint"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
+	"github.com/docker/swarmkit/manager/orchestrator/taskinit"
 	"github.com/docker/swarmkit/manager/orchestrator/update"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -27,6 +28,7 @@ type Orchestrator struct {
 	nodes map[string]*api.Node
 	// globalServices has all the global services in the cluster, indexed by ServiceID
 	globalServices map[string]globalService
+	restartTasks   map[string]struct{}
 
 	// stopChan signals to the state machine to stop running.
 	stopChan chan struct{}
@@ -51,11 +53,12 @@ func NewGlobalOrchestrator(store *store.MemoryStore) *Orchestrator {
 		doneChan:       make(chan struct{}),
 		updater:        updater,
 		restarts:       restartSupervisor,
+		restartTasks:   make(map[string]struct{}),
 	}
 }
 
 func (g *Orchestrator) initTasks(ctx context.Context, readTx store.ReadTx) error {
-	return orchestrator.InitTasks(ctx, g.store, readTx, orchestrator.IsGlobalService, g.restarts)
+	return taskinit.CheckTasks(ctx, g.store, readTx, g, g.restarts)
 }
 
 // Run contains the global orchestrator event loop
@@ -103,13 +106,6 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 		return err
 	}
 
-	g.store.View(func(readTx store.ReadTx) {
-		err = g.initTasks(ctx, readTx)
-	})
-	if err != nil {
-		return err
-	}
-
 	var reconcileServiceIDs []string
 	for _, s := range existingServices {
 		if orchestrator.IsGlobalService(s) {
@@ -117,6 +113,16 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 			reconcileServiceIDs = append(reconcileServiceIDs, s.ID)
 		}
 	}
+
+	// fix tasks in store before reconciliation loop
+	g.store.View(func(readTx store.ReadTx) {
+		err = g.initTasks(ctx, readTx)
+	})
+	if err != nil {
+		return err
+	}
+
+	g.tickTasks(ctx)
 	g.reconcileServices(ctx, reconcileServiceIDs)
 
 	for {
@@ -163,15 +169,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 				g.removeTasksFromNode(ctx, v.Node)
 				delete(g.nodes, v.Node.ID)
 			case state.EventUpdateTask:
-				if _, exists := g.globalServices[v.Task.ServiceID]; !exists {
-					continue
-				}
-				// global orchestrator needs to inspect when a task has terminated
-				// it should ignore tasks whose DesiredState is past running, which
-				// means the task has been processed
-				if isTaskTerminated(v.Task) {
-					g.restartTask(ctx, v.Task.ID, v.Task.ServiceID)
-				}
+				g.handleTaskChange(ctx, v.Task)
 			case state.EventDeleteTask:
 				// CLI allows deleting task
 				if _, exists := g.globalServices[v.Task.ServiceID]; !exists {
@@ -182,6 +180,52 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 		case <-g.stopChan:
 			return nil
 		}
+		g.tickTasks(ctx)
+	}
+}
+
+// FixTask validates a task with the current cluster settings, and takes
+// action to make it conformant to node state and service constraint
+// it's called at orchestrator initialization
+func (g *Orchestrator) FixTask(ctx context.Context, batch *store.Batch, t *api.Task) {
+	if _, exists := g.globalServices[t.ServiceID]; !exists {
+		return
+	}
+	// if a task's DesiredState has past running, the task has been processed
+	if t.DesiredState > api.TaskStateRunning {
+		return
+	}
+
+	var node *api.Node
+	if t.NodeID != "" {
+		node = g.nodes[t.NodeID]
+	}
+	// if the node no longer valid, remove the task
+	if t.NodeID == "" || orchestrator.InvalidNode(node) {
+		g.removeTask(ctx, batch, t)
+		return
+	}
+
+	// restart a task if it fails
+	if t.Status.State > api.TaskStateRunning {
+		g.restartTasks[t.ID] = struct{}{}
+	}
+}
+
+// handleTaskChange defines what orchestrator does when a task is updated by agent
+func (g *Orchestrator) handleTaskChange(ctx context.Context, t *api.Task) {
+	if _, exists := g.globalServices[t.ServiceID]; !exists {
+		return
+	}
+	// if a task's DesiredState has past running, which
+	// means the task has been processed
+	if t.DesiredState > api.TaskStateRunning {
+		return
+	}
+
+	// if a task has passed running, restart it
+	if t.Status.State > api.TaskStateRunning {
+		g.restartTasks[t.ID] = struct{}{}
 	}
 }
 
@@ -238,7 +282,7 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 			nodeTasks[serviceID] = make(map[string][]*api.Task)
 
 			for _, t := range tasks {
-				if isTaskRunning(t) {
+				if t.DesiredState <= api.TaskStateRunning {
 					// Collect all running instances of this service
 					nodeTasks[serviceID][t.NodeID] = append(nodeTasks[serviceID][t.NodeID], t)
 				} else {
@@ -380,7 +424,7 @@ func (g *Orchestrator) reconcileServicesOneNode(ctx context.Context, serviceIDs 
 			if t.ServiceID != serviceID {
 				continue
 			}
-			if isTaskRunning(t) {
+			if t.DesiredState <= api.TaskStateRunning {
 				tasks[serviceID] = append(tasks[serviceID], t)
 			} else {
 				if isTaskCompleted(t, orchestrator.RestartCondition(t)) {
@@ -458,24 +502,33 @@ func (g *Orchestrator) reconcileServicesOneNode(ctx context.Context, serviceIDs 
 	}
 }
 
-// restartTask calls the restart supervisor's Restart function, which
-// sets a task's desired state to shutdown and restarts it if the restart
-// policy calls for it to be restarted.
-func (g *Orchestrator) restartTask(ctx context.Context, taskID string, serviceID string) {
-	err := g.store.Update(func(tx store.Tx) error {
-		t := store.GetTask(tx, taskID)
-		if t == nil || t.DesiredState > api.TaskStateRunning {
-			return nil
+func (g *Orchestrator) tickTasks(ctx context.Context) {
+	if len(g.restartTasks) == 0 {
+		return
+	}
+	_, err := g.store.Batch(func(batch *store.Batch) error {
+		for taskID := range g.restartTasks {
+			err := batch.Update(func(tx store.Tx) error {
+				t := store.GetTask(tx, taskID)
+				if t == nil || t.DesiredState > api.TaskStateRunning {
+					return nil
+				}
+				service := store.GetService(tx, t.ServiceID)
+				if service == nil {
+					return nil
+				}
+				return g.restarts.Restart(ctx, tx, g.cluster, service, *t)
+			})
+			if err != nil {
+				log.G(ctx).WithError(err).Errorf("orchestrator restartTask transaction failed")
+			}
 		}
-		service := store.GetService(tx, serviceID)
-		if service == nil {
-			return nil
-		}
-		return g.restarts.Restart(ctx, tx, g.cluster, service, *t)
+		return nil
 	})
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("global orchestrator: restartTask transaction failed")
 	}
+	g.restartTasks = make(map[string]struct{})
 }
 
 func (g *Orchestrator) removeTask(ctx context.Context, batch *store.Batch, t *api.Task) {
@@ -514,18 +567,15 @@ func (g *Orchestrator) removeTasks(ctx context.Context, batch *store.Batch, task
 	}
 }
 
-func isTaskRunning(t *api.Task) bool {
-	return t != nil && t.DesiredState <= api.TaskStateRunning
+// IsRelatedService returns true if the service should be governed by this orchestrator
+func (g *Orchestrator) IsRelatedService(service *api.Service) bool {
+	return orchestrator.IsGlobalService(service)
 }
 
 func isTaskCompleted(t *api.Task, restartPolicy api.RestartPolicy_RestartCondition) bool {
-	if t == nil || isTaskRunning(t) {
+	if t == nil || t.DesiredState <= api.TaskStateRunning {
 		return false
 	}
 	return restartPolicy == api.RestartOnNone ||
 		(restartPolicy == api.RestartOnFailure && t.Status.State == api.TaskStateCompleted)
-}
-
-func isTaskTerminated(t *api.Task) bool {
-	return t != nil && t.Status.State > api.TaskStateRunning
 }

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -14,20 +14,20 @@ import (
 
 var (
 	node1 = &api.Node{
-		ID: "id1",
+		ID: "nodeid1",
 		Description: &api.NodeDescription{
 			Hostname: "name1",
 		},
 	}
 	node2 = &api.Node{
-		ID: "id2",
+		ID: "nodeid2",
 		Description: &api.NodeDescription{
 			Hostname: "name2",
 		},
 	}
 
 	service1 = &api.Service{
-		ID: "id1",
+		ID: "serviceid1",
 		Spec: api.ServiceSpec{
 			Annotations: api.Annotations{
 				Name: "name1",
@@ -44,7 +44,7 @@ var (
 	}
 
 	service2 = &api.Service{
-		ID: "id2",
+		ID: "serviceid2",
 		Spec: api.ServiceSpec{
 			Annotations: api.Annotations{
 				Name: "name2",
@@ -93,7 +93,7 @@ func TestSetup(t *testing.T) {
 
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask1.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask1.NodeID, "id1")
+	assert.Equal(t, observedTask1.NodeID, "nodeid1")
 }
 
 func TestAddNode(t *testing.T) {
@@ -110,7 +110,7 @@ func TestAddNode(t *testing.T) {
 	observedTask2 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask2.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask2.NodeID, "id2")
+	assert.Equal(t, observedTask2.NodeID, "nodeid2")
 }
 
 func TestDeleteNode(t *testing.T) {
@@ -127,7 +127,7 @@ func TestDeleteNode(t *testing.T) {
 	// task should be set to dead
 	observedTask := testutils.WatchShutdownTask(t, watch)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask.NodeID, "id1")
+	assert.Equal(t, observedTask.NodeID, "nodeid1")
 }
 
 func TestNodeAvailability(t *testing.T) {
@@ -149,7 +149,7 @@ func TestNodeAvailability(t *testing.T) {
 	// task should be set to dead
 	observedTask1 := testutils.WatchShutdownTask(t, watch)
 	assert.Equal(t, observedTask1.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask1.NodeID, "id1")
+	assert.Equal(t, observedTask1.NodeID, "nodeid1")
 
 	// set node1 to active
 	updateNodeAvailability(t, store, node1, api.NodeAvailabilityActive)
@@ -157,7 +157,7 @@ func TestNodeAvailability(t *testing.T) {
 	observedTask2 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask2.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask2.NodeID, "id1")
+	assert.Equal(t, observedTask2.NodeID, "nodeid1")
 }
 
 func TestAddService(t *testing.T) {
@@ -174,7 +174,7 @@ func TestAddService(t *testing.T) {
 	observedTask := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name2")
-	assert.True(t, observedTask.NodeID == "id1")
+	assert.True(t, observedTask.NodeID == "nodeid1")
 }
 
 func TestDeleteService(t *testing.T) {
@@ -191,7 +191,7 @@ func TestDeleteService(t *testing.T) {
 	// task should be deleted
 	observedTask := testutils.WatchTaskDelete(t, watch)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask.NodeID, "id1")
+	assert.Equal(t, observedTask.NodeID, "nodeid1")
 }
 
 func TestRemoveTask(t *testing.T) {
@@ -206,7 +206,7 @@ func TestRemoveTask(t *testing.T) {
 
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask1.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask1.NodeID, "id1")
+	assert.Equal(t, observedTask1.NodeID, "nodeid1")
 
 	// delete the task
 	deleteTask(t, store, observedTask1)
@@ -215,7 +215,7 @@ func TestRemoveTask(t *testing.T) {
 	observedTask2 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask2.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask2.ServiceAnnotations.Name, "name1")
-	assert.Equal(t, observedTask2.NodeID, "id1")
+	assert.Equal(t, observedTask2.NodeID, "nodeid1")
 }
 
 func addService(t *testing.T, s *store.MemoryStore, service *api.Service) {
@@ -266,4 +266,198 @@ func deleteTask(t *testing.T, s *store.MemoryStore, task *api.Task) {
 		assert.NoError(t, store.DeleteTask(tx, task.ID))
 		return nil
 	})
+}
+
+func TestInitializationRejectedTasks(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	// create nodes, services and tasks in store directly
+	// where orchestrator runs, it should fix tasks to declarative state
+	addNode(t, s, node1)
+	addService(t, s, service1)
+	tasks := []*api.Task{
+		// nodeid1 has a rejected task for serviceid1
+		{
+			ID:           "task1",
+			Slot:         0,
+			DesiredState: api.TaskStateReady,
+			Status: api.TaskStatus{
+				State: api.TaskStateRejected,
+			},
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "task1",
+			},
+			ServiceID: "serviceid1",
+			NodeID:    "nodeid1",
+		},
+	}
+	for _, task := range tasks {
+		addTask(t, s, task)
+	}
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewGlobalOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask1.ID, "task1")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateRejected)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateReady)
+
+	observedTask2 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask2.ID, "task1")
+	assert.Equal(t, observedTask2.Status.State, api.TaskStateRejected)
+	assert.Equal(t, observedTask2.DesiredState, api.TaskStateShutdown)
+
+	observedTask3 := testutils.WatchTaskCreate(t, watch)
+	assert.Equal(t, observedTask3.NodeID, "nodeid1")
+	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
+}
+
+func TestInitializationFailedTasks(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	// create nodes, services and tasks in store directly
+	// where orchestrator runs, it should fix tasks to declarative state
+	addNode(t, s, node1)
+	addService(t, s, service1)
+	tasks := []*api.Task{
+		// nodeid1 has a failed task for serviceid1
+		{
+			ID:           "task1",
+			Slot:         0,
+			DesiredState: api.TaskStateRunning,
+			Status: api.TaskStatus{
+				State: api.TaskStateFailed,
+			},
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "task1",
+			},
+			ServiceID: "serviceid1",
+			NodeID:    "nodeid1",
+		},
+	}
+	for _, task := range tasks {
+		addTask(t, s, task)
+	}
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewGlobalOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask1.ID, "task1")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateFailed)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateRunning)
+
+	observedTask2 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask2.ID, "task1")
+	assert.Equal(t, observedTask2.Status.State, api.TaskStateFailed)
+	assert.Equal(t, observedTask2.DesiredState, api.TaskStateShutdown)
+
+	observedTask3 := testutils.WatchTaskCreate(t, watch)
+	assert.Equal(t, observedTask3.NodeID, "nodeid1")
+	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
+}
+
+func TestInitializationExtraTask(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	// create nodes, services and tasks in store directly
+	// where orchestrator runs, it should fix tasks to declarative state
+	addNode(t, s, node1)
+	addService(t, s, service1)
+	tasks := []*api.Task{
+		// nodeid1 has 2 tasks for serviceid1
+		{
+			ID:           "task1",
+			Slot:         0,
+			DesiredState: api.TaskStateRunning,
+			Status: api.TaskStatus{
+				State: api.TaskStateRunning,
+			},
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "task1",
+			},
+			ServiceID: "serviceid1",
+			NodeID:    "nodeid1",
+		},
+		{
+			ID:           "task2",
+			Slot:         0,
+			DesiredState: api.TaskStateRunning,
+			Status: api.TaskStatus{
+				State: api.TaskStateRunning,
+			},
+			Spec: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			ServiceAnnotations: api.Annotations{
+				Name: "task2",
+			},
+			ServiceID: "serviceid1",
+			NodeID:    "nodeid1",
+		},
+	}
+	for _, task := range tasks {
+		addTask(t, s, task)
+	}
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewGlobalOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	assert.True(t, observedTask1.ID == "task1" || observedTask1.ID == "task2")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateRunning)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateShutdown)
 }

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -2,11 +2,14 @@ package replicated
 
 import (
 	"testing"
+	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/testutils"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/protobuf/ptypes"
+	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -423,4 +426,325 @@ func TestReplicatedScaleDown(t *testing.T) {
 			assert.Equal(t, "node2", tasks[1].NodeID)
 		}
 	})
+}
+
+func TestInitializationRejectedTasks(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	service1 := &api.Service{
+		ID: "serviceid1",
+		Spec: api.ServiceSpec{
+			Annotations: api.Annotations{
+				Name: "name1",
+			},
+			Task: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			Mode: &api.ServiceSpec_Replicated{
+				Replicated: &api.ReplicatedService{
+					Replicas: 1,
+				},
+			},
+		},
+	}
+
+	err := s.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateService(tx, service1))
+
+		nodes := []*api.Node{
+			{
+				ID: "node1",
+				Spec: api.NodeSpec{
+					Annotations: api.Annotations{
+						Name: "name1",
+					},
+					Availability: api.NodeAvailabilityActive,
+				},
+				Status: api.NodeStatus{
+					State: api.NodeStatus_READY,
+				},
+			},
+		}
+		for _, node := range nodes {
+			assert.NoError(t, store.CreateNode(tx, node))
+		}
+
+		// 1 rejected task is in store before orchestrator starts
+		tasks := []*api.Task{
+			{
+				ID:           "task1",
+				Slot:         1,
+				DesiredState: api.TaskStateReady,
+				Status: api.TaskStatus{
+					State: api.TaskStateRejected,
+				},
+				Spec: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+				},
+				ServiceAnnotations: api.Annotations{
+					Name: "task1",
+				},
+				ServiceID: "serviceid1",
+				NodeID:    "node1",
+			},
+		}
+		for _, task := range tasks {
+			assert.NoError(t, store.CreateTask(tx, task))
+		}
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewReplicatedOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	// initTask triggers an update event
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask1.ID, "task1")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateRejected)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateReady)
+
+	// the tasket moves to SHUTDOWN
+	observedTask2 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask2.ID, "task1")
+	assert.Equal(t, observedTask2.Status.State, api.TaskStateRejected)
+	assert.Equal(t, observedTask2.DesiredState, api.TaskStateShutdown)
+
+	// a new task is created
+	observedTask3 := testutils.WatchTaskCreate(t, watch)
+	assert.Equal(t, observedTask3.ServiceID, "serviceid1")
+	// it has not been scheduled
+	assert.Equal(t, observedTask3.NodeID, "")
+	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
+}
+
+func TestInitializationFailedTasks(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	service1 := &api.Service{
+		ID: "serviceid1",
+		Spec: api.ServiceSpec{
+			Annotations: api.Annotations{
+				Name: "name1",
+			},
+			Task: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+			},
+			Mode: &api.ServiceSpec_Replicated{
+				Replicated: &api.ReplicatedService{
+					Replicas: 1,
+				},
+			},
+		},
+	}
+
+	err := s.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateService(tx, service1))
+
+		nodes := []*api.Node{
+			{
+				ID: "node1",
+				Spec: api.NodeSpec{
+					Annotations: api.Annotations{
+						Name: "name1",
+					},
+					Availability: api.NodeAvailabilityActive,
+				},
+				Status: api.NodeStatus{
+					State: api.NodeStatus_READY,
+				},
+			},
+		}
+		for _, node := range nodes {
+			assert.NoError(t, store.CreateNode(tx, node))
+		}
+
+		// 1 failed task is in store before orchestrator starts
+		tasks := []*api.Task{
+			{
+				ID:           "task1",
+				Slot:         1,
+				DesiredState: api.TaskStateRunning,
+				Status: api.TaskStatus{
+					State: api.TaskStateFailed,
+				},
+				Spec: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+				},
+				ServiceAnnotations: api.Annotations{
+					Name: "task1",
+				},
+				ServiceID: "serviceid1",
+				NodeID:    "node1",
+			},
+		}
+		for _, task := range tasks {
+			assert.NoError(t, store.CreateTask(tx, task))
+		}
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewReplicatedOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	// initTask triggers an update
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask1.ID, "task1")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateFailed)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateRunning)
+
+	// orchestrator moves task to Shutdown
+	observedTask2 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask2.ID, "task1")
+	assert.Equal(t, observedTask2.Status.State, api.TaskStateFailed)
+	assert.Equal(t, observedTask2.DesiredState, api.TaskStateShutdown)
+
+	// a new task is created
+	observedTask3 := testutils.WatchTaskCreate(t, watch)
+	assert.Equal(t, observedTask3.ServiceID, "serviceid1")
+	assert.Equal(t, observedTask3.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask3.DesiredState, api.TaskStateReady)
+}
+
+func TestInitializationDelayStart(t *testing.T) {
+	ctx := context.Background()
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	service1 := &api.Service{
+		ID: "serviceid1",
+		Spec: api.ServiceSpec{
+			Annotations: api.Annotations{
+				Name: "name1",
+			},
+			Task: api.TaskSpec{
+				Runtime: &api.TaskSpec_Container{
+					Container: &api.ContainerSpec{},
+				},
+				Restart: &api.RestartPolicy{
+					Condition: api.RestartOnAny,
+					Delay:     gogotypes.DurationProto(100 * time.Millisecond),
+				},
+			},
+			Mode: &api.ServiceSpec_Replicated{
+				Replicated: &api.ReplicatedService{
+					Replicas: 1,
+				},
+			},
+		},
+	}
+
+	before := time.Now()
+	err := s.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateService(tx, service1))
+
+		nodes := []*api.Node{
+			{
+				ID: "node1",
+				Spec: api.NodeSpec{
+					Annotations: api.Annotations{
+						Name: "name1",
+					},
+					Availability: api.NodeAvailabilityActive,
+				},
+				Status: api.NodeStatus{
+					State: api.NodeStatus_READY,
+				},
+			},
+		}
+		for _, node := range nodes {
+			assert.NoError(t, store.CreateNode(tx, node))
+		}
+
+		// 1 failed task is in store before orchestrator starts
+		tasks := []*api.Task{
+			{
+				ID:           "task1",
+				Slot:         1,
+				DesiredState: api.TaskStateReady,
+				Status: api.TaskStatus{
+					State:     api.TaskStateReady,
+					Timestamp: ptypes.MustTimestampProto(before),
+				},
+				Spec: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+					Restart: &api.RestartPolicy{
+						Condition: api.RestartOnAny,
+						Delay:     gogotypes.DurationProto(100 * time.Millisecond),
+					},
+				},
+				ServiceAnnotations: api.Annotations{
+					Name: "task1",
+				},
+				ServiceID: "serviceid1",
+				NodeID:    "node1",
+			},
+		}
+		for _, task := range tasks {
+			assert.NoError(t, store.CreateTask(tx, task))
+		}
+
+		return nil
+	})
+	assert.NoError(t, err)
+
+	// watch orchestration events
+	watch, cancel := state.Watch(s.WatchQueue(), state.EventCreateTask{}, state.EventUpdateTask{}, state.EventDeleteTask{})
+	defer cancel()
+
+	orchestrator := NewReplicatedOrchestrator(s)
+	defer orchestrator.Stop()
+
+	go func() {
+		assert.NoError(t, orchestrator.Run(ctx))
+	}()
+
+	// initTask triggers an update
+	observedTask1 := testutils.WatchTaskUpdate(t, watch)
+	after := time.Now()
+	assert.Equal(t, observedTask1.ID, "task1")
+	assert.Equal(t, observedTask1.Status.State, api.TaskStateReady)
+	assert.Equal(t, observedTask1.DesiredState, api.TaskStateRunning)
+
+	// At least 100 ms should have elapsed
+	if after.Sub(before) < 100*time.Millisecond {
+		t.Fatalf("restart delay should have elapsed. Got: %v", after.Sub(before))
+	}
 }

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -223,3 +223,8 @@ func (r *Orchestrator) deleteTask(ctx context.Context, batch *store.Batch, t *ap
 		log.G(ctx).WithError(err).Errorf("deleting task %s failed", t.ID)
 	}
 }
+
+// IsRelatedService returns true if the service should be governed by this orchestrator
+func (r *Orchestrator) IsRelatedService(service *api.Service) bool {
+	return orchestrator.IsReplicatedService(service)
+}

--- a/manager/orchestrator/replicated/tasks.go
+++ b/manager/orchestrator/replicated/tasks.go
@@ -1,15 +1,12 @@
 package replicated
 
 import (
-	"time"
-
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	gogotypes "github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
 )
 
@@ -18,94 +15,8 @@ import (
 // service-level reconciliation, which observes changes to services and creates
 // and/or kills tasks to match the service definition.
 
-func invalidNode(n *api.Node) bool {
-	return n == nil ||
-		n.Status.State == api.NodeStatus_DOWN ||
-		n.Spec.Availability == api.NodeAvailabilityDrain
-}
-
 func (r *Orchestrator) initTasks(ctx context.Context, readTx store.ReadTx) error {
-	tasks, err := store.FindTasks(readTx, store.All)
-	if err != nil {
-		return err
-	}
-	for _, t := range tasks {
-		if t.NodeID != "" {
-			n := store.GetNode(readTx, t.NodeID)
-			if invalidNode(n) && t.Status.State <= api.TaskStateRunning && t.DesiredState <= api.TaskStateRunning {
-				r.restartTasks[t.ID] = struct{}{}
-			}
-		}
-	}
-
-	_, err = r.store.Batch(func(batch *store.Batch) error {
-		for _, t := range tasks {
-			if t.ServiceID == "" {
-				continue
-			}
-
-			// TODO(aluzzardi): We should NOT retrieve the service here.
-			service := store.GetService(readTx, t.ServiceID)
-			if service == nil {
-				// Service was deleted
-				err := batch.Update(func(tx store.Tx) error {
-					return store.DeleteTask(tx, t.ID)
-				})
-				if err != nil {
-					log.G(ctx).WithError(err).Error("failed to set task desired state to dead")
-				}
-				continue
-			}
-			// TODO(aluzzardi): This is shady. We should have a more generic condition.
-			if t.DesiredState != api.TaskStateReady || !orchestrator.IsReplicatedService(service) {
-				continue
-			}
-			restartDelay := orchestrator.DefaultRestartDelay
-			if t.Spec.Restart != nil && t.Spec.Restart.Delay != nil {
-				var err error
-				restartDelay, err = gogotypes.DurationFromProto(t.Spec.Restart.Delay)
-				if err != nil {
-					log.G(ctx).WithError(err).Error("invalid restart delay")
-					restartDelay = orchestrator.DefaultRestartDelay
-				}
-			}
-			if restartDelay != 0 {
-				timestamp, err := gogotypes.TimestampFromProto(t.Status.Timestamp)
-				if err == nil {
-					restartTime := timestamp.Add(restartDelay)
-					calculatedRestartDelay := restartTime.Sub(time.Now())
-					if calculatedRestartDelay < restartDelay {
-						restartDelay = calculatedRestartDelay
-					}
-					if restartDelay > 0 {
-						_ = batch.Update(func(tx store.Tx) error {
-							t := store.GetTask(tx, t.ID)
-							// TODO(aluzzardi): This is shady as well. We should have a more generic condition.
-							if t == nil || t.DesiredState != api.TaskStateReady {
-								return nil
-							}
-							r.restarts.DelayStart(ctx, tx, nil, t.ID, restartDelay, true)
-							return nil
-						})
-						continue
-					}
-				} else {
-					log.G(ctx).WithError(err).Error("invalid status timestamp")
-				}
-			}
-
-			// Start now
-			err := batch.Update(func(tx store.Tx) error {
-				return r.restarts.StartNow(tx, t.ID)
-			})
-			if err != nil {
-				log.G(ctx).WithError(err).WithField("task.id", t.ID).Error("moving task out of delayed state failed")
-			}
-		}
-		return nil
-	})
-
-	return err
+	return orchestrator.InitTasks(ctx, r.store, readTx, orchestrator.IsReplicatedService, r.restarts)
 }
 
 func (r *Orchestrator) handleTaskEvent(ctx context.Context, event events.Event) {
@@ -196,7 +107,7 @@ func (r *Orchestrator) restartTasksByNodeID(ctx context.Context, nodeID string) 
 }
 
 func (r *Orchestrator) handleNodeChange(ctx context.Context, n *api.Node) {
-	if !invalidNode(n) {
+	if !orchestrator.InvalidNode(n) {
 		return
 	}
 
@@ -228,7 +139,7 @@ func (r *Orchestrator) handleTaskChange(ctx context.Context, t *api.Task) {
 	}
 
 	if t.Status.State > api.TaskStateRunning ||
-		(t.NodeID != "" && invalidNode(n)) {
+		(t.NodeID != "" && orchestrator.InvalidNode(n)) {
 		r.restartTasks[t.ID] = struct{}{}
 	}
 }

--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -6,18 +6,8 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/log"
-	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
-	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 )
-
-// Restarter defines an interface to start or delay start tasks
-type restarter interface {
-	StartNow(tx store.Tx, taskID string) error
-	DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Task, newTaskID string, delay time.Duration, waitStop bool) <-chan struct{}
-}
 
 // DefaultRestartDelay is the restart delay value to use when none is
 // specified.
@@ -76,118 +66,9 @@ func IsTaskDirty(s *api.Service, t *api.Task) bool {
 		(t.Endpoint != nil && !reflect.DeepEqual(s.Spec.Endpoint, t.Endpoint.Spec))
 }
 
-// InvalidNode is true if the node is nil, down, or Drain
+// InvalidNode is true if the node is nil, down, or drained
 func InvalidNode(n *api.Node) bool {
 	return n == nil ||
 		n.Status.State == api.NodeStatus_DOWN ||
 		n.Spec.Availability == api.NodeAvailabilityDrain
-}
-
-type isRelatedService func(*api.Service) bool
-
-// InitTasks fix tasks in store before orchestrator run. Previous manager might haven't finished processing their updates.
-func InitTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, relatedService isRelatedService, restart restarter) error {
-	_, err := s.Batch(func(batch *store.Batch) error {
-		tasks, err := store.FindTasks(readTx, store.All)
-		if err != nil {
-			return err
-		}
-		for _, t := range tasks {
-			if t.ServiceID == "" {
-				continue
-			}
-
-			// TODO(aluzzardi): We should NOT retrieve the service here.
-			service := store.GetService(readTx, t.ServiceID)
-			if service == nil {
-				// Service was deleted
-				err := batch.Update(func(tx store.Tx) error {
-					return store.DeleteTask(tx, t.ID)
-				})
-				if err != nil {
-					log.G(ctx).WithError(err).Error("failed to set task desired state to dead")
-				}
-				continue
-			}
-			// only handle tasks belong to related service type
-			if !relatedService(service) {
-				continue
-			}
-			// if the task shouldn't be run on the specified node, set the task to shutdown
-			// so orchestrator can work on it
-			if t.NodeID != "" {
-				n := store.GetNode(readTx, t.NodeID)
-				if InvalidNode(n) && t.DesiredState <= api.TaskStateRunning {
-					t.DesiredState = api.TaskStateShutdown
-					err = batch.Update(func(tx store.Tx) error {
-						return store.UpdateTask(tx, t)
-					})
-					if err != nil {
-						log.G(ctx).WithError(err).Error("failed to update task")
-					}
-					continue
-				}
-			}
-			// if a task failed but desired state is alive, trigger update so orchestrator
-			// can look at it
-			if t.DesiredState <= api.TaskStateRunning && t.Status.State > api.TaskStateRunning {
-				err := batch.Update(func(tx store.Tx) error {
-					return store.UpdateTask(tx, t)
-				})
-				if err != nil {
-					log.G(ctx).WithError(err).Error("failed to update task")
-				}
-				continue
-			}
-			// if a task's desired state is ready, orchestrator may need to start it
-			if t.DesiredState != api.TaskStateReady {
-				continue
-			}
-			// respect restart delay
-			restartDelay := DefaultRestartDelay
-			if t.Spec.Restart != nil && t.Spec.Restart.Delay != nil {
-				var err error
-				restartDelay, err = gogotypes.DurationFromProto(t.Spec.Restart.Delay)
-				if err != nil {
-					log.G(ctx).WithError(err).Error("invalid restart delay")
-					restartDelay = DefaultRestartDelay
-				}
-			}
-			if restartDelay != 0 {
-				timestamp, err := gogotypes.TimestampFromProto(t.Status.Timestamp)
-				if err == nil {
-					restartTime := timestamp.Add(restartDelay)
-					calculatedRestartDelay := restartTime.Sub(time.Now())
-					if calculatedRestartDelay < restartDelay {
-						restartDelay = calculatedRestartDelay
-					}
-					if restartDelay > 0 {
-						_ = batch.Update(func(tx store.Tx) error {
-							t := store.GetTask(tx, t.ID)
-							// TODO(aluzzardi): This is shady as well. We should have a more generic condition.
-							if t == nil || t.DesiredState != api.TaskStateReady {
-								return nil
-							}
-							restart.DelayStart(ctx, tx, nil, t.ID, restartDelay, true)
-							return nil
-						})
-						continue
-					}
-				} else {
-					log.G(ctx).WithError(err).Error("invalid status timestamp")
-				}
-			}
-
-			// Start now
-			err := batch.Update(func(tx store.Tx) error {
-				return restart.StartNow(tx, t.ID)
-			})
-			if err != nil {
-				log.G(ctx).WithError(err).WithField("task.id", t.ID).Error("moving task out of delayed state failed")
-			}
-		}
-		return nil
-	})
-
-	return err
 }

--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -6,8 +6,18 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	gogotypes "github.com/gogo/protobuf/types"
+	"golang.org/x/net/context"
 )
+
+// Restarter defines an interface to start or delay start tasks
+type restarter interface {
+	StartNow(tx store.Tx, taskID string) error
+	DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Task, newTaskID string, delay time.Duration, waitStop bool) <-chan struct{}
+}
 
 // DefaultRestartDelay is the restart delay value to use when none is
 // specified.
@@ -64,4 +74,120 @@ func RestartCondition(task *api.Task) api.RestartPolicy_RestartCondition {
 func IsTaskDirty(s *api.Service, t *api.Task) bool {
 	return !reflect.DeepEqual(s.Spec.Task, t.Spec) ||
 		(t.Endpoint != nil && !reflect.DeepEqual(s.Spec.Endpoint, t.Endpoint.Spec))
+}
+
+// InvalidNode is true if the node is nil, down, or Drain
+func InvalidNode(n *api.Node) bool {
+	return n == nil ||
+		n.Status.State == api.NodeStatus_DOWN ||
+		n.Spec.Availability == api.NodeAvailabilityDrain
+}
+
+type isRelatedService func(*api.Service) bool
+
+// InitTasks fix tasks in store before orchestrator run. Previous manager might haven't finished processing their updates.
+func InitTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, relatedService isRelatedService, restart restarter) error {
+	_, err := s.Batch(func(batch *store.Batch) error {
+		tasks, err := store.FindTasks(readTx, store.All)
+		if err != nil {
+			return err
+		}
+		for _, t := range tasks {
+			if t.ServiceID == "" {
+				continue
+			}
+
+			// TODO(aluzzardi): We should NOT retrieve the service here.
+			service := store.GetService(readTx, t.ServiceID)
+			if service == nil {
+				// Service was deleted
+				err := batch.Update(func(tx store.Tx) error {
+					return store.DeleteTask(tx, t.ID)
+				})
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to set task desired state to dead")
+				}
+				continue
+			}
+			// only handle tasks belong to related service type
+			if !relatedService(service) {
+				continue
+			}
+			// if the task shouldn't be run on the specified node, set the task to shutdown
+			// so orchestrator can work on it
+			if t.NodeID != "" {
+				n := store.GetNode(readTx, t.NodeID)
+				if InvalidNode(n) && t.DesiredState <= api.TaskStateRunning {
+					t.DesiredState = api.TaskStateShutdown
+					err = batch.Update(func(tx store.Tx) error {
+						return store.UpdateTask(tx, t)
+					})
+					if err != nil {
+						log.G(ctx).WithError(err).Error("failed to update task")
+					}
+					continue
+				}
+			}
+			// if a task failed but desired state is alive, trigger update so orchestrator
+			// can look at it
+			if t.DesiredState <= api.TaskStateRunning && t.Status.State > api.TaskStateRunning {
+				err := batch.Update(func(tx store.Tx) error {
+					return store.UpdateTask(tx, t)
+				})
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to update task")
+				}
+				continue
+			}
+			// if a task's desired state is ready, orchestrator may need to start it
+			if t.DesiredState != api.TaskStateReady {
+				continue
+			}
+			// respect restart delay
+			restartDelay := DefaultRestartDelay
+			if t.Spec.Restart != nil && t.Spec.Restart.Delay != nil {
+				var err error
+				restartDelay, err = gogotypes.DurationFromProto(t.Spec.Restart.Delay)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("invalid restart delay")
+					restartDelay = DefaultRestartDelay
+				}
+			}
+			if restartDelay != 0 {
+				timestamp, err := gogotypes.TimestampFromProto(t.Status.Timestamp)
+				if err == nil {
+					restartTime := timestamp.Add(restartDelay)
+					calculatedRestartDelay := restartTime.Sub(time.Now())
+					if calculatedRestartDelay < restartDelay {
+						restartDelay = calculatedRestartDelay
+					}
+					if restartDelay > 0 {
+						_ = batch.Update(func(tx store.Tx) error {
+							t := store.GetTask(tx, t.ID)
+							// TODO(aluzzardi): This is shady as well. We should have a more generic condition.
+							if t == nil || t.DesiredState != api.TaskStateReady {
+								return nil
+							}
+							restart.DelayStart(ctx, tx, nil, t.ID, restartDelay, true)
+							return nil
+						})
+						continue
+					}
+				} else {
+					log.G(ctx).WithError(err).Error("invalid status timestamp")
+				}
+			}
+
+			// Start now
+			err := batch.Update(func(tx store.Tx) error {
+				return restart.StartNow(tx, t.ID)
+			})
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("task.id", t.ID).Error("moving task out of delayed state failed")
+			}
+		}
+		return nil
+	})
+
+	return err
 }

--- a/manager/orchestrator/taskinit/init.go
+++ b/manager/orchestrator/taskinit/init.go
@@ -1,0 +1,103 @@
+package taskinit
+
+import (
+	"time"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/orchestrator"
+	"github.com/docker/swarmkit/manager/orchestrator/restart"
+	"github.com/docker/swarmkit/manager/state/store"
+	gogotypes "github.com/gogo/protobuf/types"
+	"golang.org/x/net/context"
+)
+
+// InitHandler defines orchestrator's action to fix tasks at start.
+type InitHandler interface {
+	IsRelatedService(service *api.Service) bool
+	FixTask(ctx context.Context, batch *store.Batch, t *api.Task)
+}
+
+// CheckTasks fixes tasks in the store before orchestrator runs. The previous leader might
+// not have finished processing their updates and left them in an inconsistent state.
+func CheckTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, initHandler InitHandler, startSupervisor *restart.Supervisor) error {
+	_, err := s.Batch(func(batch *store.Batch) error {
+		tasks, err := store.FindTasks(readTx, store.All)
+		if err != nil {
+			return err
+		}
+		for _, t := range tasks {
+			if t.ServiceID == "" {
+				continue
+			}
+
+			// TODO(aluzzardi): We should NOT retrieve the service here.
+			service := store.GetService(readTx, t.ServiceID)
+			if service == nil {
+				// Service was deleted
+				err := batch.Update(func(tx store.Tx) error {
+					return store.DeleteTask(tx, t.ID)
+				})
+				if err != nil {
+					log.G(ctx).WithError(err).Error("failed to delete task")
+				}
+				continue
+			}
+			if !initHandler.IsRelatedService(service) {
+				continue
+			}
+
+			// handle task updates from agent which should have been triggered by task update events
+			initHandler.FixTask(ctx, batch, t)
+
+			// desired state ready is a transient state that it should be started.
+			// however previous leader may not have started it, retry start here
+			if t.DesiredState != api.TaskStateReady || t.Status.State > api.TaskStateRunning {
+				continue
+			}
+			restartDelay := orchestrator.DefaultRestartDelay
+			if t.Spec.Restart != nil && t.Spec.Restart.Delay != nil {
+				var err error
+				restartDelay, err = gogotypes.DurationFromProto(t.Spec.Restart.Delay)
+				if err != nil {
+					log.G(ctx).WithError(err).Error("invalid restart delay")
+					restartDelay = orchestrator.DefaultRestartDelay
+				}
+			}
+			if restartDelay != 0 {
+				timestamp, err := gogotypes.TimestampFromProto(t.Status.Timestamp)
+				if err == nil {
+					restartTime := timestamp.Add(restartDelay)
+					calculatedRestartDelay := restartTime.Sub(time.Now())
+					if calculatedRestartDelay < restartDelay {
+						restartDelay = calculatedRestartDelay
+					}
+					if restartDelay > 0 {
+						_ = batch.Update(func(tx store.Tx) error {
+							t := store.GetTask(tx, t.ID)
+							// TODO(aluzzardi): This is shady as well. We should have a more generic condition.
+							if t == nil || t.DesiredState != api.TaskStateReady {
+								return nil
+							}
+							startSupervisor.DelayStart(ctx, tx, nil, t.ID, restartDelay, true)
+							return nil
+						})
+						continue
+					}
+				} else {
+					log.G(ctx).WithError(err).Error("invalid status timestamp")
+				}
+			}
+
+			// Start now
+			err := batch.Update(func(tx store.Tx) error {
+				return startSupervisor.StartNow(tx, t.ID)
+			})
+			if err != nil {
+				log.G(ctx).WithError(err).WithField("task.id", t.ID).Error("moving task out of delayed state failed")
+			}
+		}
+		return nil
+	})
+	return err
+}


### PR DESCRIPTION
Fix #1812. 

Global orchestrator considers a `rejected` task not running and adds a new task to it. But this should be handled by task restart logic.  
 
```
gtest.0.tvi9nt4n7ghn  busybox:latest  ip-172-19-241-146          Ready          Rejected 1 second ago            "failed to allocate gateway (1…"
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>