### PR TITLE
raft: Use TransferLeadership to make leader demotion safer

### DIFF
--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -532,7 +532,7 @@ func TestUpdateNode(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func testUpdateNodeDemote(leader bool, t *testing.T) {
+func testUpdateNodeDemote(t *testing.T) {
 	tc := cautils.NewTestCA(nil)
 	defer tc.Stop()
 	ts := newTestServer(t)
@@ -654,14 +654,8 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 		return nil
 	}))
 
-	var demoteNode, lastNode *raftutils.TestNode
-	if leader {
-		demoteNode = nodes[1]
-		lastNode = nodes[2]
-	} else {
-		demoteNode = nodes[2]
-		lastNode = nodes[1]
-	}
+	demoteNode := nodes[2]
+	lastNode := nodes[1]
 
 	raftMember = ts.Server.raft.GetMemberByNodeID(demoteNode.SecurityConfig.ClientTLSCreds.NodeID())
 	assert.NotNil(t, raftMember)
@@ -734,10 +728,5 @@ func testUpdateNodeDemote(leader bool, t *testing.T) {
 
 func TestUpdateNodeDemote(t *testing.T) {
 	t.Parallel()
-	testUpdateNodeDemote(false, t)
-}
-
-func TestUpdateNodeDemoteLeader(t *testing.T) {
-	t.Parallel()
-	testUpdateNodeDemote(true, t)
+	testUpdateNodeDemote(t)
 }

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -295,6 +295,19 @@ func (t *Transport) Active(id uint64) bool {
 	return active
 }
 
+// LongestActive returns the ID of the peer that has been active for the longest
+// length of time.
+func (t *Transport) LongestActive() (uint64, error) {
+	p, err := t.longestActive()
+	if err != nil {
+		return 0, err
+	}
+
+	return p.id, nil
+}
+
+// longestActive returns the peer that has been active for the longest length of
+// time.
 func (t *Transport) longestActive() (*peer, error) {
 	var longest *peer
 	var longestTime time.Time


### PR DESCRIPTION
When we demote the leader, we currently wait for all queued messages to be sent, as a best-effort approach to making sure the other nodes find out that the node removal has been committed, and stop treating the current leader as a cluster member. This doesn't work perfectly.

To make this more robust, use `TransferLeadership` when the leader is trying to remove itself. The new leader's reconcilation loop will kick in and remove the old leader.

cc @LK4D4 @cyli