### PR TITLE
node should exit from error

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -297,10 +297,12 @@ func (n *Node) run(ctx context.Context) (err error) {
 	go func() {
 		managerErr = n.superviseManager(ctx, securityConfig, managerReady) // store err and loop
 		wg.Done()
+		cancel()
 	}()
 	go func() {
 		agentErr = n.runAgent(ctx, db, securityConfig.ClientTLSCreds, agentReady)
 		wg.Done()
+		cancel()
 	}()
 
 	go func() {


### PR DESCRIPTION
Fix https://github.com/docker/docker/issues/29885. When manager or agent function fails, node run should exit and report error. 

cc @tonistiigi. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>