### PR TITLE
move secret validation into task validation

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -125,7 +125,7 @@ func validateContainerSpec(container *api.ContainerSpec) error {
 	return nil
 }
 
-func validateTask(taskSpec api.TaskSpec) error {
+func validateTaskSpec(taskSpec api.TaskSpec) error {
 	if err := validateResourceRequirements(taskSpec.Resources); err != nil {
 		return err
 	}
@@ -135,6 +135,11 @@ func validateTask(taskSpec api.TaskSpec) error {
 	}
 
 	if err := validatePlacement(taskSpec.Placement); err != nil {
+		return err
+	}
+
+	// Check to see if the Secret Reference portion of the spec is valid
+	if err := validateSecretRefsSpec(taskSpec); err != nil {
 		return err
 	}
 
@@ -218,8 +223,8 @@ func validateEndpointSpec(epSpec *api.EndpointSpec) error {
 
 // validateSecretRefsSpec finds if the secrets passed in spec are valid and have no
 // conflicting targets.
-func validateSecretRefsSpec(spec *api.ServiceSpec) error {
-	container := spec.Task.GetContainer()
+func validateSecretRefsSpec(spec api.TaskSpec) error {
+	container := spec.GetContainer()
 	if container == nil {
 		return nil
 	}
@@ -257,6 +262,7 @@ func validateSecretRefsSpec(spec *api.ServiceSpec) error {
 
 	return nil
 }
+
 func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error {
 	for _, na := range networks {
 		var network *api.Network
@@ -297,7 +303,7 @@ func validateServiceSpec(spec *api.ServiceSpec) error {
 	if err := validateAnnotations(spec.Annotations); err != nil {
 		return err
 	}
-	if err := validateTask(spec.Task); err != nil {
+	if err := validateTaskSpec(spec.Task); err != nil {
 		return err
 	}
 	if err := validateUpdate(spec.Update); err != nil {
@@ -307,10 +313,6 @@ func validateServiceSpec(spec *api.ServiceSpec) error {
 		return err
 	}
 	if err := validateMode(spec); err != nil {
-		return err
-	}
-	// Check to see if the Secret Reference portion of the spec is valid
-	if err := validateSecretRefsSpec(spec); err != nil {
 		return err
 	}
 

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -168,7 +168,7 @@ func TestValidateMode(t *testing.T) {
 	}
 }
 
-func TestValidateTask(t *testing.T) {
+func TestValidateTaskSpec(t *testing.T) {
 	type badSource struct {
 		s api.TaskSpec
 		c codes.Code
@@ -210,7 +210,7 @@ func TestValidateTask(t *testing.T) {
 			c: codes.InvalidArgument,
 		},
 	} {
-		err := validateTask(bad.s)
+		err := validateTaskSpec(bad.s)
 		assert.Error(t, err)
 		assert.Equal(t, bad.c, grpc.Code(err))
 	}
@@ -219,7 +219,7 @@ func TestValidateTask(t *testing.T) {
 		createSpec("", "image", 0).Task,
 		createSpecWithHostnameTemplate("service", "{{.Service.Name}}-{{.Task.Slot}}").Task,
 	} {
-		err := validateTask(good)
+		err := validateTaskSpec(good)
 		assert.NoError(t, err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that type `ServiceSpec` has fields like:
```
type ServiceSpec struct {
	Annotations Annotations `protobuf:"bytes,1,opt,name=annotations" json:"annotations"`
	Task TaskSpec `protobuf:"bytes,2,opt,name=task" json:"task"`
	Mode isServiceSpec_Mode `protobuf_oneof:"mode"`
	Update *UpdateConfig `protobuf:"bytes,6,opt,name=update" json:"update,omitempty"`
	Networks []*NetworkAttachmentConfig `protobuf:"bytes,7,rep,name=networks" json:"networks,omitempty"`
	Endpoint *EndpointSpec `protobuf:"bytes,8,opt,name=endpoint" json:"endpoint,omitempty"`
}
```

Then I think in https://github.com/docker/swarmkit/blob/master/manager/controlapi/service.go#L293-L318:
```

func validateServiceSpec(spec *api.ServiceSpec) error {
	if spec == nil {
		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
	}
	if err := validateAnnotations(spec.Annotations); err != nil {
		return err
	}
	if err := validateTask(spec.Task); err != nil {
		return err
	}
	if err := validateUpdate(spec.Update); err != nil {
		return err
	}
	if err := validateEndpointSpec(spec.Endpoint); err != nil {
		return err
	}
	if err := validateMode(spec); err != nil {
		return err
	}
	// Check to see if the Secret Reference portion of the spec is valid
	if err := validateSecretRefsSpec(spec); err != nil {
		return err
	}

	return nil
}
```
`validateSecretRefsSpec` is not proper to validate in the scope of `ServiceSpec`. Since secret is under scope of taskSpec, So I think it is much better to validate secret in taskSpec validation.

**What I did**:
1. move secret validation into task validation;
2. change func name `validateTask` into `validateTaskSpec` to be more consistent.
