### PR TITLE
raft: Fix race when proposal is cancelled and triggered at the same time

### DIFF
--- a/manager/state/raft/wait.go
+++ b/manager/state/raft/wait.go
@@ -50,7 +50,7 @@ func (w *wait) trigger(id uint64, x interface{}) bool {
 	return false
 }
 
-func (w *wait) cancel(id uint64) {
+func (w *wait) cancel(id uint64) bool {
 	w.l.Lock()
 	waitItem, ok := w.m[id]
 	delete(w.m, id)
@@ -58,6 +58,7 @@ func (w *wait) cancel(id uint64) {
 	if ok && waitItem.cancel != nil {
 		waitItem.cancel()
 	}
+	return ok
 }
 
 func (w *wait) cancelAll() {


### PR DESCRIPTION
The demotion changes revealed an interesting race. If a proposal is
triggered at the same moment that something cancels it, the callback can
be called (which commits the transaction to memory), but an error can be
returned from `ProposeValue`, which causes the transaction to be aborted.

ProposeValue should return an error if and only if the callback was not
called.

Add a return value to `cancel()`. If `cancel` fails because the proposal was
already triggered, avoid returning an error.

Also, remove the `applyResult` type, since it isn't useful.