### PR TITLE
ca+node: Allow expired certs when forcing a new cluster

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -151,6 +151,22 @@ func (rca *RootCA) IssueAndSaveNewCertificates(kw KeyWriter, cn, ou, org string)
 	return &tlsKeyPair, nil
 }
 
+// Normally we can just call cert.Verify(opts), but since we actually want more information about
+// whether a certificate is not yet valid or expired, we also need to perform the expiry checks ourselves.
+func verifyCertificate(cert *x509.Certificate, opts x509.VerifyOptions) error {
+	_, err := cert.Verify(opts)
+	if invalidErr, ok := err.(x509.CertificateInvalidError); ok && invalidErr.Reason == x509.Expired {
+		now := time.Now().UTC()
+		if now.Before(cert.NotBefore) {
+			return errors.Wrapf(err, "certificate not valid before %s, and it is currently %s",
+				cert.NotBefore.UTC().Format(time.RFC1123), now.Format(time.RFC1123))
+		}
+		return errors.Wrapf(err, "certificate expires at %s, and it is currently %s",
+			cert.NotAfter.UTC().Format(time.RFC1123), now.Format(time.RFC1123))
+	}
+	return err
+}
+
 // RequestAndSaveNewCertificates gets new certificates issued, either by signing them locally if a signer is
 // available, or by requesting them from the remote server at remoteAddr.
 func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWriter, config CertificateRequestConfig) (*tls.Certificate, error) {
@@ -199,7 +215,7 @@ func (rca *RootCA) RequestAndSaveNewCertificates(ctx context.Context, kw KeyWrit
 		Roots: rca.Pool,
 	}
 	// Check to see if this certificate was signed by our CA, and isn't expired
-	if _, err := X509Cert.Verify(opts); err != nil {
+	if err := verifyCertificate(X509Cert, opts); err != nil {
 		return nil, err
 	}
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -189,7 +189,7 @@ func GenerateJoinToken(rootCA *RootCA) string {
 
 func getCAHashFromToken(token string) (digest.Digest, error) {
 	split := strings.Split(token, "-")
-	if len(split) != 4 || split[0] != "SWMTKN" || split[1] != "1" {
+	if len(split) != 4 || split[0] != "SWMTKN" || split[1] != "1" || len(split[2]) != base36DigestLen || len(split[3]) != maxGeneratedSecretLength {
 		return "", errors.New("invalid join token")
 	}
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	cfconfig "github.com/cloudflare/cfssl/config"
+	events "github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/identity"
@@ -445,8 +446,15 @@ func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, connBroker *conne
 func RenewTLSConfig(ctx context.Context, s *SecurityConfig, connBroker *connectionbroker.Broker, renew <-chan struct{}) <-chan CertificateUpdate {
 	updates := make(chan CertificateUpdate)
 
+	backoffConfig := events.ExponentialBackoffConfig{
+		Base:   time.Second * 5,
+		Factor: time.Minute,
+		Max:    1 * time.Hour,
+	}
+
 	go func() {
 		var retry time.Duration
+		expBackoff := events.NewExponentialBackoff(backoffConfig)
 		defer close(updates)
 		for {
 			ctx = log.WithModule(ctx, "tls")
@@ -472,18 +480,12 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, connBroker *connecti
 					return
 				}
 			} else {
-				// If we have an expired certificate, we let's stick with the starting default in
-				// the hope that this is a temporary clock skew.
+				// If we have an expired certificate, try to renew immediately: the hope that this is a temporary clock skew, or
+				// we can issue our own TLS certs.
 				if validUntil.Before(time.Now()) {
-					log.WithError(err).Errorf("failed to create a new client TLS config")
-
-					select {
-					case updates <- CertificateUpdate{Err: errors.New("TLS certificate is expired")}:
-					case <-ctx.Done():
-						log.Info("shutting down certificate renewal routine")
-						return
-					}
-
+					log.Warn("the current TLS certificate is expired, so an attempt to renew it will be made immediately")
+					// retry immediately(ish) with exponential backoff
+					retry = expBackoff.Proceed(nil)
 				} else {
 					// Random retry time between 50% and 80% of the total time to expiration
 					retry = calculateRandomExpiry(validFrom, validUntil)
@@ -508,8 +510,10 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, connBroker *connecti
 			var certUpdate CertificateUpdate
 			if err := RenewTLSConfigNow(ctx, s, connBroker); err != nil {
 				certUpdate.Err = err
+				expBackoff.Failure(nil, nil)
 			} else {
 				certUpdate.Role = s.ClientTLSCreds.Role()
+				expBackoff = events.NewExponentialBackoff(backoffConfig)
 			}
 
 			select {

--- a/ca/config.go
+++ b/ca/config.go
@@ -273,7 +273,7 @@ func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter) 
 	}
 
 	// Check to see if this certificate was signed by our CA, and isn't expired
-	if _, err := X509Cert.Verify(opts); err != nil {
+	if err := verifyCertificate(X509Cert, opts); err != nil {
 		return nil, err
 	}
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -242,7 +242,7 @@ func DownloadRootCA(ctx context.Context, paths CertPaths, token string, connBrok
 
 // LoadSecurityConfig loads TLS credentials from disk, or returns an error if
 // these credentials do not exist or are unusable.
-func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter) (*SecurityConfig, error) {
+func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter, allowExpired bool) (*SecurityConfig, error) {
 	ctx = log.WithModule(ctx, "tls")
 
 	// At this point we've successfully loaded the CA details from disk, or
@@ -273,7 +273,7 @@ func LoadSecurityConfig(ctx context.Context, rootCA RootCA, krw *KeyReadWriter) 
 	}
 
 	// Check to see if this certificate was signed by our CA, and isn't expired
-	if err := verifyCertificate(X509Cert, opts); err != nil {
+	if err := verifyCertificate(X509Cert, opts, allowExpired); err != nil {
 		return nil, err
 	}
 

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -1,7 +1,12 @@
 package ca_test
 
 import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -10,10 +15,12 @@ import (
 	"golang.org/x/net/context"
 
 	cfconfig "github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/helpers"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,6 +137,70 @@ func TestCreateSecurityConfigNoCerts(t *testing.T) {
 	assert.Equal(t, rootCA, *nodeConfig.RootCA())
 }
 
+func TestLoadSecurityConfigExpiredCert(t *testing.T) {
+	tc := testutils.NewTestCA(t)
+	defer tc.Stop()
+
+	_, key, err := ca.GenerateNewCSR()
+	require.NoError(t, err)
+	require.NoError(t, ioutil.WriteFile(tc.Paths.Node.Key, key, 0600))
+	certKey, err := helpers.ParsePrivateKeyPEM(key)
+	require.NoError(t, err)
+
+	rootKey, err := helpers.ParsePrivateKeyPEM(tc.RootCA.Key)
+	require.NoError(t, err)
+	rootCert, err := helpers.ParseCertificatePEM(tc.RootCA.Cert)
+	require.NoError(t, err)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	require.NoError(t, err)
+
+	genCert := func(notBefore, notAfter time.Time) {
+		derBytes, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+			SerialNumber: serialNumber,
+			Subject: pkix.Name{
+				CommonName:         "CN",
+				OrganizationalUnit: []string{"OU"},
+				Organization:       []string{"ORG"},
+			},
+			NotBefore: notBefore,
+			NotAfter:  notAfter,
+		}, rootCert, certKey.Public(), rootKey)
+		require.NoError(t, err)
+		certBytes := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: derBytes,
+		})
+		require.NoError(t, ioutil.WriteFile(tc.Paths.Node.Cert, certBytes, 0644))
+	}
+
+	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
+	now := time.Now()
+
+	// A cert that is not yet valid is not valid even if expiry is allowed
+	genCert(now.Add(time.Hour), now.Add(time.Hour*2))
+
+	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
+	require.Error(t, err)
+	require.IsType(t, x509.CertificateInvalidError{}, errors.Cause(err))
+
+	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, true)
+	require.Error(t, err)
+	require.IsType(t, x509.CertificateInvalidError{}, errors.Cause(err))
+
+	// a cert that is expired is not valid if expiry is not allowed
+	genCert(now.Add(time.Hour*-3), now.Add(time.Hour*-1))
+
+	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
+	require.Error(t, err)
+	require.IsType(t, x509.CertificateInvalidError{}, errors.Cause(err))
+
+	// but it is valid if expiry is allowed
+	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, true)
+	require.NoError(t, err)
+}
+
 func TestLoadSecurityConfigInvalidCert(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
@@ -141,7 +212,7 @@ some random garbage\n
 
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
 
-	_, err := ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw)
+	_, err := ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
 	assert.Error(t, err)
 
 	nodeConfig, err := tc.RootCA.CreateSecurityConfig(tc.Context, krw,
@@ -167,7 +238,7 @@ some random garbage\n
 
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
 
-	_, err := ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw)
+	_, err := ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
 	assert.Error(t, err)
 
 	nodeConfig, err := tc.RootCA.CreateSecurityConfig(tc.Context, krw,
@@ -190,7 +261,7 @@ func TestLoadSecurityConfigIncorrectPassphrase(t *testing.T) {
 		"nodeID", ca.WorkerRole, tc.Organization)
 	require.NoError(t, err)
 
-	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, ca.NewKeyReadWriter(paths.Node, nil, nil))
+	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, ca.NewKeyReadWriter(paths.Node, nil, nil), false)
 	require.IsType(t, ca.ErrInvalidKEK{}, err)
 }
 

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -54,9 +54,14 @@ func TestDownloadRootCAWrongCAHash(t *testing.T) {
 	os.RemoveAll(tc.Paths.RootCA.Cert)
 
 	// invalid token
-	_, err := ca.DownloadRootCA(tc.Context, tc.Paths.RootCA, "invalidtoken", tc.ConnBroker)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid join token")
+	for _, invalid := range []string{
+		"invalidtoken", // completely invalid
+		"SWMTKN-1-3wkodtpeoipd1u1hi0ykdcdwhw16dk73ulqqtn14b3indz68rf-4myj5xihyto11dg1cn55w8p6", // mistyped
+	} {
+		_, err := ca.DownloadRootCA(tc.Context, tc.Paths.RootCA, invalid, tc.ConnBroker)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid join token")
+	}
 
 	// invalid hash token
 	splitToken := strings.Split(tc.ManagerToken, "-")
@@ -65,7 +70,7 @@ func TestDownloadRootCAWrongCAHash(t *testing.T) {
 
 	os.RemoveAll(tc.Paths.RootCA.Cert)
 
-	_, err = ca.DownloadRootCA(tc.Context, tc.Paths.RootCA, replacementToken, tc.ConnBroker)
+	_, err := ca.DownloadRootCA(tc.Context, tc.Paths.RootCA, replacementToken, tc.ConnBroker)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "remote CA does not match fingerprint.")
 }

--- a/node/node.go
+++ b/node/node.go
@@ -568,7 +568,8 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		return nil, err
 	}
 	if err == nil {
-		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, false)
+		// if forcing a new cluster, we allow the certificates to be expired - a new set will be generated
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, n.config.ForceNewCluster)
 		if err != nil {
 			_, isInvalidKEK := errors.Cause(err).(ca.ErrInvalidKEK)
 			if isInvalidKEK {
@@ -606,7 +607,7 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		// - We wait for CreateSecurityConfig to finish since we need a certificate to operate.
 
 		// Attempt to load certificate from disk
-		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, false)
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, n.config.ForceNewCluster)
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
 				"node.id": securityConfig.ClientTLSCreds.NodeID(),

