### PR TITLE
swarmctl: Fix usage and add a validation for 'swarmctl node update'

### DIFF
--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -165,6 +165,11 @@ func updateNode(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return errors.New("node ID missing")
 	}
+
+	if len(args) > 1 {
+		return errors.New("command takes exactly 1 argument")
+	}
+
 	c, err := common.Dial(cmd)
 	if err != nil {
 		return err

--- a/cmd/swarmctl/node/update.go
+++ b/cmd/swarmctl/node/update.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	updateCmd = &cobra.Command{
-		Use:   "update [OPTIONS] <node ID>",
+		Use:   "update <node ID>",
 		Short: "Update a node",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := updateNode(cmd, args); err != nil {


### PR DESCRIPTION
This PR includes the following:

- Fix usage of `swarmctl node update`
- Add a argument length validation into `updateNode()`

Signed-off-by: Kei Ohmura <ohmura.kei@gmail.com>