### PR TITLE
Use `golang.org/x/net/context` instead of `context`

### DIFF
--- a/cmd/swarmctl/service/logs.go
+++ b/cmd/swarmctl/service/logs.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -10,6 +9,7 @@ import (
 	"github.com/docker/swarmkit/cmd/swarmctl/common"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 var (

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -1,7 +1,6 @@
 package logbroker
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
+	"golang.org/x/net/context"
 )
 
 type subscription struct {

--- a/manager/state/raft/storage/storage_test.go
+++ b/manager/state/raft/storage/storage_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 func TestBootstrapFromDisk(t *testing.T) {

--- a/manager/state/raft/storage/walwrap.go
+++ b/manager/state/raft/storage/walwrap.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // This package wraps the github.com/coreos/etcd/wal package, and encrypts

--- a/manager/state/raft/storage/walwrap_test.go
+++ b/manager/state/raft/storage/walwrap_test.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 var _ WALFactory = walCryptor{}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
@@ -16,6 +15,7 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 // If there is nothing on disk and no join addr, we create a new CA and a new set of TLS certs.


### PR DESCRIPTION
This allows to compile swarmkit with GO 1.6.

/cc @aaronlehmann @stevvooe @LK4D4 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>