### PR TITLE
Gracefully fail if Network and IPAM plugins are used

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -76,7 +76,7 @@ func validateAnnotations(m api.Annotations) error {
 	return nil
 }
 
-func validateDriver(driver *api.Driver) error {
+func validateDriver(driver *api.Driver, defName string) error {
 	if driver == nil {
 		// It is ok to not specify the driver. We will choose
 		// a default driver.
@@ -87,5 +87,8 @@ func validateDriver(driver *api.Driver) error {
 		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
 	}
 
+	if driver.Name != defName {
+		return grpc.Errorf(codes.InvalidArgument, "invalid driver (%s) specified", driver.Name)
+	}
 	return nil
 }

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -54,7 +56,7 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 		return nil
 	}
 
-	if err := validateDriver(ipam.Driver); err != nil {
+	if err := validateDriver(ipam.Driver, ipamapi.DefaultIPAM); err != nil {
 		return err
 	}
 
@@ -76,7 +78,7 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 		return err
 	}
 
-	if err := validateDriver(spec.DriverConfig); err != nil {
+	if err := validateDriver(spec.DriverConfig, networkallocator.DefaultDriver); err != nil {
 		return err
 	}
 

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -86,9 +86,13 @@ func createServiceInNetwork(t *testing.T, ts *testServer, name, image string, nw
 }
 
 func TestValidateDriver(t *testing.T) {
-	assert.NoError(t, validateDriver(nil))
+	assert.NoError(t, validateDriver(nil, ""))
 
-	err := validateDriver(&api.Driver{Name: ""})
+	err := validateDriver(&api.Driver{Name: ""}, "")
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	err = validateDriver(&api.Driver{Name: "test"}, "default")
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }


### PR DESCRIPTION
Due to multiple issues in both plugin-v1 and plugin-v2 support, 
this patch will disable the network plugin support by gracefully 
failing the network create if either network or ipam plugin is used. 😢 

We will revisit the support once the plugin issues are resolved.

Signed-off-by: Madhu Venugopal <madhu@docker.com>