### PR TITLE
manager: Add a function to check if the raft state is dirty

### DIFF
--- a/manager/dirty.go
+++ b/manager/dirty.go
@@ -1,0 +1,57 @@
+package manager
+
+import (
+	"reflect"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state/store"
+)
+
+// IsStateDirty returns true if any objects have been added to raft which make
+// the state "dirty". Currently, the existence of any object other than the
+// default cluster or the local node implies a dirty state.
+func (m *Manager) IsStateDirty() (bool, error) {
+	var (
+		storeSnapshot *api.StoreSnapshot
+		err           error
+	)
+	m.raftNode.MemoryStore().View(func(readTx store.ReadTx) {
+		storeSnapshot, err = m.raftNode.MemoryStore().Save(readTx)
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	// Check Nodes and Clusters fields.
+	nodeID := m.config.SecurityConfig.ClientTLSCreds.NodeID()
+	if len(storeSnapshot.Nodes) > 1 || (len(storeSnapshot.Nodes) == 1 && storeSnapshot.Nodes[0].ID != nodeID) {
+		return true, nil
+	}
+
+	clusterID := m.config.SecurityConfig.ClientTLSCreds.Organization()
+	if len(storeSnapshot.Clusters) > 1 || (len(storeSnapshot.Clusters) == 1 && storeSnapshot.Clusters[0].ID != clusterID) {
+		return true, nil
+	}
+
+	// Use reflection to check that other fields don't have values. This
+	// lets us implement a whitelist-type approach, where we don't need to
+	// remember to add individual types here.
+
+	val := reflect.ValueOf(*storeSnapshot)
+	numFields := val.NumField()
+
+	for i := 0; i != numFields; i++ {
+		field := val.Field(i)
+		structField := val.Type().Field(i)
+		if structField.Type.Kind() != reflect.Slice {
+			panic("unexpected field type in StoreSnapshot")
+		}
+		if structField.Name != "Nodes" && structField.Name != "Clusters" && field.Len() != 0 {
+			// One of the other data types has an entry
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -1,0 +1,84 @@
+package manager
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/manager/state"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsStateDirty(t *testing.T) {
+	ctx := context.Background()
+
+	temp, err := ioutil.TempFile("", "test-socket")
+	assert.NoError(t, err)
+	assert.NoError(t, temp.Close())
+	assert.NoError(t, os.Remove(temp.Name()))
+
+	defer os.RemoveAll(temp.Name())
+
+	stateDir, err := ioutil.TempDir("", "test-raft")
+	assert.NoError(t, err)
+	defer os.RemoveAll(stateDir)
+
+	tc := testutils.NewTestCA(t, func(p ca.CertPaths) *ca.KeyReadWriter {
+		return ca.NewKeyReadWriter(p, []byte("kek"), nil)
+	})
+	defer tc.Stop()
+
+	managerSecurityConfig, err := tc.NewNodeConfig(ca.ManagerRole)
+	assert.NoError(t, err)
+
+	m, err := New(&Config{
+		RemoteAPI:        RemoteAddrs{ListenAddr: "127.0.0.1:0"},
+		ControlAPI:       temp.Name(),
+		StateDir:         stateDir,
+		SecurityConfig:   managerSecurityConfig,
+		AutoLockManagers: true,
+		UnlockKey:        []byte("kek"),
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, m)
+
+	go m.Run(ctx)
+	defer m.Stop(ctx, false)
+
+	// State should never be dirty just after creating the manager
+	isDirty, err := m.IsStateDirty()
+	assert.NoError(t, err)
+	assert.False(t, isDirty)
+
+	// Wait for cluster and node to be created.
+	watch, cancel := state.Watch(m.raftNode.MemoryStore().WatchQueue())
+	defer cancel()
+	<-watch
+	<-watch
+
+	// Updating the node should not cause the state to become dirty
+	assert.NoError(t, m.raftNode.MemoryStore().Update(func(tx store.Tx) error {
+		node := store.GetNode(tx, m.config.SecurityConfig.ClientTLSCreds.NodeID())
+		require.NotNil(t, node)
+		node.Spec.Availability = api.NodeAvailabilityPause
+		return store.UpdateNode(tx, node)
+	}))
+	isDirty, err = m.IsStateDirty()
+	assert.NoError(t, err)
+	assert.False(t, isDirty)
+
+	// Adding a service should cause the state to become dirty
+	assert.NoError(t, m.raftNode.MemoryStore().Update(func(tx store.Tx) error {
+		return store.CreateService(tx, &api.Service{ID: "foo"})
+	}))
+	isDirty, err = m.IsStateDirty()
+	assert.NoError(t, err)
+	assert.True(t, isDirty)
+}

--- a/node/node.go
+++ b/node/node.go
@@ -514,6 +514,20 @@ func (n *Node) Agent() *agent.Agent {
 	return n.agent
 }
 
+// IsStateDirty returns true if any objects have been added to raft which make
+// the state "dirty". Currently, the existence of any object other than the
+// default cluster or the local node implies a dirty state.
+func (n *Node) IsStateDirty() (bool, error) {
+	n.RLock()
+	defer n.RUnlock()
+
+	if n.manager == nil {
+		return false, errors.New("node is not a manager")
+	}
+
+	return n.manager.IsStateDirty()
+}
+
 // Remotes returns a list of known peers known to node.
 func (n *Node) Remotes() []api.Peer {
 	weights := n.remotes.Weights()


### PR DESCRIPTION
As one of the requirements for enabling Swarm mode by default, we need
to prevent "swarm init" or "swarm join" commands from unintentionally
overwriting data that was added to Raft previously. We do this by adding
a `IsStateDirty` method that inspects the contents of the Raft store.
Any data other than a cluster object and object for the local node make
the state dirty.

Note that this function is inherently racy, since new data could be
added while the check is run, or shortly afterwards. However this is
considered acceptable, since the purpose is to check for old data that
the user may accidentally overwrite, not concurrent modifications.

cc @aluzzardi @ehazlett