### PR TITLE
Replace gogoproto.customname with plugin that maps ID name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ fmt: ## run go fmt
 		(echo "👹 please format Go code with 'gofmt -s -w'" && false)
 	@test -z "$$(find . -path ./vendor -prune -o ! -name timestamp.proto ! -name duration.proto -name '*.proto' -type f -exec grep -Hn -e "^ " {} \; | tee /dev/stderr)" || \
 		(echo "👹 please indent proto files with tabs only" && false)
-	@test -z "$$(find . -path ./vendor -prune -o -name '*.proto' -type f -exec grep -Hn "id = " {} \; | grep -v gogoproto.customname | tee /dev/stderr)" || \
-		(echo "👹 id fields in proto files must have a gogoproto.customname set" && false)
 	@test -z "$$(find . -path ./vendor -prune -o -name '*.proto' -type f -exec grep -Hn "Meta meta = " {} \; | grep -v '(gogoproto.nullable) = false' | tee /dev/stderr)" || \
 		(echo "👹 meta fields in proto files must have option (gogoproto.nullable) = false" && false)
 

--- a/api/ca.proto
+++ b/api/ca.proto
@@ -30,7 +30,7 @@ service NodeCA {
 }
 
 message NodeCertificateStatusRequest {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 }
 
 message NodeCertificateStatusResponse {
@@ -54,7 +54,7 @@ message IssueNodeCertificateRequest {
 }
 
 message IssueNodeCertificateResponse {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 	NodeSpec.Membership node_membership = 2;
 }
 

--- a/api/control.proto
+++ b/api/control.proto
@@ -119,7 +119,7 @@ service Control {
 }
 
 message GetNodeRequest {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 }
 
 message GetNodeResponse {
@@ -129,7 +129,7 @@ message GetNodeResponse {
 message ListNodesRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
 		repeated NodeSpec.Membership memberships = 4;
 		repeated NodeRole roles = 5;
@@ -148,7 +148,7 @@ message ListNodesResponse {
 // to request a new availability for a node, such as PAUSE. Invalid updates
 // will be denied and cause an error.
 message UpdateNodeRequest {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 	Version node_version = 2;
 	NodeSpec spec = 3;
 }
@@ -159,7 +159,7 @@ message UpdateNodeResponse {
 
 // RemoveNodeRequest requests to delete the specified node from store.
 message RemoveNodeRequest {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 	bool force = 2;
 }
 
@@ -167,7 +167,7 @@ message RemoveNodeResponse {
 }
 
 message GetTaskRequest {
-	string task_id = 1 [(gogoproto.customname) = "TaskID"];
+	string task_id = 1;
 }
 
 message GetTaskResponse {
@@ -175,7 +175,7 @@ message GetTaskResponse {
 }
 
 message RemoveTaskRequest {
-	string task_id = 1 [(gogoproto.customname) = "TaskID"];
+	string task_id = 1;
 }
 
 message RemoveTaskResponse {
@@ -184,10 +184,10 @@ message RemoveTaskResponse {
 message ListTasksRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
-		repeated string service_ids = 4 [(gogoproto.customname) = "ServiceIDs"];
-		repeated string node_ids = 5 [(gogoproto.customname) = "NodeIDs"];
+		repeated string service_ids = 4;
+		repeated string node_ids = 5;
 		repeated docker.swarmkit.v1.TaskState desired_states = 6;
 		// NamePrefixes matches all objects with the given prefixes
 		repeated string name_prefixes = 7;
@@ -209,7 +209,7 @@ message CreateServiceResponse {
 }
 
 message GetServiceRequest {
-	string service_id = 1 [(gogoproto.customname) = "ServiceID"];
+	string service_id = 1;
 }
 
 message GetServiceResponse {
@@ -217,7 +217,7 @@ message GetServiceResponse {
 }
 
 message UpdateServiceRequest {
-	string service_id = 1 [(gogoproto.customname) = "ServiceID"];
+	string service_id = 1;
 	Version service_version = 2;
 	ServiceSpec spec = 3;
 }
@@ -227,7 +227,7 @@ message UpdateServiceResponse {
 }
 
 message RemoveServiceRequest {
-	string service_id = 1 [(gogoproto.customname) = "ServiceID"];
+	string service_id = 1;
 }
 
 message RemoveServiceResponse {
@@ -236,7 +236,7 @@ message RemoveServiceResponse {
 message ListServicesRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
 		// NamePrefixes matches all objects with the given prefixes
 		repeated string name_prefixes = 4;
@@ -259,7 +259,7 @@ message CreateNetworkResponse {
 
 message GetNetworkRequest {
 	string name = 1;
-	string network_id = 2 [(gogoproto.customname) = "NetworkID"];
+	string network_id = 2;
 }
 
 message GetNetworkResponse {
@@ -268,7 +268,7 @@ message GetNetworkResponse {
 
 message RemoveNetworkRequest {
 	string name = 1;
-	string network_id = 2 [(gogoproto.customname) = "NetworkID"];
+	string network_id = 2;
 }
 
 message RemoveNetworkResponse {}
@@ -276,7 +276,7 @@ message RemoveNetworkResponse {}
 message ListNetworksRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
 		// NamePrefixes matches all objects with the given prefixes
 		repeated string name_prefixes = 4;
@@ -290,7 +290,7 @@ message ListNetworksResponse {
 }
 
 message GetClusterRequest {
-	string cluster_id = 1 [(gogoproto.customname) = "ClusterID"];
+	string cluster_id = 1;
 }
 
 message GetClusterResponse {
@@ -300,7 +300,7 @@ message GetClusterResponse {
 message ListClustersRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
 		// NamePrefixes matches all objects with the given prefixes
 		repeated string name_prefixes = 4;
@@ -328,7 +328,7 @@ message KeyRotation {
 
 message UpdateClusterRequest {
 	// ClusterID is the cluster ID to update.
-	string cluster_id = 1 [(gogoproto.customname) = "ClusterID"];
+	string cluster_id = 1;
 
 	// ClusterVersion is the version of the cluster being updated.
 	Version cluster_version = 2;
@@ -346,7 +346,7 @@ message UpdateClusterResponse {
 
 // GetSecretRequest is the request to get a `Secret` object given a secret id.
 message GetSecretRequest {
-	string secret_id = 1 [(gogoproto.customname) = "SecretID"];
+	string secret_id = 1;
 }
 
 // GetSecretResponse contains the Secret corresponding to the id in
@@ -358,7 +358,7 @@ message GetSecretResponse {
 
 message UpdateSecretRequest {
 	// SecretID is the secret ID to update.
-	string secret_id = 1 [(gogoproto.customname) = "SecretID"];
+	string secret_id = 1;
 
 	// SecretVersion is the version of the secret being updated.
 	Version secret_version = 2;
@@ -378,7 +378,7 @@ message UpdateSecretResponse {
 message ListSecretsRequest {
 	message Filters {
 		repeated string names = 1;
-		repeated string id_prefixes = 2 [(gogoproto.customname) = "IDPrefixes"];
+		repeated string id_prefixes = 2;
 		map<string, string> labels = 3;
 		repeated string name_prefixes = 4;
 	}
@@ -410,7 +410,7 @@ message CreateSecretResponse {
 // RemoveSecretRequest contains the ID of the secret that should be removed.  This
 // removes all versions of the secret.
 message RemoveSecretRequest {
-	string secret_id = 1 [(gogoproto.customname) = "SecretID"];
+	string secret_id = 1;
 }
 
 // RemoveSecretResponse is an empty object indicating the successful removal of

--- a/api/dispatcher.proto
+++ b/api/dispatcher.proto
@@ -66,7 +66,7 @@ message SessionRequest {
 	// SessionID is empty or invalid, a new SessionID will be assigned.
 	//
 	// See SessionMessage.SessionID for details.
-	string session_id = 2 [(gogoproto.customname) = "SessionID"];
+	string session_id = 2;
 }
 
 // SessionMessage instructs an agent on various actions as part of the current
@@ -115,7 +115,7 @@ message SessionMessage {
 	// We considered placing this field in a GRPC header. Because this is a
 	// critical feature of the protocol, we thought it should be represented
 	// directly in the RPC message set.
-	string session_id = 1 [(gogoproto.customname) = "SessionID"];
+	string session_id = 1;
 
 	// Node identifies the registering node.
 	Node node = 2;
@@ -130,7 +130,7 @@ message SessionMessage {
 
 // HeartbeatRequest provides identifying properties for a single heartbeat.
 message HeartbeatRequest {
-	string session_id = 1 [(gogoproto.customname) = "SessionID"];
+	string session_id = 1;
 }
 
 message HeartbeatResponse {
@@ -142,10 +142,10 @@ message HeartbeatResponse {
 message UpdateTaskStatusRequest {
 	// Tasks should contain all statuses for running tasks. Only the status
 	// field must be set. The spec is not required.
-	string session_id = 1 [(gogoproto.customname) = "SessionID"];
+	string session_id = 1;
 
 	message TaskStatusUpdate {
-		string task_id = 1 [(gogoproto.customname) = "TaskID"];
+		string task_id = 1;
 		TaskStatus status = 2;
 	}
 
@@ -157,7 +157,7 @@ message  UpdateTaskStatusResponse{
 }
 
 message TasksRequest {
-	string session_id = 1 [(gogoproto.customname) = "SessionID"];
+	string session_id = 1;
 }
 
 message TasksMessage {
@@ -167,7 +167,7 @@ message TasksMessage {
 }
 
 message AssignmentsRequest {
-	string session_id = 1 [(gogoproto.customname) = "SessionID"];
+	string session_id = 1;
 }
 
 message Assignment {

--- a/api/logbroker.proto
+++ b/api/logbroker.proto
@@ -54,16 +54,16 @@ message LogSubscriptionOptions {
 // possible. For example, if they want to listen to all the tasks of a service,
 // they should use the service id, rather than specifying the individual tasks.
 message LogSelector {
-	repeated string service_ids = 1 [(gogoproto.customname) = "ServiceIDs"];
-	repeated string node_ids = 2 [(gogoproto.customname) = "NodeIDs"];
-	repeated string task_ids = 3 [(gogoproto.customname) = "TaskIDs"];
+	repeated string service_ids = 1;
+	repeated string node_ids = 2;
+	repeated string task_ids = 3;
 }
 
 // LogContext marks the context from which a log message was generated.
 message LogContext {
-	string service_id = 1 [(gogoproto.customname) = "ServiceID"];
-	string node_id = 2 [(gogoproto.customname) = "NodeID"];
-	string task_id = 3 [(gogoproto.customname) = "TaskID"];
+	string service_id = 1;
+	string node_id = 2;
+	string task_id = 3;
 }
 
 // LogMessage
@@ -147,7 +147,7 @@ message ListenSubscriptionsRequest { }
 // If Options.Follow == false, the worker should end the subscription on its own.
 message SubscriptionMessage {
 	// ID identifies the subscription.
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	// Selector defines which sources should be sent for the subscription.
 	LogSelector selector = 2;
@@ -163,7 +163,7 @@ message SubscriptionMessage {
 message PublishLogsMessage {
 	// SubscriptionID identifies which subscription the set of messages should
 	// be sent to. We can think of this as a "mail box" for the subscription.
-	string subscription_id = 1 [(gogoproto.customname) = "SubscriptionID"];
+	string subscription_id = 1;
 
 	// Messages is the log message for publishing.
 	repeated LogMessage messages = 2 [(gogoproto.nullable) = false];

--- a/api/objects.proto
+++ b/api/objects.proto
@@ -25,7 +25,7 @@ message Meta {
 // Node provides the internal node state as seen by the cluster.
 message Node {
 	// ID specifies the identity of the node.
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 
@@ -63,7 +63,7 @@ message Node {
 }
 
 message Service {
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 
@@ -101,7 +101,7 @@ message Endpoint {
 	// and the IP addresses the target service will be made available under.
 	message VirtualIP {
 		// NetworkID for which this endpoint attachment was created.
-		string network_id = 1 [(gogoproto.customname) = "NetworkID"];
+		string network_id = 1;
 
 		// A virtual IP is used to address this service in IP
 		// layer that the client can use to send requests to
@@ -123,7 +123,7 @@ message Endpoint {
 // immutable and idempotent. Once it is dispatched to a node, it will not be
 // dispatched to another node.
 message Task {
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 
@@ -133,7 +133,7 @@ message Task {
 
 	// ServiceID indicates the service under which this task is orchestrated. This
 	// should almost always be set.
-	string service_id = 4 [(gogoproto.customname) = "ServiceID"];
+	string service_id = 4;
 
 	// Slot is the service slot number for a task.
 	// For example, if a replicated service has replicas = 2, there will be a
@@ -142,7 +142,7 @@ message Task {
 
 	// NodeID indicates the node to which the task is assigned. If this field
 	// is empty or not set, the task is unassigned.
-	string node_id = 6 [(gogoproto.customname) = "NodeID"];
+	string node_id = 6;
 
 	// Annotations defines the names and labels for the runtime, as set by
 	// the cluster manager.
@@ -204,7 +204,7 @@ message NetworkAttachment {
 }
 
 message Network {
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 
@@ -220,7 +220,7 @@ message Network {
 
 // Cluster provides global cluster settings.
 message Cluster {
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 
@@ -256,7 +256,7 @@ message Cluster {
 // information that is generated from the secret data in the `spec`, such as
 // the digest and size of the secret data.
 message Secret {
-	string id = 1 [(gogoproto.customname) = "ID"];
+	string id = 1;
 
 	Meta meta = 2 [(gogoproto.nullable) = false];
 

--- a/api/raft.proto
+++ b/api/raft.proto
@@ -40,10 +40,10 @@ service RaftMembership {
 message RaftMember {
 	// RaftID specifies the internal ID used by the manager in a raft context, it can never be modified
 	// and is used only for information purposes
-	uint64 raft_id = 1 [(gogoproto.customname) = "RaftID"];
+	uint64 raft_id = 1;
 
 	// NodeID is the node's ID.
-	string node_id = 2 [(gogoproto.customname) = "NodeID"];
+	string node_id = 2;
 
 	// Addr specifies the address of the member
 	string addr = 3;
@@ -59,7 +59,7 @@ message JoinRequest {
 
 message JoinResponse {
 	// RaftID is the ID assigned to the new member.
-	uint64 raft_id = 1 [(gogoproto.customname) = "RaftID"];
+	uint64 raft_id = 1;
 
 	// Members is the membership set of the cluster.
 	repeated RaftMember members = 2;
@@ -84,7 +84,7 @@ message ProcessRaftMessageResponse {}
 
 message ResolveAddressRequest {
 	// raft_id is the ID to resolve to an address.
-	uint64 raft_id = 1 [(gogoproto.customname) = "RaftID"];
+	uint64 raft_id = 1;
 }
 
 message ResolveAddressResponse {
@@ -96,7 +96,7 @@ message ResolveAddressResponse {
 // over the raft backend with a request ID to track when the
 // action is effectively applied
 message InternalRaftRequest {
-	uint64 id = 1 [(gogoproto.customname) = "ID"];
+	uint64 id = 1;
 
 	repeated StoreAction action = 2;
 }

--- a/api/resource.proto
+++ b/api/resource.proto
@@ -20,15 +20,15 @@ service ResourceAllocator {
 
 message AttachNetworkRequest {
 	NetworkAttachmentConfig config = 1;
-	string container_id = 2 [(gogoproto.customname) = "ContainerID"];
+	string container_id = 2;
 }
 
 message AttachNetworkResponse {
-	string attachment_id = 1 [(gogoproto.customname) = "AttachmentID"];
+	string attachment_id = 1;
 }
 
 message DetachNetworkRequest {
-	string attachment_id = 1 [(gogoproto.customname) = "AttachmentID"];
+	string attachment_id = 1;
 }
 
 message DetachNetworkResponse {}

--- a/api/specs.proto
+++ b/api/specs.proto
@@ -130,7 +130,7 @@ message TaskSpec {
 message NetworkAttachmentSpec {
 	// ContainerID spcifies a unique ID of the container for which
 	// this attachment is for.
-	string container_id = 1 [(gogoproto.customname) = "ContainerID"];
+	string container_id = 1;
 }
 
 

--- a/api/types.proto
+++ b/api/types.proto
@@ -410,7 +410,7 @@ enum TaskState {
 
 // Container specific status.
 message ContainerStatus {
-	string container_id = 1 [(gogoproto.customname) = "ContainerID"];
+	string container_id = 1;
 
 	int32 pid = 2 [(gogoproto.customname) = "PID"];
 	int32 exit_code = 3;
@@ -574,7 +574,7 @@ message IPAMOptions {
 
 // Peer should be used anywhere where we are describing a remote peer.
 message Peer {
-	string node_id = 1 [(gogoproto.customname) = "NodeID"];
+	string node_id = 1;
 	string addr = 2;
 }
 
@@ -787,7 +787,7 @@ message EncryptionKey {
 message ManagerStatus {
 	// RaftID specifies the internal ID used by the manager in a raft context, it can never be modified
 	// and is used only for information purposes
-	uint64 raft_id = 1 [(gogoproto.customname) = "RaftID"];
+	uint64 raft_id = 1;
 
 	// Addr is the address advertised to raft.
 	string addr = 2;
@@ -805,7 +805,7 @@ message SecretReference {
 	// SecretID represents the ID of the specific Secret that we're
 	// referencing. This identifier exists so that SecretReferences don't leak
 	// any information about the secret contents.
-	string secret_id = 1 [(gogoproto.customname) = "SecretID"];
+	string secret_id = 1;
 
 	// SecretName is the name of the secret that this references, but this is just provided for
 	// lookup/display purposes.  The secret in the reference will be identified by its ID.

--- a/cmd/protoc-gen-gogoswarm/main.go
+++ b/cmd/protoc-gen-gogoswarm/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/docker/swarmkit/protobuf/plugin"
 	_ "github.com/docker/swarmkit/protobuf/plugin/authenticatedwrapper"
 	_ "github.com/docker/swarmkit/protobuf/plugin/deepcopy"
 	_ "github.com/docker/swarmkit/protobuf/plugin/raftproxy"
@@ -21,6 +22,7 @@ func main() {
 		vanity.TurnOnStringerAll,
 		vanity.TurnOnUnmarshalerAll,
 		vanity.TurnOnSizerAll,
+		plugin.CustomNameID,
 	} {
 		vanity.ForEachFile(files, opt)
 	}

--- a/protobuf/plugin/customnameid.go
+++ b/protobuf/plugin/customnameid.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"strings"
+
+	"github.com/gogo/protobuf/gogoproto"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
+	"github.com/gogo/protobuf/vanity"
+)
+
+// CustomNameID preprocess the field, and set the [(gogoproto.customname) = "..."]
+// if necessary, in order to avoid setting `gogoproto.customname` manually.
+// The automatically assigned name should conform to Golang convention.
+func CustomNameID(file *descriptor.FileDescriptorProto) {
+
+	f := func(field *descriptor.FieldDescriptorProto) {
+		// Skip if [(gogoproto.customname) = "..."] has already been set.
+		if gogoproto.IsCustomName(field) {
+			return
+		}
+		// Skip if embedded
+		if gogoproto.IsEmbed(field) {
+			return
+		}
+		if field.OneofIndex != nil {
+			return
+		}
+		fieldName := generator.CamelCase(*field.Name)
+		switch {
+		case *field.Name == "id":
+			// id -> ID
+			fieldName = "ID"
+		case strings.HasPrefix(*field.Name, "id_"):
+			// id_some -> IDSome
+			fieldName = "ID" + fieldName[2:]
+		case strings.HasSuffix(*field.Name, "_id"):
+			// some_id -> SomeID
+			fieldName = fieldName[:len(fieldName)-2] + "ID"
+		case strings.HasSuffix(*field.Name, "_ids"):
+			// some_ids -> SomeIDs
+			fieldName = fieldName[:len(fieldName)-3] + "IDs"
+		default:
+			return
+		}
+		if field.Options == nil {
+			field.Options = &descriptor.FieldOptions{}
+		}
+		if err := proto.SetExtension(field.Options, gogoproto.E_Customname, &fieldName); err != nil {
+			panic(err)
+		}
+	}
+
+	// Iterate through all fields in file
+	vanity.ForEachFieldExcludingExtensions(file.MessageType, f)
+}


### PR DESCRIPTION
This fix tries to address the issue in #1785 where `gogoproto.customname` was repeatedly used  to manually map ID names conforming to golang convention.

This fix address the issue by preprocess the fields and
set `gogoproto.E_Customname` as needed, if name matches
certain pattern:
1. id -> ID
2. id_some -> IDSome
3. some_id -> SomeID
4. some_ids -> SomeIDs

This fix does not change the generated pb.go.

This fix fixes #1785.

Signed-off-by: Yong Tang <yong.tang.github@outlook.com>

/cc @aaronlehmann @stevvooe 