### PR TITLE
Simplify Fatalf to Fatal

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -127,7 +127,7 @@ func TestHandleSessionMessage(t *testing.T) {
 	for _, m := range messages {
 		err := agent.handleSessionMessage(ctx, m)
 		if err != nil {
-			t.Fatalf("err should be nil")
+			t.Fatal("err should be nil")
 		}
 	}
 }

--- a/agent/reporter_test.go
+++ b/agent/reporter_test.go
@@ -40,7 +40,7 @@ func TestReporter(t *testing.T) {
 		key := uniqueStatus{taskID, status}
 		// make sure we get the status only once.
 		if _, ok := unique[key]; ok {
-			t.Fatalf("encountered status twice")
+			t.Fatal("encountered status twice")
 		}
 
 		if status.State == api.TaskStateCompleted {

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -46,7 +46,7 @@ func TestTaskManager(t *testing.T) {
 			select {
 			case <-ready:
 			default:
-				t.Fatalf("should be running before ready")
+				t.Fatal("should be running before ready")
 			}
 		case api.TaskStateCompleted:
 			select {
@@ -80,7 +80,7 @@ func TestTaskManager(t *testing.T) {
 			select {
 			case <-tm.closed:
 			default:
-				t.Fatalf("not actually closed")
+				t.Fatal("not actually closed")
 			}
 
 			assert.NoError(t, tm.Close()) // hit a second time to make sure it behaves

--- a/manager/dispatcher/heartbeat/heartbeat_test.go
+++ b/manager/dispatcher/heartbeat/heartbeat_test.go
@@ -17,7 +17,7 @@ func TestHeartbeatBeat(t *testing.T) {
 	hb.Stop()
 	select {
 	case <-ch:
-		t.Fatalf("Heartbeat was expired")
+		t.Fatal("Heartbeat was expired")
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -31,7 +31,7 @@ func TestHeartbeatTimeout(t *testing.T) {
 	select {
 	case <-ch:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatalf("timeoutFunc wasn't called in timely fashion")
+		t.Fatal("timeoutFunc wasn't called in timely fashion")
 	}
 }
 
@@ -48,7 +48,7 @@ func TestHeartbeatReactivate(t *testing.T) {
 		select {
 		case <-ch:
 		case <-time.After(500 * time.Millisecond):
-			t.Fatalf("timeoutFunc wasn't called in timely fashion")
+			t.Fatal("timeoutFunc wasn't called in timely fashion")
 		}
 	}
 }
@@ -65,6 +65,6 @@ func TestHeartbeatUpdate(t *testing.T) {
 	select {
 	case <-ch:
 	case <-time.After(500 * time.Millisecond):
-		t.Fatalf("timeoutFunc wasn't called in timely fashion")
+		t.Fatal("timeoutFunc wasn't called in timely fashion")
 	}
 }

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -1780,7 +1780,7 @@ func watchAssignmentFailure(t *testing.T, watch chan events.Event) *api.Task {
 				}
 			}
 		case <-time.After(time.Second):
-			t.Fatalf("no task assignment failure")
+			t.Fatal("no task assignment failure")
 		}
 	}
 }
@@ -1797,7 +1797,7 @@ func watchAssignment(t *testing.T, watch chan events.Event) *api.Task {
 				}
 			}
 		case <-time.After(time.Second):
-			t.Fatalf("no task assignment")
+			t.Fatal("no task assignment")
 		}
 	}
 }

--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -134,7 +134,7 @@ func (n *Node) loadAndStart(ctx context.Context, forceNewCluster bool) error {
 		// force commit newly appended entries
 		err := n.raftLogger.SaveEntries(st, toAppEnts)
 		if err != nil {
-			log.G(ctx).WithError(err).Fatalf("failed to save WAL while forcing new cluster")
+			log.G(ctx).WithError(err).Fatal("failed to save WAL while forcing new cluster")
 		}
 		if len(toAppEnts) != 0 {
 			st.Commit = toAppEnts[len(toAppEnts)-1].Index

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1091,7 +1091,7 @@ func TestBatchFailure(t *testing.T) {
 	// Shouldn't be anything after the first transaction
 	select {
 	case <-watch:
-		t.Fatalf("unexpected additional events")
+		t.Fatal("unexpected additional events")
 	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/remotes/remotes_test.go
+++ b/remotes/remotes_test.go
@@ -184,7 +184,7 @@ func TestRemotesZeroWeights(t *testing.T) {
 	// here, we ensure that three is at least three times more likely to be
 	// selected. This is somewhat arbitrary.
 	if count[api.Peer{Addr: "three"}] <= count[api.Peer{Addr: "one"}]*3 || count[api.Peer{Addr: "three"}] <= count[api.Peer{Addr: "two"}] {
-		t.Fatalf("three should outpace one and two")
+		t.Fatal("three should outpace one and two")
 	}
 }
 


### PR DESCRIPTION
as the source code said:
```go
// Fatal is equivalent to Log followed by FailNow.
func (c *common) Fatal(args ...interface{}) {
	c.log(fmt.Sprintln(args...))
	c.FailNow()
}

// Fatalf is equivalent to Logf followed by FailNow.
func (c *common) Fatalf(format string, args ...interface{}) {
	c.log(fmt.Sprintf(format, args...))
	c.FailNow()
}
```
If there is no need string format, we can just use Fatal instead.

Signed-off-by: kevinetc123 <kaiwentan@harmonycloud.cn>