### PR TITLE
manager: Test must hold lock when calling becomeFollower

### DIFF
--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -479,7 +479,9 @@ func TestManagerUpdatesSecurityConfig(t *testing.T) {
 	}, 1*time.Second))
 
 	// stop running CA server and other leader functions
+	m.mu.Lock()
 	m.becomeFollower()
+	m.mu.Unlock()
 
 	newRootCert, _, err := testutils.CreateRootCertAndKey("rootOther")
 	require.NoError(t, err)


### PR DESCRIPTION
This fixes a data race.

cc @cyli