--- a/node/node.go
+++ b/node/node.go
@@ -568,7 +568,7 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		return nil, err
 	}
 	if err == nil {
-		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw)
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, false)
 		if err != nil {
 			_, isInvalidKEK := errors.Cause(err).(ca.ErrInvalidKEK)
 			if isInvalidKEK {
@@ -606,7 +606,7 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 		// - We wait for CreateSecurityConfig to finish since we need a certificate to operate.
 
 		// Attempt to load certificate from disk
-		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw)
+		securityConfig, err = ca.LoadSecurityConfig(ctx, rootCA, krw, false)
 		if err == nil {
 			log.G(ctx).WithFields(logrus.Fields{
 				"node.id": securityConfig.ClientTLSCreds.NodeID(),


### PR DESCRIPTION
This is based on https://github.com/docker/swarmkit/pull/1912.

This PR makes the following changes:

1.  Allows a node to start up with expired certs if `ForceNewCluster` is set
1.  Changes the certificate renewal loop renew immediately if the certificate is expired.  This allows a `ForceNewCluster`'d node to get new TLS certificates soon.  This means that a leader can also recover from expired certificates.  No other node can recover, however, since renewing TLS certs would mean that they have to request a new cert from the CA, and would not be able to establish a mTLS connection to the CA due to expired certs.   This mean that we keep making requests to the CA even when there's no chance of recovery, which may not be desirable.

cc @aaronlehmann @LK4D4