### PR TITLE
Support node IP constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Some of *SwarmKit*'s main features are:
         |:------------- |:-------------| :-------------|
         | node.id | node's ID | `node.id == 2ivku8v2gvtg4`|
         | node.hostname | node's hostname | `node.hostname != node-2`|
+        | node.ip | node's IP address | `node.ip != 172.19.17.0/24`|
         | node.role |  node's manager or worker role | `node.role == manager`|
         | node.platform.os |  node's operating system | `node.platform.os == linux`|
         | node.platform.arch |  node's architecture | `node.platform.arch == x86_64`|


### PR DESCRIPTION
Fix #1880. 

This change adds support for `node.ip` constraint. It matches IPv4/IPv6 address or CIDR subnet.

```
node.ip==192.168.42.5
node.ip!=192.168.42.5
node.ip==2001:db8::8/64
node.ip!=2001:db8::8/64
```
 
Signed-off-by: Dong Chen <dongluo.chen@docker.com>