### PR TITLE
Allow managers not to expose a remote API port

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -125,7 +125,7 @@ func pollServiceReady(t *testing.T, c *testCluster, sid string) {
 func newCluster(t *testing.T, numWorker, numManager int) *testCluster {
 	cl := newTestCluster()
 	for i := 0; i < numManager; i++ {
-		require.NoError(t, cl.AddManager(), "manager number %d", i+1)
+		require.NoError(t, cl.AddManager(false), "manager number %d", i+1)
 	}
 	for i := 0; i < numWorker; i++ {
 		require.NoError(t, cl.AddAgent(), "agent number %d", i+1)
@@ -143,6 +143,28 @@ func TestClusterCreate(t *testing.T) {
 	defer func() {
 		require.NoError(t, cl.Stop())
 	}()
+}
+
+func TestServiceCreateLateBind(t *testing.T) {
+	t.Parallel()
+
+	numWorker, numManager := 3, 3
+
+	cl := newTestCluster()
+	for i := 0; i < numManager; i++ {
+		require.NoError(t, cl.AddManager(true), "manager number %d", i+1)
+	}
+	for i := 0; i < numWorker; i++ {
+		require.NoError(t, cl.AddAgent(), "agent number %d", i+1)
+	}
+
+	defer func() {
+		require.NoError(t, cl.Stop())
+	}()
+
+	sid, err := cl.CreateService("test_service", 60)
+	require.NoError(t, err)
+	pollServiceReady(t, cl, sid)
 }
 
 func TestServiceCreate(t *testing.T) {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -72,7 +72,7 @@ type Config struct {
 
 	// RemoteAPI is a listening address for serving the remote API, and
 	// an optional advertise address.
-	RemoteAPI RemoteAddrs
+	RemoteAPI *RemoteAddrs
 
 	// JoinRaft is an optional address of a node in an existing raft
 	// cluster to join.
@@ -115,8 +115,7 @@ type Config struct {
 // This is the high-level object holding and initializing all the manager
 // subsystems.
 type Manager struct {
-	config    *Config
-	listeners []net.Listener
+	config Config
 
 	caserver               *ca.Server
 	dispatcher             *dispatcher.Dispatcher
@@ -136,9 +135,18 @@ type Manager struct {
 
 	cancelFunc context.CancelFunc
 
-	mu      sync.Mutex
+	// mu is a general mutex used to coordinate starting/stopping and
+	// leadership events.
+	mu sync.Mutex
+	// addrMu is a mutex that protects config.ControlAPI and config.RemoteAPI
+	addrMu sync.Mutex
+
 	started chan struct{}
 	stopped bool
+
+	remoteListener  chan net.Listener
+	controlListener chan net.Listener
+	errServe        chan error
 }
 
 type closeOnceListener struct {
@@ -156,29 +164,6 @@ func (l *closeOnceListener) Close() error {
 
 // New creates a Manager which has not started to accept requests yet.
 func New(config *Config) (*Manager, error) {
-	dispatcherConfig := dispatcher.DefaultConfig()
-
-	// If an AdvertiseAddr was specified, we use that as our
-	// externally-reachable address.
-	advertiseAddr := config.RemoteAPI.AdvertiseAddr
-
-	var advertiseAddrPort string
-	if advertiseAddr == "" {
-		// Otherwise, we know we are joining an existing swarm. Use a
-		// wildcard address to trigger remote autodetection of our
-		// address.
-		var err error
-		_, advertiseAddrPort, err = net.SplitHostPort(config.RemoteAPI.ListenAddr)
-		if err != nil {
-			return nil, fmt.Errorf("missing or invalid listen address %s", config.RemoteAPI.ListenAddr)
-		}
-
-		// Even with an IPv6 listening address, it's okay to use
-		// 0.0.0.0 here. Any "unspecified" (wildcard) IP will
-		// be substituted with the actual source address.
-		advertiseAddr = net.JoinHostPort("0.0.0.0", advertiseAddrPort)
-	}
-
 	err := os.MkdirAll(config.StateDir, 0700)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create state directory")
@@ -189,49 +174,6 @@ func New(config *Config) (*Manager, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create raft state directory")
 	}
-
-	var listeners []net.Listener
-
-	// don't create a socket directory if we're on windows. we used named pipe
-	if runtime.GOOS != "windows" {
-		err := os.MkdirAll(filepath.Dir(config.ControlAPI), 0700)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to create socket directory")
-		}
-	}
-
-	l, err := xnet.ListenLocal(config.ControlAPI)
-
-	// A unix socket may fail to bind if the file already
-	// exists. Try replacing the file.
-	if runtime.GOOS != "windows" {
-		unwrappedErr := err
-		if op, ok := unwrappedErr.(*net.OpError); ok {
-			unwrappedErr = op.Err
-		}
-		if sys, ok := unwrappedErr.(*os.SyscallError); ok {
-			unwrappedErr = sys.Err
-		}
-		if unwrappedErr == syscall.EADDRINUSE {
-			os.Remove(config.ControlAPI)
-			l, err = xnet.ListenLocal(config.ControlAPI)
-		}
-	}
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to listen on control API address")
-	}
-
-	listeners = append(listeners, l)
-
-	l, err = net.Listen("tcp", config.RemoteAPI.ListenAddr)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to listen on remote API address")
-	}
-	if advertiseAddrPort == "0" {
-		advertiseAddr = l.Addr().String()
-		config.RemoteAPI.ListenAddr = advertiseAddr
-	}
-	listeners = append(listeners, l)
 
 	raftCfg := raft.DefaultNodeConfig()
 
@@ -249,7 +191,6 @@ func New(config *Config) (*Manager, error) {
 
 	newNodeOpts := raft.NodeOptions{
 		ID:              config.SecurityConfig.ClientTLSCreds.NodeID(),
-		Addr:            advertiseAddr,
 		JoinAddr:        config.JoinRaft,
 		Config:          raftCfg,
 		StateDir:        raftStateDir,
@@ -263,19 +204,130 @@ func New(config *Config) (*Manager, error) {
 		grpc.Creds(config.SecurityConfig.ServerTLSCreds)}
 
 	m := &Manager{
-		config:      config,
-		listeners:   listeners,
-		caserver:    ca.NewServer(raftNode.MemoryStore(), config.SecurityConfig),
-		dispatcher:  dispatcher.New(raftNode, dispatcherConfig),
-		logbroker:   logbroker.New(raftNode.MemoryStore()),
-		server:      grpc.NewServer(opts...),
-		localserver: grpc.NewServer(opts...),
-		raftNode:    raftNode,
-		started:     make(chan struct{}),
-		dekRotator:  dekRotator,
+		config:          *config,
+		caserver:        ca.NewServer(raftNode.MemoryStore(), config.SecurityConfig),
+		dispatcher:      dispatcher.New(raftNode, dispatcher.DefaultConfig()),
+		logbroker:       logbroker.New(raftNode.MemoryStore()),
+		server:          grpc.NewServer(opts...),
+		localserver:     grpc.NewServer(opts...),
+		raftNode:        raftNode,
+		started:         make(chan struct{}),
+		dekRotator:      dekRotator,
+		remoteListener:  make(chan net.Listener, 1),
+		controlListener: make(chan net.Listener, 1),
+		errServe:        make(chan error, 2),
+	}
+
+	if config.ControlAPI != "" {
+		m.config.ControlAPI = ""
+		if err := m.BindControl(config.ControlAPI); err != nil {
+			return nil, err
+		}
+	}
+
+	if config.RemoteAPI != nil {
+		m.config.RemoteAPI = nil
+		// The context isn't used in this case (before (*Manager).Run).
+		if err := m.BindRemote(context.Background(), *config.RemoteAPI); err != nil {
+			if config.ControlAPI != "" {
+				l := <-m.controlListener
+				l.Close()
+			}
+			return nil, err
+		}
 	}
 
 	return m, nil
+}
+
+// BindControl binds a local socket for the control API.
+func (m *Manager) BindControl(addr string) error {
+	m.addrMu.Lock()
+	defer m.addrMu.Unlock()
+
+	if m.config.ControlAPI != "" {
+		return errors.New("manager already has a control API address")
+	}
+
+	// don't create a socket directory if we're on windows. we used named pipe
+	if runtime.GOOS != "windows" {
+		err := os.MkdirAll(filepath.Dir(addr), 0700)
+		if err != nil {
+			return errors.Wrap(err, "failed to create socket directory")
+		}
+	}
+
+	l, err := xnet.ListenLocal(addr)
+
+	// A unix socket may fail to bind if the file already
+	// exists. Try replacing the file.
+	if runtime.GOOS != "windows" {
+		unwrappedErr := err
+		if op, ok := unwrappedErr.(*net.OpError); ok {
+			unwrappedErr = op.Err
+		}
+		if sys, ok := unwrappedErr.(*os.SyscallError); ok {
+			unwrappedErr = sys.Err
+		}
+		if unwrappedErr == syscall.EADDRINUSE {
+			os.Remove(addr)
+			l, err = xnet.ListenLocal(addr)
+		}
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to listen on control API address")
+	}
+
+	m.config.ControlAPI = addr
+	m.controlListener <- l
+	return nil
+}
+
+// BindRemote binds a port for the remote API.
+func (m *Manager) BindRemote(ctx context.Context, addrs RemoteAddrs) error {
+	m.addrMu.Lock()
+	defer m.addrMu.Unlock()
+
+	if m.config.RemoteAPI != nil {
+		return errors.New("manager already has remote API address")
+	}
+
+	// If an AdvertiseAddr was specified, we use that as our
+	// externally-reachable address.
+	advertiseAddr := addrs.AdvertiseAddr
+
+	var advertiseAddrPort string
+	if advertiseAddr == "" {
+		// Otherwise, we know we are joining an existing swarm. Use a
+		// wildcard address to trigger remote autodetection of our
+		// address.
+		var err error
+		_, advertiseAddrPort, err = net.SplitHostPort(addrs.ListenAddr)
+		if err != nil {
+			return fmt.Errorf("missing or invalid listen address %s", addrs.ListenAddr)
+		}
+
+		// Even with an IPv6 listening address, it's okay to use
+		// 0.0.0.0 here. Any "unspecified" (wildcard) IP will
+		// be substituted with the actual source address.
+		advertiseAddr = net.JoinHostPort("0.0.0.0", advertiseAddrPort)
+	}
+
+	l, err := net.Listen("tcp", addrs.ListenAddr)
+	if err != nil {
+		return errors.Wrap(err, "failed to listen on remote API address")
+	}
+	if advertiseAddrPort == "0" {
+		advertiseAddr = l.Addr().String()
+		addrs.ListenAddr = advertiseAddr
+	}
+
+	m.config.RemoteAPI = &addrs
+
+	m.raftNode.SetAddr(ctx, advertiseAddr)
+	m.remoteListener <- l
+
+	return nil
 }
 
 // RemovedFromRaft returns a channel that's closed if the manager is removed
@@ -286,6 +338,12 @@ func (m *Manager) RemovedFromRaft() <-chan struct{} {
 
 // Addr returns tcp address on which remote api listens.
 func (m *Manager) Addr() string {
+	m.addrMu.Lock()
+	defer m.addrMu.Unlock()
+
+	if m.config.RemoteAPI == nil {
+		return ""
+	}
 	return m.config.RemoteAPI.ListenAddr
 }
 
@@ -357,12 +415,17 @@ func (m *Manager) Run(parent context.Context) error {
 	// requests (it has no TLS information to put in the metadata map).
 	forwardAsOwnRequest := func(ctx context.Context) (context.Context, error) { return ctx, nil }
 	handleRequestLocally := func(ctx context.Context) (context.Context, error) {
-		var remoteAddr string
-		if m.config.RemoteAPI.AdvertiseAddr != "" {
-			remoteAddr = m.config.RemoteAPI.AdvertiseAddr
-		} else {
-			remoteAddr = m.config.RemoteAPI.ListenAddr
+		remoteAddr := "127.0.0.1:0"
+
+		m.addrMu.Lock()
+		if m.config.RemoteAPI != nil {
+			if m.config.RemoteAPI.AdvertiseAddr != "" {
+				remoteAddr = m.config.RemoteAPI.AdvertiseAddr
+			} else {
+				remoteAddr = m.config.RemoteAPI.ListenAddr
+			}
 		}
+		m.addrMu.Unlock()
 
 		creds := m.config.SecurityConfig.ClientTLSCreds
 
@@ -408,10 +471,8 @@ func (m *Manager) Run(parent context.Context) error {
 	healthServer.SetServingStatus("Raft", api.HealthCheckResponse_NOT_SERVING)
 	localHealthServer.SetServingStatus("ControlAPI", api.HealthCheckResponse_NOT_SERVING)
 
-	errServe := make(chan error, len(m.listeners))
-	for _, lis := range m.listeners {
-		go m.serveListener(ctx, errServe, lis)
-	}
+	go m.serveListener(ctx, m.remoteListener)
+	go m.serveListener(ctx, m.controlListener)
 
 	defer func() {
 		m.server.Stop()
@@ -459,7 +520,7 @@ func (m *Manager) Run(parent context.Context) error {
 	}
 
 	// wait for an error in serving.
-	err = <-errServe
+	err = <-m.errServe
 	m.mu.Lock()
 	if m.stopped {
 		m.mu.Unlock()
@@ -759,7 +820,13 @@ func (m *Manager) handleLeadershipEvents(ctx context.Context, leadershipCh chan 
 }
 
 // serveListener serves a listener for local and non local connections.
-func (m *Manager) serveListener(ctx context.Context, errServe chan error, l net.Listener) {
+func (m *Manager) serveListener(ctx context.Context, lCh <-chan net.Listener) {
+	var l net.Listener
+	select {
+	case l = <-lCh:
+	case <-ctx.Done():
+		return
+	}
 	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(
 		logrus.Fields{
 			"proto": l.Addr().Network(),
@@ -770,10 +837,10 @@ func (m *Manager) serveListener(ctx context.Context, errServe chan error, l net.
 		// we need to disallow double closes because UnixListener.Close
 		// can delete unix-socket file of newer listener. grpc calls
 		// Close twice indeed: in Serve and in Stop.
-		errServe <- m.localserver.Serve(&closeOnceListener{Listener: l})
+		m.errServe <- m.localserver.Serve(&closeOnceListener{Listener: l})
 	} else {
 		log.G(ctx).Info("Listening for connections")
-		errServe <- m.server.Serve(l)
+		m.errServe <- m.server.Serve(l)
 	}
 }
 

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -56,7 +56,7 @@ func TestManager(t *testing.T) {
 	assert.NoError(t, err)
 
 	m, err := New(&Config{
-		RemoteAPI:        RemoteAddrs{ListenAddr: "127.0.0.1:0"},
+		RemoteAPI:        &RemoteAddrs{ListenAddr: "127.0.0.1:0"},
 		ControlAPI:       temp.Name(),
 		StateDir:         stateDir,
 		SecurityConfig:   managerSecurityConfig,
@@ -218,7 +218,7 @@ func TestManagerLockUnlock(t *testing.T) {
 	require.NoError(t, err)
 
 	m, err := New(&Config{
-		RemoteAPI:      RemoteAddrs{ListenAddr: "127.0.0.1:0"},
+		RemoteAPI:      &RemoteAddrs{ListenAddr: "127.0.0.1:0"},
 		ControlAPI:     temp.Name(),
 		StateDir:       stateDir,
 		SecurityConfig: managerSecurityConfig,

--- a/manager/state/raft/membership/cluster.go
+++ b/manager/state/raft/membership/cluster.go
@@ -143,6 +143,7 @@ func (c *Cluster) UpdateMember(id uint64, m *api.RaftMember) error {
 		return nil
 	}
 	oldMember.RaftMember = m
+	c.broadcastUpdate()
 	return nil
 }
 

--- a/node/node.go
+++ b/node/node.go
@@ -135,11 +135,11 @@ func (n *Node) RemoteAPIAddr() (string, error) {
 	n.RLock()
 	defer n.RUnlock()
 	if n.manager == nil {
-		return "", errors.Errorf("node is not manager")
+		return "", errors.New("manager is not running")
 	}
 	addr := n.manager.Addr()
 	if addr == "" {
-		return "", errors.Errorf("manager addr is not set")
+		return "", errors.New("manager addr is not set")
 	}
 	return addr, nil
 }
@@ -184,6 +184,21 @@ func New(c *Config) (*Node, error) {
 	n.roleCond = sync.NewCond(n.RLocker())
 	n.connCond = sync.NewCond(n.RLocker())
 	return n, nil
+}
+
+// BindRemote starts a listener that exposes the remote API.
+func (n *Node) BindRemote(ctx context.Context, listenAddr string, advertiseAddr string) error {
+	n.RLock()
+	defer n.RUnlock()
+
+	if n.manager == nil {
+		return errors.New("manager is not running")
+	}
+
+	return n.manager.BindRemote(ctx, manager.RemoteAddrs{
+		ListenAddr:    listenAddr,
+		AdvertiseAddr: advertiseAddr,
+	})
 }
 
 // Start starts a node instance.
@@ -670,13 +685,18 @@ func (n *Node) waitRole(ctx context.Context, role string) error {
 }
 
 func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig, ready chan struct{}, workerRole <-chan struct{}) error {
-	remoteAddr, _ := n.remotes.Select(n.NodeID())
-	m, err := manager.New(&manager.Config{
-		ForceNewCluster: n.config.ForceNewCluster,
-		RemoteAPI: manager.RemoteAddrs{
+	var remoteAPI *manager.RemoteAddrs
+	if n.config.ListenRemoteAPI != "" {
+		remoteAPI = &manager.RemoteAddrs{
 			ListenAddr:    n.config.ListenRemoteAPI,
 			AdvertiseAddr: n.config.AdvertiseRemoteAPI,
-		},
+		}
+	}
+
+	remoteAddr, _ := n.remotes.Select(n.NodeID())
+	m, err := manager.New(&manager.Config{
+		ForceNewCluster:  n.config.ForceNewCluster,
+		RemoteAPI:        remoteAPI,
 		ControlAPI:       n.config.ListenControlAPI,
 		SecurityConfig:   securityConfig,
 		ExternalCAs:      n.config.ExternalCAs,


### PR DESCRIPTION
We'd like Docker to support swarm services without needing to run `swarm init`. One of the preconditions for this is that the swarm manager needs to operate and be useful without exposing a port to the outside world.

This PR is split into multiple parts, which will each become a separate PR for ease of review. The first few commits are focused on allowing the agent and certificate issuance/renewal to work without relying on a TCP connection to back to the same process. This works by exposing servers such as the dispatcher and node CA on the unix socket (or equivalent), and using that instead of a TCP connection. In theory we could codegen something to patch the calls straight through to the handlers (with some stuff injected onto the context to identify the caller as the local node), but for now, using the unix socket is good enough. This required some changes to the raft proxy to let it inject the local node identity onto the context when it's calling the handler locally.

- [x] Fix demotion (#1829)
- [x] Expose the dispatcher, node CA, and a few other services on the UNIX socket. Inject the local node identity when they receive connections this way. (#1828)
- [x] Add a `connectionbroker` package. This is a small abstraction on top of `Remotes` that provides a gRPC connection to a manager. If running on a manager, it uses the unix socket, otherwise it will pick a remote manager using `Remotes`. This allows things like agent and certificate renewal to work even on a single node with no TCP port bound. (#1850)
- [x] Convert the agent and CA client to use `connectionbroker`. (#1851)
- [ ] Separate binding ports from creating the manager. Add methods to `Manager` and `Node` that allow binding a port after the manager is already running. A small change to raft allows the raft code to get the machine's external address after raft is already running, instead of relying on having it already. (This PR)
- [ ] A simple integration test that binds a port after starting the first manager. (This PR)


cc @aluzzardi @LK4D4 @diogomonica @cyli @tonistiigi @stevvooe