### PR TITLE
allocator: Update unallocatedServices properly after service updates

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -387,6 +387,9 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 			return a.commitAllocatedService(ctx, batch, s)
 		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to commit allocation during update for service %s", s.ID)
+			nc.unallocatedServices[s.ID] = s
+		} else {
+			delete(nc.unallocatedServices, s.ID)
 		}
 	case state.EventDeleteService:
 		s := v.Service.Copy()


### PR DESCRIPTION
If a service update caused the service to be successfully allocated, that service should be removed from `unallocatedServices`.

If the allocation was unsuccessful, `unallocatedServices` should be updated to contain the latest version of the service.

cc @alexmavr @yongtang @aboch