### PR TITLE
Avoid encryption key rotation on leader change

### DIFF
--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -200,8 +200,6 @@ func (k *KeyManager) Run(ctx context.Context) error {
 	} else {
 		k.keyRing.lClock = cluster.EncryptionKeyLamportClock
 		k.keyRing.keys = cluster.NetworkBootstrapKeys
-
-		k.rotateKey(ctx)
 	}
 
 	ticker := time.NewTicker(k.config.RotationInterval)


### PR DESCRIPTION
Related to [docker #25608](https://github.com/docker/docker/issues/25608)
Also seen by an UCP customer.

In a 3 manager 2 workers cluster I was able to recreate the issue by reloading all the managers at the same time. There are two symptoms: 
- encrypted gossip traffic failing with the error `No installed keys could decrypt the message`
- If there are networks with datapath encryption enabled a panic in the overlay driver sometimes.

When the leader goes down one of the other two nodes become a leader and does a key rotation and updates the store. But since its going down as well,there isn't enough time for workers to connect to that lead manager. When the managers come back up a new leader is elected and that does a key rotation again. In essence when workers get the keys from the new leader two keys in the set have changed. But the current key rotation handling logic in the workers assume/expect only one key change in the set. The case where multiple keys change is not handled well and that results in the issues mentioned earlier.

There are two fixes for this:
- Don't do key rotation on a leader change. This a safe/small change which can go into 1.12.x and 1.13.x
- Update the key handling to cope with random changes. Ideally such random changes shouldn't happen. Nevertheless its good to handle it to be safer. Its more involved change in libnetwork and in overlay driver. Will do this change only for docker master.

Signed-off-by: Santhosh Manohar <santhosh@docker.com>