### PR TITLE
external-ca-example: Correct example swarmd command

### DIFF
--- a/cmd/external-ca-example/README.md
+++ b/cmd/external-ca-example/README.md
@@ -10,7 +10,7 @@ Now, run `external-ca-example`:
 
 ```
 $ external-ca-example
-INFO[0000] Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url https://localhost:58631/sign
+INFO[0000] Now run: swarmd -d . --listen-control-api ./swarmd.sock --external-ca protocol=cfssl,url=https://localhost:58631/sign
 ```
 
 This command initializes a new root CA along with the node certificate for the
@@ -26,10 +26,8 @@ Try joining new nodes to your cluster. Change into a new, empty directory and
 run `swarmd` again with an argument to join the previous manager node:
 
 ```
-$ swarmd -d . --listen-control-api ./swarmd.sock --listen-remote-api 0.0.0.0:4343 --join-addr localhost:4242
+$ swarmd -d . --listen-control-api ./swarmd.sock --listen-remote-api 0.0.0.0:4343 --join-addr localhost:4242 --join-token ...
 Warning: Specifying a valid address with --listen-remote-api may be necessary for other managers to reach this one.
-INFO[0000] Waiting for TLS certificate to be issued...  
-INFO[0000] Downloaded new TLS credentials with role: swarm-worker.
 ```
 
 If this new node does not block indefinitely waiting for a TLS certificate to

--- a/cmd/external-ca-example/main.go
+++ b/cmd/external-ca-example/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	defer server.Stop()
 
-	logrus.Infof("Now run: swarmd --manager -d . --listen-control-api ./swarmd.sock --external-ca-url %s", server.URL)
+	logrus.Infof("Now run: swarmd -d . --listen-control-api ./swarmd.sock --external-ca protocol=cfssl,url=%s", server.URL)
 
 	sigC := make(chan os.Signal, 1)
 	signal.Notify(sigC, syscall.SIGTERM, syscall.SIGINT)


### PR DESCRIPTION
Update this to reflect current `--external-ca` CLI option, and the lack of a `--manager` option in the current implementation.