### PR TITLE
updater: Decrease default monitoring period

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -21,7 +21,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 )
 
-const defaultMonitor = 30 * time.Second
+const defaultMonitor = 5 * time.Second
 
 // Supervisor supervises a set of updates. It's responsible for keeping track of updates,
 // shutting them down and replacing them.


### PR DESCRIPTION
The updater monitors a tasks after they start to make sure they don't
fail immediately. The default time interval for this is 30s. However,
this is a bit long for synchronous updates to wait. Reduce it to 5s.
Users who would like a longer monitoring period should specify their own
value, or ideally use a health check in the service definition.