### PR TITLE
Error when attempting to do logs on TTY service

### DIFF
--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -259,6 +259,11 @@ func (c *containerAdapter) createVolumes(ctx context.Context) error {
 }
 
 func (c *containerAdapter) logs(ctx context.Context, options api.LogSubscriptionOptions) (io.ReadCloser, error) {
+	conf := c.container.config()
+	if conf != nil && conf.Tty {
+		return nil, errors.New("logs not supported on services with TTY")
+	}
+
 	apiOptions := types.ContainerLogsOptions{
 		Follow:     options.Follow,
 		Timestamps: true,


### PR DESCRIPTION
Before this PR, attempting to do logs on service with TTY was undefined behavior and caused `~*~*~weird errors~*~*~`. This doesn't fix that, but disallows the undefined behavior until we do.