### PR TITLE
validate more fields in update

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -98,6 +98,20 @@ func validateUpdate(uc *api.UpdateConfig) error {
 		return grpc.Errorf(codes.InvalidArgument, "TaskSpec: update-delay cannot be negative")
 	}
 
+	if uc.Monitor != nil {
+		monitor, err := gogotypes.DurationFromProto(uc.Monitor)
+		if err != nil {
+			return err
+		}
+		if monitor < 0 {
+			return grpc.Errorf(codes.InvalidArgument, "TaskSpec: update-monitor cannot be negative")
+		}
+	}
+
+	if uc.MaxFailureRatio < 0 || uc.MaxFailureRatio > 1 {
+		return grpc.Errorf(codes.InvalidArgument, "TaskSpec: update-maxfailureratio cannot be less than 0 or bigger than 1")
+	}
+
 	return nil
 }
 

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -303,10 +303,16 @@ func TestValidateUpdate(t *testing.T) {
 	bad := []*api.UpdateConfig{
 		{Delay: -1 * time.Second},
 		{Delay: -1000 * time.Second},
+		{Monitor: gogotypes.DurationProto(time.Duration(-1 * time.Second))},
+		{Monitor: gogotypes.DurationProto(time.Duration(-1000 * time.Second))},
+		{MaxFailureRatio: -0.1},
+		{MaxFailureRatio: 1.1},
 	}
 
 	good := []*api.UpdateConfig{
 		{Delay: time.Second},
+		{Monitor: gogotypes.DurationProto(time.Duration(time.Second))},
+		{MaxFailureRatio: 0.5},
 	}
 
 	for _, b := range bad {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

validate more fields in update when creating a service or update a service.