### PR TITLE
Revert recent CA server changes

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -133,6 +133,7 @@ type Dispatcher struct {
 }
 
 // New returns Dispatcher with cluster interface(usually raft.Node).
+// NOTE: each handler which does something with raft must add to Dispatcher.wg
 func New(cluster Cluster, c *Config) *Dispatcher {
 	d := &Dispatcher{
 		nodes:                 newNodeStore(c.HeartbeatPeriod, c.HeartbeatEpsilon, c.GracePeriodMultiplier, c.RateLimitPeriod),


### PR DESCRIPTION
This reverts #1841 and #1854.

`ca` unit tests appear to be hanging in CI runs against `master`. It's either because of these changes or #1851. Unfortunately I can't reproduce the problem locally. #1851 has passed CI several times, so I'm starting by trying to revert #1841 / #1854. If these turn out to be the problem, I'll figure out what's going on later, and open a fixed PR with that change.