### PR TITLE
swarmctl: Match full name, not name prefix

### DIFF
--- a/cmd/swarmctl/cluster/common.go
+++ b/cmd/swarmctl/cluster/common.go
@@ -16,7 +16,7 @@ func getCluster(ctx context.Context, c api.ControlClient, input string) (*api.Cl
 	rl, err := c.ListClusters(ctx,
 		&api.ListClustersRequest{
 			Filters: &api.ListClustersRequest_Filters{
-				NamePrefixes: []string{input},
+				Names: []string{input},
 			},
 		},
 	)

--- a/cmd/swarmctl/network/common.go
+++ b/cmd/swarmctl/network/common.go
@@ -15,11 +15,11 @@ func GetNetwork(ctx context.Context, c api.ControlClient, input string) (*api.Ne
 	// GetService to match via full ID.
 	rg, err := c.GetNetwork(ctx, &api.GetNetworkRequest{NetworkID: input})
 	if err != nil {
-		// If any error (including NotFound), ListServices to match via ID prefix and full name.
+		// If any error (including NotFound), ListServices to match via full name.
 		rl, err := c.ListNetworks(ctx,
 			&api.ListNetworksRequest{
 				Filters: &api.ListNetworksRequest_Filters{
-					NamePrefixes: []string{input},
+					Names: []string{input},
 				},
 			},
 		)

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -136,11 +136,11 @@ func getNode(ctx context.Context, c api.ControlClient, input string) (*api.Node,
 	// GetNode to match via full ID.
 	rg, err := c.GetNode(ctx, &api.GetNodeRequest{NodeID: input})
 	if err != nil {
-		// If any error (including NotFound), ListServices to match via ID prefix and full name.
+		// If any error (including NotFound), ListServices to match via full name.
 		rl, err := c.ListNodes(ctx,
 			&api.ListNodesRequest{
 				Filters: &api.ListNodesRequest_Filters{
-					NamePrefixes: []string{input},
+					Names: []string{input},
 				},
 			},
 		)

--- a/cmd/swarmctl/service/common.go
+++ b/cmd/swarmctl/service/common.go
@@ -12,11 +12,11 @@ func getService(ctx context.Context, c api.ControlClient, input string) (*api.Se
 	// GetService to match via full ID.
 	rg, err := c.GetService(ctx, &api.GetServiceRequest{ServiceID: input})
 	if err != nil {
-		// If any error (including NotFound), ListServices to match via ID prefix and name prefix.
+		// If any error (including NotFound), ListServices to match via full name.
 		rl, err := c.ListServices(ctx,
 			&api.ListServicesRequest{
 				Filters: &api.ListServicesRequest_Filters{
-					NamePrefixes: []string{input},
+					Names: []string{input},
 				},
 			},
 		)


### PR DESCRIPTION
The swarmctl tool resolves names with the `NamePrefixes` filter. This
doesn't seem right. The user should give full names, not abbreviated
ones. It causes problems with services whose names share prefixes - for
example it's difficult to remove a service named "busybox" when one
named "busybox-top" also exists.

A case could be made for supporting ID prefixes instead, but this
isn't currently implemented, so it doesn't seem like a priority.

Use `Name` instead of `NamePrefixes` to switch to exact name matching.

cc @stevvooe