### PR TITLE
scheduler: Tasks with a desired state < RUNNING should count

### DIFF
--- a/manager/scheduler/constraint_test.go
+++ b/manager/scheduler/constraint_test.go
@@ -55,7 +55,7 @@ func setupEnv() {
 			},
 		},
 		Tasks: make(map[string]*api.Task),
-		DesiredRunningTasksCountByService: make(map[string]int),
+		ActiveTasksCountByService: make(map[string]int),
 	}
 }
 

--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -35,8 +35,8 @@ func (ns *nodeSet) addOrUpdateNode(n NodeInfo) {
 	if n.Tasks == nil {
 		n.Tasks = make(map[string]*api.Task)
 	}
-	if n.DesiredRunningTasksCountByService == nil {
-		n.DesiredRunningTasksCountByService = make(map[string]int)
+	if n.ActiveTasksCountByService == nil {
+		n.ActiveTasksCountByService = make(map[string]int)
 	}
 	if n.recentFailures == nil {
 		n.recentFailures = make(map[string][]time.Time)
@@ -96,8 +96,8 @@ func (ns *nodeSet) tree(serviceID string, preferences []*api.PlacementPreference
 			// sure that the tree structure is not affected by
 			// which properties nodes have and don't have.
 
-			if node.DesiredRunningTasksCountByService != nil {
-				tree.tasks += node.DesiredRunningTasksCountByService[serviceID]
+			if node.ActiveTasksCountByService != nil {
+				tree.tasks += node.ActiveTasksCountByService[serviceID]
 			}
 
 			if tree.next == nil {

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -517,8 +517,8 @@ func (s *Scheduler) scheduleTaskGroup(ctx context.Context, taskGroup map[string]
 			}
 		}
 
-		tasksByServiceA := a.DesiredRunningTasksCountByService[t.ServiceID]
-		tasksByServiceB := b.DesiredRunningTasksCountByService[t.ServiceID]
+		tasksByServiceA := a.ActiveTasksCountByService[t.ServiceID]
+		tasksByServiceB := b.ActiveTasksCountByService[t.ServiceID]
 
 		if tasksByServiceA < tasksByServiceB {
 			return true
@@ -528,7 +528,7 @@ func (s *Scheduler) scheduleTaskGroup(ctx context.Context, taskGroup map[string]
 		}
 
 		// Total number of tasks breaks ties.
-		return a.DesiredRunningTasksCount < b.DesiredRunningTasksCount
+		return a.ActiveTasksCount < b.ActiveTasksCount
 	}
 
 	var prefs []*api.PlacementPreference


### PR DESCRIPTION
Currently, the scheduler counts tasks on each node with desired state of
RUNNING. This works fine for sequential updates, but in parallel
updates, the scheduler can assign tasks unfairly, because the ones it
already assigned may not have changed their desired state to RUNNING
yet. In an update with unlimited parallelism, all the tasks may end up
on the same node, even when there are multiple nodes that can accomodate
the tasks.

Fix this by considering all tasks with a desired state at or below
RUNNING to be active. For example, tasks at READY should be seen the
same way as RUNNING tasks by the scheduler - they were assigned to that
node and will eventually start running.

cc @jlhawn @aluzzardi @dongluochen