### PR TITLE
Do not append the root certificate to the leaf server/client TLS cert

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -317,31 +317,7 @@ func (rca *RootCA) ParseValidateAndSignCSR(csrBytes []byte, cn, ou, org string) 
 		return nil, errors.Wrap(err, "failed to sign node certificate")
 	}
 
-	return rca.AppendFirstRootPEM(cert)
-}
-
-// AppendFirstRootPEM appends the first certificate from this RootCA's cert
-// bundle to the given cert bundle (which should already be encoded as a series
-// of PEM-encoded certificate blocks).
-func (rca *RootCA) AppendFirstRootPEM(cert []byte) ([]byte, error) {
-	// Append the first root CA Cert to the certificate, to create a valid chain
-	// Get the first Root CA Cert on the bundle
-	firstRootCA, _, err := helpers.ParseOneCertificateFromPEM(rca.Cert)
-	if err != nil {
-		return nil, err
-	}
-	if len(firstRootCA) < 1 {
-		return nil, errors.New("no valid Root CA certificates found")
-	}
-	// Convert the first root CA back to PEM
-	firstRootCAPEM := helpers.EncodeCertificatePEM(firstRootCA[0])
-	if firstRootCAPEM == nil {
-		return nil, errors.New("error while encoding the Root CA certificate")
-	}
-	// Append this Root CA to the certificate to make [Cert PEM]\n[Root PEM][EOF]
-	certChain := append(cert, firstRootCAPEM...)
-
-	return certChain, nil
+	return cert, nil
 }
 
 // NewRootCA creates a new RootCA object from unparsed PEM cert bundle and key byte

--- a/ca/external.go
+++ b/ca/external.go
@@ -89,9 +89,8 @@ func (eca *ExternalCA) Sign(ctx context.Context, req signer.SignRequest) (cert [
 	for _, url := range urls {
 		cert, err = makeExternalSignRequest(ctx, client, url, csrJSON)
 		if err == nil {
-			return eca.rootCA.AppendFirstRootPEM(cert)
+			return cert, err
 		}
-
 		logrus.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
 	}
 


### PR DESCRIPTION
This is not required as per RFC5246 section 7.4.2, and if we wanted to support cross-signed intermediates we probably should not include the self-signed root.

cc @diogomonica 