### PR TITLE
Networkallocator must make use of plugin-v2 apis

### DIFF
--- a/agent/exec/container/api_client_test.mock.go
+++ b/agent/exec/container/api_client_test.mock.go
@@ -379,7 +379,7 @@ func (_mr *_MockAPIClientRecorder) ContainerWait(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ContainerWait", arg0, arg1)
 }
 
-func (_m *MockAPIClient) ContainersPrune(_param0 context.Context, _param1 types.ContainersPruneConfig) (types.ContainersPruneReport, error) {
+func (_m *MockAPIClient) ContainersPrune(_param0 context.Context, _param1 filters.Args) (types.ContainersPruneReport, error) {
 	ret := _m.ctrl.Call(_m, "ContainersPrune", _param0, _param1)
 	ret0, _ := ret[0].(types.ContainersPruneReport)
 	ret1, _ := ret[1].(error)
@@ -577,7 +577,7 @@ func (_mr *_MockAPIClientRecorder) ImageTag(arg0, arg1, arg2 interface{}) *gomoc
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "ImageTag", arg0, arg1, arg2)
 }
 
-func (_m *MockAPIClient) ImagesPrune(_param0 context.Context, _param1 types.ImagesPruneConfig) (types.ImagesPruneReport, error) {
+func (_m *MockAPIClient) ImagesPrune(_param0 context.Context, _param1 filters.Args) (types.ImagesPruneReport, error) {
 	ret := _m.ctrl.Call(_m, "ImagesPrune", _param0, _param1)
 	ret0, _ := ret[0].(types.ImagesPruneReport)
 	ret1, _ := ret[1].(error)
@@ -674,7 +674,7 @@ func (_mr *_MockAPIClientRecorder) NetworkRemove(arg0, arg1 interface{}) *gomock
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "NetworkRemove", arg0, arg1)
 }
 
