### PR TITLE
Add swarmkitstate/ and bin/swarmkitstate/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ _testmain.go
 *.prof
 
 bin/
+
+# ignore the obvious locations of swarmkitstate
+swarmkitstate
+bin/swarmkitstate


### PR DESCRIPTION
These are obvious locations where `swarmkitstate` might be created during
testing, but the `swarmkitstate` should literally never be checked into
verison control, ever, and so shouldn't show up in git status.

Signed-off-by: Drew Erny <drew.erny@docker.com>