### PR TITLE
all: Import crypto/rand as "cryptorand"

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -686,7 +686,7 @@ func EncryptECPrivateKey(key []byte, passphraseStr string) ([]byte, error) {
 		return nil, errors.New("error while decoding PEM key")
 	}
 
-	encryptedPEMBlock, err := x509.EncryptPEMBlock(rand.Reader,
+	encryptedPEMBlock, err := x509.EncryptPEMBlock(cryptorand.Reader,
 		"EC PRIVATE KEY",
 		keyBlock.Bytes,
 		passphrase,

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -3,7 +3,7 @@ package ca_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
@@ -128,7 +128,7 @@ func TestGetLocalRootCA(t *testing.T) {
 	assert.True(t, rootCA3.CanSign())
 
 	// Try with a private key that does not match the CA cert public key.
-	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), cryptorand.Reader)
 	assert.NoError(t, err)
 	privKeyBytes, err := x509.MarshalECPrivateKey(privKey)
 	assert.NoError(t, err)

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -1,7 +1,8 @@
 package ca_test
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -16,8 +17,6 @@ import (
 	"google.golang.org/grpc"
 
 	"golang.org/x/net/context"
-
-	"crypto/tls"
 
 	cfconfig "github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/helpers"
@@ -158,11 +157,11 @@ func TestLoadSecurityConfigExpiredCert(t *testing.T) {
 	require.NoError(t, err)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	serialNumber, err := cryptorand.Int(cryptorand.Reader, serialNumberLimit)
 	require.NoError(t, err)
 
 	genCert := func(notBefore, notAfter time.Time) {
-		derBytes, err := x509.CreateCertificate(rand.Reader, &x509.Certificate{
+		derBytes, err := x509.CreateCertificate(cryptorand.Reader, &x509.Certificate{
 			SerialNumber: serialNumber,
 			Subject: pkix.Name{
 				CommonName:         "CN",

--- a/ca/keyreadwriter.go
+++ b/ca/keyreadwriter.go
@@ -1,7 +1,7 @@
 package ca
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"io/ioutil"
@@ -345,7 +345,7 @@ func (k *KeyReadWriter) readKey() (*pem.Block, error) {
 // writing it to disk.  If the kek is nil, writes it to disk unencrypted.
 func (k *KeyReadWriter) writeKey(keyBlock *pem.Block, kekData KEKData, pkh PEMKeyHeaders) error {
 	if kekData.KEK != nil {
-		encryptedPEMBlock, err := x509.EncryptPEMBlock(rand.Reader,
+		encryptedPEMBlock, err := x509.EncryptPEMBlock(cryptorand.Reader,
 			keyBlock.Type,
 			keyBlock.Bytes,
 			kekData.KEK,

--- a/identity/randomid.go
+++ b/identity/randomid.go
@@ -1,7 +1,7 @@
 package identity
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"fmt"
 	"io"
 	"math/big"
@@ -10,7 +10,7 @@ import (
 var (
 	// idReader is used for random id generation. This declaration allows us to
 	// replace it for testing.
-	idReader = rand.Reader
+	idReader = cryptorand.Reader
 )
 
 // parameters for random identifier generation. We can tweak this when there is

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
@@ -517,7 +517,7 @@ func TestForceNewCluster(t *testing.T) {
 	expiredCertTemplate := managerCerts[0]
 	expiredCertTemplate.NotBefore = time.Now().Add(time.Hour * -5)
 	expiredCertTemplate.NotAfter = time.Now().Add(time.Hour * -3)
-	expiredCertDERBytes, err := x509.CreateCertificate(rand.Reader, expiredCertTemplate, rootCert, expiredCertTemplate.PublicKey, rootKey)
+	expiredCertDERBytes, err := x509.CreateCertificate(cryptorand.Reader, expiredCertTemplate, rootCert, expiredCertTemplate.PublicKey, rootKey)
 	require.NoError(t, err)
 	expiredCertPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",

--- a/manager/encryption/encryption.go
+++ b/manager/encryption/encryption.go
@@ -1,7 +1,7 @@
 package encryption
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -105,7 +105,7 @@ func Defaults(key []byte) (Encrypter, Decrypter) {
 // using this package
 func GenerateSecretKey() []byte {
 	secretData := make([]byte, naclSecretboxKeySize)
-	if _, err := io.ReadFull(rand.Reader, secretData); err != nil {
+	if _, err := io.ReadFull(cryptorand.Reader, secretData); err != nil {
 		// panic if we can't read random data
 		panic(errors.Wrap(err, "failed to read random bytes"))
 	}

--- a/manager/encryption/nacl.go
+++ b/manager/encryption/nacl.go
@@ -1,7 +1,7 @@
 package encryption
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"fmt"
 	"io"
 
@@ -37,7 +37,7 @@ func (n NACLSecretbox) Algorithm() api.MaybeEncryptedRecord_Algorithm {
 // Encrypt encrypts some bytes and returns an encrypted record
 func (n NACLSecretbox) Encrypt(data []byte) (*api.MaybeEncryptedRecord, error) {
 	var nonce [24]byte
-	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+	if _, err := io.ReadFull(cryptorand.Reader, nonce[:]); err != nil {
 		return nil, err
 	}
 

--- a/manager/encryption/nacl_test.go
+++ b/manager/encryption/nacl_test.go
@@ -1,7 +1,7 @@
 package encryption
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"io"
 	"testing"
 
@@ -14,7 +14,7 @@ import (
 // of these can be decrypted into the same data though.
 func TestNACLSecretbox(t *testing.T) {
 	key := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, key)
+	_, err := io.ReadFull(cryptorand.Reader, key)
 	require.NoError(t, err)
 
 	crypter := NewNACLSecretbox(key)
@@ -40,7 +40,7 @@ func TestNACLSecretbox(t *testing.T) {
 
 func TestNACLSecretboxInvalidAlgorithm(t *testing.T) {
 	key := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, key)
+	_, err := io.ReadFull(cryptorand.Reader, key)
 	require.NoError(t, err)
 
 	crypter := NewNACLSecretbox(key)
@@ -55,7 +55,7 @@ func TestNACLSecretboxInvalidAlgorithm(t *testing.T) {
 
 func TestNACLSecretboxCannotDecryptWithoutRightKey(t *testing.T) {
 	key := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, key)
+	_, err := io.ReadFull(cryptorand.Reader, key)
 	require.NoError(t, err)
 
 	crypter := NewNACLSecretbox(key)
@@ -69,7 +69,7 @@ func TestNACLSecretboxCannotDecryptWithoutRightKey(t *testing.T) {
 
 func TestNACLSecretboxInvalidNonce(t *testing.T) {
 	key := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, key)
+	_, err := io.ReadFull(cryptorand.Reader, key)
 	require.NoError(t, err)
 
 	crypter := NewNACLSecretbox(key)

--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -6,7 +6,7 @@ package keymanager
 // which is used to exchange service discovery and overlay network control
 // plane information. It can also be used to encrypt overlay data traffic.
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/binary"
 	"sync"
 	"time"
@@ -95,7 +95,7 @@ func New(store *store.MemoryStore, config *Config) *KeyManager {
 func (k *KeyManager) allocateKey(ctx context.Context, subsys string) *api.EncryptionKey {
 	key := make([]byte, k.config.Keylen)
 
-	_, err := rand.Read(key)
+	_, err := cryptorand.Read(key)
 	if err != nil {
 		panic(errors.Wrap(err, "key generated failed"))
 	}
@@ -232,7 +232,7 @@ func (k *KeyManager) Stop() error {
 // genSkew generates a random uint64 number between 0 and 65535
 func genSkew() uint64 {
 	b := make([]byte, 2)
-	if _, err := rand.Read(b); err != nil {
+	if _, err := cryptorand.Read(b); err != nil {
 		panic(err)
 	}
 	return uint64(binary.BigEndian.Uint16(b))


### PR DESCRIPTION
I'm a bit uncomfortable with importing crypto/rand as "rand", because
this name can clash with math/rand. The packages both define a Read
function. If code is moved around and an IDE helpfully imports math/rand
for something that needs cryptographic randomness, this can introduce a
big vulnerability.

Import crypto/rand as "cryptorand" instead to make this less ambiguous.