### PR TITLE
allocator: Less aggressive retry

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	// set artificially low retry interval for testing
+	retryInterval = 5 * time.Millisecond
+}
+
 func TestAllocator(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)


### PR DESCRIPTION
Instead of retrying unallocated tasks, services, and networks every time data changes in the store, limit these retries to every 5 minutes.

When a repeated attempt to allocate one of these objects fails, log it at the debug log level, to reduce noise in the logs.

cc @alexmavr @yongtang @aboch