### PR TITLE
ca: when the Root CA is updated in the security config, update all TLS creds too

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -666,17 +666,11 @@ func saveRootCA(rootCA RootCA, paths CertPaths) error {
 }
 
 // GenerateNewCSR returns a newly generated key and CSR signed with said key
-func GenerateNewCSR() (csr, key []byte, err error) {
+func GenerateNewCSR() ([]byte, []byte, error) {
 	req := &cfcsr.CertificateRequest{
 		KeyRequest: cfcsr.NewBasicKeyRequest(),
 	}
-
-	csr, key, err = cfcsr.ParseRequest(req)
-	if err != nil {
-		return
-	}
-
-	return
+	return cfcsr.ParseRequest(req)
 }
 
 // EncryptECPrivateKey receives a PEM encoded private key and returns an encrypted

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -34,22 +34,22 @@ import (
 
 // TestCA is a structure that encapsulates everything needed to test a CA Server
 type TestCA struct {
-	RootCA                ca.RootCA
-	ExternalSigningServer *ExternalSigningServer
-	MemoryStore           *store.MemoryStore
-	TempDir, Organization string
-	Paths                 *ca.SecurityConfigPaths
-	Server                *grpc.Server
-	CAServer              *ca.Server
-	Context               context.Context
-	NodeCAClients         []api.NodeCAClient
-	CAClients             []api.CAClient
-	Conns                 []*grpc.ClientConn
-	WorkerToken           string
-	ManagerToken          string
-	ConnBroker            *connectionbroker.Broker
-	KeyReadWriter         *ca.KeyReadWriter
-	watchCancel           func()
+	RootCA                      ca.RootCA
+	ExternalSigningServer       *ExternalSigningServer
+	MemoryStore                 *store.MemoryStore
+	Addr, TempDir, Organization string
+	Paths                       *ca.SecurityConfigPaths
+	Server                      *grpc.Server
+	CAServer                    *ca.Server
+	Context                     context.Context
+	NodeCAClients               []api.NodeCAClient
+	CAClients                   []api.CAClient
+	Conns                       []*grpc.ClientConn
+	WorkerToken                 string
+	ManagerToken                string
+	ConnBroker                  *connectionbroker.Broker
+	KeyReadWriter               *ca.KeyReadWriter
+	watchCancel                 func()
 }
 
 // Stop cleans up after TestCA
@@ -224,6 +224,7 @@ func NewTestCA(t *testing.T, krwGenerators ...func(ca.CertPaths) *ca.KeyReadWrit
 		CAClients:             caClients,
 		NodeCAClients:         nodeCAClients,
 		Conns:                 conns,
+		Addr:                  l.Addr().String(),
 		Server:                grpcServer,
 		CAServer:              caServer,
 		WorkerToken:           workerToken,

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
@@ -133,6 +134,16 @@ func (c *MutableTLSCreds) LoadNewTLSConfig(newConfig *tls.Config) error {
 	c.config = newConfig
 
 	return nil
+}
+
+// UpdateCAs updates the root CAs and client CAs of the existing TLS config in place
+func (c *MutableTLSCreds) UpdateCAs(rootCAs, clientCAs *x509.CertPool) {
+	c.Lock()
+	defer c.Unlock()
+	config := tlsconfig.Clone(c.config)
+	config.RootCAs = rootCAs
+	config.ClientCAs = clientCAs
+	c.config = config
 }
 
 // Config returns the current underlying TLS config.


### PR DESCRIPTION
So that both can use the new root CA pool to validate peers.