### PR TITLE
Fix service logs since option

### DIFF
--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -270,7 +270,7 @@ func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscription
 		if err != nil {
 			return nil, err
 		}
-		apiOptions.Since = since.Format(time.RFC3339Nano)
+		apiOptions.Since = fmt.Sprintf("%d.%09d", since.Unix(), int64(since.Nanosecond()))
 	}
 
 	if options.Tail < 0 {


### PR DESCRIPTION
Fixes the format of the service logs since option in the reference
dockerapi implementation. Before this change, since failed silently
because the docker daemon cannot handle a timestamp in the format
RFC3339Nano.

This PR does not add a `--since` flag to swarmctl, because it is a
companion PR to reflect a PR I'm about to put into docker/docker.

Signed-off-by: Drew Erny <drew.erny@docker.com>