### PR TITLE
Fix remaining manager being removed from member list by --force-new-cluster

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1826,10 +1826,10 @@ func createConfigChangeEnts(ids []uint64, self uint64, term, index uint64) []raf
 // - ConfChangeAddNode, in which case the contained ID will be added into the set.
 // - ConfChangeRemoveNode, in which case the contained ID will be removed from the set.
 func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
-	ids := make(map[uint64]bool)
+	ids := make(map[uint64]struct{})
 	if snap != nil {
 		for _, id := range snap.Metadata.ConfState.Nodes {
-			ids[id] = true
+			ids[id] = struct{}{}
 		}
 	}
 	for _, e := range ents {
@@ -1845,7 +1845,7 @@ func getIDs(snap *raftpb.Snapshot, ents []raftpb.Entry) []uint64 {
 		}
 		switch cc.Type {
 		case raftpb.ConfChangeAddNode:
-			ids[cc.NodeID] = true
+			ids[cc.NodeID] = struct{}{}
 		case raftpb.ConfChangeRemoveNode:
 			delete(ids, cc.NodeID)
 		case raftpb.ConfChangeUpdateNode:

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -58,9 +58,9 @@ func TestRaftBootstrap(t *testing.T) {
 	nodes, _ := raftutils.NewRaftCluster(t, tc)
 	defer raftutils.TeardownCluster(t, nodes)
 
-	assert.Equal(t, 3, len(nodes[1].GetMemberlist()))
-	assert.Equal(t, 3, len(nodes[2].GetMemberlist()))
-	assert.Equal(t, 3, len(nodes[3].GetMemberlist()))
+	assert.Len(t, nodes[1].GetMemberlist(), 3)
+	assert.Len(t, nodes[2].GetMemberlist(), 3)
+	assert.Len(t, nodes[3].GetMemberlist(), 3)
 }
 
 func TestRaftJoinTwice(t *testing.T) {
@@ -144,10 +144,10 @@ func TestRaftLeaderDown(t *testing.T) {
 
 	// The value should be replicated on all remaining nodes
 	raftutils.CheckValue(t, clockSource, leaderNode, value)
-	assert.Equal(t, len(leaderNode.GetMemberlist()), 3)
+	assert.Len(t, leaderNode.GetMemberlist(), 3)
 
 	raftutils.CheckValue(t, clockSource, followerNode, value)
-	assert.Equal(t, len(followerNode.GetMemberlist()), 3)
+	assert.Len(t, followerNode.GetMemberlist(), 3)
 }
 
 func TestRaftFollowerDown(t *testing.T) {
@@ -169,10 +169,10 @@ func TestRaftFollowerDown(t *testing.T) {
 
 	// The value should be replicated on all remaining nodes
 	raftutils.CheckValue(t, clockSource, nodes[1], value)
-	assert.Equal(t, len(nodes[1].GetMemberlist()), 3)
+	assert.Len(t, nodes[1].GetMemberlist(), 3)
 
 	raftutils.CheckValue(t, clockSource, nodes[2], value)
-	assert.Equal(t, len(nodes[2].GetMemberlist()), 3)
+	assert.Len(t, nodes[2].GetMemberlist(), 3)
 }
 
 func TestRaftLogReplication(t *testing.T) {
@@ -299,16 +299,16 @@ func TestRaftFollowerLeave(t *testing.T) {
 
 	// Value should be replicated on every node
 	raftutils.CheckValue(t, clockSource, nodes[1], value)
-	assert.Equal(t, len(nodes[1].GetMemberlist()), 4)
+	assert.Len(t, nodes[1].GetMemberlist(), 4)
 
 	raftutils.CheckValue(t, clockSource, nodes[2], value)
-	assert.Equal(t, len(nodes[2].GetMemberlist()), 4)
+	assert.Len(t, nodes[2].GetMemberlist(), 4)
 
 	raftutils.CheckValue(t, clockSource, nodes[3], value)
-	assert.Equal(t, len(nodes[3].GetMemberlist()), 4)
+	assert.Len(t, nodes[3].GetMemberlist(), 4)
 
 	raftutils.CheckValue(t, clockSource, nodes[4], value)
-	assert.Equal(t, len(nodes[4].GetMemberlist()), 4)
+	assert.Len(t, nodes[4].GetMemberlist(), 4)
 }
 
 func TestRaftLeaderLeave(t *testing.T) {
@@ -370,10 +370,10 @@ func TestRaftLeaderLeave(t *testing.T) {
 
 	// The value should be replicated on all remaining nodes
 	raftutils.CheckValue(t, clockSource, leaderNode, value)
-	assert.Equal(t, len(leaderNode.GetMemberlist()), 2)
+	assert.Len(t, leaderNode.GetMemberlist(), 2)
 
 	raftutils.CheckValue(t, clockSource, followerNode, value)
-	assert.Equal(t, len(followerNode.GetMemberlist()), 2)
+	assert.Len(t, followerNode.GetMemberlist(), 2)
 
 	raftutils.TeardownCluster(t, newCluster)
 }
@@ -397,7 +397,7 @@ func TestRaftNewNodeGetsData(t *testing.T) {
 	// Value should be replicated on every node
 	for _, node := range nodes {
 		raftutils.CheckValue(t, clockSource, node, value)
-		assert.Equal(t, len(node.GetMemberlist()), 4)
+		assert.Len(t, node.GetMemberlist(), 4)
 	}
 }
 
@@ -417,7 +417,7 @@ func TestRaftRejoin(t *testing.T) {
 
 	// The value should be replicated on node 3
 	raftutils.CheckValue(t, clockSource, nodes[3], values[0])
-	assert.Equal(t, len(nodes[3].GetMemberlist()), 3)
+	assert.Len(t, nodes[3].GetMemberlist(), 3)
 
 	// Stop node 3
 	nodes[3].Server.Stop()
@@ -550,7 +550,7 @@ func TestRaftForceNewCluster(t *testing.T) {
 
 	// The memberlist should contain 3 members on each node
 	for i := 1; i <= 3; i++ {
-		assert.Equal(t, len(nodes[uint64(i)].GetMemberlist()), 3)
+		assert.Len(t, nodes[uint64(i)].GetMemberlist(), 3)
 	}
 
 	// Stop all nodes
@@ -574,7 +574,7 @@ func TestRaftForceNewCluster(t *testing.T) {
 	raftutils.WaitForCluster(t, clockSource, nodes)
 
 	// The memberlist should contain only one node (self)
-	assert.Equal(t, len(nodes[1].GetMemberlist()), 1)
+	assert.Len(t, nodes[1].GetMemberlist(), 1)
 
 	// Add 2 more members
 	nodes[2] = raftutils.NewJoinNode(t, clockSource, nodes[1].Address, tc)
@@ -592,7 +592,7 @@ func TestRaftForceNewCluster(t *testing.T) {
 
 	// The memberlist should contain 3 members on each node
 	for i := 1; i <= 3; i++ {
-		assert.Equal(t, len(nodes[uint64(i)].GetMemberlist()), 3)
+		assert.Len(t, nodes[uint64(i)].GetMemberlist(), 3)
 	}
 
 	// Propose another value
@@ -692,7 +692,7 @@ func TestRaftJoinWithIncorrectAddress(t *testing.T) {
 	assert.Contains(t, grpc.ErrorDesc(err), "could not connect to prospective new cluster member using its advertised address")
 
 	// Check if first node still has only itself registered in the memberlist
-	assert.Equal(t, len(nodes[1].GetMemberlist()), 1)
+	assert.Len(t, nodes[1].GetMemberlist(), 1)
 }
 
 func TestStress(t *testing.T) {


### PR DESCRIPTION
When loading a snapshot while forcing a new cluster, we need to avoid removing ourselves from the member list. This caused the restored swarm to show zero managers.

Add a test.

Also, fix a few small items:

- Remove unnecessary cast
- Change `map[uint64]bool` to `map[uint64]struct{}`
- Remove trailing space in log message
- Active members listed in the snapshot should be added to the removed list, not simply ignored.
- Use `assert.Len` in raft tests.

This is a 1.13-rc regression caused by #1469.

cc @LK4D4 @cyli