### PR TITLE
scheduler: Correctly count tasks at bottom level of decision tree

### DIFF
--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -111,6 +111,10 @@ func (ns *nodeSet) tree(serviceID string, preferences []*api.PlacementPreference
 			tree = next
 		}
 
+		if node.ActiveTasksCountByService != nil {
+			tree.tasks += node.ActiveTasksCountByService[serviceID]
+		}
+
 		if tree.nodeHeap.lessFunc == nil {
 			tree.nodeHeap.lessFunc = nodeLess
 		}


### PR DESCRIPTION
Each node in the decision tree has a count of tasks assigned at or below
that node. The bottom level did not have this count populated. Fix this
so that topology-aware scheduling works correctly when tasks are
scheduled individually.

Test coverage for this is coming in the next PR.

cc @dongluochen