### PR TITLE
Correct fmt.Fprintf

### DIFF
--- a/cmd/swarm-bench/collector.go
+++ b/cmd/swarm-bench/collector.go
@@ -51,7 +51,7 @@ func (c *Collector) Stats(w io.Writer, unit time.Duration) {
 	t := c.t.Snapshot()
 	ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 
-	fmt.Fprintf(w, "stats:\n")
+	fmt.Fprintln(w, "stats:")
 	fmt.Fprintf(w, "  count:       %9d\n", t.Count())
 	fmt.Fprintf(w, "  min:         %12.2f%s\n", float64(t.Min())/du, duSuffix)
 	fmt.Fprintf(w, "  max:         %12.2f%s\n", float64(t.Max())/du, duSuffix)

--- a/cmd/swarmctl/cluster/inspect.go
+++ b/cmd/swarmctl/cluster/inspect.go
@@ -19,26 +19,26 @@ func printClusterSummary(cluster *api.Cluster) {
 
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", cluster.ID)
 	common.FprintfIfNotEmpty(w, "Name\t: %s\n", cluster.Spec.Annotations.Name)
-	fmt.Fprintf(w, "Orchestration settings:\n")
+	fmt.Fprintln(w, "Orchestration settings:")
 	fmt.Fprintf(w, "  Task history entries: %d\n", cluster.Spec.Orchestration.TaskHistoryRetentionLimit)
 
 	heartbeatPeriod, err := gogotypes.DurationFromProto(cluster.Spec.Dispatcher.HeartbeatPeriod)
 	if err == nil {
-		fmt.Fprintf(w, "Dispatcher settings:\n")
+		fmt.Fprintln(w, "Dispatcher settings:")
 		fmt.Fprintf(w, "  Dispatcher heartbeat period: %s\n", heartbeatPeriod.String())
 	}
 
-	fmt.Fprintf(w, "Certificate Authority settings:\n")
+	fmt.Fprintln(w, "Certificate Authority settings:")
 	if cluster.Spec.CAConfig.NodeCertExpiry != nil {
 		clusterDuration, err := gogotypes.DurationFromProto(cluster.Spec.CAConfig.NodeCertExpiry)
 		if err != nil {
-			fmt.Fprintf(w, "  Certificate Validity Duration: [ERROR PARSING DURATION]\n")
+			fmt.Fprintln(w, "  Certificate Validity Duration: [ERROR PARSING DURATION]")
 		} else {
 			fmt.Fprintf(w, "  Certificate Validity Duration: %s\n", clusterDuration.String())
 		}
 	}
 	if len(cluster.Spec.CAConfig.ExternalCAs) > 0 {
-		fmt.Fprintf(w, "  External CAs:\n")
+		fmt.Fprintln(w, "  External CAs:")
 		for _, ca := range cluster.Spec.CAConfig.ExternalCAs {
 			fmt.Fprintf(w, "    %s: %s\n", ca.Protocol, ca.URL)
 		}

--- a/cmd/swarmctl/node/inspect.go
+++ b/cmd/swarmctl/node/inspect.go
@@ -30,7 +30,7 @@ func printNodeSummary(node *api.Node) {
 		common.FprintfIfNotEmpty(w, "Hostname\t: %s\n", node.Description.Hostname)
 	}
 	if len(spec.Annotations.Labels) != 0 {
-		fmt.Fprintf(w, "Node Labels\t:")
+		fmt.Fprint(w, "Node Labels\t:")
 		// sort label output for readability
 		var keys []string
 		for k := range spec.Annotations.Labels {
@@ -46,7 +46,7 @@ func printNodeSummary(node *api.Node) {
 	common.FprintfIfNotEmpty(w, "  State\t: %s\n", node.Status.State.String())
 	common.FprintfIfNotEmpty(w, "  Message\t: %s\n", node.Status.Message)
 	common.FprintfIfNotEmpty(w, "  Availability\t: %s\n", spec.Availability.String())
-	common.FprintfIfNotEmpty(w, "  Address:\t: %s\n", node.Status.Addr)
+	common.FprintfIfNotEmpty(w, "  Address\t: %s\n", node.Status.Addr)
 
 	if node.ManagerStatus != nil {
 		fmt.Fprintln(w, "Manager status:\t")
@@ -93,7 +93,7 @@ func printNodeSummary(node *api.Node) {
 		common.FprintfIfNotEmpty(w, "Engine Version\t: %s\n", desc.Engine.EngineVersion)
 
 		if len(desc.Engine.Labels) != 0 {
-			fmt.Fprintf(w, "Engine Labels\t:")
+			fmt.Fprint(w, "Engine Labels\t:")
 			var keys []string
 			for k := range desc.Engine.Labels {
 				keys = append(keys, k)
@@ -149,7 +149,7 @@ var (
 
 			printNodeSummary(node)
 			if len(r.Tasks) > 0 {
-				fmt.Printf("\n")
+				fmt.Println()
 				task.Print(r.Tasks, all, common.NewResolver(cmd, c))
 			}
 

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -80,7 +80,7 @@ func printServiceSummary(service *api.Service, running int) {
 		}
 	}
 	if len(service.Spec.Task.Networks) > 0 {
-		fmt.Fprintf(w, "  Networks:\t")
+		fmt.Fprint(w, "  Networks:")
 		for _, n := range service.Spec.Task.Networks {
 			fmt.Fprintf(w, " %s", n.Target)
 		}
@@ -191,7 +191,7 @@ var (
 
 			printServiceSummary(service, running)
 			if len(r.Tasks) > 0 {
-				fmt.Printf("\n")
+				fmt.Println()
 				task.Print(r.Tasks, all, res)
 			}
 

--- a/cmd/swarmctl/task/inspect.go
+++ b/cmd/swarmctl/task/inspect.go
@@ -125,7 +125,7 @@ var (
 
 			printTaskSummary(task, res)
 			if len(previous) > 0 {
-				fmt.Printf("\n===> Task Parents\n")
+				fmt.Println("\n===> Task Parents")
 				Print(previous, true, res)
 			}
 


### PR DESCRIPTION
Correct fmt.Fprintf and fmt.Printf, because the values used for formatting text does not appear to contain a placeholder.

Signed-off-by: fate-grand-order <chenjg@harmonycloud.cn>