### PR TITLE
integration: Improve logging

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -147,7 +147,18 @@ func pollServiceReady(t *testing.T, c *testCluster, sid string, replicas int) {
 }
 
 func newCluster(t *testing.T, numWorker, numManager int) *testCluster {
-	cl := newTestCluster()
+	// Get name of caller
+	var testName string
+	pc, _, _, ok := runtime.Caller(1)
+	if ok {
+		funcName := runtime.FuncForPC(pc).Name()
+		splitted := strings.Split(funcName, ".")
+		if len(splitted) > 1 {
+			testName = splitted[len(splitted)-1]
+		}
+	}
+
+	cl := newTestCluster(testName)
 	for i := 0; i < numManager; i++ {
 		require.NoError(t, cl.AddManager(false, nil), "manager number %d", i+1)
 	}
@@ -174,7 +185,7 @@ func TestServiceCreateLateBind(t *testing.T) {
 
 	numWorker, numManager := 3, 3
 
-	cl := newTestCluster()
+	cl := newTestCluster("TestServiceCreateLateBind")
 	for i := 0; i < numManager; i++ {
 		require.NoError(t, cl.AddManager(true, nil), "manager number %d", i+1)
 	}
@@ -489,7 +500,7 @@ func TestForceNewCluster(t *testing.T) {
 
 	// start a new cluster with the external CA bootstrapped
 	numWorker, numManager := 0, 1
-	cl := newTestCluster()
+	cl := newTestCluster("TestForceNewCluster")
 	defer func() {
 		require.NoError(t, cl.Stop())
 	}()

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -983,7 +983,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	}(m.globalOrchestrator)
 
 	go func(roleManager *roleManager) {
-		roleManager.Run()
+		roleManager.Run(ctx)
 	}(m.roleManager)
 }
 

--- a/manager/role_manager.go
+++ b/manager/role_manager.go
@@ -41,7 +41,8 @@ func newRoleManager(store *store.MemoryStore, raftNode *raft.Node) *roleManager 
 }
 
 // Run is roleManager's main loop.
