### PR TITLE
raft: fix deadlock in processInternalRaftRequest

### DIFF
--- a/manager/state/raft/wait.go
+++ b/manager/state/raft/wait.go
@@ -50,15 +50,17 @@ func (w *wait) trigger(id uint64, x interface{}) bool {
 	return false
 }
 
-func (w *wait) cancel(id uint64) bool {
+func (w *wait) cancel(id uint64) {
 	w.l.Lock()
 	waitItem, ok := w.m[id]
 	delete(w.m, id)
 	w.l.Unlock()
-	if ok && waitItem.cancel != nil {
-		waitItem.cancel()
+	if ok {
+		if waitItem.cancel != nil {
+			waitItem.cancel()
+		}
+		close(waitItem.ch)
 	}
-	return ok
 }
 
 func (w *wait) cancelAll() {
@@ -70,5 +72,6 @@ func (w *wait) cancelAll() {
 		if waitItem.cancel != nil {
 			waitItem.cancel()
 		}
+		close(waitItem.ch)
 	}
 }


### PR DESCRIPTION
It's possible that the wait item is canceled and not triggered so that the result channel might be empty.

ping @aaronlehmann 