### PR TITLE
Global orchestrator reconcileServices should look at desired state only

### DIFF
--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -504,7 +504,7 @@ func (g *Orchestrator) removeTasks(ctx context.Context, batch *store.Batch, task
 }
 
 func isTaskRunning(t *api.Task) bool {
-	return t != nil && t.DesiredState <= api.TaskStateRunning && t.Status.State <= api.TaskStateRunning
+	return t != nil && t.DesiredState <= api.TaskStateRunning
 }
 
 func isTaskCompleted(t *api.Task, restartPolicy api.RestartPolicy_RestartCondition) bool {


### PR DESCRIPTION
Global orchestrator reconcileServices should look at desired state only to avoid creating multiple tasks. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>