### PR TITLE
Revert "Gracefully fail if Network and IPAM plugins are used"

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -76,7 +76,7 @@ func validateAnnotations(m api.Annotations) error {
 	return nil
 }
 
-func validateDriver(driver *api.Driver, defName string) error {
+func validateDriver(driver *api.Driver) error {
 	if driver == nil {
 		// It is ok to not specify the driver. We will choose
 		// a default driver.
@@ -87,8 +87,5 @@ func validateDriver(driver *api.Driver, defName string) error {
 		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
 	}
 
-	if driver.Name != defName {
-		return grpc.Errorf(codes.InvalidArgument, "invalid driver (%s) specified", driver.Name)
-	}
 	return nil
 }

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -56,7 +54,7 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 		return nil
 	}
 
-	if err := validateDriver(ipam.Driver, ipamapi.DefaultIPAM); err != nil {
+	if err := validateDriver(ipam.Driver); err != nil {
 		return err
 	}
 
@@ -78,7 +76,7 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 		return err
 	}
 
-	if err := validateDriver(spec.DriverConfig, networkallocator.DefaultDriver); err != nil {
+	if err := validateDriver(spec.DriverConfig); err != nil {
 		return err
 	}
 

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -86,13 +86,9 @@ func createServiceInNetwork(t *testing.T, ts *testServer, name, image string, nw
 }
 
 func TestValidateDriver(t *testing.T) {
-	assert.NoError(t, validateDriver(nil, ""))
+	assert.NoError(t, validateDriver(nil))
 
-	err := validateDriver(&api.Driver{Name: ""}, "")
-	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
-
-	err = validateDriver(&api.Driver{Name: "test"}, "default")
+	err := validateDriver(&api.Driver{Name: ""})
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }


### PR DESCRIPTION
With https://github.com/docker/swarmkit/pull/1876 in, we must revert https://github.com/docker/swarmkit/pull/1856.

This reverts commit 775a4bc0febbcace936511a36ca30144e81e2c63.