### PR TITLE
logbroker: Fix flaky test TestLogBrokerNoFollow

### DIFF
--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -173,7 +173,7 @@ func (lb *LogBroker) watchSubscriptions(nodeID string) ([]*subscription, chan ev
 	}))
 
 	// Grab current subscriptions.
-	subscriptions := make([]*subscription, 0, len(lb.registeredSubscriptions))
+	subscriptions := make([]*subscription, 0)
 	for _, s := range lb.registeredSubscriptions {
 		if s.Contains(nodeID) {
 			subscriptions = append(subscriptions, s)


### PR DESCRIPTION
The issue appears to be that stream RPC handlers are invoked
asynchronously. When `ListenSubscriptions` is called and returns a stream,
we don't have a guarantee that any code inside that RPC handler has
executed yet. When we call `SubscribeLogs`, `ListenSubscriptions` may not
have called `registerSubscription` yet, in which case `SubscribeLogs` will
think the associated node is down, and will call `Done` for that node
automatically.

Since the current API doesn't give us a way to ensure that the node has
registered as a log listener, insert a sleep to give
`ListenSusbscriptions` time to do its work. Ideally there would be a
better way to do this.

Also, remove some synchronization in `listenSubscriptions` that doesn't
help, and remove a capacity argument to `make` in a case where only a
subset of the original slice's values are being copied.

Fixes #1777 

ping @aluzzardi