### PR TITLE
Add more validation around Replicas parameter

### DIFF
--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -144,6 +144,30 @@ func TestValidateResourceRequirements(t *testing.T) {
 	}
 }
 
+func TestValidateMode(t *testing.T) {
+	negative := -4
+	bad := []*api.ServiceSpec{
+		// -4 jammed into the replicas field, underflowing the uint64
+		{Mode: &api.ServiceSpec_Replicated{Replicated: &api.ReplicatedService{Replicas: uint64(negative)}}},
+		{},
+	}
+
+	good := []*api.ServiceSpec{
+		{Mode: &api.ServiceSpec_Replicated{Replicated: &api.ReplicatedService{Replicas: 2}}},
+		{Mode: &api.ServiceSpec_Global{}},
+	}
+
+	for _, b := range bad {
+		err := validateMode(b)
+		assert.Error(t, err)
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	}
+
+	for _, g := range good {
+		assert.NoError(t, validateMode(g))
+	}
+}
+
 func TestValidateTask(t *testing.T) {
 	type badSource struct {
 		s api.TaskSpec


### PR DESCRIPTION
This parameter is declared as a uint64, but if an API user tries to put
a negative number in it and underflows the field, the replicated
orchestrator will panic when it converts the value to an int and tries
to use it as as slice index.

Fix this in the replicated orchestrator by avoiding the conversion to
int, and also add validation in controlapi that the sign bit is unset.

Fixes #1906

cc @alexellis @samoht