### PR TITLE
Do not use tlsconfig.Clone, which is unsafe in go 1.7 if the config is already being used

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -155,7 +155,7 @@ func (s *SecurityConfig) updateTLSCredentials(certificates []tls.Certificate) er
 		return errors.Wrap(err, "failed to create a new server config using the new root CA")
 	}
 
-	if err := s.ClientTLSCreds.LoadNewTLSConfig(clientConfig); err != nil {
+	if err := s.ClientTLSCreds.loadNewTLSConfig(clientConfig); err != nil {
 		return errors.Wrap(err, "failed to update the client credentials")
 	}
 
@@ -167,7 +167,7 @@ func (s *SecurityConfig) updateTLSCredentials(certificates []tls.Certificate) er
 		MinVersion:   tls.VersionTLS12,
 	})
 
-	if err := s.ServerTLSCreds.LoadNewTLSConfig(serverConfig); err != nil {
+	if err := s.ServerTLSCreds.loadNewTLSConfig(serverConfig); err != nil {
 		return errors.Wrap(err, "failed to update the server TLS credentials")
 	}
 

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -120,8 +120,8 @@ func (c *MutableTLSCreds) ServerHandshake(rawConn net.Conn) (net.Conn, credentia
 	return conn, credentials.TLSInfo{State: conn.ConnectionState()}, nil
 }
 
-// LoadNewTLSConfig replaces the currently loaded TLS config with a new one
-func (c *MutableTLSCreds) LoadNewTLSConfig(newConfig *tls.Config) error {
+// loadNewTLSConfig replaces the currently loaded TLS config with a new one
+func (c *MutableTLSCreds) loadNewTLSConfig(newConfig *tls.Config) error {
 	newSubject, err := GetAndValidateCertificateSubject(newConfig.Certificates)
 	if err != nil {
 		return err

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
@@ -134,16 +133,6 @@ func (c *MutableTLSCreds) LoadNewTLSConfig(newConfig *tls.Config) error {
 	c.config = newConfig
 
 	return nil
-}
-
-// UpdateCAs updates the root CAs and client CAs of the existing TLS config in place
-func (c *MutableTLSCreds) UpdateCAs(rootCAs, clientCAs *x509.CertPool) {
-	c.Lock()
-	defer c.Unlock()
-	config := tlsconfig.Clone(c.config)
-	config.RootCAs = rootCAs
-	config.ClientCAs = clientCAs
-	c.config = config
 }
 
 // Config returns the current underlying TLS config.

--- a/ca/transport_test.go
+++ b/ca/transport_test.go
@@ -16,7 +16,7 @@ func TestNewMutableTLS(t *testing.T) {
 	cert, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN", ca.ManagerRole, tc.Organization)
 	assert.NoError(t, err)
 
-	tlsConfig, err := ca.NewServerTLSConfig(cert, tc.RootCA.Pool)
+	tlsConfig, err := ca.NewServerTLSConfig([]tls.Certificate{*cert}, tc.RootCA.Pool)
 	assert.NoError(t, err)
 	creds, err := ca.NewMutableTLS(tlsConfig)
 	assert.NoError(t, err)
@@ -47,9 +47,9 @@ func TestLoadNewTLSConfig(t *testing.T) {
 	assert.NoError(t, err)
 	cert2, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN2", ca.WorkerRole, tc.Organization)
 	assert.NoError(t, err)
-	tlsConfig1, err := ca.NewServerTLSConfig(cert1, tc.RootCA.Pool)
+	tlsConfig1, err := ca.NewServerTLSConfig([]tls.Certificate{*cert1}, tc.RootCA.Pool)
 	assert.NoError(t, err)
-	tlsConfig2, err := ca.NewServerTLSConfig(cert2, tc.RootCA.Pool)
+	tlsConfig2, err := ca.NewServerTLSConfig([]tls.Certificate{*cert2}, tc.RootCA.Pool)
 	assert.NoError(t, err)
 
 	// Load the first TLS config into a MutableTLS

--- a/ca/transport_test.go
+++ b/ca/transport_test.go
@@ -1,66 +1,85 @@
-package ca_test
+package ca
 
 import (
 	"crypto/tls"
+	"io/ioutil"
+	"os"
 	"testing"
 
-	"github.com/docker/swarmkit/ca"
-	"github.com/docker/swarmkit/ca/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMutableTLS(t *testing.T) {
-	tc := testutils.NewTestCA(t)
-	defer tc.Stop()
+	tempdir, err := ioutil.TempDir("", "test-transport")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	paths := NewConfigPaths(tempdir)
+	krw := NewKeyReadWriter(paths.Node, nil, nil)
 
-	cert, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN", ca.ManagerRole, tc.Organization)
+	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	require.NoError(t, err)
+
+	cert, err := rootCA.IssueAndSaveNewCertificates(krw, "CN", ManagerRole, "org")
 	assert.NoError(t, err)
 
-	tlsConfig, err := ca.NewServerTLSConfig([]tls.Certificate{*cert}, tc.RootCA.Pool)
+	tlsConfig, err := NewServerTLSConfig([]tls.Certificate{*cert}, rootCA.Pool)
 	assert.NoError(t, err)
-	creds, err := ca.NewMutableTLS(tlsConfig)
+	creds, err := NewMutableTLS(tlsConfig)
 	assert.NoError(t, err)
-	assert.Equal(t, ca.ManagerRole, creds.Role())
+	assert.Equal(t, ManagerRole, creds.Role())
 	assert.Equal(t, "CN", creds.NodeID())
 }
 
 func TestGetAndValidateCertificateSubject(t *testing.T) {
-	tc := testutils.NewTestCA(t)
-	defer tc.Stop()
+	tempdir, err := ioutil.TempDir("", "test-transport")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	paths := NewConfigPaths(tempdir)
+	krw := NewKeyReadWriter(paths.Node, nil, nil)
 
-	cert, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN", ca.ManagerRole, tc.Organization)
+	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	require.NoError(t, err)
+
+	cert, err := rootCA.IssueAndSaveNewCertificates(krw, "CN", ManagerRole, "org")
 	assert.NoError(t, err)
 
-	name, err := ca.GetAndValidateCertificateSubject([]tls.Certificate{*cert})
+	name, err := GetAndValidateCertificateSubject([]tls.Certificate{*cert})
 	assert.NoError(t, err)
 	assert.Equal(t, "CN", name.CommonName)
 	assert.Len(t, name.OrganizationalUnit, 1)
-	assert.Equal(t, ca.ManagerRole, name.OrganizationalUnit[0])
+	assert.Equal(t, ManagerRole, name.OrganizationalUnit[0])
 }
 
 func TestLoadNewTLSConfig(t *testing.T) {
-	tc := testutils.NewTestCA(t)
-	defer tc.Stop()
+	tempdir, err := ioutil.TempDir("", "test-transport")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+	paths := NewConfigPaths(tempdir)
+	krw := NewKeyReadWriter(paths.Node, nil, nil)
+
+	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	require.NoError(t, err)
 
 	// Create two different certs and two different TLS configs
-	cert1, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN1", ca.ManagerRole, tc.Organization)
+	cert1, err := rootCA.IssueAndSaveNewCertificates(krw, "CN1", ManagerRole, "org")
 	assert.NoError(t, err)
-	cert2, err := tc.RootCA.IssueAndSaveNewCertificates(tc.KeyReadWriter, "CN2", ca.WorkerRole, tc.Organization)
+	cert2, err := rootCA.IssueAndSaveNewCertificates(krw, "CN2", WorkerRole, "org")
 	assert.NoError(t, err)
-	tlsConfig1, err := ca.NewServerTLSConfig([]tls.Certificate{*cert1}, tc.RootCA.Pool)
+	tlsConfig1, err := NewServerTLSConfig([]tls.Certificate{*cert1}, rootCA.Pool)
 	assert.NoError(t, err)
-	tlsConfig2, err := ca.NewServerTLSConfig([]tls.Certificate{*cert2}, tc.RootCA.Pool)
+	tlsConfig2, err := NewServerTLSConfig([]tls.Certificate{*cert2}, rootCA.Pool)
 	assert.NoError(t, err)
 
 	// Load the first TLS config into a MutableTLS
-	creds, err := ca.NewMutableTLS(tlsConfig1)
+	creds, err := NewMutableTLS(tlsConfig1)
 	assert.NoError(t, err)
-	assert.Equal(t, ca.ManagerRole, creds.Role())
+	assert.Equal(t, ManagerRole, creds.Role())
 	assert.Equal(t, "CN1", creds.NodeID())
 
 	// Load the new Config and assert it changed
-	err = creds.LoadNewTLSConfig(tlsConfig2)
+	err = creds.loadNewTLSConfig(tlsConfig2)
 	assert.NoError(t, err)
-	assert.Equal(t, ca.WorkerRole, creds.Role())
+	assert.Equal(t, WorkerRole, creds.Role())
 	assert.Equal(t, "CN2", creds.NodeID())
 }


### PR DESCRIPTION
Rather than clone the config, since we already have utilities to create a new TLS configuration for the client and server using the TLS certs themselves and the root pool, just recreate a new TLS configuration rather than attempt to clone the existing one.

Accessing the certificates in the `tls.Config` object does not cause a data race:

```
package main_test

import (
	"crypto/tls"
	"fmt"
	"net/http"
	"net/http/httptest"
	"testing"

	"github.com/stretchr/testify/require"
)

// TestDockerTLSConfigClone attempts to trigger a data race when calling config.Clone while a server is running
func TestDockerTLSConfigClone(t *testing.T) {
	client := http.Client{
		Transport: &http.Transport{
			TLSClientConfig: &tls.Config{
				InsecureSkipVerify: true,
			},
		},
	}

	s := httptest.NewTLSServer(http.DefaultServeMux)
	defer s.Close()
	go func() {
		fmt.Println(s.TLS.Certificates)
	}()

	done := make(chan struct{})
	go func() {
		defer close(done)
		_, err := client.Get(s.URL)
		require.NoError(t, err)
	}()

	<-done
}
```
is fine under go 1.7 and go 1.8

Fixes #2012.