### PR TITLE
deepcopy: copy scalars with memset

### DIFF
--- a/api/ca.pb.go
+++ b/api/ca.pb.go
@@ -179,7 +179,7 @@ func (m *NodeCertificateStatusRequest) Copy() *NodeCertificateStatusRequest {
 func (m *NodeCertificateStatusRequest) CopyFrom(src interface{}) {
 
 	o := src.(*NodeCertificateStatusRequest)
-	m.NodeID = o.NodeID
+	*m = *o
 }
 
 func (m *NodeCertificateStatusResponse) Copy() *NodeCertificateStatusResponse {
@@ -194,6 +194,7 @@ func (m *NodeCertificateStatusResponse) Copy() *NodeCertificateStatusResponse {
 func (m *NodeCertificateStatusResponse) CopyFrom(src interface{}) {
 
 	o := src.(*NodeCertificateStatusResponse)
+	*m = *o
 	if o.Status != nil {
 		m.Status = &IssuanceStatus{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Status, o.Status)
@@ -216,10 +217,7 @@ func (m *IssueNodeCertificateRequest) Copy() *IssueNodeCertificateRequest {
 func (m *IssueNodeCertificateRequest) CopyFrom(src interface{}) {
 
 	o := src.(*IssueNodeCertificateRequest)
-	m.Role = o.Role
-	m.CSR = o.CSR
-	m.Token = o.Token
-	m.Availability = o.Availability
+	*m = *o
 }
 
 func (m *IssueNodeCertificateResponse) Copy() *IssueNodeCertificateResponse {
@@ -234,8 +232,7 @@ func (m *IssueNodeCertificateResponse) Copy() *IssueNodeCertificateResponse {
 func (m *IssueNodeCertificateResponse) CopyFrom(src interface{}) {
 
 	o := src.(*IssueNodeCertificateResponse)
-	m.NodeID = o.NodeID
-	m.NodeMembership = o.NodeMembership
+	*m = *o
 }
 
 func (m *GetRootCACertificateRequest) Copy() *GetRootCACertificateRequest {
@@ -260,7 +257,7 @@ func (m *GetRootCACertificateResponse) Copy() *GetRootCACertificateResponse {
 func (m *GetRootCACertificateResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetRootCACertificateResponse)
-	m.Certificate = o.Certificate
+	*m = *o
 }
 
 func (m *GetUnlockKeyRequest) Copy() *GetUnlockKeyRequest {
@@ -285,7 +282,7 @@ func (m *GetUnlockKeyResponse) Copy() *GetUnlockKeyResponse {
 func (m *GetUnlockKeyResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetUnlockKeyResponse)
-	m.UnlockKey = o.UnlockKey
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Version, &o.Version)
 }
 

--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -835,7 +835,7 @@ func (m *GetNodeRequest) Copy() *GetNodeRequest {
 func (m *GetNodeRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetNodeRequest)
-	m.NodeID = o.NodeID
+	*m = *o
 }
 
 func (m *GetNodeResponse) Copy() *GetNodeResponse {
@@ -850,6 +850,7 @@ func (m *GetNodeResponse) Copy() *GetNodeResponse {
 func (m *GetNodeResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetNodeResponse)
+	*m = *o
 	if o.Node != nil {
 		m.Node = &Node{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Node, o.Node)
@@ -868,6 +869,7 @@ func (m *ListNodesRequest) Copy() *ListNodesRequest {
 func (m *ListNodesRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListNodesRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListNodesRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -886,6 +888,7 @@ func (m *ListNodesRequest_Filters) Copy() *ListNodesRequest_Filters {
 func (m *ListNodesRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListNodesRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -932,6 +935,7 @@ func (m *ListNodesResponse) Copy() *ListNodesResponse {
 func (m *ListNodesResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListNodesResponse)
+	*m = *o
 	if o.Nodes != nil {
 		m.Nodes = make([]*Node, len(o.Nodes))
 		for i := range m.Nodes {
@@ -954,7 +958,7 @@ func (m *UpdateNodeRequest) Copy() *UpdateNodeRequest {
 func (m *UpdateNodeRequest) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateNodeRequest)
-	m.NodeID = o.NodeID
+	*m = *o
 	if o.NodeVersion != nil {
 		m.NodeVersion = &Version{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.NodeVersion, o.NodeVersion)
@@ -977,6 +981,7 @@ func (m *UpdateNodeResponse) Copy() *UpdateNodeResponse {
 func (m *UpdateNodeResponse) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateNodeResponse)
+	*m = *o
 	if o.Node != nil {
 		m.Node = &Node{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Node, o.Node)
@@ -995,8 +1000,7 @@ func (m *RemoveNodeRequest) Copy() *RemoveNodeRequest {
 func (m *RemoveNodeRequest) CopyFrom(src interface{}) {
 
 	o := src.(*RemoveNodeRequest)
-	m.NodeID = o.NodeID
-	m.Force = o.Force
+	*m = *o
 }
 
 func (m *RemoveNodeResponse) Copy() *RemoveNodeResponse {
@@ -1021,7 +1025,7 @@ func (m *GetTaskRequest) Copy() *GetTaskRequest {
 func (m *GetTaskRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetTaskRequest)
-	m.TaskID = o.TaskID
+	*m = *o
 }
 
 func (m *GetTaskResponse) Copy() *GetTaskResponse {
@@ -1036,6 +1040,7 @@ func (m *GetTaskResponse) Copy() *GetTaskResponse {
 func (m *GetTaskResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetTaskResponse)
+	*m = *o
 	if o.Task != nil {
 		m.Task = &Task{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Task, o.Task)
@@ -1054,7 +1059,7 @@ func (m *RemoveTaskRequest) Copy() *RemoveTaskRequest {
 func (m *RemoveTaskRequest) CopyFrom(src interface{}) {
 
 	o := src.(*RemoveTaskRequest)
-	m.TaskID = o.TaskID
+	*m = *o
 }
 
 func (m *RemoveTaskResponse) Copy() *RemoveTaskResponse {
@@ -1079,6 +1084,7 @@ func (m *ListTasksRequest) Copy() *ListTasksRequest {
 func (m *ListTasksRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListTasksRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListTasksRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -1097,6 +1103,7 @@ func (m *ListTasksRequest_Filters) Copy() *ListTasksRequest_Filters {
 func (m *ListTasksRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListTasksRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -1148,6 +1155,7 @@ func (m *ListTasksResponse) Copy() *ListTasksResponse {
 func (m *ListTasksResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListTasksResponse)
+	*m = *o
 	if o.Tasks != nil {
 		m.Tasks = make([]*Task, len(o.Tasks))
 		for i := range m.Tasks {
@@ -1170,6 +1178,7 @@ func (m *CreateServiceRequest) Copy() *CreateServiceRequest {
 func (m *CreateServiceRequest) CopyFrom(src interface{}) {
 
 	o := src.(*CreateServiceRequest)
+	*m = *o
 	if o.Spec != nil {
 		m.Spec = &ServiceSpec{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Spec, o.Spec)
@@ -1188,6 +1197,7 @@ func (m *CreateServiceResponse) Copy() *CreateServiceResponse {
 func (m *CreateServiceResponse) CopyFrom(src interface{}) {
 
 	o := src.(*CreateServiceResponse)
+	*m = *o
 	if o.Service != nil {
 		m.Service = &Service{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Service, o.Service)
@@ -1206,7 +1216,7 @@ func (m *GetServiceRequest) Copy() *GetServiceRequest {
 func (m *GetServiceRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetServiceRequest)
-	m.ServiceID = o.ServiceID
+	*m = *o
 }
 
 func (m *GetServiceResponse) Copy() *GetServiceResponse {
@@ -1221,6 +1231,7 @@ func (m *GetServiceResponse) Copy() *GetServiceResponse {
 func (m *GetServiceResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetServiceResponse)
+	*m = *o
 	if o.Service != nil {
 		m.Service = &Service{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Service, o.Service)
@@ -1239,7 +1250,7 @@ func (m *UpdateServiceRequest) Copy() *UpdateServiceRequest {
 func (m *UpdateServiceRequest) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateServiceRequest)
-	m.ServiceID = o.ServiceID
+	*m = *o
 	if o.ServiceVersion != nil {
 		m.ServiceVersion = &Version{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.ServiceVersion, o.ServiceVersion)
@@ -1262,6 +1273,7 @@ func (m *UpdateServiceResponse) Copy() *UpdateServiceResponse {
 func (m *UpdateServiceResponse) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateServiceResponse)
+	*m = *o
 	if o.Service != nil {
 		m.Service = &Service{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Service, o.Service)
@@ -1280,7 +1292,7 @@ func (m *RemoveServiceRequest) Copy() *RemoveServiceRequest {
 func (m *RemoveServiceRequest) CopyFrom(src interface{}) {
 
 	o := src.(*RemoveServiceRequest)
-	m.ServiceID = o.ServiceID
+	*m = *o
 }
 
 func (m *RemoveServiceResponse) Copy() *RemoveServiceResponse {
@@ -1305,6 +1317,7 @@ func (m *ListServicesRequest) Copy() *ListServicesRequest {
 func (m *ListServicesRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListServicesRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListServicesRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -1323,6 +1336,7 @@ func (m *ListServicesRequest_Filters) Copy() *ListServicesRequest_Filters {
 func (m *ListServicesRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListServicesRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -1359,6 +1373,7 @@ func (m *ListServicesResponse) Copy() *ListServicesResponse {
 func (m *ListServicesResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListServicesResponse)
+	*m = *o
 	if o.Services != nil {
 		m.Services = make([]*Service, len(o.Services))
 		for i := range m.Services {
@@ -1381,6 +1396,7 @@ func (m *CreateNetworkRequest) Copy() *CreateNetworkRequest {
 func (m *CreateNetworkRequest) CopyFrom(src interface{}) {
 
 	o := src.(*CreateNetworkRequest)
+	*m = *o
 	if o.Spec != nil {
 		m.Spec = &NetworkSpec{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Spec, o.Spec)
@@ -1399,6 +1415,7 @@ func (m *CreateNetworkResponse) Copy() *CreateNetworkResponse {
 func (m *CreateNetworkResponse) CopyFrom(src interface{}) {
 
 	o := src.(*CreateNetworkResponse)
+	*m = *o
 	if o.Network != nil {
 		m.Network = &Network{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Network, o.Network)
@@ -1417,8 +1434,7 @@ func (m *GetNetworkRequest) Copy() *GetNetworkRequest {
 func (m *GetNetworkRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetNetworkRequest)
-	m.Name = o.Name
-	m.NetworkID = o.NetworkID
+	*m = *o
 }
 
 func (m *GetNetworkResponse) Copy() *GetNetworkResponse {
@@ -1433,6 +1449,7 @@ func (m *GetNetworkResponse) Copy() *GetNetworkResponse {
 func (m *GetNetworkResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetNetworkResponse)
+	*m = *o
 	if o.Network != nil {
 		m.Network = &Network{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Network, o.Network)
@@ -1451,8 +1468,7 @@ func (m *RemoveNetworkRequest) Copy() *RemoveNetworkRequest {
 func (m *RemoveNetworkRequest) CopyFrom(src interface{}) {
 
 	o := src.(*RemoveNetworkRequest)
-	m.Name = o.Name
-	m.NetworkID = o.NetworkID
+	*m = *o
 }
 
 func (m *RemoveNetworkResponse) Copy() *RemoveNetworkResponse {
@@ -1477,6 +1493,7 @@ func (m *ListNetworksRequest) Copy() *ListNetworksRequest {
 func (m *ListNetworksRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListNetworksRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListNetworksRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -1495,6 +1512,7 @@ func (m *ListNetworksRequest_Filters) Copy() *ListNetworksRequest_Filters {
 func (m *ListNetworksRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListNetworksRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -1531,6 +1549,7 @@ func (m *ListNetworksResponse) Copy() *ListNetworksResponse {
 func (m *ListNetworksResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListNetworksResponse)
+	*m = *o
 	if o.Networks != nil {
 		m.Networks = make([]*Network, len(o.Networks))
 		for i := range m.Networks {
@@ -1553,7 +1572,7 @@ func (m *GetClusterRequest) Copy() *GetClusterRequest {
 func (m *GetClusterRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetClusterRequest)
-	m.ClusterID = o.ClusterID
+	*m = *o
 }
 
 func (m *GetClusterResponse) Copy() *GetClusterResponse {
@@ -1568,6 +1587,7 @@ func (m *GetClusterResponse) Copy() *GetClusterResponse {
 func (m *GetClusterResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetClusterResponse)
+	*m = *o
 	if o.Cluster != nil {
 		m.Cluster = &Cluster{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Cluster, o.Cluster)
@@ -1586,6 +1606,7 @@ func (m *ListClustersRequest) Copy() *ListClustersRequest {
 func (m *ListClustersRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListClustersRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListClustersRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -1604,6 +1625,7 @@ func (m *ListClustersRequest_Filters) Copy() *ListClustersRequest_Filters {
 func (m *ListClustersRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListClustersRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -1640,6 +1662,7 @@ func (m *ListClustersResponse) Copy() *ListClustersResponse {
 func (m *ListClustersResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListClustersResponse)
+	*m = *o
 	if o.Clusters != nil {
 		m.Clusters = make([]*Cluster, len(o.Clusters))
 		for i := range m.Clusters {
@@ -1662,9 +1685,7 @@ func (m *KeyRotation) Copy() *KeyRotation {
 func (m *KeyRotation) CopyFrom(src interface{}) {
 
 	o := src.(*KeyRotation)
-	m.WorkerJoinToken = o.WorkerJoinToken
-	m.ManagerJoinToken = o.ManagerJoinToken
-	m.ManagerUnlockKey = o.ManagerUnlockKey
+	*m = *o
 }
 
 func (m *UpdateClusterRequest) Copy() *UpdateClusterRequest {
@@ -1679,7 +1700,7 @@ func (m *UpdateClusterRequest) Copy() *UpdateClusterRequest {
 func (m *UpdateClusterRequest) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateClusterRequest)
-	m.ClusterID = o.ClusterID
+	*m = *o
 	if o.ClusterVersion != nil {
 		m.ClusterVersion = &Version{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.ClusterVersion, o.ClusterVersion)
@@ -1703,6 +1724,7 @@ func (m *UpdateClusterResponse) Copy() *UpdateClusterResponse {
 func (m *UpdateClusterResponse) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateClusterResponse)
+	*m = *o
 	if o.Cluster != nil {
 		m.Cluster = &Cluster{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Cluster, o.Cluster)
@@ -1721,7 +1743,7 @@ func (m *GetSecretRequest) Copy() *GetSecretRequest {
 func (m *GetSecretRequest) CopyFrom(src interface{}) {
 
 	o := src.(*GetSecretRequest)
-	m.SecretID = o.SecretID
+	*m = *o
 }
 
 func (m *GetSecretResponse) Copy() *GetSecretResponse {
@@ -1736,6 +1758,7 @@ func (m *GetSecretResponse) Copy() *GetSecretResponse {
 func (m *GetSecretResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetSecretResponse)
+	*m = *o
 	if o.Secret != nil {
 		m.Secret = &Secret{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Secret, o.Secret)
@@ -1754,7 +1777,7 @@ func (m *UpdateSecretRequest) Copy() *UpdateSecretRequest {
 func (m *UpdateSecretRequest) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateSecretRequest)
-	m.SecretID = o.SecretID
+	*m = *o
 	if o.SecretVersion != nil {
 		m.SecretVersion = &Version{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.SecretVersion, o.SecretVersion)
@@ -1777,6 +1800,7 @@ func (m *UpdateSecretResponse) Copy() *UpdateSecretResponse {
 func (m *UpdateSecretResponse) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateSecretResponse)
+	*m = *o
 	if o.Secret != nil {
 		m.Secret = &Secret{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Secret, o.Secret)
@@ -1795,6 +1819,7 @@ func (m *ListSecretsRequest) Copy() *ListSecretsRequest {
 func (m *ListSecretsRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ListSecretsRequest)
+	*m = *o
 	if o.Filters != nil {
 		m.Filters = &ListSecretsRequest_Filters{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Filters, o.Filters)
@@ -1813,6 +1838,7 @@ func (m *ListSecretsRequest_Filters) Copy() *ListSecretsRequest_Filters {
 func (m *ListSecretsRequest_Filters) CopyFrom(src interface{}) {
 
 	o := src.(*ListSecretsRequest_Filters)
+	*m = *o
 	if o.Names != nil {
 		m.Names = make([]string, len(o.Names))
 		copy(m.Names, o.Names)
@@ -1849,6 +1875,7 @@ func (m *ListSecretsResponse) Copy() *ListSecretsResponse {
 func (m *ListSecretsResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ListSecretsResponse)
+	*m = *o
 	if o.Secrets != nil {
 		m.Secrets = make([]*Secret, len(o.Secrets))
 		for i := range m.Secrets {
@@ -1871,6 +1898,7 @@ func (m *CreateSecretRequest) Copy() *CreateSecretRequest {
 func (m *CreateSecretRequest) CopyFrom(src interface{}) {
 
 	o := src.(*CreateSecretRequest)
+	*m = *o
 	if o.Spec != nil {
 		m.Spec = &SecretSpec{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Spec, o.Spec)
@@ -1889,6 +1917,7 @@ func (m *CreateSecretResponse) Copy() *CreateSecretResponse {
 func (m *CreateSecretResponse) CopyFrom(src interface{}) {
 
 	o := src.(*CreateSecretResponse)
+	*m = *o
 	if o.Secret != nil {
 		m.Secret = &Secret{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Secret, o.Secret)
@@ -1907,7 +1936,7 @@ func (m *RemoveSecretRequest) Copy() *RemoveSecretRequest {
 func (m *RemoveSecretRequest) CopyFrom(src interface{}) {
 
 	o := src.(*RemoveSecretRequest)
-	m.SecretID = o.SecretID
+	*m = *o
 }
 
 func (m *RemoveSecretResponse) Copy() *RemoveSecretResponse {

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -472,11 +472,11 @@ func (m *SessionRequest) Copy() *SessionRequest {
 func (m *SessionRequest) CopyFrom(src interface{}) {
 
 	o := src.(*SessionRequest)
+	*m = *o
 	if o.Description != nil {
 		m.Description = &NodeDescription{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Description, o.Description)
 	}
-	m.SessionID = o.SessionID
 }
 
 func (m *SessionMessage) Copy() *SessionMessage {
@@ -491,7 +491,7 @@ func (m *SessionMessage) Copy() *SessionMessage {
 func (m *SessionMessage) CopyFrom(src interface{}) {
 
 	o := src.(*SessionMessage)
-	m.SessionID = o.SessionID
+	*m = *o
 	if o.Node != nil {
 		m.Node = &Node{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Node, o.Node)
@@ -526,7 +526,7 @@ func (m *HeartbeatRequest) Copy() *HeartbeatRequest {
 func (m *HeartbeatRequest) CopyFrom(src interface{}) {
 
 	o := src.(*HeartbeatRequest)
-	m.SessionID = o.SessionID
+	*m = *o
 }
 
 func (m *HeartbeatResponse) Copy() *HeartbeatResponse {
@@ -541,6 +541,7 @@ func (m *HeartbeatResponse) Copy() *HeartbeatResponse {
 func (m *HeartbeatResponse) CopyFrom(src interface{}) {
 
 	o := src.(*HeartbeatResponse)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Period, &o.Period)
 }
 
@@ -556,7 +557,7 @@ func (m *UpdateTaskStatusRequest) Copy() *UpdateTaskStatusRequest {
 func (m *UpdateTaskStatusRequest) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateTaskStatusRequest)
-	m.SessionID = o.SessionID
+	*m = *o
 	if o.Updates != nil {
 		m.Updates = make([]*UpdateTaskStatusRequest_TaskStatusUpdate, len(o.Updates))
 		for i := range m.Updates {
@@ -579,7 +580,7 @@ func (m *UpdateTaskStatusRequest_TaskStatusUpdate) Copy() *UpdateTaskStatusReque
 func (m *UpdateTaskStatusRequest_TaskStatusUpdate) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateTaskStatusRequest_TaskStatusUpdate)
-	m.TaskID = o.TaskID
+	*m = *o
 	if o.Status != nil {
 		m.Status = &TaskStatus{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Status, o.Status)
@@ -608,7 +609,7 @@ func (m *TasksRequest) Copy() *TasksRequest {
 func (m *TasksRequest) CopyFrom(src interface{}) {
 
 	o := src.(*TasksRequest)
-	m.SessionID = o.SessionID
+	*m = *o
 }
 
 func (m *TasksMessage) Copy() *TasksMessage {
@@ -623,6 +624,7 @@ func (m *TasksMessage) Copy() *TasksMessage {
 func (m *TasksMessage) CopyFrom(src interface{}) {
 
 	o := src.(*TasksMessage)
+	*m = *o
 	if o.Tasks != nil {
 		m.Tasks = make([]*Task, len(o.Tasks))
 		for i := range m.Tasks {
@@ -645,7 +647,7 @@ func (m *AssignmentsRequest) Copy() *AssignmentsRequest {
 func (m *AssignmentsRequest) CopyFrom(src interface{}) {
 
 	o := src.(*AssignmentsRequest)
-	m.SessionID = o.SessionID
+	*m = *o
 }
 
 func (m *Assignment) Copy() *Assignment {
@@ -660,6 +662,7 @@ func (m *Assignment) Copy() *Assignment {
 func (m *Assignment) CopyFrom(src interface{}) {
 
 	o := src.(*Assignment)
+	*m = *o
 	if o.Item != nil {
 		switch o.Item.(type) {
 		case *Assignment_Task:
@@ -691,11 +694,11 @@ func (m *AssignmentChange) Copy() *AssignmentChange {
 func (m *AssignmentChange) CopyFrom(src interface{}) {
 
 	o := src.(*AssignmentChange)
+	*m = *o
 	if o.Assignment != nil {
 		m.Assignment = &Assignment{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Assignment, o.Assignment)
 	}
-	m.Action = o.Action
 }
 
 func (m *AssignmentsMessage) Copy() *AssignmentsMessage {
@@ -710,9 +713,7 @@ func (m *AssignmentsMessage) Copy() *AssignmentsMessage {
 func (m *AssignmentsMessage) CopyFrom(src interface{}) {
 
 	o := src.(*AssignmentsMessage)
-	m.Type = o.Type
-	m.AppliesTo = o.AppliesTo
-	m.ResultsIn = o.ResultsIn
+	*m = *o
 	if o.Changes != nil {
 		m.Changes = make([]*AssignmentChange, len(o.Changes))
 		for i := range m.Changes {

--- a/api/duration/duration.pb.go
+++ b/api/duration/duration.pb.go
@@ -110,8 +110,7 @@ func (m *Duration) Copy() *Duration {
 func (m *Duration) CopyFrom(src interface{}) {
 
 	o := src.(*Duration)
-	m.Seconds = o.Seconds
-	m.Nanos = o.Nanos
+	*m = *o
 }
 
 func (this *Duration) GoString() string {

--- a/api/health.pb.go
+++ b/api/health.pb.go
@@ -114,7 +114,7 @@ func (m *HealthCheckRequest) Copy() *HealthCheckRequest {
 func (m *HealthCheckRequest) CopyFrom(src interface{}) {
 
 	o := src.(*HealthCheckRequest)
-	m.Service = o.Service
+	*m = *o
 }
 
 func (m *HealthCheckResponse) Copy() *HealthCheckResponse {
@@ -129,7 +129,7 @@ func (m *HealthCheckResponse) Copy() *HealthCheckResponse {
 func (m *HealthCheckResponse) CopyFrom(src interface{}) {
 
 	o := src.(*HealthCheckResponse)
-	m.Status = o.Status
+	*m = *o
 }
 
 func (this *HealthCheckRequest) GoString() string {

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -278,13 +278,12 @@ func (m *LogSubscriptionOptions) Copy() *LogSubscriptionOptions {
 func (m *LogSubscriptionOptions) CopyFrom(src interface{}) {
 
 	o := src.(*LogSubscriptionOptions)
+	*m = *o
 	if o.Streams != nil {
 		m.Streams = make([]LogStream, len(o.Streams))
 		copy(m.Streams, o.Streams)
 	}
 
-	m.Follow = o.Follow
-	m.Tail = o.Tail
 	if o.Since != nil {
 		m.Since = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Since, o.Since)
@@ -303,6 +302,7 @@ func (m *LogSelector) Copy() *LogSelector {
 func (m *LogSelector) CopyFrom(src interface{}) {
 
 	o := src.(*LogSelector)
+	*m = *o
 	if o.ServiceIDs != nil {
 		m.ServiceIDs = make([]string, len(o.ServiceIDs))
 		copy(m.ServiceIDs, o.ServiceIDs)
@@ -332,9 +332,7 @@ func (m *LogContext) Copy() *LogContext {
 func (m *LogContext) CopyFrom(src interface{}) {
 
 	o := src.(*LogContext)
-	m.ServiceID = o.ServiceID
-	m.NodeID = o.NodeID
-	m.TaskID = o.TaskID
+	*m = *o
 }
 
 func (m *LogMessage) Copy() *LogMessage {
@@ -349,13 +347,12 @@ func (m *LogMessage) Copy() *LogMessage {
 func (m *LogMessage) CopyFrom(src interface{}) {
 
 	o := src.(*LogMessage)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Context, &o.Context)
 	if o.Timestamp != nil {
 		m.Timestamp = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Timestamp, o.Timestamp)
 	}
-	m.Stream = o.Stream
-	m.Data = o.Data
 }
 
 func (m *SubscribeLogsRequest) Copy() *SubscribeLogsRequest {
@@ -370,6 +367,7 @@ func (m *SubscribeLogsRequest) Copy() *SubscribeLogsRequest {
 func (m *SubscribeLogsRequest) CopyFrom(src interface{}) {
 
 	o := src.(*SubscribeLogsRequest)
+	*m = *o
 	if o.Selector != nil {
 		m.Selector = &LogSelector{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Selector, o.Selector)
@@ -392,6 +390,7 @@ func (m *SubscribeLogsMessage) Copy() *SubscribeLogsMessage {
 func (m *SubscribeLogsMessage) CopyFrom(src interface{}) {
 
 	o := src.(*SubscribeLogsMessage)
+	*m = *o
 	if o.Messages != nil {
 		m.Messages = make([]LogMessage, len(o.Messages))
 		for i := range m.Messages {
@@ -423,7 +422,7 @@ func (m *SubscriptionMessage) Copy() *SubscriptionMessage {
 func (m *SubscriptionMessage) CopyFrom(src interface{}) {
 
 	o := src.(*SubscriptionMessage)
-	m.ID = o.ID
+	*m = *o
 	if o.Selector != nil {
 		m.Selector = &LogSelector{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Selector, o.Selector)
@@ -432,7 +431,6 @@ func (m *SubscriptionMessage) CopyFrom(src interface{}) {
 		m.Options = &LogSubscriptionOptions{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Options, o.Options)
 	}
-	m.Close = o.Close
 }
 
 func (m *PublishLogsMessage) Copy() *PublishLogsMessage {
@@ -447,7 +445,7 @@ func (m *PublishLogsMessage) Copy() *PublishLogsMessage {
 func (m *PublishLogsMessage) CopyFrom(src interface{}) {
 
 	o := src.(*PublishLogsMessage)
-	m.SubscriptionID = o.SubscriptionID
+	*m = *o
 	if o.Messages != nil {
 		m.Messages = make([]LogMessage, len(o.Messages))
 		for i := range m.Messages {

--- a/api/objects.pb.go
+++ b/api/objects.pb.go
@@ -299,6 +299,7 @@ func (m *Meta) Copy() *Meta {
 func (m *Meta) CopyFrom(src interface{}) {
 
 	o := src.(*Meta)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Version, &o.Version)
 	if o.CreatedAt != nil {
 		m.CreatedAt = &docker_swarmkit_v1.Timestamp{}
@@ -322,7 +323,7 @@ func (m *Node) Copy() *Node {
 func (m *Node) CopyFrom(src interface{}) {
 
 	o := src.(*Node)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
 	if o.Description != nil {
@@ -339,7 +340,6 @@ func (m *Node) CopyFrom(src interface{}) {
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Attachment, o.Attachment)
 	}
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Certificate, &o.Certificate)
-	m.Role = o.Role
 }
 
 func (m *Service) Copy() *Service {
@@ -354,7 +354,7 @@ func (m *Service) Copy() *Service {
 func (m *Service) CopyFrom(src interface{}) {
 
 	o := src.(*Service)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
 	if o.PreviousSpec != nil {
@@ -383,6 +383,7 @@ func (m *Endpoint) Copy() *Endpoint {
 func (m *Endpoint) CopyFrom(src interface{}) {
 
 	o := src.(*Endpoint)
+	*m = *o
 	if o.Spec != nil {
 		m.Spec = &EndpointSpec{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Spec, o.Spec)
@@ -417,8 +418,7 @@ func (m *Endpoint_VirtualIP) Copy() *Endpoint_VirtualIP {
 func (m *Endpoint_VirtualIP) CopyFrom(src interface{}) {
 
 	o := src.(*Endpoint_VirtualIP)
-	m.NetworkID = o.NetworkID
-	m.Addr = o.Addr
+	*m = *o
 }
 
 func (m *Task) Copy() *Task {
@@ -433,16 +433,12 @@ func (m *Task) Copy() *Task {
 func (m *Task) CopyFrom(src interface{}) {
 
 	o := src.(*Task)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
-	m.ServiceID = o.ServiceID
-	m.Slot = o.Slot
-	m.NodeID = o.NodeID
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.ServiceAnnotations, &o.ServiceAnnotations)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Status, &o.Status)
-	m.DesiredState = o.DesiredState
 	if o.Networks != nil {
 		m.Networks = make([]*NetworkAttachment, len(o.Networks))
 		for i := range m.Networks {
@@ -473,6 +469,7 @@ func (m *NetworkAttachment) Copy() *NetworkAttachment {
 func (m *NetworkAttachment) CopyFrom(src interface{}) {
 
 	o := src.(*NetworkAttachment)
+	*m = *o
 	if o.Network != nil {
 		m.Network = &Network{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Network, o.Network)
@@ -501,7 +498,7 @@ func (m *Network) Copy() *Network {
 func (m *Network) CopyFrom(src interface{}) {
 
 	o := src.(*Network)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
 	if o.DriverState != nil {
@@ -526,7 +523,7 @@ func (m *Cluster) Copy() *Cluster {
 func (m *Cluster) CopyFrom(src interface{}) {
 
 	o := src.(*Cluster)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.RootCA, &o.RootCA)
@@ -538,7 +535,6 @@ func (m *Cluster) CopyFrom(src interface{}) {
 		}
 	}
 
-	m.EncryptionKeyLamportClock = o.EncryptionKeyLamportClock
 	if o.BlacklistedCertificates != nil {
 		m.BlacklistedCertificates = make(map[string]*BlacklistedCertificate, len(o.BlacklistedCertificates))
 		for k, v := range o.BlacklistedCertificates {
@@ -569,10 +565,9 @@ func (m *Secret) Copy() *Secret {
 func (m *Secret) CopyFrom(src interface{}) {
 
 	o := src.(*Secret)
-	m.ID = o.ID
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Meta, &o.Meta)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Spec, &o.Spec)
-	m.Internal = o.Internal
 }
 
 func (this *Meta) GoString() string {

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -497,9 +497,7 @@ func (m *RaftMember) Copy() *RaftMember {
 func (m *RaftMember) CopyFrom(src interface{}) {
 
 	o := src.(*RaftMember)
-	m.RaftID = o.RaftID
-	m.NodeID = o.NodeID
-	m.Addr = o.Addr
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Status, &o.Status)
 }
 
@@ -515,7 +513,7 @@ func (m *JoinRequest) Copy() *JoinRequest {
 func (m *JoinRequest) CopyFrom(src interface{}) {
 
 	o := src.(*JoinRequest)
-	m.Addr = o.Addr
+	*m = *o
 }
 
 func (m *JoinResponse) Copy() *JoinResponse {
@@ -530,7 +528,7 @@ func (m *JoinResponse) Copy() *JoinResponse {
 func (m *JoinResponse) CopyFrom(src interface{}) {
 
 	o := src.(*JoinResponse)
-	m.RaftID = o.RaftID
+	*m = *o
 	if o.Members != nil {
 		m.Members = make([]*RaftMember, len(o.Members))
 		for i := range m.Members {
@@ -558,6 +556,7 @@ func (m *LeaveRequest) Copy() *LeaveRequest {
 func (m *LeaveRequest) CopyFrom(src interface{}) {
 
 	o := src.(*LeaveRequest)
+	*m = *o
 	if o.Node != nil {
 		m.Node = &RaftMember{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Node, o.Node)
@@ -596,7 +595,7 @@ func (m *ResolveAddressRequest) Copy() *ResolveAddressRequest {
 func (m *ResolveAddressRequest) CopyFrom(src interface{}) {
 
 	o := src.(*ResolveAddressRequest)
-	m.RaftID = o.RaftID
+	*m = *o
 }
 
 func (m *ResolveAddressResponse) Copy() *ResolveAddressResponse {
@@ -611,7 +610,7 @@ func (m *ResolveAddressResponse) Copy() *ResolveAddressResponse {
 func (m *ResolveAddressResponse) CopyFrom(src interface{}) {
 
 	o := src.(*ResolveAddressResponse)
-	m.Addr = o.Addr
+	*m = *o
 }
 
 func (m *InternalRaftRequest) Copy() *InternalRaftRequest {
@@ -626,7 +625,7 @@ func (m *InternalRaftRequest) Copy() *InternalRaftRequest {
 func (m *InternalRaftRequest) CopyFrom(src interface{}) {
 
 	o := src.(*InternalRaftRequest)
-	m.ID = o.ID
+	*m = *o
 	if o.Action != nil {
 		m.Action = make([]*StoreAction, len(o.Action))
 		for i := range m.Action {
@@ -649,7 +648,7 @@ func (m *StoreAction) Copy() *StoreAction {
 func (m *StoreAction) CopyFrom(src interface{}) {
 
 	o := src.(*StoreAction)
-	m.Action = o.Action
+	*m = *o
 	if o.Target != nil {
 		switch o.Target.(type) {
 		case *StoreAction_Node:

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -115,11 +115,11 @@ func (m *AttachNetworkRequest) Copy() *AttachNetworkRequest {
 func (m *AttachNetworkRequest) CopyFrom(src interface{}) {
 
 	o := src.(*AttachNetworkRequest)
+	*m = *o
 	if o.Config != nil {
 		m.Config = &NetworkAttachmentConfig{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Config, o.Config)
 	}
-	m.ContainerID = o.ContainerID
 }
 
 func (m *AttachNetworkResponse) Copy() *AttachNetworkResponse {
@@ -134,7 +134,7 @@ func (m *AttachNetworkResponse) Copy() *AttachNetworkResponse {
 func (m *AttachNetworkResponse) CopyFrom(src interface{}) {
 
 	o := src.(*AttachNetworkResponse)
-	m.AttachmentID = o.AttachmentID
+	*m = *o
 }
 
 func (m *DetachNetworkRequest) Copy() *DetachNetworkRequest {
@@ -149,7 +149,7 @@ func (m *DetachNetworkRequest) Copy() *DetachNetworkRequest {
 func (m *DetachNetworkRequest) CopyFrom(src interface{}) {
 
 	o := src.(*DetachNetworkRequest)
-	m.AttachmentID = o.AttachmentID
+	*m = *o
 }
 
 func (m *DetachNetworkResponse) Copy() *DetachNetworkResponse {

--- a/api/snapshot.pb.go
+++ b/api/snapshot.pb.go
@@ -97,6 +97,7 @@ func (m *StoreSnapshot) Copy() *StoreSnapshot {
 func (m *StoreSnapshot) CopyFrom(src interface{}) {
 
 	o := src.(*StoreSnapshot)
+	*m = *o
 	if o.Nodes != nil {
 		m.Nodes = make([]*Node, len(o.Nodes))
 		for i := range m.Nodes {
@@ -159,6 +160,7 @@ func (m *ClusterSnapshot) Copy() *ClusterSnapshot {
 func (m *ClusterSnapshot) CopyFrom(src interface{}) {
 
 	o := src.(*ClusterSnapshot)
+	*m = *o
 	if o.Members != nil {
 		m.Members = make([]*RaftMember, len(o.Members))
 		for i := range m.Members {
@@ -186,7 +188,7 @@ func (m *Snapshot) Copy() *Snapshot {
 func (m *Snapshot) CopyFrom(src interface{}) {
 
 	o := src.(*Snapshot)
-	m.Version = o.Version
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Membership, &o.Membership)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Store, &o.Store)
 }

--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -657,10 +657,8 @@ func (m *NodeSpec) Copy() *NodeSpec {
 func (m *NodeSpec) CopyFrom(src interface{}) {
 
 	o := src.(*NodeSpec)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
-	m.DesiredRole = o.DesiredRole
-	m.Membership = o.Membership
-	m.Availability = o.Availability
 }
 
 func (m *ServiceSpec) Copy() *ServiceSpec {
@@ -675,6 +673,7 @@ func (m *ServiceSpec) Copy() *ServiceSpec {
 func (m *ServiceSpec) CopyFrom(src interface{}) {
 
 	o := src.(*ServiceSpec)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Task, &o.Task)
 	if o.Update != nil {
@@ -724,7 +723,7 @@ func (m *ReplicatedService) Copy() *ReplicatedService {
 func (m *ReplicatedService) CopyFrom(src interface{}) {
 
 	o := src.(*ReplicatedService)
-	m.Replicas = o.Replicas
+	*m = *o
 }
 
 func (m *GlobalService) Copy() *GlobalService {
@@ -749,6 +748,7 @@ func (m *TaskSpec) Copy() *TaskSpec {
 func (m *TaskSpec) CopyFrom(src interface{}) {
 
 	o := src.(*TaskSpec)
+	*m = *o
 	if o.Resources != nil {
 		m.Resources = &ResourceRequirements{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Resources, o.Resources)
@@ -773,7 +773,6 @@ func (m *TaskSpec) CopyFrom(src interface{}) {
 		}
 	}
 
-	m.ForceUpdate = o.ForceUpdate
 	if o.Runtime != nil {
 		switch o.Runtime.(type) {
 		case *TaskSpec_Attachment:
@@ -805,7 +804,7 @@ func (m *NetworkAttachmentSpec) Copy() *NetworkAttachmentSpec {
 func (m *NetworkAttachmentSpec) CopyFrom(src interface{}) {
 
 	o := src.(*NetworkAttachmentSpec)
-	m.ContainerID = o.ContainerID
+	*m = *o
 }
 
 func (m *ContainerSpec) Copy() *ContainerSpec {
@@ -820,7 +819,7 @@ func (m *ContainerSpec) Copy() *ContainerSpec {
 func (m *ContainerSpec) CopyFrom(src interface{}) {
 
 	o := src.(*ContainerSpec)
-	m.Image = o.Image
+	*m = *o
 	if o.Labels != nil {
 		m.Labels = make(map[string]string, len(o.Labels))
 		for k, v := range o.Labels {
@@ -838,21 +837,16 @@ func (m *ContainerSpec) CopyFrom(src interface{}) {
 		copy(m.Args, o.Args)
 	}
 
-	m.Hostname = o.Hostname
 	if o.Env != nil {
 		m.Env = make([]string, len(o.Env))
 		copy(m.Env, o.Env)
 	}
 
-	m.Dir = o.Dir
-	m.User = o.User
 	if o.Groups != nil {
 		m.Groups = make([]string, len(o.Groups))
 		copy(m.Groups, o.Groups)
 	}
 
-	m.TTY = o.TTY
-	m.OpenStdin = o.OpenStdin
 	if o.Mounts != nil {
 		m.Mounts = make([]Mount, len(o.Mounts))
 		for i := range m.Mounts {
@@ -903,7 +897,7 @@ func (m *ContainerSpec_PullOptions) Copy() *ContainerSpec_PullOptions {
 func (m *ContainerSpec_PullOptions) CopyFrom(src interface{}) {
 
 	o := src.(*ContainerSpec_PullOptions)
-	m.RegistryAuth = o.RegistryAuth
+	*m = *o
 }
 
 func (m *ContainerSpec_DNSConfig) Copy() *ContainerSpec_DNSConfig {
@@ -918,6 +912,7 @@ func (m *ContainerSpec_DNSConfig) Copy() *ContainerSpec_DNSConfig {
 func (m *ContainerSpec_DNSConfig) CopyFrom(src interface{}) {
 
 	o := src.(*ContainerSpec_DNSConfig)
+	*m = *o
 	if o.Nameservers != nil {
 		m.Nameservers = make([]string, len(o.Nameservers))
 		copy(m.Nameservers, o.Nameservers)
@@ -947,7 +942,7 @@ func (m *EndpointSpec) Copy() *EndpointSpec {
 func (m *EndpointSpec) CopyFrom(src interface{}) {
 
 	o := src.(*EndpointSpec)
-	m.Mode = o.Mode
+	*m = *o
 	if o.Ports != nil {
 		m.Ports = make([]*PortConfig, len(o.Ports))
 		for i := range m.Ports {
@@ -970,18 +965,16 @@ func (m *NetworkSpec) Copy() *NetworkSpec {
 func (m *NetworkSpec) CopyFrom(src interface{}) {
 
 	o := src.(*NetworkSpec)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
 	if o.DriverConfig != nil {
 		m.DriverConfig = &Driver{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.DriverConfig, o.DriverConfig)
 	}
-	m.Ipv6Enabled = o.Ipv6Enabled
-	m.Internal = o.Internal
 	if o.IPAM != nil {
 		m.IPAM = &IPAMOptions{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.IPAM, o.IPAM)
 	}
-	m.Attachable = o.Attachable
 }
 
 func (m *ClusterSpec) Copy() *ClusterSpec {
@@ -996,6 +989,7 @@ func (m *ClusterSpec) Copy() *ClusterSpec {
 func (m *ClusterSpec) CopyFrom(src interface{}) {
 
 	o := src.(*ClusterSpec)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.AcceptancePolicy, &o.AcceptancePolicy)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Orchestration, &o.Orchestration)
@@ -1018,8 +1012,8 @@ func (m *SecretSpec) Copy() *SecretSpec {
 func (m *SecretSpec) CopyFrom(src interface{}) {
 
 	o := src.(*SecretSpec)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
-	m.Data = o.Data
 }
 
 func (this *NodeSpec) GoString() string {

--- a/api/timestamp/timestamp.pb.go
+++ b/api/timestamp/timestamp.pb.go
@@ -123,8 +123,7 @@ func (m *Timestamp) Copy() *Timestamp {
 func (m *Timestamp) CopyFrom(src interface{}) {
 
 	o := src.(*Timestamp)
-	m.Seconds = o.Seconds
-	m.Nanos = o.Nanos
+	*m = *o
 }
 
 func (this *Timestamp) GoString() string {

--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -1704,7 +1704,7 @@ func (m *Version) Copy() *Version {
 func (m *Version) CopyFrom(src interface{}) {
 
 	o := src.(*Version)
-	m.Index = o.Index
+	*m = *o
 }
 
 func (m *Annotations) Copy() *Annotations {
@@ -1719,7 +1719,7 @@ func (m *Annotations) Copy() *Annotations {
 func (m *Annotations) CopyFrom(src interface{}) {
 
 	o := src.(*Annotations)
-	m.Name = o.Name
+	*m = *o
 	if o.Labels != nil {
 		m.Labels = make(map[string]string, len(o.Labels))
 		for k, v := range o.Labels {
@@ -1741,8 +1741,7 @@ func (m *Resources) Copy() *Resources {
 func (m *Resources) CopyFrom(src interface{}) {
 
 	o := src.(*Resources)
-	m.NanoCPUs = o.NanoCPUs
-	m.MemoryBytes = o.MemoryBytes
+	*m = *o
 }
 
 func (m *ResourceRequirements) Copy() *ResourceRequirements {
@@ -1757,6 +1756,7 @@ func (m *ResourceRequirements) Copy() *ResourceRequirements {
 func (m *ResourceRequirements) CopyFrom(src interface{}) {
 
 	o := src.(*ResourceRequirements)
+	*m = *o
 	if o.Limits != nil {
 		m.Limits = &Resources{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Limits, o.Limits)
@@ -1779,8 +1779,7 @@ func (m *Platform) Copy() *Platform {
 func (m *Platform) CopyFrom(src interface{}) {
 
 	o := src.(*Platform)
-	m.Architecture = o.Architecture
-	m.OS = o.OS
+	*m = *o
 }
 
 func (m *PluginDescription) Copy() *PluginDescription {
@@ -1795,8 +1794,7 @@ func (m *PluginDescription) Copy() *PluginDescription {
 func (m *PluginDescription) CopyFrom(src interface{}) {
 
 	o := src.(*PluginDescription)
-	m.Type = o.Type
-	m.Name = o.Name
+	*m = *o
 }
 
 func (m *EngineDescription) Copy() *EngineDescription {
@@ -1811,7 +1809,7 @@ func (m *EngineDescription) Copy() *EngineDescription {
 func (m *EngineDescription) CopyFrom(src interface{}) {
 
 	o := src.(*EngineDescription)
-	m.EngineVersion = o.EngineVersion
+	*m = *o
 	if o.Labels != nil {
 		m.Labels = make(map[string]string, len(o.Labels))
 		for k, v := range o.Labels {
@@ -1840,7 +1838,7 @@ func (m *NodeDescription) Copy() *NodeDescription {
 func (m *NodeDescription) CopyFrom(src interface{}) {
 
 	o := src.(*NodeDescription)
-	m.Hostname = o.Hostname
+	*m = *o
 	if o.Platform != nil {
 		m.Platform = &Platform{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Platform, o.Platform)
@@ -1867,9 +1865,7 @@ func (m *RaftMemberStatus) Copy() *RaftMemberStatus {
 func (m *RaftMemberStatus) CopyFrom(src interface{}) {
 
 	o := src.(*RaftMemberStatus)
-	m.Leader = o.Leader
-	m.Reachability = o.Reachability
-	m.Message = o.Message
+	*m = *o
 }
 
 func (m *NodeStatus) Copy() *NodeStatus {
@@ -1884,9 +1880,7 @@ func (m *NodeStatus) Copy() *NodeStatus {
 func (m *NodeStatus) CopyFrom(src interface{}) {
 
 	o := src.(*NodeStatus)
-	m.State = o.State
-	m.Message = o.Message
-	m.Addr = o.Addr
+	*m = *o
 }
 
 func (m *Image) Copy() *Image {
@@ -1901,7 +1895,7 @@ func (m *Image) Copy() *Image {
 func (m *Image) CopyFrom(src interface{}) {
 
 	o := src.(*Image)
-	m.Reference = o.Reference
+	*m = *o
 }
 
 func (m *Mount) Copy() *Mount {
@@ -1916,10 +1910,7 @@ func (m *Mount) Copy() *Mount {
 func (m *Mount) CopyFrom(src interface{}) {
 
 	o := src.(*Mount)
-	m.Type = o.Type
-	m.Source = o.Source
-	m.Target = o.Target
-	m.ReadOnly = o.ReadOnly
+	*m = *o
 	if o.BindOptions != nil {
 		m.BindOptions = &Mount_BindOptions{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.BindOptions, o.BindOptions)
@@ -1946,7 +1937,7 @@ func (m *Mount_BindOptions) Copy() *Mount_BindOptions {
 func (m *Mount_BindOptions) CopyFrom(src interface{}) {
 
 	o := src.(*Mount_BindOptions)
-	m.Propagation = o.Propagation
+	*m = *o
 }
 
 func (m *Mount_VolumeOptions) Copy() *Mount_VolumeOptions {
@@ -1961,7 +1952,7 @@ func (m *Mount_VolumeOptions) Copy() *Mount_VolumeOptions {
 func (m *Mount_VolumeOptions) CopyFrom(src interface{}) {
 
 	o := src.(*Mount_VolumeOptions)
-	m.NoCopy = o.NoCopy
+	*m = *o
 	if o.Labels != nil {
 		m.Labels = make(map[string]string, len(o.Labels))
 		for k, v := range o.Labels {
@@ -1987,8 +1978,7 @@ func (m *Mount_TmpfsOptions) Copy() *Mount_TmpfsOptions {
 func (m *Mount_TmpfsOptions) CopyFrom(src interface{}) {
 
 	o := src.(*Mount_TmpfsOptions)
-	m.SizeBytes = o.SizeBytes
-	m.Mode = o.Mode
+	*m = *o
 }
 
 func (m *RestartPolicy) Copy() *RestartPolicy {
@@ -2003,12 +1993,11 @@ func (m *RestartPolicy) Copy() *RestartPolicy {
 func (m *RestartPolicy) CopyFrom(src interface{}) {
 
 	o := src.(*RestartPolicy)
-	m.Condition = o.Condition
+	*m = *o
 	if o.Delay != nil {
 		m.Delay = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Delay, o.Delay)
 	}
-	m.MaxAttempts = o.MaxAttempts
 	if o.Window != nil {
 		m.Window = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Window, o.Window)
@@ -2027,14 +2016,12 @@ func (m *UpdateConfig) Copy() *UpdateConfig {
 func (m *UpdateConfig) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateConfig)
-	m.Parallelism = o.Parallelism
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Delay, &o.Delay)
-	m.FailureAction = o.FailureAction
 	if o.Monitor != nil {
 		m.Monitor = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Monitor, o.Monitor)
 	}
-	m.MaxFailureRatio = o.MaxFailureRatio
 }
 
 func (m *UpdateStatus) Copy() *UpdateStatus {
@@ -2049,7 +2036,7 @@ func (m *UpdateStatus) Copy() *UpdateStatus {
 func (m *UpdateStatus) CopyFrom(src interface{}) {
 
 	o := src.(*UpdateStatus)
-	m.State = o.State
+	*m = *o
 	if o.StartedAt != nil {
 		m.StartedAt = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.StartedAt, o.StartedAt)
@@ -2058,7 +2045,6 @@ func (m *UpdateStatus) CopyFrom(src interface{}) {
 		m.CompletedAt = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.CompletedAt, o.CompletedAt)
 	}
-	m.Message = o.Message
 }
 
 func (m *ContainerStatus) Copy() *ContainerStatus {
@@ -2073,9 +2059,7 @@ func (m *ContainerStatus) Copy() *ContainerStatus {
 func (m *ContainerStatus) CopyFrom(src interface{}) {
 
 	o := src.(*ContainerStatus)
-	m.ContainerID = o.ContainerID
-	m.PID = o.PID
-	m.ExitCode = o.ExitCode
+	*m = *o
 }
 
 func (m *PortStatus) Copy() *PortStatus {
@@ -2090,6 +2074,7 @@ func (m *PortStatus) Copy() *PortStatus {
 func (m *PortStatus) CopyFrom(src interface{}) {
 
 	o := src.(*PortStatus)
+	*m = *o
 	if o.Ports != nil {
 		m.Ports = make([]*PortConfig, len(o.Ports))
 		for i := range m.Ports {
@@ -2112,13 +2097,11 @@ func (m *TaskStatus) Copy() *TaskStatus {
 func (m *TaskStatus) CopyFrom(src interface{}) {
 
 	o := src.(*TaskStatus)
+	*m = *o
 	if o.Timestamp != nil {
 		m.Timestamp = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Timestamp, o.Timestamp)
 	}
-	m.State = o.State
-	m.Message = o.Message
-	m.Err = o.Err
 	if o.PortStatus != nil {
 		m.PortStatus = &PortStatus{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.PortStatus, o.PortStatus)
@@ -2148,7 +2131,7 @@ func (m *NetworkAttachmentConfig) Copy() *NetworkAttachmentConfig {
 func (m *NetworkAttachmentConfig) CopyFrom(src interface{}) {
 
 	o := src.(*NetworkAttachmentConfig)
-	m.Target = o.Target
+	*m = *o
 	if o.Aliases != nil {
 		m.Aliases = make([]string, len(o.Aliases))
 		copy(m.Aliases, o.Aliases)
@@ -2173,10 +2156,7 @@ func (m *IPAMConfig) Copy() *IPAMConfig {
 func (m *IPAMConfig) CopyFrom(src interface{}) {
 
 	o := src.(*IPAMConfig)
-	m.Family = o.Family
-	m.Subnet = o.Subnet
-	m.Range = o.Range
-	m.Gateway = o.Gateway
+	*m = *o
 	if o.Reserved != nil {
 		m.Reserved = make(map[string]string, len(o.Reserved))
 		for k, v := range o.Reserved {
@@ -2198,11 +2178,7 @@ func (m *PortConfig) Copy() *PortConfig {
 func (m *PortConfig) CopyFrom(src interface{}) {
 
 	o := src.(*PortConfig)
-	m.Name = o.Name
-	m.Protocol = o.Protocol
-	m.TargetPort = o.TargetPort
-	m.PublishedPort = o.PublishedPort
-	m.PublishMode = o.PublishMode
+	*m = *o
 }
 
 func (m *Driver) Copy() *Driver {
@@ -2217,7 +2193,7 @@ func (m *Driver) Copy() *Driver {
 func (m *Driver) CopyFrom(src interface{}) {
 
 	o := src.(*Driver)
-	m.Name = o.Name
+	*m = *o
 	if o.Options != nil {
 		m.Options = make(map[string]string, len(o.Options))
 		for k, v := range o.Options {
@@ -2239,6 +2215,7 @@ func (m *IPAMOptions) Copy() *IPAMOptions {
 func (m *IPAMOptions) CopyFrom(src interface{}) {
 
 	o := src.(*IPAMOptions)
+	*m = *o
 	if o.Driver != nil {
 		m.Driver = &Driver{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Driver, o.Driver)
@@ -2265,8 +2242,7 @@ func (m *Peer) Copy() *Peer {
 func (m *Peer) CopyFrom(src interface{}) {
 
 	o := src.(*Peer)
-	m.NodeID = o.NodeID
-	m.Addr = o.Addr
+	*m = *o
 }
 
 func (m *WeightedPeer) Copy() *WeightedPeer {
@@ -2281,11 +2257,11 @@ func (m *WeightedPeer) Copy() *WeightedPeer {
 func (m *WeightedPeer) CopyFrom(src interface{}) {
 
 	o := src.(*WeightedPeer)
+	*m = *o
 	if o.Peer != nil {
 		m.Peer = &Peer{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Peer, o.Peer)
 	}
-	m.Weight = o.Weight
 }
 
 func (m *IssuanceStatus) Copy() *IssuanceStatus {
@@ -2300,8 +2276,7 @@ func (m *IssuanceStatus) Copy() *IssuanceStatus {
 func (m *IssuanceStatus) CopyFrom(src interface{}) {
 
 	o := src.(*IssuanceStatus)
-	m.State = o.State
-	m.Err = o.Err
+	*m = *o
 }
 
 func (m *AcceptancePolicy) Copy() *AcceptancePolicy {
@@ -2316,6 +2291,7 @@ func (m *AcceptancePolicy) Copy() *AcceptancePolicy {
 func (m *AcceptancePolicy) CopyFrom(src interface{}) {
 
 	o := src.(*AcceptancePolicy)
+	*m = *o
 	if o.Policies != nil {
 		m.Policies = make([]*AcceptancePolicy_RoleAdmissionPolicy, len(o.Policies))
 		for i := range m.Policies {
@@ -2338,8 +2314,7 @@ func (m *AcceptancePolicy_RoleAdmissionPolicy) Copy() *AcceptancePolicy_RoleAdmi
 func (m *AcceptancePolicy_RoleAdmissionPolicy) CopyFrom(src interface{}) {
 
 	o := src.(*AcceptancePolicy_RoleAdmissionPolicy)
-	m.Role = o.Role
-	m.Autoaccept = o.Autoaccept
+	*m = *o
 	if o.Secret != nil {
 		m.Secret = &AcceptancePolicy_RoleAdmissionPolicy_Secret{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Secret, o.Secret)
@@ -2358,8 +2333,7 @@ func (m *AcceptancePolicy_RoleAdmissionPolicy_Secret) Copy() *AcceptancePolicy_R
 func (m *AcceptancePolicy_RoleAdmissionPolicy_Secret) CopyFrom(src interface{}) {
 
 	o := src.(*AcceptancePolicy_RoleAdmissionPolicy_Secret)
-	m.Data = o.Data
-	m.Alg = o.Alg
+	*m = *o
 }
 
 func (m *ExternalCA) Copy() *ExternalCA {
@@ -2374,8 +2348,7 @@ func (m *ExternalCA) Copy() *ExternalCA {
 func (m *ExternalCA) CopyFrom(src interface{}) {
 
 	o := src.(*ExternalCA)
-	m.Protocol = o.Protocol
-	m.URL = o.URL
+	*m = *o
 	if o.Options != nil {
 		m.Options = make(map[string]string, len(o.Options))
 		for k, v := range o.Options {
@@ -2397,6 +2370,7 @@ func (m *CAConfig) Copy() *CAConfig {
 func (m *CAConfig) CopyFrom(src interface{}) {
 
 	o := src.(*CAConfig)
+	*m = *o
 	if o.NodeCertExpiry != nil {
 		m.NodeCertExpiry = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.NodeCertExpiry, o.NodeCertExpiry)
@@ -2423,7 +2397,7 @@ func (m *OrchestrationConfig) Copy() *OrchestrationConfig {
 func (m *OrchestrationConfig) CopyFrom(src interface{}) {
 
 	o := src.(*OrchestrationConfig)
-	m.TaskHistoryRetentionLimit = o.TaskHistoryRetentionLimit
+	*m = *o
 }
 
 func (m *TaskDefaults) Copy() *TaskDefaults {
@@ -2438,6 +2412,7 @@ func (m *TaskDefaults) Copy() *TaskDefaults {
 func (m *TaskDefaults) CopyFrom(src interface{}) {
 
 	o := src.(*TaskDefaults)
+	*m = *o
 	if o.LogDriver != nil {
 		m.LogDriver = &Driver{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.LogDriver, o.LogDriver)
@@ -2456,6 +2431,7 @@ func (m *DispatcherConfig) Copy() *DispatcherConfig {
 func (m *DispatcherConfig) CopyFrom(src interface{}) {
 
 	o := src.(*DispatcherConfig)
+	*m = *o
 	if o.HeartbeatPeriod != nil {
 		m.HeartbeatPeriod = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.HeartbeatPeriod, o.HeartbeatPeriod)
@@ -2474,11 +2450,7 @@ func (m *RaftConfig) Copy() *RaftConfig {
 func (m *RaftConfig) CopyFrom(src interface{}) {
 
 	o := src.(*RaftConfig)
-	m.SnapshotInterval = o.SnapshotInterval
-	m.KeepOldSnapshots = o.KeepOldSnapshots
-	m.LogEntriesForSlowFollowers = o.LogEntriesForSlowFollowers
-	m.HeartbeatTick = o.HeartbeatTick
-	m.ElectionTick = o.ElectionTick
+	*m = *o
 }
 
 func (m *EncryptionConfig) Copy() *EncryptionConfig {
@@ -2493,7 +2465,7 @@ func (m *EncryptionConfig) Copy() *EncryptionConfig {
 func (m *EncryptionConfig) CopyFrom(src interface{}) {
 
 	o := src.(*EncryptionConfig)
-	m.AutoLockManagers = o.AutoLockManagers
+	*m = *o
 }
 
 func (m *Placement) Copy() *Placement {
@@ -2508,6 +2480,7 @@ func (m *Placement) Copy() *Placement {
 func (m *Placement) CopyFrom(src interface{}) {
 
 	o := src.(*Placement)
+	*m = *o
 	if o.Constraints != nil {
 		m.Constraints = make([]string, len(o.Constraints))
 		copy(m.Constraints, o.Constraints)
@@ -2527,8 +2500,7 @@ func (m *JoinTokens) Copy() *JoinTokens {
 func (m *JoinTokens) CopyFrom(src interface{}) {
 
 	o := src.(*JoinTokens)
-	m.Worker = o.Worker
-	m.Manager = o.Manager
+	*m = *o
 }
 
 func (m *RootCA) Copy() *RootCA {
@@ -2543,9 +2515,7 @@ func (m *RootCA) Copy() *RootCA {
 func (m *RootCA) CopyFrom(src interface{}) {
 
 	o := src.(*RootCA)
-	m.CAKey = o.CAKey
-	m.CACert = o.CACert
-	m.CACertHash = o.CACertHash
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.JoinTokens, &o.JoinTokens)
 }
 
@@ -2561,11 +2531,8 @@ func (m *Certificate) Copy() *Certificate {
 func (m *Certificate) CopyFrom(src interface{}) {
 
 	o := src.(*Certificate)
-	m.Role = o.Role
-	m.CSR = o.CSR
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Status, &o.Status)
-	m.Certificate = o.Certificate
-	m.CN = o.CN
 }
 
 func (m *EncryptionKey) Copy() *EncryptionKey {
@@ -2580,10 +2547,7 @@ func (m *EncryptionKey) Copy() *EncryptionKey {
 func (m *EncryptionKey) CopyFrom(src interface{}) {
 
 	o := src.(*EncryptionKey)
-	m.Subsystem = o.Subsystem
-	m.Algorithm = o.Algorithm
-	m.Key = o.Key
-	m.LamportTime = o.LamportTime
+	*m = *o
 }
 
 func (m *ManagerStatus) Copy() *ManagerStatus {
@@ -2598,10 +2562,7 @@ func (m *ManagerStatus) Copy() *ManagerStatus {
 func (m *ManagerStatus) CopyFrom(src interface{}) {
 
 	o := src.(*ManagerStatus)
-	m.RaftID = o.RaftID
-	m.Addr = o.Addr
-	m.Leader = o.Leader
-	m.Reachability = o.Reachability
+	*m = *o
 }
 
 func (m *SecretReference) Copy() *SecretReference {
@@ -2616,8 +2577,7 @@ func (m *SecretReference) Copy() *SecretReference {
 func (m *SecretReference) CopyFrom(src interface{}) {
 
 	o := src.(*SecretReference)
-	m.SecretID = o.SecretID
-	m.SecretName = o.SecretName
+	*m = *o
 	if o.Target != nil {
 		switch o.Target.(type) {
 		case *SecretReference_File:
@@ -2643,10 +2603,7 @@ func (m *SecretReference_FileTarget) Copy() *SecretReference_FileTarget {
 func (m *SecretReference_FileTarget) CopyFrom(src interface{}) {
 
 	o := src.(*SecretReference_FileTarget)
-	m.Name = o.Name
-	m.UID = o.UID
-	m.GID = o.GID
-	m.Mode = o.Mode
+	*m = *o
 }
 
 func (m *BlacklistedCertificate) Copy() *BlacklistedCertificate {
@@ -2661,6 +2618,7 @@ func (m *BlacklistedCertificate) Copy() *BlacklistedCertificate {
 func (m *BlacklistedCertificate) CopyFrom(src interface{}) {
 
 	o := src.(*BlacklistedCertificate)
+	*m = *o
 	if o.Expiry != nil {
 		m.Expiry = &docker_swarmkit_v1.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Expiry, o.Expiry)
@@ -2679,6 +2637,7 @@ func (m *HealthConfig) Copy() *HealthConfig {
 func (m *HealthConfig) CopyFrom(src interface{}) {
 
 	o := src.(*HealthConfig)
+	*m = *o
 	if o.Test != nil {
 		m.Test = make([]string, len(o.Test))
 		copy(m.Test, o.Test)
@@ -2692,7 +2651,6 @@ func (m *HealthConfig) CopyFrom(src interface{}) {
 		m.Timeout = &docker_swarmkit_v11.Duration{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Timeout, o.Timeout)
 	}
-	m.Retries = o.Retries
 }
 
 func (m *MaybeEncryptedRecord) Copy() *MaybeEncryptedRecord {
@@ -2707,9 +2665,7 @@ func (m *MaybeEncryptedRecord) Copy() *MaybeEncryptedRecord {
 func (m *MaybeEncryptedRecord) CopyFrom(src interface{}) {
 
 	o := src.(*MaybeEncryptedRecord)
-	m.Algorithm = o.Algorithm
-	m.Data = o.Data
-	m.Nonce = o.Nonce
+	*m = *o
 }
 
 func (this *Version) GoString() string {

--- a/protobuf/plugin/deepcopy/deepcopy.go
+++ b/protobuf/plugin/deepcopy/deepcopy.go
@@ -57,6 +57,9 @@ func (d *deepCopyGen) genMsgDeepCopy(m *generator.Descriptor) {
 
 	d.P("o := src.(*", ccTypeName, ")")
 
+	// shallow copy handles all scalars
+	d.P("*m = *o")
+
 	oneofByIndex := [][]*descriptor.FieldDescriptorProto{}
 	for _, f := range m.Field {
 		fName := generator.CamelCase(*f.Name)
@@ -106,8 +109,7 @@ func (d *deepCopyGen) genMsgDeepCopy(m *generator.Descriptor) {
 			continue
 		}
 
-		// Handle all kinds of scalar type
-		d.P("m.", fName, " = o.", fName)
+		// skip: field was a scalar handled by shallow copy!
 	}
 
 	for i, oo := range m.GetOneofDecl() {

--- a/protobuf/plugin/deepcopy/test/deepcopy.pb.go
+++ b/protobuf/plugin/deepcopy/test/deepcopy.pb.go
@@ -577,21 +577,7 @@ func (m *BasicScalar) Copy() *BasicScalar {
 func (m *BasicScalar) CopyFrom(src interface{}) {
 
 	o := src.(*BasicScalar)
-	m.Field1 = o.Field1
-	m.Field2 = o.Field2
-	m.Field3 = o.Field3
-	m.Field4 = o.Field4
-	m.Field5 = o.Field5
-	m.Field6 = o.Field6
-	m.Field7 = o.Field7
-	m.Field8 = o.Field8
-	m.Field9 = o.Field9
-	m.Field10 = o.Field10
-	m.Field11 = o.Field11
-	m.Field12 = o.Field12
-	m.Field13 = o.Field13
-	m.Field14 = o.Field14
-	m.Field15 = o.Field15
+	*m = *o
 }
 
 func (m *RepeatedScalar) Copy() *RepeatedScalar {
@@ -606,6 +592,7 @@ func (m *RepeatedScalar) Copy() *RepeatedScalar {
 func (m *RepeatedScalar) CopyFrom(src interface{}) {
 
 	o := src.(*RepeatedScalar)
+	*m = *o
 	if o.Field1 != nil {
 		m.Field1 = make([]float64, len(o.Field1))
 		copy(m.Field1, o.Field1)
@@ -695,6 +682,7 @@ func (m *RepeatedScalarPacked) Copy() *RepeatedScalarPacked {
 func (m *RepeatedScalarPacked) CopyFrom(src interface{}) {
 
 	o := src.(*RepeatedScalarPacked)
+	*m = *o
 	if o.Field1 != nil {
 		m.Field1 = make([]float64, len(o.Field1))
 		copy(m.Field1, o.Field1)
@@ -774,6 +762,7 @@ func (m *ExternalStruct) Copy() *ExternalStruct {
 func (m *ExternalStruct) CopyFrom(src interface{}) {
 
 	o := src.(*ExternalStruct)
+	*m = *o
 	if o.Field1 != nil {
 		m.Field1 = &BasicScalar{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Field1, o.Field1)
@@ -800,6 +789,7 @@ func (m *RepeatedExternalStruct) Copy() *RepeatedExternalStruct {
 func (m *RepeatedExternalStruct) CopyFrom(src interface{}) {
 
 	o := src.(*RepeatedExternalStruct)
+	*m = *o
 	if o.Field1 != nil {
 		m.Field1 = make([]*BasicScalar, len(o.Field1))
 		for i := range m.Field1 {
@@ -838,6 +828,7 @@ func (m *NonNullableExternalStruct) Copy() *NonNullableExternalStruct {
 func (m *NonNullableExternalStruct) CopyFrom(src interface{}) {
 
 	o := src.(*NonNullableExternalStruct)
+	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Field1, &o.Field1)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Field2, &o.Field2)
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Field3, &o.Field3)
@@ -855,6 +846,7 @@ func (m *RepeatedNonNullableExternalStruct) Copy() *RepeatedNonNullableExternalS
 func (m *RepeatedNonNullableExternalStruct) CopyFrom(src interface{}) {
 
 	o := src.(*RepeatedNonNullableExternalStruct)
+	*m = *o
 	if o.Field1 != nil {
 		m.Field1 = make([]BasicScalar, len(o.Field1))
 		for i := range m.Field1 {
@@ -890,6 +882,7 @@ func (m *MapStruct) Copy() *MapStruct {
 func (m *MapStruct) CopyFrom(src interface{}) {
 
 	o := src.(*MapStruct)
+	*m = *o
 	if o.NullableMap != nil {
 		m.NullableMap = make(map[string]*BasicScalar, len(o.NullableMap))
 		for k, v := range o.NullableMap {
@@ -921,6 +914,7 @@ func (m *OneOf) Copy() *OneOf {
 func (m *OneOf) CopyFrom(src interface{}) {
 
 	o := src.(*OneOf)
+	*m = *o
 	if o.Fields != nil {
 		switch o.Fields.(type) {
 		case *OneOf_Field1:


### PR DESCRIPTION
To ensure that pointers get set to nil, we now set all the fields with a
shallow copy before copying each component. This should be both safer
and faster.

Signed-off-by: Stephen J Day <stephen.day@docker.com>