### PR TITLE
Vendor upstream logrus

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -25,7 +25,7 @@ github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/Microsoft/go-winio f778f05015353be65d242f3fedc18695756153bb
-github.com/Sirupsen/logrus f76d643702a30fbffecdfe50831e11881c96ceb3 https://github.com/aaronlehmann/logrus
+github.com/Sirupsen/logrus v0.11.0
 github.com/beorn7/perks/quantile 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/boltdb/bolt e72f08ddb5a52992c0a44c7dda9316c7333938b2
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a


### PR DESCRIPTION
We used to vendor a fork which had fixes we needed. Now the fixes have
been merged upstream. This switches vendor.conf over to the latest
released version, which happens to be identical to the fork we were
vendoring before. This is also the version vendored by docker/docker.