### PR TITLE
Relocate customnameid gogo plugin

### DIFF
--- a/cmd/protoc-gen-gogoswarm/customnameid.go
+++ b/cmd/protoc-gen-gogoswarm/customnameid.go
@@ -1,4 +1,4 @@
-package plugin
+package main
 
 import (
 	"strings"

--- a/cmd/protoc-gen-gogoswarm/main.go
+++ b/cmd/protoc-gen-gogoswarm/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/docker/swarmkit/protobuf/plugin"
 	_ "github.com/docker/swarmkit/protobuf/plugin/authenticatedwrapper"
 	_ "github.com/docker/swarmkit/protobuf/plugin/deepcopy"
 	_ "github.com/docker/swarmkit/protobuf/plugin/raftproxy"
@@ -22,7 +21,7 @@ func main() {
 		vanity.TurnOnStringerAll,
 		vanity.TurnOnUnmarshalerAll,
 		vanity.TurnOnSizerAll,
-		plugin.CustomNameID,
+		CustomNameID,
 	} {
 		vanity.ForEachFile(files, opt)
 	}


### PR DESCRIPTION
This was located in `protobuf/plugin`, which is imported by swarmkit code.
Because it imports some extra protobuf packages, it was adding
dependencies to code that vendors swarmkit.

Move this code to `cmd/protoc-gen-gogoswarm`, since it's only needed for
this code generation tool. This avoids new dependencies for swarmkit
downstreams.

cc @yongtang