### PR TITLE
dispatcher: Correct problems with starting and stopping

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -899,7 +899,7 @@ func TestTaskUpdate(t *testing.T) {
 		assert.Equal(t, grpc.Code(err), codes.PermissionDenied)
 	}
 
-	gd.dispatcherServer.processUpdates()
+	gd.dispatcherServer.processUpdates(context.Background())
 
 	gd.Store.View(func(readTx store.ReadTx) {
 		storeTask1 := store.GetTask(readTx, testTask1.ID)


### PR DESCRIPTION
The Stop method did not wait for Run to complete, so in theory it would be possible to call Run again before the first instance is complete. Fix this by adding a waitgroup.

`d.ctx` is used in some places without locking. In a fast restart scenario, this could cause the wrong context to be used. Make sure that all uses of `d.ctx` use locking.