### PR TITLE
Fix portsAllocatedInHostPublishMode

### DIFF
--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -285,7 +285,8 @@ func (pa *portAllocator) portsAllocatedInHostPublishMode(s *api.Service) bool {
 
 	if s.Spec.Endpoint != nil {
 		for _, portConfig := range s.Spec.Endpoint.Ports {
-			if portConfig.PublishMode == api.PublishModeHost {
+			if portConfig.PublishMode == api.PublishModeHost &&
+				portConfig.PublishedPort != 0 {
 				if portStates.delState(portConfig) == nil {
 					return false
 				}

--- a/manager/allocator/networkallocator/portallocator_test.go
+++ b/manager/allocator/networkallocator/portallocator_test.go
@@ -361,6 +361,121 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 			},
 			expect: true,
 		},
+		{
+			// published port not specified
+			// we are not in charge of allocating one, for us it
+			// is as allocated, we need to skip the allocation
+			input: &api.Service{
+				Spec: api.ServiceSpec{
+					Endpoint: &api.EndpointSpec{
+						Ports: []*api.PortConfig{
+							{
+								Name:        "test4",
+								Protocol:    api.ProtocolUDP,
+								TargetPort:  99,
+								PublishMode: api.PublishModeHost,
+							},
+						},
+					},
+				},
+				Endpoint: &api.Endpoint{
+					Ports: []*api.PortConfig{
+						{
+							Name:        "test4",
+							Protocol:    api.ProtocolUDP,
+							TargetPort:  99,
+							PublishMode: api.PublishModeHost,
+						},
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			// one published port not specified, the other specified
+			// we are still in charge of allocating one
+			input: &api.Service{
+				Spec: api.ServiceSpec{
+					Endpoint: &api.EndpointSpec{
+						Ports: []*api.PortConfig{
+							{
+								Name:        "test5",
+								Protocol:    api.ProtocolUDP,
+								TargetPort:  99,
+								PublishMode: api.PublishModeHost,
+							},
+							{
+								Name:          "test5",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    99,
+								PublishedPort: 30099,
+								PublishMode:   api.PublishModeHost,
+							},
+						},
+					},
+				},
+				Endpoint: &api.Endpoint{
+					Ports: []*api.PortConfig{
+						{
+							Name:        "test5",
+							Protocol:    api.ProtocolUDP,
+							TargetPort:  99,
+							PublishMode: api.PublishModeHost,
+						},
+						{
+							Name:        "test5",
+							Protocol:    api.ProtocolTCP,
+							TargetPort:  99,
+							PublishMode: api.PublishModeHost,
+						},
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			// one published port not specified, the other specified
+			// we are still in charge of allocating one and we did.
+			input: &api.Service{
+				Spec: api.ServiceSpec{
+					Endpoint: &api.EndpointSpec{
+						Ports: []*api.PortConfig{
+							{
+								Name:        "test6",
+								Protocol:    api.ProtocolUDP,
+								TargetPort:  99,
+								PublishMode: api.PublishModeHost,
+							},
+							{
+								Name:          "test6",
+								Protocol:      api.ProtocolTCP,
+								TargetPort:    99,
+								PublishedPort: 30099,
+								PublishMode:   api.PublishModeHost,
+							},
+						},
+					},
+				},
+				Endpoint: &api.Endpoint{
+					Ports: []*api.PortConfig{
+						{
+							Name:        "test6",
+							Protocol:    api.ProtocolUDP,
+							TargetPort:  99,
+							PublishMode: api.PublishModeHost,
+						},
+						{
+							Name:          "test6",
+							Protocol:      api.ProtocolTCP,
+							TargetPort:    99,
+							PublishedPort: 30099,
+							PublishMode:   api.PublishModeHost,
+						},
+					},
+				},
+			},
+			expect: true,
+		},
 	}
 	for _, singleTest := range testCases {
 		expect := pa.portsAllocatedInHostPublishMode(singleTest.input)


### PR DESCRIPTION
- It needs to skip the configured to allocated port state check
  when the configured host mode publish port is missing.
  Because swarm will never get to know the currently published
  port (state), which is being chosen by the engine on each
  node, and therefore may be a different port in each host.

Related to docker/docker/issues/30938

Signed-off-by: Alessandro Boch <aboch@docker.com>