### PR TITLE
Convert code to use connectionbroker package

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/remotes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +74,7 @@ func TestAgentStartStop(t *testing.T) {
 
 	agent, err := New(&Config{
 		Executor:    &NoopExecutor{},
-		Managers:    remotes,
+		ConnBroker:  connectionbroker.New(remotes),
 		Credentials: agentSecurityConfig.ClientTLSCreds,
 		DB:          db,
 	})
@@ -147,7 +148,7 @@ func agentTestEnv(t *testing.T) (*Agent, func()) {
 
 	agent, err := New(&Config{
 		Executor:    &NoopExecutor{},
-		Managers:    remotes,
+		ConnBroker:  connectionbroker.New(remotes),
 		Credentials: agentSecurityConfig.ClientTLSCreds,
 		DB:          db,
 	})

--- a/agent/config.go
+++ b/agent/config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/remotes"
+	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/credentials"
 )
@@ -14,9 +14,9 @@ type Config struct {
 	// Hostname the name of host for agent instance.
 	Hostname string
 
-	// Managers provides the manager backend used by the agent. It will be
-	// updated with managers weights as observed by the agent.
-	Managers remotes.Remotes
+	// ConnBroker provides a connection broker for retrieving gRPC
+	// connections to managers.
+	ConnBroker *connectionbroker.Broker
 
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor

--- a/agent/resource.go
+++ b/agent/resource.go
@@ -30,7 +30,7 @@ type ResourceAllocator interface {
 func (r *resourceAllocator) AttachNetwork(ctx context.Context, id, target string, addresses []string) (string, error) {
 	var taskID string
 	if err := r.agent.withSession(ctx, func(session *session) error {
-		client := api.NewResourceAllocatorClient(session.conn)
+		client := api.NewResourceAllocatorClient(session.conn.ClientConn)
 		r, err := client.AttachNetwork(ctx, &api.AttachNetworkRequest{
 			Config: &api.NetworkAttachmentConfig{
 				Target:    target,
@@ -53,7 +53,7 @@ func (r *resourceAllocator) AttachNetwork(ctx context.Context, id, target string
 // DetachNetwork deletes a network attachment.
 func (r *resourceAllocator) DetachNetwork(ctx context.Context, aID string) error {
 	return r.agent.withSession(ctx, func(session *session) error {
-		client := api.NewResourceAllocatorClient(session.conn)
+		client := api.NewResourceAllocatorClient(session.conn.ClientConn)
 		_, err := client.DetachNetwork(ctx, &api.DetachNetworkRequest{
 			AttachmentID: aID,
 		})

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -258,7 +258,7 @@ func TestGetRemoteCA(t *testing.T) {
 	d, err := digest.Parse("sha256:" + mdStr)
 	assert.NoError(t, err)
 
-	cert, err := ca.GetRemoteCA(tc.Context, d, tc.Remotes)
+	cert, err := ca.GetRemoteCA(tc.Context, d, tc.ConnBroker)
 	assert.NoError(t, err)
 	assert.NotNil(t, cert)
 }
@@ -276,7 +276,7 @@ func TestGetRemoteCAInvalidHash(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
 
-	_, err := ca.GetRemoteCA(tc.Context, "sha256:2d2f968475269f0dde5299427cf74348ee1d6115b95c6e3f283e5a4de8da445b", tc.Remotes)
+	_, err := ca.GetRemoteCA(tc.Context, "sha256:2d2f968475269f0dde5299427cf74348ee1d6115b95c6e3f283e5a4de8da445b", tc.ConnBroker)
 	assert.Error(t, err)
 }
 
@@ -288,8 +288,8 @@ func TestRequestAndSaveNewCertificates(t *testing.T) {
 	rca := ca.RootCA{Cert: tc.RootCA.Cert, Pool: tc.RootCA.Pool}
 	cert, err := rca.RequestAndSaveNewCertificates(tc.Context, tc.KeyReadWriter,
 		ca.CertificateRequestConfig{
-			Token:   tc.ManagerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.ManagerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	assert.NotNil(t, cert)
@@ -306,8 +306,8 @@ func TestRequestAndSaveNewCertificates(t *testing.T) {
 	// the worker token is also unencrypted
 	cert, err = rca.RequestAndSaveNewCertificates(tc.Context, tc.KeyReadWriter,
 		ca.CertificateRequestConfig{
-			Token:   tc.WorkerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.WorkerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	assert.NotNil(t, cert)
@@ -330,8 +330,8 @@ func TestRequestAndSaveNewCertificates(t *testing.T) {
 
 	_, err = rca.RequestAndSaveNewCertificates(tc.Context, tc.KeyReadWriter,
 		ca.CertificateRequestConfig{
-			Token:   tc.ManagerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.ManagerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 
@@ -345,8 +345,8 @@ func TestRequestAndSaveNewCertificates(t *testing.T) {
 	// if it's a worker though, the key is always unencrypted, even though the manager key is encrypted
 	_, err = rca.RequestAndSaveNewCertificates(tc.Context, tc.KeyReadWriter,
 		ca.CertificateRequestConfig{
-			Token:   tc.WorkerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.WorkerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	_, _, err = unencryptedKeyReader.Read()
@@ -412,8 +412,8 @@ func TestGetRemoteSignedCertificate(t *testing.T) {
 
 	certs, err := ca.GetRemoteSignedCertificate(context.Background(), csr, tc.RootCA.Pool,
 		ca.CertificateRequestConfig{
-			Token:   tc.ManagerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.ManagerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	assert.NotNil(t, certs)
@@ -429,8 +429,8 @@ func TestGetRemoteSignedCertificate(t *testing.T) {
 	// Test the expiration for an worker certificate
 	certs, err = ca.GetRemoteSignedCertificate(tc.Context, csr, tc.RootCA.Pool,
 		ca.CertificateRequestConfig{
-			Token:   tc.WorkerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.WorkerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	assert.NotNil(t, certs)
@@ -452,8 +452,8 @@ func TestGetRemoteSignedCertificateNodeInfo(t *testing.T) {
 
 	cert, err := ca.GetRemoteSignedCertificate(context.Background(), csr, tc.RootCA.Pool,
 		ca.CertificateRequestConfig{
-			Token:   tc.WorkerToken,
-			Remotes: tc.Remotes,
+			Token:      tc.WorkerToken,
+			ConnBroker: tc.ConnBroker,
 		})
 	assert.NoError(t, err)
 	assert.NotNil(t, cert)
@@ -476,8 +476,8 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	go func() {
 		_, err := ca.GetRemoteSignedCertificate(context.Background(), csr, tc.RootCA.Pool,
 			ca.CertificateRequestConfig{
-				Token:   tc.WorkerToken,
-				Remotes: tc.Remotes,
+				Token:      tc.WorkerToken,
+				ConnBroker: tc.ConnBroker,
 			})
 		completed <- err
 	}()

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudflare/cfssl/signer/local"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -45,7 +46,7 @@ type TestCA struct {
 	Conns                 []*grpc.ClientConn
 	WorkerToken           string
 	ManagerToken          string
-	Remotes               remotes.Remotes
+	ConnBroker            *connectionbroker.Broker
 	KeyReadWriter         *ca.KeyReadWriter
 }
 
@@ -199,7 +200,7 @@ func NewTestCA(t *testing.T, krwGenerators ...func(ca.CertPaths) *ca.KeyReadWrit
 		CAServer:              caServer,
 		WorkerToken:           workerToken,
 		ManagerToken:          managerToken,
-		Remotes:               remotes,
+		ConnBroker:            connectionbroker.New(remotes),
 		KeyReadWriter:         krw,
 	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -101,7 +101,7 @@ func TestLoadSecurityConfigLoadFromDisk(t *testing.T) {
 
 	tc := cautils.NewTestCA(t)
 	defer tc.Stop()
-	peer, err := tc.Remotes.Select()
+	peer, err := tc.ConnBroker.Remotes().Select()
 	require.NoError(t, err)
 
 	// Load successfully with valid passphrase
@@ -169,7 +169,7 @@ func TestLoadSecurityConfigDownloadAllCerts(t *testing.T) {
 	tc := cautils.NewTestCA(t)
 	defer tc.Stop()
 
-	peer, err := tc.Remotes.Select()
+	peer, err := tc.ConnBroker.Remotes().Select()
 	require.NoError(t, err)
 
 	node, err = New(&Config{


### PR DESCRIPTION
By using `connectionbroker` instead of using `remotes` directly, subsystems
like the agent can connect directly to the local manager when running on
a node that acts as a manager. This avoids the need for the manager to
expose a TCP port at all times.