### PR TITLE
ca: all managers will update their security configs when cluster root CA updated

### DIFF
--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -167,7 +167,7 @@ func NewTestCA(t *testing.T, krwGenerators ...func(ca.CertPaths) *ca.KeyReadWrit
 	workerToken := ca.GenerateJoinToken(&rootCA)
 
 	createClusterObject(t, s, organization, workerToken, managerToken, externalCAs...)
-	caServer := ca.NewServer(s, managerConfig)
+	caServer := ca.NewServer(s, managerConfig, false)
 	caServer.SetReconciliationRetryInterval(50 * time.Millisecond)
 	api.RegisterCAServer(grpcServer, caServer)
 	api.RegisterNodeCAServer(grpcServer, caServer)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -208,9 +208,8 @@ func New(config *Config) (*Manager, error) {
 	}
 
 	m := &Manager{
-		config: *config,
-		// manager will tell the CA server to update the RootCA, so skip having the CA server autoupdate the root ca material
-		caserver:        ca.NewServer(raftNode.MemoryStore(), config.SecurityConfig, true),
+		config:          *config,
+		caserver:        ca.NewServer(raftNode.MemoryStore(), config.SecurityConfig),
 		dispatcher:      dispatcher.New(raftNode, dispatcher.DefaultConfig()),
 		logbroker:       logbroker.New(raftNode.MemoryStore()),
 		server:          grpc.NewServer(opts...),


### PR DESCRIPTION
Rather than just the leader that is running the CA server.  This way on root rotation, all managers will get root changes right away.

#1983 will actually update the TLS creds with the new root pool when the RootCA is updated