### PR TITLE
transport: using multiple addresses

### DIFF
--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -29,31 +29,66 @@ type peer struct {
 	cancel context.CancelFunc
 	done   chan struct{}
 
-	mu      sync.Mutex
-	cc      *grpc.ClientConn
-	addr    string
-	newAddr string
+	mu             sync.Mutex
+	cc             *grpc.ClientConn
+	ccAddr         string
+	alternateAddrs map[string]struct{}
 
 	active       bool
 	becameActive time.Time
 }
 
-func newPeer(id uint64, addr string, tr *Transport) (*peer, error) {
-	cc, err := tr.dial(addr)
+func toAddrMap(curAddr string, addrs []string) map[string]struct{} {
+	addrMap := make(map[string]struct{}, len(addrs)-1)
+	for _, a := range addrs {
+		if a == curAddr {
+			continue
+		}
+		addrMap[a] = struct{}{}
+	}
+	return addrMap
+}
+
+func dialToAddrs(id uint64, tr *Transport, addrs ...string) (*grpc.ClientConn, string, error) {
+	if len(addrs) == 0 {
+		return nil, "", errors.New("addrs list can't be empty")
+	}
+	var (
+		cc   *grpc.ClientConn
+		addr string
+	)
+	for _, a := range addrs {
+		c, err := tr.dial(a)
+		if err == nil {
+			addr = a
+			cc = c
+			break
+		}
+		log.G(tr.ctx).WithError(err).Errorf("failed to create connection to %x at address %s", id, a)
+	}
+	if cc == nil {
+		return nil, "", errors.New("dial failed for all provided addresses")
+	}
+	return cc, addr, nil
+}
+
+func newPeer(id uint64, tr *Transport, addrs ...string) (*peer, error) {
+	cc, addr, err := dialToAddrs(id, tr, addrs...)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create conn for %x with addr %s", id, addr)
+		return nil, err
 	}
 	ctx, cancel := context.WithCancel(tr.ctx)
 	ctx = log.WithField(ctx, "peer_id", fmt.Sprintf("%x", id))
 	p := &peer{
-		id:     id,
-		addr:   addr,
-		cc:     cc,
-		tr:     tr,
-		ctx:    ctx,
-		cancel: cancel,
-		msgc:   make(chan raftpb.Message, 4096),
-		done:   make(chan struct{}),
+		id:             id,
+		ccAddr:         addr,
+		alternateAddrs: toAddrMap(addr, addrs),
+		cc:             cc,
+		tr:             tr,
+		ctx:            ctx,
+		cancel:         cancel,
+		msgc:           make(chan raftpb.Message, 4096),
+		done:           make(chan struct{}),
 	}
 	go p.run(ctx)
 	return p, nil
@@ -84,31 +119,31 @@ func (p *peer) send(m raftpb.Message) (err error) {
 	return nil
 }
 
-func (p *peer) update(addr string) error {
+func (p *peer) update(addrs ...string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.addr == addr {
-		return nil
-	}
-	cc, err := p.tr.dial(addr)
+	cc, addr, err := dialToAddrs(p.id, p.tr, addrs...)
 	if err != nil {
 		return err
 	}
 
+	p.alternateAddrs = toAddrMap(addr, addrs)
+
 	p.cc.Close()
 	p.cc = cc
-	p.addr = addr
+	p.ccAddr = addr
 	return nil
 }
 
-func (p *peer) updateAddr(addr string) error {
+func (p *peer) updateAddr(addrs ...string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.addr == addr {
-		return nil
+	addrMap := make(map[string]struct{}, len(addrs))
+	for _, a := range addrs {
+		addrMap[a] = struct{}{}
 	}
-	log.G(p.ctx).Debugf("peer %x updated to address %s, it will be used if old failed", p.id, addr)
-	p.newAddr = addr
+	p.alternateAddrs = addrMap
+	log.G(p.ctx).Debugf("peer %x updated to addresses %v", p.id, addrs)
 	return nil
 }
 
@@ -121,7 +156,7 @@ func (p *peer) conn() *grpc.ClientConn {
 func (p *peer) address() string {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	return p.addr
+	return p.ccAddr
 }
 
 func (p *peer) resolveAddr(ctx context.Context, id uint64) (string, error) {
@@ -219,11 +254,22 @@ func (p *peer) drain() error {
 	}
 }
 
-func (p *peer) handleAddressChange(ctx context.Context) error {
+func (p *peer) chooseAddr() string {
 	p.mu.Lock()
-	newAddr := p.newAddr
-	p.newAddr = ""
-	p.mu.Unlock()
+	defer p.mu.Unlock()
+	if len(p.alternateAddrs) == 0 {
+		return ""
+	}
+	var addr string
+	for a := range p.alternateAddrs {
+		addr = a
+		break
+	}
+	return addr
+}
+
+func (p *peer) handleAddressChange(ctx context.Context) error {
+	newAddr := p.chooseAddr()
 	if newAddr == "" {
 		return nil
 	}
@@ -242,8 +288,10 @@ func (p *peer) handleAddressChange(ctx context.Context) error {
 	p.mu.Lock()
 	p.cc.Close()
 	p.cc = cc
-	p.addr = newAddr
-	p.tr.config.UpdateNode(p.id, p.addr)
+	p.alternateAddrs[p.ccAddr] = struct{}{}
+	delete(p.alternateAddrs, newAddr)
+	p.ccAddr = newAddr
+	p.tr.config.UpdateNode(p.id, p.ccAddr)
 	p.mu.Unlock()
 	return nil
 }
@@ -279,7 +327,7 @@ func (p *peer) run(ctx context.Context) {
 			// or timed out for correct raft work.
 			err := p.sendProcessMessage(context.Background(), m)
 			if err != nil {
-				log.G(ctx).WithError(err).Debugf("failed to send message %s", m.Type)
+				log.G(ctx).WithError(err).Debugf("failed to send message %s to address %s", m.Type, p.address())
 				p.setInactive()
 				if err := p.handleAddressChange(ctx); err != nil {
 					log.G(ctx).WithError(err).Error("failed to change address after failure")

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -150,24 +150,21 @@ func (t *Transport) Send(m raftpb.Message) error {
 }
 
 // AddPeer adds new peer with id and address addr to Transport.
-// If there is already peer with such id in Transport it will return error if
-// address is different (UpdatePeer should be used) or nil otherwise.
-func (t *Transport) AddPeer(id uint64, addr string) error {
+// It chooses first address to which it's able to dial and using rest as backup.
+func (t *Transport) AddPeer(id uint64, addrs ...string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.stopped {
 		return errors.New("transport stopped")
 	}
-	if ep, ok := t.peers[id]; ok {
-		if ep.address() == addr {
-			return nil
-		}
-		return errors.Errorf("peer %x already added with addr %s", id, ep.addr)
-	}
-	log.G(t.ctx).Debugf("transport: add peer %x with address %s", id, addr)
-	p, err := newPeer(id, addr, t)
+	log.G(t.ctx).Debugf("transport: addding peer %x with addresses %v", id, addrs)
+	p, err := newPeer(id, t, addrs...)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create peer %x with addr %s", id, addr)
+		return errors.Wrapf(err, "failed to create peer %x with addresses %v", id, addrs)
+	}
+	if ep, ok := t.peers[id]; ok {
+		ep.stop()
+		<-ep.done
 	}
 	t.peers[id] = p
 	return nil
@@ -203,7 +200,8 @@ func (t *Transport) RemovePeer(id uint64) error {
 }
 
 // UpdatePeer updates peer with new address. It replaces connection immediately.
-func (t *Transport) UpdatePeer(id uint64, addr string) error {
+// It chooses first address to which it's able to dial and using rest as backup.
+func (t *Transport) UpdatePeer(id uint64, addrs ...string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -214,16 +212,16 @@ func (t *Transport) UpdatePeer(id uint64, addr string) error {
 	if !ok {
 		return ErrIsNotFound
 	}
-	if err := p.update(addr); err != nil {
+	if err := p.update(addrs...); err != nil {
 		return err
 	}
-	log.G(t.ctx).Debugf("peer %x updated to address %s", id, addr)
+	log.G(t.ctx).Debugf("peer %x updated to addresses %v", id, addrs)
 	return nil
 }
 
 // UpdatePeerAddr updates peer with new address, but delays connection creation.
 // New address won't be used until first failure on old address.
-func (t *Transport) UpdatePeerAddr(id uint64, addr string) error {
+func (t *Transport) UpdatePeerAddr(id uint64, addrs ...string) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -234,7 +232,7 @@ func (t *Transport) UpdatePeerAddr(id uint64, addr string) error {
 	if !ok {
 		return ErrIsNotFound
 	}
-	if err := p.updateAddr(addr); err != nil {
+	if err := p.updateAddr(addrs...); err != nil {
 		return err
 	}
 	return nil
@@ -366,7 +364,7 @@ func (t *Transport) resolvePeer(ctx context.Context, id uint64) (*peer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newPeer(id, addr, t)
+	return newPeer(id, t, addr)
 }
 
 func (t *Transport) sendUnknownMessage(ctx context.Context, m raftpb.Message) error {

--- a/vendor.conf
+++ b/vendor.conf
@@ -26,7 +26,7 @@ github.com/opencontainers/go-digest a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 github.com/davecgh/go-spew 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 github.com/Microsoft/go-winio f778f05015353be65d242f3fedc18695756153bb
 github.com/Sirupsen/logrus v0.11.0
-github.com/beorn7/perks/quantile 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
+github.com/beorn7/perks 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
 github.com/boltdb/bolt e72f08ddb5a52992c0a44c7dda9316c7333938b2
 github.com/cloudflare/cfssl 7fb22c8cba7ecaf98e4082d22d65800cf45e042a
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0


### PR DESCRIPTION
This is preparation for using multiple addresses in the cluster. It looks "kinda" consistent, but I'm sure it will be much uglier from raft point of view.
Idea is to have additional field in `RaftMember`: `BackupAddrs` which will store all previous addresses and `UpdatePeer` will receive combined `Addr` and `BackupAddrs`.
WDYT @aaronlehmann 