### PR TITLE
ca: Server waitgroup/locking fixes, take 2

### DIFF
--- a/ca/server.go
+++ b/ca/server.go
@@ -28,7 +28,6 @@ const (
 // breaking it apart doesn't seem worth it.
 type Server struct {
 	mu                          sync.Mutex
-	wg                          sync.WaitGroup
 	ctx                         context.Context
 	cancel                      func()
 	store                       *store.MemoryStore
@@ -102,10 +101,9 @@ func (s *Server) NodeCertificateStatus(ctx context.Context, request *api.NodeCer
 		return nil, grpc.Errorf(codes.InvalidArgument, codes.InvalidArgument.String())
 	}
 
-	if err := s.addTask(); err != nil {
+	if err := s.isRunningLocked(); err != nil {
 		return nil, err
 	}
-	defer s.doneTask()
 
 	var node *api.Node
 
@@ -189,10 +187,9 @@ func (s *Server) IssueNodeCertificate(ctx context.Context, request *api.IssueNod
 		return nil, grpc.Errorf(codes.InvalidArgument, codes.InvalidArgument.String())
 	}
 
-	if err := s.addTask(); err != nil {
+	if err := s.isRunningLocked(); err != nil {
 		return nil, err
 	}
-	defer s.doneTask()
 
 	var (
 		blacklistedCerts map[string]*api.BlacklistedCertificate
@@ -374,10 +371,8 @@ func (s *Server) Run(ctx context.Context) error {
 		s.mu.Unlock()
 		return errors.New("CA signer is already running")
 	}
-	s.wg.Add(1)
 	s.mu.Unlock()
 
-	defer s.wg.Done()
 	ctx = log.WithModule(ctx, "ca")
 
 	// Retrieve the channels to keep track of changes in the cluster
@@ -407,8 +402,8 @@ func (s *Server) Run(ctx context.Context) error {
 	// returns true without joinTokens being set correctly.
 	s.mu.Lock()
 	s.ctx, s.cancel = context.WithCancel(ctx)
-	s.mu.Unlock()
 	close(s.started)
+	s.mu.Unlock()
 
 	if err != nil {
 		log.G(ctx).WithFields(logrus.Fields{
@@ -469,36 +464,30 @@ func (s *Server) Run(ctx context.Context) error {
 // Stop stops the CA and closes all grpc streams.
 func (s *Server) Stop() error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if !s.isRunning() {
-		s.mu.Unlock()
 		return errors.New("CA signer is already stopped")
 	}
 	s.cancel()
-	s.mu.Unlock()
-	// wait for all handlers to finish their CA deals,
-	s.wg.Wait()
 	s.started = make(chan struct{})
 	return nil
 }
 
 // Ready waits on the ready channel and returns when the server is ready to serve.
 func (s *Server) Ready() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.started
 }
 
-func (s *Server) addTask() error {
+func (s *Server) isRunningLocked() error {
 	s.mu.Lock()
 	if !s.isRunning() {
 		s.mu.Unlock()
 		return grpc.Errorf(codes.Aborted, "CA signer is stopped")
 	}
-	s.wg.Add(1)
 	s.mu.Unlock()
 	return nil
-}
-
-func (s *Server) doneTask() {
-	s.wg.Done()
 }
 
 func (s *Server) isRunning() bool {

--- a/ca/server.go
+++ b/ca/server.go
@@ -28,6 +28,7 @@ const (
 // breaking it apart doesn't seem worth it.
 type Server struct {
 	mu                          sync.Mutex
+	wg                          sync.WaitGroup
 	ctx                         context.Context
 	cancel                      func()
 	store                       *store.MemoryStore
@@ -39,7 +40,7 @@ type Server struct {
 	// renewal. They are indexed by node ID.
 	pending map[string]*api.Node
 
-	// Started is a channel which gets closed once the server is running
+	// started is a channel which gets closed once the server is running
 	// and able to service RPCs.
 	started chan struct{}
 }
@@ -371,8 +372,10 @@ func (s *Server) Run(ctx context.Context) error {
 		s.mu.Unlock()
 		return errors.New("CA signer is already running")
 	}
+	s.wg.Add(1)
 	s.mu.Unlock()
 
+	defer s.wg.Done()
 	ctx = log.WithModule(ctx, "ca")
 
 	// Retrieve the channels to keep track of changes in the cluster
@@ -464,7 +467,12 @@ func (s *Server) Run(ctx context.Context) error {
 // Stop stops the CA and closes all grpc streams.
 func (s *Server) Stop() error {
 	s.mu.Lock()
+
+	// Wait for Run to complete before returning
+	defer s.wg.Wait()
+
 	defer s.mu.Unlock()
+
 	if !s.isRunning() {
 		return errors.New("CA signer is already stopped")
 	}

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -133,7 +133,6 @@ type Dispatcher struct {
 }
 
 // New returns Dispatcher with cluster interface(usually raft.Node).
-// NOTE: each handler which does something with raft must add to Dispatcher.wg
 func New(cluster Cluster, c *Config) *Dispatcher {
 	d := &Dispatcher{
 		nodes:                 newNodeStore(c.HeartbeatPeriod, c.HeartbeatEpsilon, c.GracePeriodMultiplier, c.RateLimitPeriod),


### PR DESCRIPTION
This supersedes #1841 and #1854, which implemented part of this change, but were later reverted because they caused problems.

Change the CA server not to wait for handlers to finish before exiting. This isn't really necessary, and other subsystems like the dispatcher don't do it.

Fix `TestRestartRootCA` to do what was intended. It was calling a RPC that didn't depend on the server being up, and also wasn't waiting for the server to start.

Correct uses of `s.ctx` that were missing locking. These could have been races in cases where the server was restarted quickly.

The dispatcher (where this code originally came from) has some similar problems, and I'll open a separate PR for that.

cc @cyli @LK4D4