### PR TITLE
ca: Remove unneeded code to cancel requests to external CAs

### DIFF
--- a/ca/external.go
+++ b/ca/external.go
@@ -103,26 +103,9 @@ func makeExternalSignRequest(ctx context.Context, client *http.Client, url strin
 	if err != nil {
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to perform certificate signing request")}
 	}
-
-	doneReading := make(chan struct{})
-	bodyClosed := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-doneReading:
-		}
-		resp.Body.Close()
-		close(bodyClosed)
-	}()
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
-	close(doneReading)
-	<-bodyClosed
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-	}
 	if err != nil {
 		return nil, recoverableErr{err: errors.Wrap(err, "unable to read CSR response body")}
 	}


### PR DESCRIPTION
It shouldn't be necessary to manually close the request body when the
context is cancelled. ctxhttp should take care of this automatically.

Closing the body triggers a race on Go < 1.7, since it turns out ctxhttp
uses a wrapper around Body that is not reentrant.

Remove the goroutine that closes the body when the context is canceled.

cc @cyli @stevvooe