### PR TITLE
allocator: Remove deleted networks from the unallocated set

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -351,6 +351,8 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		if err := nc.nwkAllocator.Deallocate(n); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed during network free for network %s", n.ID)
 		}
+
+		delete(nc.unallocatedNetworks, n.ID)
 	case state.EventCreateService:
 		s := v.Service.Copy()
 


### PR DESCRIPTION
This looks like an oversight. Networks may have been kept in this set
forever after deletion.

cc @alexmavr @yongtang @aboch