### PR TITLE
[ca] proposal: move the RootCA key and cfssl signer object to a local signer object.

### DIFF
--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -428,8 +428,10 @@ func createAndWriteRootCA(rootCN string, paths ca.CertPaths, expiry time.Duratio
 	}
 
 	return ca.RootCA{
-		Signer: signer,
-		Key:    key,
+		Signer: &ca.LocalSigner{
+			Signer: signer,
+			Key:    key,
+		},
 		Cert:   cert,
 		Pool:   pool,
 		Digest: digest.FromBytes(cert),

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -506,7 +506,7 @@ func TestForceNewCluster(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now()
 	// we don't want it too expired, because it can't have expired before the root CA cert is valid
-	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootCA.Cert, rootCA.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
+	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootCA.Cert, rootCA.Signer.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
 
 	// restart node with an expired certificate while forcing a new cluster - it should start without error and the certificate should be renewed
 	nodeID := leader.node.NodeID()

--- a/integration/node.go
+++ b/integration/node.go
@@ -54,7 +54,7 @@ func newTestNode(joinAddr, joinToken string, lateBind bool, rootCA *ca.RootCA) (
 		if err := ioutil.WriteFile(certPaths.RootCA.Cert, rootCA.Cert, 0644); err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(certPaths.RootCA.Key, rootCA.Key, 0600); err != nil {
+		if err := ioutil.WriteFile(certPaths.RootCA.Key, rootCA.Signer.Key, 0600); err != nil {
 			return nil, err
 		}
 		// generate TLS certs for this manager for bootstrapping, else the node will generate its own CA

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1050,7 +1050,7 @@ func defaultClusterObject(
 			EncryptionConfig: encryptionConfig,
 		},
 		RootCA: api.RootCA{
-			CAKey:      rootCA.Key,
+			CAKey:      rootCA.Signer.Key,
 			CACert:     rootCA.Cert,
 			CACertHash: rootCA.Digest.String(),
 			JoinTokens: api.JoinTokens{


### PR DESCRIPTION
Was thinking that intermediates could be stored in this object, since they're only used for signing.  It's just easier to see at a glance what is and isn't relevant to signing.

At a future point we might want to distinguish between the roots used for trust and the signing cert too, in case we want to be able to sign with intermediate CAs instead of self-signed roots.