### PR TITLE
controlapi: Allow a spec to be provided for a server-side rollback

### DIFF
--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -41,7 +41,9 @@ const (
 	// be honored.
 	UpdateServiceRequest_NONE UpdateServiceRequest_Rollback = 0
 	// Roll back the service - get spec from the service's
-	// previous_spec.
+	// previous_spec. If a spec is provided in this request, it
+	// will be used instead of previous_spec. This allows parameters
+	// to be changed during the rollback.
 	UpdateServiceRequest_PREVIOUS UpdateServiceRequest_Rollback = 1
 )
 

--- a/api/control.proto
+++ b/api/control.proto
@@ -227,7 +227,9 @@ message UpdateServiceRequest {
 		NONE = 0;
 
 		// Roll back the service - get spec from the service's
-		// previous_spec.
+		// previous_spec. If a spec is provided in this request, it
+		// will be used instead of previous_spec. This allows parameters
+		// to be changed during the rollback.
 		PREVIOUS = 1;
 	}
 

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -557,12 +557,18 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		service.Meta.Version = *request.ServiceVersion
 
 		if request.Rollback == api.UpdateServiceRequest_PREVIOUS {
-			if service.PreviousSpec == nil {
-				return grpc.Errorf(codes.FailedPrecondition, "service %s does not have a previous spec", request.ServiceID)
+			curSpec := service.Spec.Copy()
+
+			if request.Spec != nil {
+				service.Spec = *request.Spec.Copy()
+			} else {
+				if service.PreviousSpec == nil {
+					return grpc.Errorf(codes.FailedPrecondition, "service %s does not have a previous spec", request.ServiceID)
+				}
+
+				service.Spec = *service.PreviousSpec.Copy()
 			}
 
-			curSpec := service.Spec.Copy()
-			service.Spec = *service.PreviousSpec.Copy()
 			service.PreviousSpec = curSpec
 
 			service.UpdateStatus = &api.UpdateStatus{


### PR DESCRIPTION
We recently added support for server-side rollbacks, where the controlapi copies the previous spec over, instead of having the client supply it. This lets the manager recognize this update as a rollback, so it can honor the rollback-specific update parameters.

The problem with this is that it would break the existing ability to initiate a rollback while changing certain parameters, such as `--rollback --update-delay 0s` (or `--rollback --rollback-delay 0s` once rollback parameters are supported). To avoid introducing a regression, allow the client to optionally provide a spec while manually initiating a rollback. This will override `PreviousSpec`.

Note that there is another issue not addressed by this PR: what happens if a user tries to change a rollback parameter *after* initiating the rollback; for example consider the following sequence of commands:

```
$ docker service update --rollback myservice
$ docker service update --rollback-delay 0s myservice # the rollback is going slowly - i want it to go faster
```

This won't work as expected because the second command replaces the rollback with a new update. It effectively changes the direction of the update from backwards to forwards.

We might consider addressing this by checking to see if a service update actually changes the `TaskSpec`, and avoid changing the *direction* of the update if it does not. However, this still isn't a perfect solution. A service update that mixed orchestration parameters with other things could cause the update direction to change, and this might be confusing. I'm not sure what the best solution is.

cc @dongluochen @aluzzardi