### PR TITLE
Revert: Use `golang.org/x/net/context` instead of `context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Some of *SwarmKit*'s main features are:
 
 Requirements:
 
--   Go 1.6 or higher
+-   Go 1.7 or higher
 -   A [working golang](https://golang.org/doc/code.html) environment
 -   [Protobuf 3.x or higher] (https://developers.google.com/protocol-buffers/docs/downloads) to regenerate protocol buffer files (e.g. using `make generate`)
 

--- a/cmd/swarmctl/service/logs.go
+++ b/cmd/swarmctl/service/logs.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/cmd/swarmctl/common"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
-	"golang.org/x/net/context"
 )
 
 type subscription struct {

--- a/manager/state/raft/storage/storage_test.go
+++ b/manager/state/raft/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestBootstrapFromDisk(t *testing.T) {

--- a/manager/state/raft/storage/walwrap.go
+++ b/manager/state/raft/storage/walwrap.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // This package wraps the github.com/coreos/etcd/wal package, and encrypts

--- a/manager/state/raft/storage/walwrap_test.go
+++ b/manager/state/raft/storage/walwrap_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 var _ WALFactory = walCryptor{}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 // If there is nothing on disk and no join addr, we create a new CA and a new set of TLS certs.


### PR DESCRIPTION
Reverting this as it's the wrong fix, my bad 😓 🙇 

/cc @stevvooe @aaronlehmann @LK4D4 

🐸