### PR TITLE
Fix issue in service update of published ports in host mode

### DIFF
--- a/manager/allocator/network_test.go
+++ b/manager/allocator/network_test.go
@@ -1,0 +1,40 @@
+package allocator
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdatePortsInHostPublishMode(t *testing.T) {
+	service := api.Service{
+		Spec: api.ServiceSpec{
+			Endpoint: &api.EndpointSpec{
+				Ports: []*api.PortConfig{
+					{
+						Protocol:      api.ProtocolTCP,
+						TargetPort:    80,
+						PublishedPort: 10000,
+						PublishMode:   api.PublishModeHost,
+					},
+				},
+			},
+		},
+		Endpoint: &api.Endpoint{
+			Ports: []*api.PortConfig{
+				{
+					Protocol:      api.ProtocolTCP,
+					TargetPort:    80,
+					PublishedPort: 15000,
+					PublishMode:   api.PublishModeHost,
+				},
+			},
+		},
+	}
+	updatePortsInHostPublishMode(&service)
+
+	assert.Equal(t, len(service.Endpoint.Ports), 1)
+	assert.Equal(t, service.Endpoint.Ports[0].PublishedPort, uint32(10000))
+	assert.Equal(t, service.Endpoint.Spec.Ports[0].PublishedPort, uint32(10000))
+}

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -283,6 +283,12 @@ func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 	return true
 }
 
+// PortsAllocatedInHostPublishMode returns if the passed service has its published ports in
+// host (non ingress) mode allocated
+func (na *NetworkAllocator) PortsAllocatedInHostPublishMode(s *api.Service) bool {
+	return na.portAllocator.portsAllocatedInHostPublishMode(s)
+}
+
 // IsServiceAllocated returns if the passed service has its network resources allocated or not.
 func (na *NetworkAllocator) IsServiceAllocated(s *api.Service) bool {
 	// If endpoint mode is VIP and allocator does not have the

--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -269,6 +269,33 @@ func (pa *portAllocator) serviceDeallocatePorts(s *api.Service) {
 	s.Endpoint.Ports = nil
 }
 
+func (pa *portAllocator) portsAllocatedInHostPublishMode(s *api.Service) bool {
+	if s.Endpoint == nil && s.Spec.Endpoint == nil {
+		return true
+	}
+
+	portStates := allocatedPorts{}
+	if s.Endpoint != nil {
+		for _, portState := range s.Endpoint.Ports {
+			if portState.PublishMode == api.PublishModeHost {
+				portStates.addState(portState)
+			}
+		}
+	}
+
+	if s.Spec.Endpoint != nil {
+		for _, portConfig := range s.Spec.Endpoint.Ports {
+			if portConfig.PublishMode == api.PublishModeHost {
+				if portStates.delState(portConfig) == nil {
+					return false
+				}
+			}
+		}
+	}
+
+	return true
+}
+
 func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {
 	// If service has no user-defined endpoint and allocated endpoint,
 	// we assume it is allocated and return true.


### PR DESCRIPTION
This fix tries to fix the issue in docker/docker#30199 where service update will not work when published ports is host publish mode.

The reason for the issue is that `isPortsAllocated()` does not capture host publish mode.

This fix address the issue by updating allocated ports if there is any change in ports of host (non ingress) mode as well.

Unit tests have been added.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>