### PR TITLE
raft: Don't panic on Campaign failure

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -501,9 +501,7 @@ func (n *Node) Run(ctx context.Context) error {
 					n.campaignWhenAble = false
 				}
 				if len(members) == 1 && members[n.Config.ID] != nil {
-					if err := n.raftNode.Campaign(ctx); err != nil {
-						panic("raft: cannot campaign to be the leader on node restore")
-					}
+					n.raftNode.Campaign(ctx)
 				}
 			}
 


### PR DESCRIPTION
`Campaign` used to be passed a context that was derived from `Background`
(`n.Ctx`). Awhile ago, `n.Ctx` was removed, and this call to `Campaign` was
changed to use the context passed to `Run`.

This context may be cancelled before `Campaign` is complete. This leads to
a panic.

Remove the panic, because it can trigger accidentally and it serves no
purpose.

cc @aboch @LK4D4 @cyli