### PR TITLE
Cherrypick 1899 to 1.13.1

### DIFF
--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -4,7 +4,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -76,7 +79,7 @@ func validateAnnotations(m api.Annotations) error {
 	return nil
 }
 
-func validateDriver(driver *api.Driver) error {
+func validateDriver(driver *api.Driver, pg plugingetter.PluginGetter, pluginType string) error {
 	if driver == nil {
 		// It is ok to not specify the driver. We will choose
 		// a default driver.
@@ -85,6 +88,19 @@ func validateDriver(driver *api.Driver) error {
 
 	if driver.Name == "" {
 		return grpc.Errorf(codes.InvalidArgument, "driver name: if driver is specified name is required")
+	}
+
+	if strings.ToLower(driver.Name) == networkallocator.DefaultDriver || strings.ToLower(driver.Name) == ipamapi.DefaultIPAM {
+		return nil
+	}
+
+	p, err := pg.Get(driver.Name, pluginType, plugingetter.LOOKUP)
+	if err != nil {
+		return grpc.Errorf(codes.InvalidArgument, "error during lookup of plugin %s", driver.Name)
+	}
+
+	if p.IsV1() {
+		return grpc.Errorf(codes.InvalidArgument, "legacy plugin %s of type %s is not supported in swarm mode", driver.Name, pluginType)
 	}
 
 	return nil

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -47,14 +50,14 @@ func validateIPAMConfiguration(ipamConf *api.IPAMConfig) error {
 	return nil
 }
 
-func validateIPAM(ipam *api.IPAMOptions) error {
+func validateIPAM(ipam *api.IPAMOptions, pg plugingetter.PluginGetter) error {
 	if ipam == nil {
 		// It is ok to not specify any IPAM configurations. We
 		// will choose good defaults.
 		return nil
 	}
 
-	if err := validateDriver(ipam.Driver); err != nil {
+	if err := validateDriver(ipam.Driver, pg, ipamapi.PluginEndpointType); err != nil {
 		return err
 	}
 
@@ -67,7 +70,7 @@ func validateIPAM(ipam *api.IPAMOptions) error {
 	return nil
 }
 
-func validateNetworkSpec(spec *api.NetworkSpec) error {
+func validateNetworkSpec(spec *api.NetworkSpec, pg plugingetter.PluginGetter) error {
 	if spec == nil {
 		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
@@ -76,11 +79,11 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 		return err
 	}
 
-	if err := validateDriver(spec.DriverConfig); err != nil {
+	if err := validateDriver(spec.DriverConfig, pg, driverapi.NetworkPluginEndpointType); err != nil {
 		return err
 	}
 
-	if err := validateIPAM(spec.IPAM); err != nil {
+	if err := validateIPAM(spec.IPAM, pg); err != nil {
 		return err
 	}
 
@@ -93,7 +96,7 @@ func validateNetworkSpec(spec *api.NetworkSpec) error {
 func (s *Server) CreateNetwork(ctx context.Context, request *api.CreateNetworkRequest) (*api.CreateNetworkResponse, error) {
 	// if you change this function, you have to change createInternalNetwork in
 	// the tests to match it (except the part where we check the label).
-	if err := validateNetworkSpec(request.Spec); err != nil {
+	if err := validateNetworkSpec(request.Spec, s.pg); err != nil {
 		return nil, err
 	}
 

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -26,7 +26,7 @@ func createNetworkSpec(name string) *api.NetworkSpec {
 // createInternalNetwork creates an internal network for testing. it is the same
 // as Server.CreateNetwork except without the label check.
 func (s *Server) createInternalNetwork(ctx context.Context, request *api.CreateNetworkRequest) (*api.CreateNetworkResponse, error) {
-	if err := validateNetworkSpec(request.Spec); err != nil {
+	if err := validateNetworkSpec(request.Spec, nil); err != nil {
 		return nil, err
 	}
 
@@ -86,9 +86,9 @@ func createServiceInNetwork(t *testing.T, ts *testServer, name, image string, nw
 }
 
 func TestValidateDriver(t *testing.T) {
-	assert.NoError(t, validateDriver(nil))
+	assert.NoError(t, validateDriver(nil, nil, ""))
 
-	err := validateDriver(&api.Driver{Name: ""})
+	err := validateDriver(&api.Driver{Name: ""}, nil, "")
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -3,6 +3,7 @@ package controlapi
 import (
 	"errors"
 
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -18,13 +19,15 @@ type Server struct {
 	store  *store.MemoryStore
 	raft   *raft.Node
 	rootCA *ca.RootCA
+	pg     plugingetter.PluginGetter
 }
 
 // NewServer creates a Cluster API server.
-func NewServer(store *store.MemoryStore, raft *raft.Node, rootCA *ca.RootCA) *Server {
+func NewServer(store *store.MemoryStore, raft *raft.Node, rootCA *ca.RootCA, pg plugingetter.PluginGetter) *Server {
 	return &Server{
 		store:  store,
 		raft:   raft,
 		rootCA: rootCA,
+		pg:     pg,
 	}
 }

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -60,7 +60,7 @@ func newTestServer(t *testing.T) *testServer {
 
 	ts.Store = store.NewMemoryStore(&mockProposer{})
 	assert.NotNil(t, ts.Store)
-	ts.Server = NewServer(ts.Store, nil, &tc.RootCA)
+	ts.Server = NewServer(ts.Store, nil, &tc.RootCA, nil)
 	assert.NotNil(t, ts.Server)
 
 	temp, err := ioutil.TempFile("", "test-socket")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -313,7 +313,7 @@ func (m *Manager) Run(parent context.Context) error {
 		return err
 	}
 
-	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig.RootCA())
+	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig.RootCA(), m.config.PluginGetter)
 	baseResourceAPI := resourceapi.New(m.raftNode.MemoryStore())
 	healthServer := health.NewHealthServer()
 	localHealthServer := health.NewHealthServer()


### PR DESCRIPTION
In swarm mode, only network pluginv2 is supported; pluginv1 is not.
When the plugin support was re-enabled, it inadvertently allowed
both pluginv1 and pluginv2. This commit fixes that.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>