### PR TITLE
[update] Use default parallelism of 1

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -157,7 +157,7 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 	}
 
 	var (
-		parallelism            int
+		parallelism            = 1
 		delay                  time.Duration
 		failureAction          = api.UpdateConfig_PAUSE
 		allowedFailureFraction = float32(0)


### PR DESCRIPTION
If the `UpdateConfig` field in the service spec is nil, the update parallelism should default to `1` but it currently defaults to `0`.

To have "infinite" parallelism, you must now explicitly set update parallelism to `0`.