### PR TITLE
integration: Speed up TestRestartLeader

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -374,7 +374,7 @@ func TestDemoteDownedManager(t *testing.T) {
 }
 
 func TestRestartLeader(t *testing.T) {
-	numWorker, numManager := 10, 5
+	numWorker, numManager := 5, 3
 	cl := newCluster(t, numWorker, numManager)
 	defer func() {
 		require.NoError(t, cl.Stop())
@@ -385,19 +385,6 @@ func TestRestartLeader(t *testing.T) {
 	origLeaderID := leader.node.NodeID()
 
 	require.NoError(t, leader.Pause())
-
-	require.NoError(t, raftutils.PollFuncWithTimeout(nil, func() error {
-		resp, err := cl.api.GetNode(context.Background(), &api.GetNodeRequest{
-			NodeID: origLeaderID,
-		})
-		if err != nil {
-			return err
-		}
-		if resp.Node.Status.State != api.NodeStatus_DOWN {
-			return errors.Errorf("node %s is still not down", origLeaderID)
-		}
-		return nil
-	}, opsTimeout))
 
 	require.NoError(t, raftutils.PollFuncWithTimeout(nil, func() error {
 		resp, err := cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})


### PR DESCRIPTION
I should have noticed before merging it, but unfortunately `TestRestartLeader` roughly doubles the time it takes to run integration tests.

These changes take it from about 50s to 15s for me:

- Don't wait for the leader's agent to get marked as `DOWN`, as this takes
  a long time.

- Lower the number of workers and managers. In principle, the test
  doesn't need a high number of workers, since the workers are
  completely independent.

cc @LK4D4