### PR TITLE
raft: Correct duplicate and spurious snapshot reporting

### DIFF
--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -132,14 +132,6 @@ func (p *peer) resolveAddr(ctx context.Context, id uint64) (string, error) {
 	return resp.Addr, nil
 }
 
-func (p *peer) reportSnapshot(failure bool) {
-	if failure {
-		p.tr.config.ReportSnapshot(p.id, raft.SnapshotFailure)
-		return
-	}
-	p.tr.config.ReportSnapshot(p.id, raft.SnapshotFinish)
-}
-
 func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 	ctx, cancel := context.WithTimeout(ctx, p.tr.config.SendTimeout)
 	defer cancel()
@@ -151,9 +143,9 @@ func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 		if err != nil {
 			p.tr.config.ReportSnapshot(m.To, raft.SnapshotFailure)
 		} else {
+			p.tr.config.ReportSnapshot(m.To, raft.SnapshotFinish)
 		}
 	}
-	p.reportSnapshot(err != nil)
 	if err != nil {
 		p.tr.config.ReportUnreachable(m.To)
 		return err

--- a/manager/state/raft/transport/transport_test.go
+++ b/manager/state/raft/transport/transport_test.go
@@ -61,7 +61,7 @@ func testSend(ctx context.Context, c *mockCluster, from uint64, to []uint64, msg
 						continue loop
 					}
 				}
-				t.Fatalf("shapshot ot %d is not reported", id)
+				t.Fatalf("snapshot id %d is not reported", id)
 			}
 		}
 	}


### PR DESCRIPTION
There are some logical issues in the code that cause `ReportSnapshot` to
be called twice in some cases, and to be called even when a snapshot is
not involved. It looks like this might be a rebase artifact.

Fixes #1868 (I think)