### PR TITLE
Update the documentation on the deprecated `ServiceSpec.Networks`

### DIFF
--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -140,7 +140,12 @@ type ServiceSpec struct {
 	//	*ServiceSpec_Global
 	Mode isServiceSpec_Mode `protobuf_oneof:"mode"`
 	// UpdateConfig controls the rate and policy of updates.
-	Update   *UpdateConfig              `protobuf:"bytes,6,opt,name=update" json:"update,omitempty"`
+	Update *UpdateConfig `protobuf:"bytes,6,opt,name=update" json:"update,omitempty"`
+	// ServiceSpec.Networks has been deprecated and is replaced by
+	// Networks field in Task (TaskSpec.Networks).
+	// This field (ServiceSpec.Networks) is kept for compatibility.
+	// In case TaskSpec.Networks does not exist, ServiceSpec.Networks
+	// is still honored if it exists.
 	Networks []*NetworkAttachmentConfig `protobuf:"bytes,7,rep,name=networks" json:"networks,omitempty"`
 	// Service endpoint specifies the user provided configuration
 	// to properly discover and load balance a service.

--- a/api/specs.proto
+++ b/api/specs.proto
@@ -72,6 +72,11 @@ message ServiceSpec {
 	// UpdateConfig controls the rate and policy of updates.
 	UpdateConfig update = 6;
 
+	// ServiceSpec.Networks has been deprecated and is replaced by
+	// Networks field in Task (TaskSpec.Networks).
+	// This field (ServiceSpec.Networks) is kept for compatibility.
+	// In case TaskSpec.Networks does not exist, ServiceSpec.Networks
+	// is still honored if it exists.
 	repeated NetworkAttachmentConfig networks = 7 [deprecated=true];
 
 	// Service endpoint specifies the user provided configuration


### PR DESCRIPTION
The field `ServiceSpec.Networks` has been deprecated and is replaced by `ServiceSpec.Task.Networks`. There is no description for that field other than a tag of `[deprecated=true]`.

This fix updates the documentation on the deprecated `ServiceSpec.Networks` and directs user to use `ServiceSpec.Task.Networks` instead.

This fix is related to the comment:
https://github.com/docker/docker/pull/29463#issuecomment-271387898

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>