### PR TITLE
manager: Fix panic when Signer is nil

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1032,6 +1032,10 @@ func defaultClusterObject(
 	encryptionConfig api.EncryptionConfig,
 	initialUnlockKeys []*api.EncryptionKey,
 	rootCA *ca.RootCA) *api.Cluster {
+	var caKey []byte
+	if rootCA.Signer != nil {
+		caKey = rootCA.Signer.Key
+	}
 
 	return &api.Cluster{
 		ID: clusterID,
@@ -1050,7 +1054,7 @@ func defaultClusterObject(
 			EncryptionConfig: encryptionConfig,
 		},
 		RootCA: api.RootCA{
-			CAKey:      rootCA.Signer.Key,
+			CAKey:      caKey,
 			CACert:     rootCA.Cert,
 			CACertHash: rootCA.Digest.String(),
 			JoinTokens: api.JoinTokens{


### PR DESCRIPTION
The CA key was recently moved inside a `Signer` object, which may
sometimes be nil. `defaultClusterObject` is called every time the manager
becomes a leader, even though its return value won't necessarily be
written to Raft. It needs to check if `Signer` is nil.

See https://github.com/docker/docker/pull/31535

cc @cyli