### PR TITLE
node: Try to force TLS certificate renewal if role doesn't change after demotion

### DIFF
--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -227,7 +227,7 @@ func (c *testCluster) Leader() (*testNode, error) {
 			return tn, nil
 		}
 	}
-	return nil, fmt.Errorf("cluster leader is not found in storage")
+	return nil, fmt.Errorf("cluster leader is not found in api response")
 }
 
 // RemoveNode removes node entirely. It tries to demote managers.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -332,7 +332,6 @@ func TestDemotePromoteLeader(t *testing.T) {
 	pollClusterReady(t, cl, numWorker, numManager)
 }
 
-// TODO: improve test to demote the leader in case of 2 remaining managers
 func TestDemoteToSingleManager(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Currently, we wait 16 seconds for the role to change, and restart the
manager if it doesn't happen. This may be the right thing to do, because
if the node is promoted again, we might never see a role change. But
it's also possible that the 16 second timeout can be hit even with no
promotion, and this is a bad failure mode because it unexpectedly
re-adds the node to the Raft cluster.

Address this by being extra careful when the node was demoted, and
trying to force a certificate renewal in the case where we still don't
see a role change after 16 seconds.

This also adds `RenewTLSConfig` to node's waitgroup, to avoid some test
failures where `RemoveAll` returned an error because `RenewTLSConfig` was
still running.

Fixes #1991
Fixes #1997

cc @cyli @LK4D4