### PR TITLE
Fix how TestForceNewCluster checks if a service is ready

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -396,7 +396,10 @@ func (w *worker) taskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (
 }
 
 func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task) (*taskManager, error) {
-	ctx = log.WithLogger(ctx, log.G(ctx).WithField("task.id", task.ID))
+	ctx = log.WithLogger(ctx, log.G(ctx).WithFields(logrus.Fields{
+		"task.id":    task.ID,
+		"service.id": task.ServiceID,
+	}))
 
 	ctlr, status, err := exec.Resolve(ctx, task, w.executor)
 	if err := w.updateTaskStatus(ctx, tx, task.ID, status); err != nil {


### PR DESCRIPTION
This doesn't actually fix the flakey test yet - the `pollServiceReady` function is checking for all tasks on the node, instead of only the running tasks for that particular service, which masks the returned error.

The underlying cause is being fixed by @aaronlehmann in another PR. 