### PR TITLE
Add plugingetter to swarm node config.

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/agent"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -98,6 +99,9 @@ type Config struct {
 
 	// Availability allows a user to control the current scheduling status of a node
 	Availability api.NodeSpec_Availability
+
+	// PluginGetter provides access to docker's plugin inventory.
+	PluginGetter plugingetter.PluginGetter
 }
 
 // Node implements the primary node functionality for a member of a swarm


### PR DESCRIPTION
This is necessary for swarmkit to support cluster wide plugins, such as
globally scoped network plugins.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>

cc @mavenugo @aaronlehmann 