### PR TITLE
Fix integration test data race and slowness

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cloudflare/cfssl/helpers"
+	events "github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	raftutils "github.com/docker/swarmkit/manager/state/raft/testutils"
@@ -44,6 +45,10 @@ func printTrace() {
 }
 
 func TestMain(m *testing.M) {
+	ca.RenewTLSExponentialBackoff = events.ExponentialBackoffConfig{
+		Factor: time.Millisecond * 500,
+		Max:    time.Minute,
+	}
 	flag.Parse()
 	res := m.Run()
 	if *showTrace {
@@ -463,7 +468,6 @@ func TestRestartLeader(t *testing.T) {
 
 func TestForceNewCluster(t *testing.T) {
 	t.Parallel()
-	logrus.SetLevel(logrus.DebugLevel)
 
 	// create an external CA so that we can use it to generate expired certificates
 	tempDir, err := ioutil.TempDir("", "external-ca")


### PR DESCRIPTION
#1919 inadvertently left a `logrus.Debug` setting in the integration test, which was causing a data race.

Also, add the following optimizations for the integration test added in #1919:
- make the renew TLS certificate loop's exponential backoff configurable, so it can be set for testing
- if a node exits before it's ready, bail `integration.cluster.StartNode` early so we don't have to
  wait for the timeout

Signed-off-by: cyli <ying.li@docker.com>