-func (_m *MockAPIClient) NetworksPrune(_param0 context.Context, _param1 types.NetworksPruneConfig) (types.NetworksPruneReport, error) {
+func (_m *MockAPIClient) NetworksPrune(_param0 context.Context, _param1 filters.Args) (types.NetworksPruneReport, error) {
 	ret := _m.ctrl.Call(_m, "NetworksPrune", _param0, _param1)
 	ret0, _ := ret[0].(types.NetworksPruneReport)
 	ret1, _ := ret[1].(error)
@@ -749,14 +749,14 @@ func (_mr *_MockAPIClientRecorder) PluginCreate(arg0, arg1, arg2 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PluginCreate", arg0, arg1, arg2)
 }
 
-func (_m *MockAPIClient) PluginDisable(_param0 context.Context, _param1 string) error {
-	ret := _m.ctrl.Call(_m, "PluginDisable", _param0, _param1)
+func (_m *MockAPIClient) PluginDisable(_param0 context.Context, _param1 string, _param2 types.PluginDisableOptions) error {
+	ret := _m.ctrl.Call(_m, "PluginDisable", _param0, _param1, _param2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockAPIClientRecorder) PluginDisable(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "PluginDisable", arg0, arg1)
+func (_mr *_MockAPIClientRecorder) PluginDisable(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "PluginDisable", arg0, arg1, arg2)
 }
 
 func (_m *MockAPIClient) PluginEnable(_param0 context.Context, _param1 string, _param2 types.PluginEnableOptions) error {
@@ -781,10 +781,11 @@ func (_mr *_MockAPIClientRecorder) PluginInspectWithRaw(arg0, arg1 interface{}) 
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PluginInspectWithRaw", arg0, arg1)
 }
 
-func (_m *MockAPIClient) PluginInstall(_param0 context.Context, _param1 string, _param2 types.PluginInstallOptions) error {
+func (_m *MockAPIClient) PluginInstall(_param0 context.Context, _param1 string, _param2 types.PluginInstallOptions) (io.ReadCloser, error) {
 	ret := _m.ctrl.Call(_m, "PluginInstall", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockAPIClientRecorder) PluginInstall(arg0, arg1, arg2 interface{}) *gomock.Call {
@@ -802,10 +803,11 @@ func (_mr *_MockAPIClientRecorder) PluginList(arg0 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "PluginList", arg0)
 }
 
-func (_m *MockAPIClient) PluginPush(_param0 context.Context, _param1 string, _param2 string) error {
+func (_m *MockAPIClient) PluginPush(_param0 context.Context, _param1 string, _param2 string) (io.ReadCloser, error) {
 	ret := _m.ctrl.Call(_m, "PluginPush", _param0, _param1, _param2)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 func (_mr *_MockAPIClientRecorder) PluginPush(arg0, arg1, arg2 interface{}) *gomock.Call {
@@ -1123,7 +1125,7 @@ func (_mr *_MockAPIClientRecorder) VolumeRemove(arg0, arg1, arg2 interface{}) *g
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "VolumeRemove", arg0, arg1, arg2)
 }
 
-func (_m *MockAPIClient) VolumesPrune(_param0 context.Context, _param1 types.VolumesPruneConfig) (types.VolumesPruneReport, error) {
+func (_m *MockAPIClient) VolumesPrune(_param0 context.Context, _param1 filters.Args) (types.VolumesPruneReport, error) {
 	ret := _m.ctrl.Call(_m, "VolumesPrune", _param0, _param1)
 	ret0, _ := ret[0].(types.VolumesPruneReport)
 	ret1, _ := ret[1].(error)

--- a/agent/exec/container/executor.go
+++ b/agent/exec/container/executor.go
@@ -64,13 +64,9 @@ func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
 					} else if typ.Capability == "networkdriver" {
 						plgnTyp = "Network"
 					}
-					plgnName := plgn.Name
-					if plgn.Tag != "" {
-						plgnName += ":" + plgn.Tag
-					}
 					plugins[api.PluginDescription{
 						Type: plgnTyp,
-						Name: plgnName,
+						Name: plgn.Name,
 					}] = struct{}{}
 				}
 			}

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -3,6 +3,7 @@ package allocator
 import (
 	"sync"
 
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -27,6 +28,9 @@ type Allocator struct {
 	stopChan chan struct{}
 	// doneChan is closed when the allocator is finished running.
 	doneChan chan struct{}
+
+	// pluginGetter provides access to docker's plugin inventory.
+	pluginGetter plugingetter.PluginGetter
 }
 
 // taskBallot controls how the voting for task allocation is
@@ -67,14 +71,15 @@ type allocActor struct {
 
 // New returns a new instance of Allocator for use during allocation
 // stage of the manager.
-func New(store *store.MemoryStore) (*Allocator, error) {
+func New(store *store.MemoryStore, pg plugingetter.PluginGetter) (*Allocator, error) {
 	a := &Allocator{
 		store: store,
 		taskBallot: &taskBallot{
 			votes: make(map[string][]string),
 		},
-		stopChan: make(chan struct{}),
-		doneChan: make(chan struct{}),
+		stopChan:     make(chan struct{}),
+		doneChan:     make(chan struct{}),
+		pluginGetter: pg,
 	}
 
 	return a, nil

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -21,7 +21,7 @@ func TestAllocator(t *testing.T) {
 	assert.NotNil(t, s)
 	defer s.Close()
 
-	a, err := New(s)
+	a, err := New(s, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -73,7 +73,7 @@ type networkContext struct {
 }
 
 func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
-	na, err := networkallocator.New()
+	na, err := networkallocator.New(a.pluginGetter)
 	if err != nil {
 		return err
 	}

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/docker/docker/pkg/plugins"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/libnetwork/datastore"
 	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/drvregistry"
@@ -69,7 +69,7 @@ type initializer struct {
 }
 
 // New returns a new NetworkAllocator handle
-func New() (*NetworkAllocator, error) {
+func New(pg plugingetter.PluginGetter) (*NetworkAllocator, error) {
 	na := &NetworkAllocator{
 		networks: make(map[string]*network),
 		services: make(map[string]struct{}),
@@ -79,7 +79,7 @@ func New() (*NetworkAllocator, error) {
 
 	// There are no driver configurations and notification
 	// functions as of now.
-	reg, err := drvregistry.New(nil, nil, nil, nil, nil)
+	reg, err := drvregistry.New(nil, nil, nil, nil, pg)
 	if err != nil {
 		return nil, err
 	}
@@ -657,7 +657,11 @@ func (na *NetworkAllocator) resolveDriver(n *api.Network) (driverapi.Driver, str
 }
 
 func (na *NetworkAllocator) loadDriver(name string) error {
-	_, err := plugins.Get(name, driverapi.NetworkPluginEndpointType)
+	pg := na.drvRegistry.GetPluginGetter()
+	if pg == nil {
+		return fmt.Errorf("plugin store is unintialized")
+	}
+	_, err := pg.Get(name, driverapi.NetworkPluginEndpointType, plugingetter.Lookup)
 	return err
 }
 

--- a/manager/allocator/networkallocator/networkallocator_test.go
+++ b/manager/allocator/networkallocator/networkallocator_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newNetworkAllocator(t *testing.T) *NetworkAllocator {
-	na, err := New()
+	na, err := New(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, na)
 	return na

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
@@ -105,6 +106,9 @@ type Config struct {
 
 	// Availability allows a user to control the current scheduling status of a node
 	Availability api.NodeSpec_Availability
+
+	// PluginGetter provides access to docker's plugin inventory.
+	PluginGetter plugingetter.PluginGetter
 }
 
 // Manager is the cluster manager for Swarm.
@@ -833,7 +837,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	// shutdown underlying manager processes when leadership is
 	// lost.
 
-	m.allocator, err = allocator.New(s)
+	m.allocator, err = allocator.New(s, m.config.PluginGetter)
 	if err != nil {
 		log.G(ctx).WithError(err).Error("failed to create allocator")
 		// TODO(stevvooe): It doesn't seem correct here to fail

--- a/node/node.go
+++ b/node/node.go
@@ -687,6 +687,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		AutoLockManagers: n.config.AutoLockManagers,
 		UnlockKey:        n.unlockKey,
 		Availability:     n.config.Availability,
+		PluginGetter:     n.config.PluginGetter,
 	})
 	if err != nil {
 		return err

--- a/node/node.go
+++ b/node/node.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/agent"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -98,6 +99,9 @@ type Config struct {
 
 	// Availability allows a user to control the current scheduling status of a node
 	Availability api.NodeSpec_Availability
+
+	// PluginGetter provides access to docker's plugin inventory.
+	PluginGetter plugingetter.PluginGetter
 }
 
 // Node implements the primary node functionality for a member of a swarm

--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/prometheus/common ebdfc6da46522d58825777cf1f90490a5b1ef1d8
 github.com/prometheus/procfs abf152e5f3e97f2fafac028d2cc06c1feb87ffa5
 
 github.com/docker/distribution 7dba427612198a11b161a27f9d40bb2dca1ccd20
-github.com/docker/docker 0fb0d67008157add34f1e11685e23a691db92644
+github.com/docker/docker 428600108cce0a11e65ec4ebd9e439e947b55da7
 github.com/docker/go-connections 34b5052da6b11e27f5f2e357b38b571ddddd3928
 github.com/docker/go-events 37d35add5005832485c0225ec870121b78fcff1c
 github.com/docker/go-units 954fed01cc617c55d838fa2230073f2cb17386c8

--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -160,10 +160,13 @@ type ImageBuildOptions struct {
 	ShmSize        int64
 	Dockerfile     string
 	Ulimits        []*units.Ulimit
-	BuildArgs      map[string]string
-	AuthConfigs    map[string]AuthConfig
-	Context        io.Reader
-	Labels         map[string]string
+	// See the parsing of buildArgs in api/server/router/build/build_routes.go
+	// for an explaination of why BuildArgs needs to use *string instead of
+	// just a string
+	BuildArgs   map[string]*string
+	AuthConfigs map[string]AuthConfig
+	Context     io.Reader
+	Labels      map[string]string
 	// squash the resulting image's layers to the parent
 	// preserves the original image and creates a new one from the parent with all
 	// the changes applied to a single layer
@@ -337,11 +340,17 @@ type PluginEnableOptions struct {
 	Timeout int
 }
 
+// PluginDisableOptions holds parameters to disable plugins.
+type PluginDisableOptions struct {
+	Force bool
+}
+
 // PluginInstallOptions holds parameters to install a plugin.
 type PluginInstallOptions struct {
 	Disabled              bool
 	AcceptAllPermissions  bool
 	RegistryAuth          string // RegistryAuth is the base64 encoded credentials for the registry
+	RemoteRef             string // RemoteRef is the plugin name on the registry
 	PrivilegeFunc         RequestPrivilegeFunc
 	AcceptPermissionsFunc func(PluginPrivileges) (bool, error)
 	Args                  []string

--- a/vendor/github.com/docker/docker/api/types/configs.go
+++ b/vendor/github.com/docker/docker/api/types/configs.go
@@ -53,14 +53,17 @@ type ExecConfig struct {
 	Cmd          []string // Execution commands and args
 }
 
-// PluginRmConfig holds arguments for the plugin remove
-// operation. This struct is used to tell the backend what operations
-// to perform.
+// PluginRmConfig holds arguments for plugin remove.
 type PluginRmConfig struct {
 	ForceRemove bool
 }
 
-// PluginEnableConfig holds arguments for the plugin enable
+// PluginEnableConfig holds arguments for plugin enable
 type PluginEnableConfig struct {
 	Timeout int
+}
+
+// PluginDisableConfig holds arguments for plugin disable.
+type PluginDisableConfig struct {
+	ForceDisable bool
 }

--- a/vendor/github.com/docker/docker/api/types/container/config.go
+++ b/vendor/github.com/docker/docker/api/types/container/config.go
@@ -34,29 +34,29 @@ type HealthConfig struct {
 // All fields added to this struct must be marked `omitempty` to keep getting
 // predictable hashes from the old `v1Compatibility` configuration.
 type Config struct {
-	Hostname        string                // Hostname
-	Domainname      string                // Domainname
-	User            string                // User that will run the command(s) inside the container, also support user:group
-	AttachStdin     bool                  // Attach the standard input, makes possible user interaction
-	AttachStdout    bool                  // Attach the standard output
-	AttachStderr    bool                  // Attach the standard error
-	ExposedPorts    nat.PortSet           `json:",omitempty"` // List of exposed ports
-	Tty             bool                  // Attach standard streams to a tty, including stdin if it is not closed.
-	OpenStdin       bool                  // Open stdin
-	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
-	Env             []string              // List of environment variable to set in the container
-	Cmd             strslice.StrSlice     // Command to run when starting the container
-	Healthcheck     *HealthConfig         `json:",omitempty"` // Healthcheck describes how to check the container is healthy
-	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
-	Image           string                // Name of the image as it was passed by the operator (e.g. could be symbolic)
-	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container
-	WorkingDir      string                // Current directory (PWD) in the command will be launched
-	Entrypoint      strslice.StrSlice     // Entrypoint to run when starting the container
-	NetworkDisabled bool                  `json:",omitempty"` // Is network disabled
-	MacAddress      string                `json:",omitempty"` // Mac Address of the container
-	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
-	Labels          map[string]string     // List of labels set to this container
-	StopSignal      string                `json:",omitempty"` // Signal to stop a container
-	StopTimeout     *int                  `json:",omitempty"` // Timeout (in seconds) to stop a container
-	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
+	Hostname        string              // Hostname
+	Domainname      string              // Domainname
+	User            string              // User that will run the command(s) inside the container, also support user:group
+	AttachStdin     bool                // Attach the standard input, makes possible user interaction
+	AttachStdout    bool                // Attach the standard output
+	AttachStderr    bool                // Attach the standard error
+	ExposedPorts    nat.PortSet         `json:",omitempty"` // List of exposed ports
+	Tty             bool                // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool                // Open stdin
+	StdinOnce       bool                // If true, close stdin after the 1 attached client disconnects.
+	Env             []string            // List of environment variable to set in the container
+	Cmd             strslice.StrSlice   // Command to run when starting the container
+	Healthcheck     *HealthConfig       `json:",omitempty"` // Healthcheck describes how to check the container is healthy
+	ArgsEscaped     bool                `json:",omitempty"` // True if command is already escaped (Windows specific)
+	Image           string              // Name of the image as it was passed by the operator (e.g. could be symbolic)
+	Volumes         map[string]struct{} // List of volumes (mounts) used for the container
+	WorkingDir      string              // Current directory (PWD) in the command will be launched
+	Entrypoint      strslice.StrSlice   // Entrypoint to run when starting the container
+	NetworkDisabled bool                `json:",omitempty"` // Is network disabled
+	MacAddress      string              `json:",omitempty"` // Mac Address of the container
+	OnBuild         []string            // ONBUILD metadata that were defined on the image Dockerfile
+	Labels          map[string]string   // List of labels set to this container
+	StopSignal      string              `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           strslice.StrSlice   `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/vendor/github.com/docker/docker/api/types/container/host_config.go
+++ b/vendor/github.com/docker/docker/api/types/container/host_config.go
@@ -317,7 +317,7 @@ type HostConfig struct {
 
 	// Applicable to Windows
 	ConsoleSize [2]uint   // Initial console size (height,width)
-	Isolation   Isolation // Isolation technology of the container (eg default, hyperv)
+	Isolation   Isolation // Isolation technology of the container (e.g. default, hyperv)
 
 	// Contains container's resources (cgroups, ulimits)
 	Resources

--- a/vendor/github.com/docker/docker/api/types/mount/mount.go
+++ b/vendor/github.com/docker/docker/api/types/mount/mount.go
@@ -50,6 +50,16 @@ const (
 	PropagationSlave Propagation = "slave"
 )
 
+// Propagations is the list of all valid mount propagations
+var Propagations = []Propagation{
+	PropagationRPrivate,
+	PropagationPrivate,
+	PropagationRShared,
+	PropagationShared,
+	PropagationRSlave,
+	PropagationSlave,
+}
+
 // BindOptions defines options specific to mounts of type "bind".
 type BindOptions struct {
 	Propagation Propagation `json:",omitempty"`

--- a/vendor/github.com/docker/docker/api/types/network/network.go
+++ b/vendor/github.com/docker/docker/api/types/network/network.go
@@ -28,7 +28,7 @@ type EndpointIPAMConfig struct {
 	LinkLocalIPs []string `json:",omitempty"`
 }
 
-// PeerInfo represents one peer of a overlay network
+// PeerInfo represents one peer of an overlay network
 type PeerInfo struct {
 	Name string
 	IP   string

--- a/vendor/github.com/docker/docker/api/types/plugin.go
+++ b/vendor/github.com/docker/docker/api/types/plugin.go
@@ -25,10 +25,6 @@ type Plugin struct {
 	// settings
 	// Required: true
 	Settings PluginSettings `json:"Settings"`
-
-	// tag
-	// Required: true
-	Tag string `json:"Tag"`
 }
 
 // PluginConfig The config of a plugin.
@@ -71,12 +67,19 @@ type PluginConfig struct {
 	// Required: true
 	Network PluginConfigNetwork `json:"Network"`
 
+	// propagated mount
+	// Required: true
+	PropagatedMount string `json:"PropagatedMount"`
+
 	// user
 	User PluginConfigUser `json:"User,omitempty"`
 
-	// workdir
+	// work dir
 	// Required: true
-	Workdir string `json:"Workdir"`
+	WorkDir string `json:"WorkDir"`
+
+	// rootfs
+	Rootfs *PluginConfigRootfs `json:"rootfs,omitempty"`
 }
 
 // PluginConfigArgs plugin config args
@@ -137,6 +140,17 @@ type PluginConfigNetwork struct {
 	// type
 	// Required: true
 	Type string `json:"Type"`
+}
+
+// PluginConfigRootfs plugin config rootfs
+// swagger:model PluginConfigRootfs
+type PluginConfigRootfs struct {
+
+	// diff ids
+	DiffIds []string `json:"diff_ids"`
+
+	// type
+	Type string `json:"type,omitempty"`
 }
 
 // PluginConfigUser plugin config user

--- a/vendor/github.com/docker/docker/api/types/seccomp.go
+++ b/vendor/github.com/docker/docker/api/types/seccomp.go
@@ -10,7 +10,7 @@ type Seccomp struct {
 	Syscalls      []*Syscall     `json:"syscalls"`
 }
 
-// Architecture is used to represent an specific architecture
+// Architecture is used to represent a specific architecture
 // and its sub-architectures
 type Architecture struct {
 	Arch      Arch   `json:"architecture"`

--- a/vendor/github.com/docker/docker/api/types/swarm/common.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/common.go
@@ -19,3 +19,9 @@ type Annotations struct {
 	Name   string            `json:",omitempty"`
 	Labels map[string]string `json:",omitempty"`
 }
+
+// Driver represents a driver (network, logging).
+type Driver struct {
+	Name    string            `json:",omitempty"`
+	Options map[string]string `json:",omitempty"`
+}

--- a/vendor/github.com/docker/docker/api/types/swarm/network.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/network.go
@@ -109,9 +109,3 @@ type IPAMConfig struct {
 	Range   string `json:",omitempty"`
 	Gateway string `json:",omitempty"`
 }
-
-// Driver represents a network driver.
-type Driver struct {
-	Name    string            `json:",omitempty"`
-	Options map[string]string `json:",omitempty"`
-}

--- a/vendor/github.com/docker/docker/api/types/swarm/service.go
+++ b/vendor/github.com/docker/docker/api/types/swarm/service.go
@@ -6,10 +6,10 @@ import "time"
 type Service struct {
 	ID string
 	Meta
-	Spec         ServiceSpec  `json:",omitempty"`
-	PreviousSpec *ServiceSpec `json:",omitempty"`
-	Endpoint     Endpoint     `json:",omitempty"`
-	UpdateStatus UpdateStatus `json:",omitempty"`
+	Spec         ServiceSpec   `json:",omitempty"`
+	PreviousSpec *ServiceSpec  `json:",omitempty"`
+	Endpoint     Endpoint      `json:",omitempty"`
+	UpdateStatus *UpdateStatus `json:",omitempty"`
 }
 
 // ServiceSpec represents the spec of a service.
@@ -50,8 +50,8 @@ const (
 // UpdateStatus reports the status of a service update.
 type UpdateStatus struct {
 	State       UpdateState `json:",omitempty"`
-	StartedAt   time.Time   `json:",omitempty"`
-	CompletedAt time.Time   `json:",omitempty"`
+	StartedAt   *time.Time  `json:",omitempty"`
+	CompletedAt *time.Time  `json:",omitempty"`
 	Message     string      `json:",omitempty"`
 }
 

--- a/vendor/github.com/docker/docker/api/types/time/timestamp.go
+++ b/vendor/github.com/docker/docker/api/types/time/timestamp.go
@@ -84,7 +84,7 @@ func GetTimestamp(value string, reference time.Time) (string, error) {
 	}
 
 	if err != nil {
-		// if there is a `-` then its an RFC3339 like timestamp otherwise assume unixtimestamp
+		// if there is a `-` then it's an RFC3339 like timestamp otherwise assume unixtimestamp
 		if strings.Contains(value, "-") {
 			return "", err // was probably an RFC3339 like timestamp but the parser failed with an error
 		}

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -154,11 +154,11 @@ type Version struct {
 	BuildTime     string `json:",omitempty"`
 }
 
-// Commit records a external tool actual commit id version along the
-// one expect by dockerd as set at build time
+// Commit holds the Git-commit (SHA1) that a binary was built from, as reported
+// in the version-string of external tools, such as containerd, or runC.
 type Commit struct {
-	ID       string
-	Expected string
+	ID       string // ID is the actual commit ID of external tool.
+	Expected string // Expected is the commit ID of external tool expected by dockerd as set at build time.
 }
 
 // Info contains response of Engine API:
@@ -509,27 +509,6 @@ type DiskUsage struct {
 	Volumes    []*Volume
 }
 
-// ImagesPruneConfig contains the configuration for Engine API:
-// POST "/images/prune"
-type ImagesPruneConfig struct {
-	DanglingOnly bool
-}
-
-// ContainersPruneConfig contains the configuration for Engine API:
-// POST "/images/prune"
-type ContainersPruneConfig struct {
-}
-
-// VolumesPruneConfig contains the configuration for Engine API:
-// POST "/images/prune"
-type VolumesPruneConfig struct {
-}
-
-// NetworksPruneConfig contains the configuration for Engine API:
-// POST "/networks/prune"
-type NetworksPruneConfig struct {
-}
-
 // ContainersPruneReport contains the response for Engine API:
 // POST "/containers/prune"
 type ContainersPruneReport struct {
@@ -567,4 +546,13 @@ type SecretCreateResponse struct {
 // SecretListOptions holds parameters to list secrets
 type SecretListOptions struct {
 	Filters filters.Args
+}
+
+// PushResult contains the tag, manifest digest, and manifest size from the
+// push. It's used to signal this information to the trust code in the client
+// so it can sign the manifest if necessary.
+type PushResult struct {
+	Tag    string
+	Digest string
+	Size   int
 }

--- a/vendor/github.com/docker/docker/client/client.go
+++ b/vendor/github.com/docker/docker/client/client.go
@@ -86,7 +86,7 @@ type Client struct {
 // NewEnvClient initializes a new API client based on environment variables.
 // Use DOCKER_HOST to set the url to the docker server.
 // Use DOCKER_API_VERSION to set the version of the API to reach, leave empty for latest.
-// Use DOCKER_CERT_PATH to load the tls certificates from.
+// Use DOCKER_CERT_PATH to load the TLS certificates from.
 // Use DOCKER_TLS_VERIFY to enable or disable TLS verification, off by default.
 func NewEnvClient() (*Client, error) {
 	var client *http.Client

--- a/vendor/github.com/docker/docker/client/container_prune.go
+++ b/vendor/github.com/docker/docker/client/container_prune.go
@@ -5,18 +5,24 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/net/context"
 )
 
 // ContainersPrune requests the daemon to delete unused data
-func (cli *Client) ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error) {
+func (cli *Client) ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error) {
 	var report types.ContainersPruneReport
 
 	if err := cli.NewVersionError("1.25", "container prune"); err != nil {
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/containers/prune", nil, cfg, nil)
+	query, err := getFiltersQuery(pruneFilters)
+	if err != nil {
+		return report, err
+	}
+
+	serverResp, err := cli.post(ctx, "/containers/prune", query, nil, nil)
 	if err != nil {
 		return report, err
 	}

--- a/vendor/github.com/docker/docker/client/errors.go
+++ b/vendor/github.com/docker/docker/client/errors.go
@@ -244,7 +244,7 @@ func (e secretNotFoundError) Error() string {
 	return fmt.Sprintf("Error: no such secret: %s", e.name)
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e secretNotFoundError) NotFound() bool {
 	return true
 }
@@ -254,4 +254,25 @@ func (e secretNotFoundError) NotFound() bool {
 func IsErrSecretNotFound(err error) bool {
 	_, ok := err.(secretNotFoundError)
 	return ok
+}
+
+// pluginNotFoundError implements an error returned when a plugin is not in the docker host.
+type pluginNotFoundError struct {
+	name string
+}
+
+// NotFound indicates that this error type is of NotFound
+func (e pluginNotFoundError) NotFound() bool {
+	return true
+}
+
+// Error returns a string representation of a pluginNotFoundError
+func (e pluginNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such plugin: %s", e.name)
+}
+
+// IsErrPluginNotFound returns true if the error is caused
+// when a plugin is not found in the docker host.
+func IsErrPluginNotFound(err error) bool {
+	return IsErrNotFound(err)
 }

--- a/vendor/github.com/docker/docker/client/image_prune.go
+++ b/vendor/github.com/docker/docker/client/image_prune.go
@@ -5,18 +5,24 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/net/context"
 )
 
 // ImagesPrune requests the daemon to delete unused data
-func (cli *Client) ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error) {
+func (cli *Client) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (types.ImagesPruneReport, error) {
 	var report types.ImagesPruneReport
 
 	if err := cli.NewVersionError("1.25", "image prune"); err != nil {
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/images/prune", nil, cfg, nil)
+	query, err := getFiltersQuery(pruneFilters)
+	if err != nil {
+		return report, err
+	}
+
+	serverResp, err := cli.post(ctx, "/images/prune", query, nil, nil)
 	if err != nil {
 		return report, err
 	}

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -64,7 +64,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string) (int64, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
-	ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error)
+	ContainersPrune(ctx context.Context, pruneFilters filters.Args) (types.ContainersPruneReport, error)
 }
 
 // ImageAPIClient defines API client methods for the images
@@ -82,7 +82,7 @@ type ImageAPIClient interface {
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
-	ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error)
+	ImagesPrune(ctx context.Context, pruneFilter filters.Args) (types.ImagesPruneReport, error)
 }
 
 // NetworkAPIClient defines API client methods for the networks
@@ -94,7 +94,7 @@ type NetworkAPIClient interface {
 	NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
-	NetworksPrune(ctx context.Context, cfg types.NetworksPruneConfig) (types.NetworksPruneReport, error)
+	NetworksPrune(ctx context.Context, pruneFilter filters.Args) (types.NetworksPruneReport, error)
 }
 
 // NodeAPIClient defines API client methods for the nodes
@@ -110,9 +110,9 @@ type PluginAPIClient interface {
 	PluginList(ctx context.Context) (types.PluginsListResponse, error)
 	PluginRemove(ctx context.Context, name string, options types.PluginRemoveOptions) error
 	PluginEnable(ctx context.Context, name string, options types.PluginEnableOptions) error
-	PluginDisable(ctx context.Context, name string) error
-	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) error
-	PluginPush(ctx context.Context, name string, registryAuth string) error
+	PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error
+	PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) (io.ReadCloser, error)
+	PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error)
 	PluginSet(ctx context.Context, name string, args []string) error
 	PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error)
 	PluginCreate(ctx context.Context, createContext io.Reader, options types.PluginCreateOptions) error
@@ -157,7 +157,7 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (volumetypes.VolumesListOKBody, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
-	VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error)
+	VolumesPrune(ctx context.Context, pruneFilter filters.Args) (types.VolumesPruneReport, error)
 }
 
 // SecretAPIClient defines API client methods for secrets

--- a/vendor/github.com/docker/docker/client/network_prune.go
+++ b/vendor/github.com/docker/docker/client/network_prune.go
@@ -5,14 +5,24 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/net/context"
 )
 
 // NetworksPrune requests the daemon to delete unused networks
-func (cli *Client) NetworksPrune(ctx context.Context, cfg types.NetworksPruneConfig) (types.NetworksPruneReport, error) {
+func (cli *Client) NetworksPrune(ctx context.Context, pruneFilters filters.Args) (types.NetworksPruneReport, error) {
 	var report types.NetworksPruneReport
 
-	serverResp, err := cli.post(ctx, "/networks/prune", nil, cfg, nil)
+	if err := cli.NewVersionError("1.25", "network prune"); err != nil {
+		return report, err
+	}
+
+	query, err := getFiltersQuery(pruneFilters)
+	if err != nil {
+		return report, err
+	}
+
+	serverResp, err := cli.post(ctx, "/networks/prune", query, nil, nil)
 	if err != nil {
 		return report, err
 	}

--- a/vendor/github.com/docker/docker/client/ping.go
+++ b/vendor/github.com/docker/docker/client/ping.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Ping pings the server and return the value of the "Docker-Experimental" & "API-Version" headers
+// Ping pings the server and returns the value of the "Docker-Experimental" & "API-Version" headers
 func (cli *Client) Ping(ctx context.Context) (types.Ping, error) {
 	var ping types.Ping
 	req, err := cli.buildRequest("GET", fmt.Sprintf("%s/_ping", cli.basePath), nil, nil)

--- a/vendor/github.com/docker/docker/client/plugin_disable.go
+++ b/vendor/github.com/docker/docker/client/plugin_disable.go
@@ -1,12 +1,19 @@
 package client
 
 import (
+	"net/url"
+
+	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
 )
 
 // PluginDisable disables a plugin
-func (cli *Client) PluginDisable(ctx context.Context, name string) error {
-	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", nil, nil, nil)
+func (cli *Client) PluginDisable(ctx context.Context, name string, options types.PluginDisableOptions) error {
+	query := url.Values{}
+	if options.Force {
+		query.Set("force", "1")
+	}
+	resp, err := cli.post(ctx, "/plugins/"+name+"/disable", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/docker/docker/client/plugin_inspect.go
+++ b/vendor/github.com/docker/docker/client/plugin_inspect.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 
 	"github.com/docker/docker/api/types"
 	"golang.org/x/net/context"
@@ -11,8 +12,11 @@ import (
 
 // PluginInspectWithRaw inspects an existing plugin
 func (cli *Client) PluginInspectWithRaw(ctx context.Context, name string) (*types.Plugin, []byte, error) {
-	resp, err := cli.get(ctx, "/plugins/"+name, nil, nil)
+	resp, err := cli.get(ctx, "/plugins/"+name+"/json", nil, nil)
 	if err != nil {
+		if resp.statusCode == http.StatusNotFound {
+			return nil, nil, pluginNotFoundError{name}
+		}
 		return nil, nil, err
 	}
 

--- a/vendor/github.com/docker/docker/client/plugin_install.go
+++ b/vendor/github.com/docker/docker/client/plugin_install.go
@@ -2,70 +2,104 @@ package client
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
 // PluginInstall installs a plugin
-func (cli *Client) PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) (err error) {
-	// FIXME(vdemeester) name is a ref, we might want to parse/validate it here.
+func (cli *Client) PluginInstall(ctx context.Context, name string, options types.PluginInstallOptions) (rc io.ReadCloser, err error) {
 	query := url.Values{}
-	query.Set("name", name)
-	resp, err := cli.tryPluginPull(ctx, query, options.RegistryAuth)
+	if _, err := reference.ParseNamed(options.RemoteRef); err != nil {
+		return nil, errors.Wrap(err, "invalid remote reference")
+	}
+	query.Set("remote", options.RemoteRef)
+
+	resp, err := cli.tryPluginPrivileges(ctx, query, options.RegistryAuth)
 	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
+		// todo: do inspect before to check existing name before checking privileges
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			ensureReaderClosed(resp)
-			return privilegeErr
+			return nil, privilegeErr
 		}
-		resp, err = cli.tryPluginPull(ctx, query, newAuthHeader)
+		options.RegistryAuth = newAuthHeader
+		resp, err = cli.tryPluginPrivileges(ctx, query, options.RegistryAuth)
 	}
 	if err != nil {
 		ensureReaderClosed(resp)
-		return err
+		return nil, err
 	}
-
-	defer func() {
-		if err != nil {
-			delResp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
-			ensureReaderClosed(delResp)
-		}
-	}()
 
 	var privileges types.PluginPrivileges
 	if err := json.NewDecoder(resp.body).Decode(&privileges); err != nil {
 		ensureReaderClosed(resp)
-		return err
+		return nil, err
 	}
 	ensureReaderClosed(resp)
 
 	if !options.AcceptAllPermissions && options.AcceptPermissionsFunc != nil && len(privileges) > 0 {
 		accept, err := options.AcceptPermissionsFunc(privileges)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if !accept {
-			return pluginPermissionDenied{name}
+			return nil, pluginPermissionDenied{options.RemoteRef}
 		}
 	}
 
-	if len(options.Args) > 0 {
-		if err := cli.PluginSet(ctx, name, options.Args); err != nil {
-			return err
+	// set name for plugin pull, if empty should default to remote reference
+	query.Set("name", name)
+
+	resp, err = cli.tryPluginPull(ctx, query, privileges, options.RegistryAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	name = resp.header.Get("Docker-Plugin-Name")
+
+	pr, pw := io.Pipe()
+	go func() { // todo: the client should probably be designed more around the actual api
+		_, err := io.Copy(pw, resp.body)
+		if err != nil {
+			pw.CloseWithError(err)
+			return
 		}
-	}
+		defer func() {
+			if err != nil {
+				delResp, _ := cli.delete(ctx, "/plugins/"+name, nil, nil)
+				ensureReaderClosed(delResp)
+			}
+		}()
+		if len(options.Args) > 0 {
+			if err := cli.PluginSet(ctx, name, options.Args); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
 
-	if options.Disabled {
-		return nil
-	}
+		if options.Disabled {
+			pw.Close()
+			return
+		}
 
-	return cli.PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: 0})
+		err = cli.PluginEnable(ctx, name, types.PluginEnableOptions{Timeout: 0})
+		pw.CloseWithError(err)
+	}()
+	return pr, nil
 }
 
-func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
+func (cli *Client) tryPluginPrivileges(ctx context.Context, query url.Values, registryAuth string) (serverResponse, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
-	return cli.post(ctx, "/plugins/pull", query, nil, headers)
+	return cli.get(ctx, "/plugins/privileges", query, headers)
+}
+
+func (cli *Client) tryPluginPull(ctx context.Context, query url.Values, privileges types.PluginPrivileges, registryAuth string) (serverResponse, error) {
+	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
+	return cli.post(ctx, "/plugins/pull", query, privileges, headers)
 }

--- a/vendor/github.com/docker/docker/client/plugin_push.go
+++ b/vendor/github.com/docker/docker/client/plugin_push.go
@@ -1,13 +1,17 @@
 package client
 
 import (
+	"io"
+
 	"golang.org/x/net/context"
 )
 
 // PluginPush pushes a plugin to a registry
-func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) error {
+func (cli *Client) PluginPush(ctx context.Context, name string, registryAuth string) (io.ReadCloser, error) {
 	headers := map[string][]string{"X-Registry-Auth": {registryAuth}}
 	resp, err := cli.post(ctx, "/plugins/"+name+"/push", nil, nil, headers)
-	ensureReaderClosed(resp)
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return resp.body, nil
 }

--- a/vendor/github.com/docker/docker/client/swarm_init.go
+++ b/vendor/github.com/docker/docker/client/swarm_init.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmInit initializes the Swarm.
+// SwarmInit initializes the swarm.
 func (cli *Client) SwarmInit(ctx context.Context, req swarm.InitRequest) (string, error) {
 	serverResp, err := cli.post(ctx, "/swarm/init", nil, req, nil)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/swarm_inspect.go
+++ b/vendor/github.com/docker/docker/client/swarm_inspect.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmInspect inspects the Swarm.
+// SwarmInspect inspects the swarm.
 func (cli *Client) SwarmInspect(ctx context.Context) (swarm.Swarm, error) {
 	serverResp, err := cli.get(ctx, "/swarm", nil, nil)
 	if err != nil {

--- a/vendor/github.com/docker/docker/client/swarm_join.go
+++ b/vendor/github.com/docker/docker/client/swarm_join.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmJoin joins the Swarm.
+// SwarmJoin joins the swarm.
 func (cli *Client) SwarmJoin(ctx context.Context, req swarm.JoinRequest) error {
 	resp, err := cli.post(ctx, "/swarm/join", nil, req, nil)
 	ensureReaderClosed(resp)

--- a/vendor/github.com/docker/docker/client/swarm_leave.go
+++ b/vendor/github.com/docker/docker/client/swarm_leave.go
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmLeave leaves the Swarm.
+// SwarmLeave leaves the swarm.
 func (cli *Client) SwarmLeave(ctx context.Context, force bool) error {
 	query := url.Values{}
 	if force {

--- a/vendor/github.com/docker/docker/client/swarm_update.go
+++ b/vendor/github.com/docker/docker/client/swarm_update.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// SwarmUpdate updates the Swarm.
+// SwarmUpdate updates the swarm.
 func (cli *Client) SwarmUpdate(ctx context.Context, version swarm.Version, swarm swarm.Spec, flags swarm.UpdateFlags) error {
 	query := url.Values{}
 	query.Set("version", strconv.FormatUint(version.Index, 10))

--- a/vendor/github.com/docker/docker/client/transport.go
+++ b/vendor/github.com/docker/docker/client/transport.go
@@ -2,11 +2,8 @@ package client
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 )
-
-var errTLSConfigUnavailable = errors.New("TLSConfig unavailable")
 
 // transportFunc allows us to inject a mock transport for testing. We define it
 // here so we can detect the tlsconfig and return nil for only this type.
@@ -16,7 +13,7 @@ func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return tf(req)
 }
 
-// resolveTLSConfig attempts to resolve the tls configuration from the
+// resolveTLSConfig attempts to resolve the TLS configuration from the
 // RoundTripper.
 func resolveTLSConfig(transport http.RoundTripper) *tls.Config {
 	switch tr := transport.(type) {

--- a/vendor/github.com/docker/docker/client/utils.go
+++ b/vendor/github.com/docker/docker/client/utils.go
@@ -1,6 +1,10 @@
 package client
 
-import "regexp"
+import (
+	"github.com/docker/docker/api/types/filters"
+	"net/url"
+	"regexp"
+)
 
 var headerRegexp = regexp.MustCompile(`\ADocker/.+\s\((.+)\)\z`)
 
@@ -12,4 +16,18 @@ func getDockerOS(serverHeader string) string {
 		osType = matches[1]
 	}
 	return osType
+}
+
+// getFiltersQuery returns a url query with "filters" query term, based on the
+// filters provided.
+func getFiltersQuery(f filters.Args) (url.Values, error) {
+	query := url.Values{}
+	if f.Len() > 0 {
+		filterJSON, err := filters.ToParam(f)
+		if err != nil {
+			return query, err
+		}
+		query.Set("filters", filterJSON)
+	}
+	return query, nil
 }

--- a/vendor/github.com/docker/docker/client/volume_prune.go
+++ b/vendor/github.com/docker/docker/client/volume_prune.go
@@ -5,18 +5,24 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
 	"golang.org/x/net/context"
 )
 
 // VolumesPrune requests the daemon to delete unused data
-func (cli *Client) VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error) {
+func (cli *Client) VolumesPrune(ctx context.Context, pruneFilters filters.Args) (types.VolumesPruneReport, error) {
 	var report types.VolumesPruneReport
 
 	if err := cli.NewVersionError("1.25", "volume prune"); err != nil {
 		return report, err
 	}
 
-	serverResp, err := cli.post(ctx, "/volumes/prune", nil, cfg, nil)
+	query, err := getFiltersQuery(pruneFilters)
+	if err != nil {
+		return report, err
+	}
+
+	serverResp, err := cli.post(ctx, "/volumes/prune", query, nil, nil)
 	if err != nil {
 		return report, err
 	}

--- a/vendor/github.com/docker/docker/pkg/plugingetter/getter.go
+++ b/vendor/github.com/docker/docker/pkg/plugingetter/getter.go
@@ -3,24 +3,33 @@ package plugingetter
 import "github.com/docker/docker/pkg/plugins"
 
 const (
-	// LOOKUP doesn't update RefCount
-	LOOKUP = 0
-	// CREATE increments RefCount
-	CREATE = 1
-	// REMOVE decrements RefCount
-	REMOVE = -1
+	// Lookup doesn't update RefCount
+	Lookup = 0
+	// Acquire increments RefCount
+	Acquire = 1
+	// Release decrements RefCount
+	Release = -1
 )
 
-// CompatPlugin is a abstraction to handle both v2(new) and v1(legacy) plugins.
+// CompatPlugin is an abstraction to handle both v2(new) and v1(legacy) plugins.
 type CompatPlugin interface {
 	Client() *plugins.Client
 	Name() string
+	BasePath() string
 	IsV1() bool
+}
+
+// CountedPlugin is a plugin which is reference counted.
+type CountedPlugin interface {
+	Acquire()
+	Release()
+	CompatPlugin
 }
 
 // PluginGetter is the interface implemented by Store
 type PluginGetter interface {
 	Get(name, capability string, mode int) (CompatPlugin, error)
 	GetAllByCap(capability string) ([]CompatPlugin, error)
+	GetAllManagedPluginsByCap(capability string) []CompatPlugin
 	Handle(capability string, callback func(string, *plugins.Client))
 }

--- a/vendor/github.com/docker/docker/pkg/plugins/plugins.go
+++ b/vendor/github.com/docker/docker/pkg/plugins/plugins.go
@@ -70,12 +70,18 @@ type Plugin struct {
 	// Manifest of the plugin (see above)
 	Manifest *Manifest `json:"-"`
 
-	// error produced by activation
-	activateErr error
-	// specifies if the activation sequence is completed (not if it is successful or not)
-	activated bool
 	// wait for activation to finish
 	activateWait *sync.Cond
+	// error produced by activation
+	activateErr error
+	// keeps track of callback handlers run against this plugin
+	handlersRun bool
+}
+
+// BasePath returns the path to which all paths returned by the plugin are relative to.
+// For v1 plugins, this always returns the host's root directory.
+func (p *Plugin) BasePath() string {
+	return "/"
 }
 
 // Name returns the name of the plugin.
@@ -106,17 +112,49 @@ func NewLocalPlugin(name, addr string) *Plugin {
 
 func (p *Plugin) activate() error {
 	p.activateWait.L.Lock()
-	if p.activated {
+
+	if p.activated() {
+		p.runHandlers()
 		p.activateWait.L.Unlock()
 		return p.activateErr
 	}
 
 	p.activateErr = p.activateWithLock()
-	p.activated = true
 
+	p.runHandlers()
 	p.activateWait.L.Unlock()
 	p.activateWait.Broadcast()
 	return p.activateErr
+}
+
+// runHandlers runs the registered handlers for the implemented plugin types
+// This should only be run after activation, and while the activation lock is held.
+func (p *Plugin) runHandlers() {
+	if !p.activated() {
+		return
+	}
+
+	handlers.RLock()
+	if !p.handlersRun {
+		for _, iface := range p.Manifest.Implements {
+			hdlrs, handled := handlers.extpointHandlers[iface]
+			if !handled {
+				continue
+			}
+			for _, handler := range hdlrs {
+				handler(p.name, p.client)
+			}
+		}
+		p.handlersRun = true
+	}
+	handlers.RUnlock()
+
+}
+
+// activated returns if the plugin has already been activated.
+// This should only be called with the activation lock held
+func (p *Plugin) activated() bool {
+	return p.Manifest != nil
 }
 
 func (p *Plugin) activateWithLock() error {
@@ -132,24 +170,12 @@ func (p *Plugin) activateWithLock() error {
 	}
 
 	p.Manifest = m
-
-	handlers.RLock()
-	for _, iface := range m.Implements {
-		hdlrs, handled := handlers.extpointHandlers[iface]
-		if !handled {
-			continue
-		}
-		for _, handler := range hdlrs {
-			handler(p.name, p.client)
-		}
-	}
-	handlers.RUnlock()
 	return nil
 }
 
 func (p *Plugin) waitActive() error {
 	p.activateWait.L.Lock()
-	for !p.activated {
+	for !p.activated() {
 		p.activateWait.Wait()
 	}
 	p.activateWait.L.Unlock()
@@ -157,7 +183,7 @@ func (p *Plugin) waitActive() error {
 }
 
 func (p *Plugin) implements(kind string) bool {
-	if err := p.waitActive(); err != nil {
+	if p.Manifest == nil {
 		return false
 	}
 	for _, driver := range p.Manifest.Implements {
@@ -226,7 +252,7 @@ func Get(name, imp string) (*Plugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	if pl.implements(imp) {
+	if err := pl.waitActive(); err == nil && pl.implements(imp) {
 		logrus.Debugf("%s implements: %s", name, imp)
 		return pl, nil
 	}
@@ -243,9 +269,17 @@ func Handle(iface string, fn func(string, *Client)) {
 
 	hdlrs = append(hdlrs, fn)
 	handlers.extpointHandlers[iface] = hdlrs
+
+	storage.Lock()
 	for _, p := range storage.plugins {
-		p.activated = false
+		p.activateWait.L.Lock()
+		if p.activated() && p.implements(iface) {
+			p.handlersRun = false
+		}
+		p.activateWait.L.Unlock()
 	}
+	storage.Unlock()
+
 	handlers.Unlock()
 }
 
@@ -286,7 +320,7 @@ func GetAll(imp string) ([]*Plugin, error) {
 			logrus.Error(pl.err)
 			continue
 		}
-		if pl.pl.implements(imp) {
+		if err := pl.pl.waitActive(); err == nil && pl.pl.implements(imp) {
 			out = append(out, pl.pl)
 		}
 	}


### PR DESCRIPTION
This is a followup PR for https://github.com/docker/swarmkit/pull/1867 and its companion docker PR docker/docker#30145 to resolve https://github.com/docker/docker/issues/30024.

This PR carries 
1. the patch from @anusha-ragunathan (https://github.com/docker/swarmkit/pull/1867)
2. changes required to pass on the plugingetter to networkallocator
3. vendoring docker/docker to consume the changes intrduced by docker/docker#29564

ping @aaronlehmann @anusha-ragunathan 