### PR TITLE
ca: Don't block server's Stop until handlers finish

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -28,7 +28,6 @@ const (
 // breaking it apart doesn't seem worth it.
 type Server struct {
 	mu                          sync.Mutex
-	wg                          sync.WaitGroup
 	ctx                         context.Context
 	cancel                      func()
 	store                       *store.MemoryStore
@@ -102,10 +101,9 @@ func (s *Server) NodeCertificateStatus(ctx context.Context, request *api.NodeCer
 		return nil, grpc.Errorf(codes.InvalidArgument, codes.InvalidArgument.String())
 	}
 
-	if err := s.addTask(); err != nil {
+	if err := s.isRunningLocked(); err != nil {
 		return nil, err
 	}
-	defer s.doneTask()
 
 	var node *api.Node
 
@@ -189,10 +187,9 @@ func (s *Server) IssueNodeCertificate(ctx context.Context, request *api.IssueNod
 		return nil, grpc.Errorf(codes.InvalidArgument, codes.InvalidArgument.String())
 	}
 
-	if err := s.addTask(); err != nil {
+	if err := s.isRunningLocked(); err != nil {
 		return nil, err
 	}
-	defer s.doneTask()
 
 	var (
 		blacklistedCerts map[string]*api.BlacklistedCertificate
@@ -364,10 +361,8 @@ func (s *Server) Run(ctx context.Context) error {
 		s.mu.Unlock()
 		return errors.New("CA signer is already running")
 	}
-	s.wg.Add(1)
 	s.mu.Unlock()
 
-	defer s.wg.Done()
 	ctx = log.WithModule(ctx, "ca")
 
 	// Retrieve the channels to keep track of changes in the cluster
@@ -397,8 +392,8 @@ func (s *Server) Run(ctx context.Context) error {
 	// returns true without joinTokens being set correctly.
 	s.mu.Lock()
 	s.ctx, s.cancel = context.WithCancel(ctx)
-	s.mu.Unlock()
 	close(s.started)
+	s.mu.Unlock()
 
 	if err != nil {
 		log.G(ctx).WithFields(logrus.Fields{
@@ -459,36 +454,30 @@ func (s *Server) Run(ctx context.Context) error {
 // Stop stops the CA and closes all grpc streams.
 func (s *Server) Stop() error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if !s.isRunning() {
-		s.mu.Unlock()
 		return errors.New("CA signer is already stopped")
 	}
 	s.cancel()
-	s.mu.Unlock()
-	// wait for all handlers to finish their CA deals,
-	s.wg.Wait()
 	s.started = make(chan struct{})
 	return nil
 }
 
 // Ready waits on the ready channel and returns when the server is ready to serve.
 func (s *Server) Ready() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.started
 }
 
-func (s *Server) addTask() error {
+func (s *Server) isRunningLocked() error {
 	s.mu.Lock()
 	if !s.isRunning() {
 		s.mu.Unlock()
 		return grpc.Errorf(codes.Aborted, "CA signer is stopped")
 	}
-	s.wg.Add(1)
 	s.mu.Unlock()
 	return nil
-}
-
-func (s *Server) doneTask() {
-	s.wg.Done()
 }
 
 func (s *Server) isRunning() bool {

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -133,7 +133,6 @@ type Dispatcher struct {
 }
 
 // New returns Dispatcher with cluster interface(usually raft.Node).
-// NOTE: each handler which does something with raft must add to Dispatcher.wg
 func New(cluster Cluster, c *Config) *Dispatcher {
 	d := &Dispatcher{
 		nodes:                 newNodeStore(c.HeartbeatPeriod, c.HeartbeatEpsilon, c.GracePeriodMultiplier, c.RateLimitPeriod),


### PR DESCRIPTION
The ca server's Stop method waits until all running handlers finish.
This may deadlock if quorum is not met at the time. Some of the other
services like dispatcher used to work like this, but it shouldn't be
necessary anymore. Remove the wait group.

cc @cyli @LK4D4