-func (rm *roleManager) Run() {
+// ctx is only used for logging.
+func (rm *roleManager) Run(ctx context.Context) {
 	defer close(rm.doneChan)
 
 	var (
@@ -60,11 +61,11 @@ func (rm *roleManager) Run() {
 	defer cancelWatch()
 
 	if err != nil {
-		log.L.WithError(err).Error("failed to check nodes for role changes")
+		log.G(ctx).WithError(err).Error("failed to check nodes for role changes")
 	} else {
 		for _, node := range nodes {
 			rm.pending[node.ID] = node
-			rm.reconcileRole(node)
+			rm.reconcileRole(ctx, node)
 		}
 		if len(rm.pending) != 0 {
 			ticker = time.NewTicker(roleReconcileInterval)
@@ -77,14 +78,14 @@ func (rm *roleManager) Run() {
 		case event := <-watcher:
 			node := event.(state.EventUpdateNode).Node
 			rm.pending[node.ID] = node
-			rm.reconcileRole(node)
+			rm.reconcileRole(ctx, node)
 			if len(rm.pending) != 0 && ticker == nil {
 				ticker = time.NewTicker(roleReconcileInterval)
 				tickerCh = ticker.C
 			}
 		case <-tickerCh:
 			for _, node := range rm.pending {
-				rm.reconcileRole(node)
+				rm.reconcileRole(ctx, node)
 			}
 			if len(rm.pending) == 0 {
 				ticker.Stop()
@@ -100,7 +101,7 @@ func (rm *roleManager) Run() {
 	}
 }
 
-func (rm *roleManager) reconcileRole(node *api.Node) {
+func (rm *roleManager) reconcileRole(ctx context.Context, node *api.Node) {
 	if node.Role == node.Spec.DesiredRole {
 		// Nothing to do.
 		delete(rm.pending, node.ID)
@@ -118,7 +119,7 @@ func (rm *roleManager) reconcileRole(node *api.Node) {
 			return store.UpdateNode(tx, updatedNode)
 		})
 		if err != nil {
-			log.L.WithError(err).Errorf("failed to promote node %s", node.ID)
+			log.G(ctx).WithError(err).Errorf("failed to promote node %s", node.ID)
 		} else {
 			delete(rm.pending, node.ID)
 		}
@@ -129,7 +130,7 @@ func (rm *roleManager) reconcileRole(node *api.Node) {
 			// Quorum safeguard
 			if !rm.raft.CanRemoveMember(member.RaftID) {
 				// TODO(aaronl): Retry later
-				log.L.Debugf("can't demote node %s at this time: removing member from raft would result in a loss of quorum", node.ID)
+				log.G(ctx).Debugf("can't demote node %s at this time: removing member from raft would result in a loss of quorum", node.ID)
 				return
 			}
 
@@ -139,16 +140,16 @@ func (rm *roleManager) reconcileRole(node *api.Node) {
 			if member.RaftID == rm.raft.Config.ID {
 				// Don't use rmCtx, because we expect to lose
 				// leadership, which will cancel this context.
-				log.L.Info("demoted; transferring leadership")
+				log.G(ctx).Info("demoted; transferring leadership")
 				err := rm.raft.TransferLeadership(context.Background())
 				if err == nil {
 					return
 				}
-				log.L.WithError(err).Info("failed to transfer leadership")
+				log.G(ctx).WithError(err).Info("failed to transfer leadership")
 			}
 			if err := rm.raft.RemoveMember(rmCtx, member.RaftID); err != nil {
 				// TODO(aaronl): Retry later
-				log.L.WithError(err).Debugf("can't demote node %s at this time", node.ID)
+				log.G(ctx).WithError(err).Debugf("can't demote node %s at this time", node.ID)
 			}
 			return
 		}
@@ -163,7 +164,7 @@ func (rm *roleManager) reconcileRole(node *api.Node) {
 			return store.UpdateNode(tx, updatedNode)
 		})
 		if err != nil {
-			log.L.WithError(err).Errorf("failed to demote node %s", node.ID)
+			log.G(ctx).WithError(err).Errorf("failed to demote node %s", node.ID)
 		} else {
 			delete(rm.pending, node.ID)
 		}

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -375,6 +375,9 @@ func (n *Node) JoinAndStart(ctx context.Context) (err error) {
 	n.addrLock.Lock()
 	defer n.addrLock.Unlock()
 
+	// override the module field entirely, since etcd/raft is not exactly a submodule
+	n.Config.Logger = log.G(ctx).WithField("module", "raft")
+
 	// restore from snapshot
 	if loadAndStartErr == nil {
 		if n.opts.JoinAddr != "" {

--- a/node/node.go
+++ b/node/node.go
@@ -224,18 +224,20 @@ func (n *Node) run(ctx context.Context) (err error) {
 	defer cancel()
 	ctx = log.WithModule(ctx, "node")
 
-	go func() {
+	go func(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 		case <-n.stopped:
 			cancel()
 		}
-	}()
+	}(ctx)
 
 	securityConfig, err := n.loadSecurityConfig(ctx)
 	if err != nil {
 		return err
 	}
+
+	ctx = log.WithLogger(ctx, log.G(ctx).WithField("node.id", n.NodeID()))
 
 	taskDBPath := filepath.Join(n.config.StateDir, "worker/tasks.db")
 	if err := os.MkdirAll(filepath.Dir(taskDBPath), 0777); err != nil {
@@ -733,12 +735,12 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 	}
 	done := make(chan struct{})
 	var runErr error
-	go func() {
-		if err := m.Run(context.Background()); err != nil {
+	go func(logger *logrus.Entry) {
+		if err := m.Run(log.WithLogger(context.Background(), logger)); err != nil {
 			runErr = err
 		}
 		close(done)
-	}()
+	}(log.G(ctx))
 
 	var clearData bool
 	defer func() {


### PR DESCRIPTION
Since integration tests tests run in parallel, it can be very hard to tell which test a log line came from.

Add a "testname" field to the logger used for the tests.

Plumb context through roleManager so that its log messages will benefit from this.

Also preserve the logger in `(*Node).run` and `(*Node).runManager` so these
injected fields reach further.
I considered turning on debug logging, but it's an enormous amount of information.