### PR TITLE
[ca] Separate RootCA signing cert from root certs

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -111,18 +111,25 @@ type LocalSigner struct {
 	// Key will only be used by the original manager to put the private
 	// key-material in raft, no signing operations depend on it.
 	Key []byte
+
+	// Cert is one PEM encoded Certificate used as the signing CA.  It must correspond to the key.
+	Cert []byte
+
+	// just cached parsed values for validation, etc.
+	parsedCert   *x509.Certificate
+	cryptoSigner crypto.Signer
 }
 
 // RootCA is the representation of everything we need to sign certificates and/or to verify certificates
 //
-// RootCA.Cert:          [signing CA cert][CA cert1][CA cert2]
+// RootCA.Cert:          [CA cert1][CA cert2]
 // RootCA.Intermediates: [intermediate CA1][intermediate CA2][intermediate CA3]
+// RootCA.Signer.Cert:   [signing CA cert]
 // RootCA.Signer.Key:    [signing CA key]
 //
 // Requirements:
 //
-// - [signing CA key] must be the private key for [signing CA cert]
-// - [signing CA cert] must be the first cert in RootCA.Cert
+// - [signing CA key] must be the private key for [signing CA cert], and either both or none must be provided
 //
 // - [intermediate CA1] must have the same public key and subject as [signing CA cert], because otherwise when
 //   appended to a leaf certificate, the intermediates will not form a chain (because [intermediate CA1] won't because
@@ -135,10 +142,29 @@ type LocalSigner struct {
 //   valid chain from [leaf signed by signing CA cert] to one of the root certs ([signing CA cert], [CA cert1], [CA cert2])
 //   using zero or more of the intermediate certs ([intermediate CA1][intermediate CA2][intermediate CA3]) as intermediates
 //
+// Example 1:  Simple root rotation
+// - Initial state:
+// 	 - RootCA.Cert:          [Root CA1 self-signed]
+// 	 - RootCA.Intermediates: []
+// 	 - RootCA.Signer.Cert:   [Root CA1 self-signed]
+// 	 - Issued TLS cert:      [leaf signed by Root CA1]
+//
+// - Intermediate state (during root rotation):
+//   - RootCA.Cert:          [Root CA1 self-signed]
+//   - RootCA.Intermediates: [Root CA2 signed by Root CA1]
+//   - RootCA.Signer.Cert:   [Root CA2 signed by Root CA1]
+//   - Issued TLS cert:      [leaf signed by Root CA2][Root CA2 signed by Root CA1]
+//
+// - Final state:
+//   - RootCA.Cert:          [Root CA2 self-signed]
+//   - RootCA.Intermediates: []
+//   - RootCA.Signer.Cert:   [Root CA2 self-signed]
+//   - Issued TLS cert:      [leaf signed by Root CA2]
+//
 type RootCA struct {
-	// Cert contains a bundle of PEM encoded Certificate for the Root CA, the first one of which
-	// must correspond to the key in the local signer, if provided
-	Cert []byte
+	// Certs contains a bundle of self-signed, PEM encoded certificates for the Root CA to be used
+	// as the root of trust.
+	Certs []byte
 
 	// Intermediates contains a bundle of PEM encoded intermediate CA certificates to append to any
 	// issued TLS (leaf) certificates. The first one must have the same public key and subject as the
@@ -156,9 +182,9 @@ type RootCA struct {
 	Signer *LocalSigner
 }
 
-// CanSign ensures that the signer has all three necessary elements needed to operate
+// CanSign ensures that the signer has all the necessary elements needed to operate
 func (rca *RootCA) CanSign() bool {
-	if rca.Cert == nil || rca.Pool == nil || rca.Signer == nil {
+	if rca.Pool == nil || rca.Signer == nil || len(rca.Signer.Cert) == 0 || rca.Signer.Signer == nil {
 		return false
 	}
 
@@ -168,13 +194,13 @@ func (rca *RootCA) CanSign() bool {
 // IssueAndSaveNewCertificates generates a new key-pair, signs it with the local root-ca, and returns a
 // tls certificate
 func (rca *RootCA) IssueAndSaveNewCertificates(kw KeyWriter, cn, ou, org string) (*tls.Certificate, error) {
+	if !rca.CanSign() {
+		return nil, ErrNoValidSigner
+	}
+
 	csr, key, err := GenerateNewCSR()
 	if err != nil {
 		return nil, errors.Wrap(err, "error when generating new node certs")
-	}
-
-	if !rca.CanSign() {
-		return nil, ErrNoValidSigner
 	}
 
 	// Obtain a signed Certificate
@@ -343,15 +369,6 @@ func (rca *RootCA) CrossSignCACertificate(otherCAPEM []byte) ([]byte, error) {
 	}
 
 	// create a new cert with exactly the same parameters, including the public key and exact NotBefore and NotAfter
-	rootCert, err := helpers.ParseCertificatePEM(rca.Cert)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not parse old CA certificate")
-	}
-	rootSigner, err := helpers.ParsePrivateKeyPEM(rca.Signer.Key)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not parse old CA key")
-	}
-
 	newCert, err := helpers.ParseCertificatePEM(otherCAPEM)
 	if err != nil {
 		return nil, errors.New("could not parse new CA certificate")
@@ -361,7 +378,7 @@ func (rca *RootCA) CrossSignCACertificate(otherCAPEM []byte) ([]byte, error) {
 		return nil, errors.New("certificate not a CA")
 	}
 
-	derBytes, err := x509.CreateCertificate(cryptorand.Reader, newCert, rootCert, newCert.PublicKey, rootSigner)
+	derBytes, err := x509.CreateCertificate(cryptorand.Reader, newCert, rca.Signer.parsedCert, newCert.PublicKey, rca.Signer.cryptoSigner)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not cross-sign new CA certificate using old CA material")
 	}
@@ -372,28 +389,34 @@ func (rca *RootCA) CrossSignCACertificate(otherCAPEM []byte) ([]byte, error) {
 	}), nil
 }
 
+func validateSignatureAlgorithm(cert *x509.Certificate) error {
+	switch cert.SignatureAlgorithm {
+	case x509.SHA256WithRSA, x509.SHA384WithRSA, x509.SHA512WithRSA, x509.ECDSAWithSHA256, x509.ECDSAWithSHA384, x509.ECDSAWithSHA512:
+		return nil
+	default:
+		return fmt.Errorf("unsupported signature algorithm: %s", cert.SignatureAlgorithm.String())
+	}
+}
+
 // NewRootCA creates a new RootCA object from unparsed PEM cert bundle and key byte
 // slices. key may be nil, and in this case NewRootCA will return a RootCA
 // without a signer.
-func NewRootCA(certBytes, keyBytes []byte, certExpiry time.Duration, intermediates []byte) (RootCA, error) {
+func NewRootCA(rootCertBytes, signCertBytes, signKeyBytes []byte, certExpiry time.Duration, intermediates []byte) (RootCA, error) {
 	// Parse all the certificates in the cert bundle
-	parsedCerts, err := helpers.ParseCertificatesPEM(certBytes)
+	parsedCerts, err := helpers.ParseCertificatesPEM(rootCertBytes)
 	if err != nil {
-		return RootCA{}, err
+		return RootCA{}, errors.Wrap(err, "invalid root certificates")
 	}
 	// Check to see if we have at least one valid cert
 	if len(parsedCerts) < 1 {
-		return RootCA{}, errors.New("no valid Root CA certificates found")
+		return RootCA{}, errors.New("no valid root CA certificates found")
 	}
 
 	// Create a Pool with all of the certificates found
 	pool := x509.NewCertPool()
 	for _, cert := range parsedCerts {
-		switch cert.SignatureAlgorithm {
-		case x509.SHA256WithRSA, x509.SHA384WithRSA, x509.SHA512WithRSA, x509.ECDSAWithSHA256, x509.ECDSAWithSHA384, x509.ECDSAWithSHA512:
-			break
-		default:
-			return RootCA{}, fmt.Errorf("unsupported signature algorithm: %s", cert.SignatureAlgorithm.String())
+		if err := validateSignatureAlgorithm(cert); err != nil {
+			return RootCA{}, err
 		}
 		// Check to see if all of the certificates are valid, self-signed root CA certs
 		selfpool := x509.NewCertPool()
@@ -405,81 +428,42 @@ func NewRootCA(certBytes, keyBytes []byte, certExpiry time.Duration, intermediat
 	}
 
 	// Calculate the digest for our Root CA bundle
-	digest := digest.FromBytes(certBytes)
+	digest := digest.FromBytes(rootCertBytes)
 
-	// We do not yet support arbitrary chains of intermediates (e.g. the case of an offline root, and the swarm CA is an
-	// intermediate CA). We currently only intermediates for which the first intermediate is cross-signed version of the
-	// CA signing cert (the first cert of the root certs) for the purposes of root rotation.  If we wanted to support
-	// offline roots, we'd have to separate the CA signing cert from the self-signed root certs, but this intermediate
-	// validation logic should remain the same.  Either the first intermediate would BE the intermediate CA we sign with
-	// (in which case it'd have the same subject and public key), or it would be a cross-signed intermediate with the
-	// same subject and public key as our signing cert (which could be either an intermediate cert or a self-signed root
-	// cert).
+	// The intermediates supplied must be able to chain up to the root certificates, so that when they are appended to
+	// a leaf certificate, the leaf certificate can be validated through the intermediates to the root certificates.
+	var intermediatePool *x509.CertPool
+	var parsedIntermediates []*x509.Certificate
 	if len(intermediates) > 0 {
-		parsedIntermediates, err := ValidateCertChain(pool, intermediates, false)
+		parsedIntermediates, err = ValidateCertChain(pool, intermediates, false)
 		if err != nil {
 			return RootCA{}, errors.Wrap(err, "invalid intermediate chain")
 		}
-		if !bytes.Equal(parsedIntermediates[0].RawSubject, parsedCerts[0].RawSubject) ||
-			!bytes.Equal(parsedIntermediates[0].RawSubjectPublicKeyInfo, parsedCerts[0].RawSubjectPublicKeyInfo) {
-			return RootCA{}, errors.New("invalid intermediate chain - the first intermediate must have the same subject and public key as the root")
+		intermediatePool = x509.NewCertPool()
+		for _, cert := range parsedIntermediates {
+			intermediatePool.AddCert(cert)
 		}
 	}
 
-	if len(keyBytes) == 0 {
-		// This RootCA does not have a valid signer
-		return RootCA{Cert: certBytes, Intermediates: intermediates, Digest: digest, Pool: pool}, nil
-	}
-
-	var (
-		passphraseStr              string
-		passphrase, passphrasePrev []byte
-		priv                       crypto.Signer
-	)
-
-	// Attempt two distinct passphrases, so we can do a hitless passphrase rotation
-	if passphraseStr = os.Getenv(PassphraseENVVar); passphraseStr != "" {
-		passphrase = []byte(passphraseStr)
-	}
-
-	if p := os.Getenv(PassphraseENVVarPrev); p != "" {
-		passphrasePrev = []byte(p)
-	}
-
-	// Attempt to decrypt the current private-key with the passphrases provided
-	priv, err = helpers.ParsePrivateKeyPEMWithPassword(keyBytes, passphrase)
-	if err != nil {
-		priv, err = helpers.ParsePrivateKeyPEMWithPassword(keyBytes, passphrasePrev)
-		if err != nil {
-			return RootCA{}, errors.Wrap(err, "malformed private key")
-		}
-	}
-
-	// We will always use the first certificate inside of the root bundle as the active one
-	if err := ensureCertKeyMatch(parsedCerts[0], priv.Public()); err != nil {
-		return RootCA{}, err
-	}
-
-	signer, err := local.NewSigner(priv, parsedCerts[0], cfsigner.DefaultSigAlgo(priv), SigningPolicy(certExpiry))
-	if err != nil {
-		return RootCA{}, err
-	}
-
-	// If the key was loaded from disk unencrypted, but there is a passphrase set,
-	// ensure it is encrypted, so it doesn't hit raft in plain-text
-	keyBlock, _ := pem.Decode(keyBytes)
-	if keyBlock == nil {
-		// This RootCA does not have a valid signer.
-		return RootCA{Cert: certBytes, Digest: digest, Pool: pool}, nil
-	}
-	if passphraseStr != "" && !x509.IsEncryptedPEMBlock(keyBlock) {
-		keyBytes, err = EncryptECPrivateKey(keyBytes, passphraseStr)
+	var localSigner *LocalSigner
+	if len(signKeyBytes) != 0 || len(signCertBytes) != 0 {
+		localSigner, err = newLocalSigner(signKeyBytes, signCertBytes, certExpiry, pool, intermediatePool)
 		if err != nil {
 			return RootCA{}, err
 		}
+
+		// If a signer is provided and there are intermediates, then either the first intermediate would be the signer CA
+		// certificate (in which case it'd have the same subject and public key), or it would be a cross-signed
+		// intermediate with the same subject and public key as our signing CA certificate (which could be either an
+		// intermediate cert or a self-signed root cert).
+		if len(parsedIntermediates) > 0 && (!bytes.Equal(parsedIntermediates[0].RawSubject, localSigner.parsedCert.RawSubject) ||
+			!bytes.Equal(parsedIntermediates[0].RawSubjectPublicKeyInfo, localSigner.parsedCert.RawSubjectPublicKeyInfo)) {
+			return RootCA{}, errors.New(
+				"invalid intermediate chain - the first intermediate must have the same subject and public key as the signing cert")
+		}
 	}
 
-	return RootCA{Signer: &LocalSigner{Signer: signer, Key: keyBytes}, Intermediates: intermediates, Digest: digest, Cert: certBytes, Pool: pool}, nil
+	return RootCA{Signer: localSigner, Intermediates: intermediates, Digest: digest, Certs: rootCertBytes, Pool: pool}, nil
 }
 
 // ValidateCertChain checks checks that the certificates provided chain up to the root pool provided.  In addition
@@ -579,6 +563,78 @@ func ValidateCertChain(rootPool *x509.CertPool, certs []byte, allowExpired bool)
 	return parsedCerts, nil
 }
 
+// newLocalSigner validates the signing cert and signing key to create a local signer, which accepts a crypto signer and a cert
+func newLocalSigner(keyBytes, certBytes []byte, certExpiry time.Duration, rootPool, intermediatePool *x509.CertPool) (*LocalSigner, error) {
+	if len(keyBytes) == 0 || len(certBytes) == 0 {
+		return nil, errors.New("must provide both a signing key and a signing cert, or neither")
+	}
+
+	parsedCerts, err := helpers.ParseCertificatesPEM(certBytes)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid signing CA cert")
+	}
+	if len(parsedCerts) == 0 {
+		return nil, errors.New("no valid signing CA certificates found")
+	}
+	if err := validateSignatureAlgorithm(parsedCerts[0]); err != nil {
+		return nil, err
+	}
+	opts := x509.VerifyOptions{
+		Roots:         rootPool,
+		Intermediates: intermediatePool,
+	}
+	if _, err := parsedCerts[0].Verify(opts); err != nil {
+		return nil, errors.Wrap(err, "error while validating signing CA certificate against roots and intermediates")
+	}
+
+	var (
+		passphraseStr              string
+		passphrase, passphrasePrev []byte
+		priv                       crypto.Signer
+	)
+
+	// Attempt two distinct passphrases, so we can do a hitless passphrase rotation
+	if passphraseStr = os.Getenv(PassphraseENVVar); passphraseStr != "" {
+		passphrase = []byte(passphraseStr)
+	}
+
+	if p := os.Getenv(PassphraseENVVarPrev); p != "" {
+		passphrasePrev = []byte(p)
+	}
+
+	// Attempt to decrypt the current private-key with the passphrases provided
+	priv, err = helpers.ParsePrivateKeyPEMWithPassword(keyBytes, passphrase)
+	if err != nil {
+		priv, err = helpers.ParsePrivateKeyPEMWithPassword(keyBytes, passphrasePrev)
+		if err != nil {
+			return nil, errors.Wrap(err, "malformed private key")
+		}
+	}
+
+	// We will always use the first certificate inside of the root bundle as the active one
+	if err := ensureCertKeyMatch(parsedCerts[0], priv.Public()); err != nil {
+		return nil, err
+	}
+
+	signer, err := local.NewSigner(priv, parsedCerts[0], cfsigner.DefaultSigAlgo(priv), SigningPolicy(certExpiry))
+	if err != nil {
+		return nil, err
+	}
+
+	// If the key was loaded from disk unencrypted, but there is a passphrase set,
+	// ensure it is encrypted, so it doesn't hit raft in plain-text
+	// we don't have to check for nil, because if we couldn't pem-decode the bytes, then parsing above would have failed
+	keyBlock, _ := pem.Decode(keyBytes)
+	if passphraseStr != "" && !x509.IsEncryptedPEMBlock(keyBlock) {
+		keyBytes, err = EncryptECPrivateKey(keyBytes, passphraseStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to encrypt signing CA key material")
+		}
+	}
+
+	return &LocalSigner{Cert: certBytes, Key: keyBytes, Signer: signer, parsedCert: parsedCerts[0], cryptoSigner: priv}, nil
+}
+
 func ensureCertKeyMatch(cert *x509.Certificate, key crypto.PublicKey) error {
 	switch certPub := cert.PublicKey.(type) {
 	case *rsa.PublicKey:
@@ -620,6 +676,7 @@ func GetLocalRootCA(paths CertPaths) (RootCA, error) {
 
 		return RootCA{}, err
 	}
+	signingCert := cert
 
 	key, err := ioutil.ReadFile(paths.Key)
 	if err != nil {
@@ -629,9 +686,10 @@ func GetLocalRootCA(paths CertPaths) (RootCA, error) {
 		// There may not be a local key. It's okay to pass in a nil
 		// key. We'll get a root CA without a signer.
 		key = nil
+		signingCert = nil
 	}
 
-	return NewRootCA(cert, key, DefaultNodeCertExpiration, nil)
+	return NewRootCA(cert, signingCert, key, DefaultNodeCertExpiration, nil)
 }
 
 func getGRPCConnection(creds credentials.TransportCredentials, connBroker *connectionbroker.Broker, forceRemote bool) (*connectionbroker.Conn, error) {
@@ -686,7 +744,7 @@ func GetRemoteCA(ctx context.Context, d digest.Digest, connBroker *connectionbro
 
 	// NewRootCA will validate that the certificates are otherwise valid and create a RootCA object.
 	// Since there is no key, the certificate expiry does not matter and will not be used.
-	return NewRootCA(response.Certificate, nil, DefaultNodeCertExpiration, nil)
+	return NewRootCA(response.Certificate, nil, nil, DefaultNodeCertExpiration, nil)
 }
 
 // CreateRootCA creates a Certificate authority for a new Swarm Cluster, potentially
@@ -705,7 +763,7 @@ func CreateRootCA(rootCN string, paths CertPaths) (RootCA, error) {
 		return RootCA{}, err
 	}
 
-	rootCA, err := NewRootCA(cert, key, DefaultNodeCertExpiration, nil)
+	rootCA, err := NewRootCA(cert, cert, key, DefaultNodeCertExpiration, nil)
 	if err != nil {
 		return RootCA{}, err
 	}
@@ -826,7 +884,7 @@ func saveRootCA(rootCA RootCA, paths CertPaths) error {
 	}
 
 	// If the root certificate got returned successfully, save the rootCA to disk.
-	return ioutils.AtomicWriteFile(paths.Cert, rootCA.Cert, 0644)
+	return ioutils.AtomicWriteFile(paths.Cert, rootCA.Certs, 0644)
 }
 
 // GenerateNewCSR returns a newly generated key and CSR signed with said key

--- a/ca/config.go
+++ b/ca/config.go
@@ -132,7 +132,13 @@ func (s *SecurityConfig) UpdateRootCA(cert, key []byte, certExpiry time.Duration
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	rootCA, err := NewRootCA(cert, key, certExpiry, nil)
+	// If we have no signing key, then we shouldn't pass a signing cert either (because we don't want a local
+	// signer at all)
+	signingCert := cert
+	if len(key) == 0 {
+		signingCert = nil
+	}
+	rootCA, err := NewRootCA(cert, signingCert, key, certExpiry, nil)
 	if err != nil {
 		return err
 	}

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -36,8 +36,8 @@ func TestDownloadRootCASuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rootCA.Pool)
 	require.NotNil(t, rootCA.Certs)
-	require.Nil(t, rootCA.Signer)
-	require.False(t, rootCA.CanSign())
+	_, err = rootCA.Signer()
+	require.Equal(t, err, ca.ErrNoValidSigner)
 	require.Equal(t, tc.RootCA.Certs, rootCA.Certs)
 
 	// Remove the CA cert
@@ -48,8 +48,8 @@ func TestDownloadRootCASuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rootCA.Pool)
 	require.NotNil(t, rootCA.Certs)
-	require.Nil(t, rootCA.Signer)
-	require.False(t, rootCA.CanSign())
+	_, err = rootCA.Signer()
+	require.Equal(t, err, ca.ErrNoValidSigner)
 	require.Equal(t, tc.RootCA.Certs, rootCA.Certs)
 }
 
@@ -140,17 +140,19 @@ func TestCreateSecurityConfigNoCerts(t *testing.T) {
 func TestLoadSecurityConfigExpiredCert(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
+	s, err := tc.RootCA.Signer()
+	require.NoError(t, err)
 
 	krw := ca.NewKeyReadWriter(tc.Paths.Node, nil, nil)
 	now := time.Now()
 
-	_, err := tc.RootCA.IssueAndSaveNewCertificates(krw, "cn", "ou", "org")
+	_, err = tc.RootCA.IssueAndSaveNewCertificates(krw, "cn", "ou", "org")
 	require.NoError(t, err)
 	certBytes, _, err := krw.Read()
 	require.NoError(t, err)
 
 	// A cert that is not yet valid is not valid even if expiry is allowed
-	invalidCert := testutils.ReDateCert(t, certBytes, tc.RootCA.Certs, tc.RootCA.Signer.Key, now.Add(time.Hour), now.Add(time.Hour*2))
+	invalidCert := testutils.ReDateCert(t, certBytes, tc.RootCA.Certs, s.Key, now.Add(time.Hour), now.Add(time.Hour*2))
 	require.NoError(t, ioutil.WriteFile(tc.Paths.Node.Cert, invalidCert, 0700))
 
 	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
@@ -162,7 +164,7 @@ func TestLoadSecurityConfigExpiredCert(t *testing.T) {
 	require.IsType(t, x509.CertificateInvalidError{}, errors.Cause(err))
 
 	// a cert that is expired is not valid if expiry is not allowed
-	invalidCert = testutils.ReDateCert(t, certBytes, tc.RootCA.Certs, tc.RootCA.Signer.Key, now.Add(-2*time.Minute), now.Add(-1*time.Minute))
+	invalidCert = testutils.ReDateCert(t, certBytes, tc.RootCA.Certs, s.Key, now.Add(-2*time.Minute), now.Add(-1*time.Minute))
 	require.NoError(t, ioutil.WriteFile(tc.Paths.Node.Cert, invalidCert, 0700))
 
 	_, err = ca.LoadSecurityConfig(tc.Context, tc.RootCA, krw, false)
@@ -333,9 +335,11 @@ func TestSecurityConfigUpdateRootCA(t *testing.T) {
 	req := ca.PrepareCSR(csr, "cn", ca.ManagerRole, secConfig.ClientTLSCreds.Organization())
 
 	externalServer := tc.ExternalSigningServer
+	tcSigner, err := tc.RootCA.Signer()
+	require.NoError(t, err)
 	if testutils.External {
 		// stop the external server and create a new one because the external server actually has to trust our client certs as well.
-		updatedRoot, err := ca.NewRootCA(append(tc.RootCA.Certs, cert...), tc.RootCA.Signer.Cert, tc.RootCA.Signer.Key, ca.DefaultNodeCertExpiration, nil)
+		updatedRoot, err := ca.NewRootCA(append(tc.RootCA.Certs, cert...), tcSigner.Cert, tcSigner.Key, ca.DefaultNodeCertExpiration, nil)
 		require.NoError(t, err)
 		externalServer, err = testutils.NewExternalSigningServer(updatedRoot, tc.TempDir)
 		require.NoError(t, err)
@@ -350,7 +354,9 @@ func TestSecurityConfigUpdateRootCA(t *testing.T) {
 
 	// update the root CA on the "original"" security config to support both the old root
 	// and the "new root" (the testing CA root)
-	err = secConfig.UpdateRootCA(append(rootCA.Certs, tc.RootCA.Certs...), rootCA.Signer.Key, ca.DefaultNodeCertExpiration)
+	rSigner, err := rootCA.Signer()
+	require.NoError(t, err)
+	err = secConfig.UpdateRootCA(append(rootCA.Certs, tc.RootCA.Certs...), rSigner.Key, ca.DefaultNodeCertExpiration)
 	require.NoError(t, err)
 
 	// can now connect to the test CA using our modified security config, and can cannect to our server using
@@ -397,8 +403,8 @@ func TestRenewTLSConfigUpdateRootCARace(t *testing.T) {
 		go func() {
 			defer close(done1)
 			var key []byte
-			if rootCA.Signer != nil {
-				key = rootCA.Signer.Key
+			if signer, err := rootCA.Signer(); err == nil {
+				key = signer.Key
 			}
 			require.NoError(t, secConfig.UpdateRootCA(append(rootCA.Certs, cert...), key, ca.DefaultNodeCertExpiration))
 		}()
@@ -428,6 +434,8 @@ func TestRenewTLSConfigWorker(t *testing.T) {
 
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
+	s, err := tc.RootCA.Signer()
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -439,9 +447,11 @@ func TestRenewTLSConfigWorker(t *testing.T) {
 	// Create a new RootCA, and change the policy to issue 6 minute certificates
 	// Because of the default backdate of 5 minutes, this issues certificates
 	// valid for 1 minute.
-	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, tc.RootCA.Signer.Cert, tc.RootCA.Signer.Key, ca.DefaultNodeCertExpiration, nil)
+	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, s.Cert, s.Key, ca.DefaultNodeCertExpiration, nil)
 	assert.NoError(t, err)
-	newRootCA.Signer.SetPolicy(&cfconfig.Signing{
+	newSigner, err := newRootCA.Signer()
+	require.NoError(t, err)
+	newSigner.SetPolicy(&cfconfig.Signing{
 		Default: &cfconfig.SigningProfile{
 			Usage:  []string{"signing", "key encipherment", "server auth", "client auth"},
 			Expiry: 6 * time.Minute,
@@ -482,6 +492,8 @@ func TestRenewTLSConfigManager(t *testing.T) {
 
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
+	s, err := tc.RootCA.Signer()
+	assert.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -493,9 +505,11 @@ func TestRenewTLSConfigManager(t *testing.T) {
 	// Create a new RootCA, and change the policy to issue 6 minute certificates
 	// Because of the default backdate of 5 minutes, this issues certificates
 	// valid for 1 minute.
-	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, tc.RootCA.Signer.Cert, tc.RootCA.Signer.Key, ca.DefaultNodeCertExpiration, nil)
+	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, s.Cert, s.Key, ca.DefaultNodeCertExpiration, nil)
 	assert.NoError(t, err)
-	newRootCA.Signer.SetPolicy(&cfconfig.Signing{
+	newSigner, err := newRootCA.Signer()
+	assert.NoError(t, err)
+	newSigner.SetPolicy(&cfconfig.Signing{
 		Default: &cfconfig.SigningProfile{
 			Usage:  []string{"signing", "key encipherment", "server auth", "client auth"},
 			Expiry: 6 * time.Minute,
@@ -538,6 +552,8 @@ func TestRenewTLSConfigWithNoNode(t *testing.T) {
 
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()
+	s, err := tc.RootCA.Signer()
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -549,9 +565,11 @@ func TestRenewTLSConfigWithNoNode(t *testing.T) {
 	// Create a new RootCA, and change the policy to issue 6 minute certificates.
 	// Because of the default backdate of 5 minutes, this issues certificates
 	// valid for 1 minute.
-	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, tc.RootCA.Signer.Cert, tc.RootCA.Signer.Key, ca.DefaultNodeCertExpiration, nil)
+	newRootCA, err := ca.NewRootCA(tc.RootCA.Certs, s.Cert, s.Key, ca.DefaultNodeCertExpiration, nil)
 	assert.NoError(t, err)
-	newRootCA.Signer.SetPolicy(&cfconfig.Signing{
+	newSigner, err := newRootCA.Signer()
+	assert.NoError(t, err)
+	newSigner.SetPolicy(&cfconfig.Signing{
 		Default: &cfconfig.SigningProfile{
 			Usage:  []string{"signing", "key encipherment", "server auth", "client auth"},
 			Expiry: 6 * time.Minute,

--- a/ca/external.go
+++ b/ca/external.go
@@ -106,13 +106,14 @@ func (eca *ExternalCA) Sign(ctx context.Context, req signer.SignRequest) (cert [
 // CrossSignRootCA takes a RootCA object, generates a CA CSR, sends a signing request with the CA CSR to the external
 // CFSSL API server in order to obtain a cross-signed root
 func (eca *ExternalCA) CrossSignRootCA(ctx context.Context, rca RootCA) ([]byte, error) {
-	if !rca.CanSign() {
-		return nil, errors.Wrap(ErrNoValidSigner, "cannot generate CSR for a cross-signed root")
-	}
 	// ExtractCertificateRequest generates a new key request, and we want to continue to use the old
 	// key.  However, ExtractCertificateRequest will also convert the pkix.Name to csr.Name, which we
 	// need in order to generate a signing request
-	rootCert := rca.Signer.parsedCert
+	rcaSigner, err := rca.Signer()
+	if err != nil {
+		return nil, err
+	}
+	rootCert := rcaSigner.parsedCert
 	cfCSRObj := csr.ExtractCertificateRequest(rootCert)
 
 	der, err := x509.CreateCertificateRequest(cryptorand.Reader, &x509.CertificateRequest{
@@ -124,7 +125,7 @@ func (eca *ExternalCA) CrossSignRootCA(ctx context.Context, rca RootCA) ([]byte,
 		DNSNames:                rootCert.DNSNames,
 		EmailAddresses:          rootCert.EmailAddresses,
 		IPAddresses:             rootCert.IPAddresses,
-	}, rca.Signer.cryptoSigner)
+	}, rcaSigner.cryptoSigner)
 	if err != nil {
 		return nil, err
 	}

--- a/ca/external_test.go
+++ b/ca/external_test.go
@@ -33,7 +33,7 @@ func TestExternalCACrossSign(t *testing.T) {
 	cert2, key2, err := testutils.CreateRootCertAndKey("rootCN2")
 	require.NoError(t, err)
 
-	rootCA2, err := ca.NewRootCA(cert2, key2, ca.DefaultNodeCertExpiration, nil)
+	rootCA2, err := ca.NewRootCA(cert2, cert2, key2, ca.DefaultNodeCertExpiration, nil)
 	require.NoError(t, err)
 
 	krw := ca.NewKeyReadWriter(paths.Node, nil, nil)

--- a/ca/server.go
+++ b/ca/server.go
@@ -361,7 +361,7 @@ func (s *Server) GetRootCACertificate(ctx context.Context, request *api.GetRootC
 	})
 
 	return &api.GetRootCACertificateResponse{
-		Certificate: s.securityConfig.RootCA().Cert,
+		Certificate: s.securityConfig.RootCA().Certs,
 	}, nil
 }
 

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -15,9 +15,7 @@ import (
 	cfcsr "github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/initca"
-	"github.com/cloudflare/cfssl/log"
 	cfsigner "github.com/cloudflare/cfssl/signer"
-	"github.com/cloudflare/cfssl/signer/local"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/connectionbroker"
@@ -26,8 +24,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/remotes"
-	"github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -292,7 +288,11 @@ func genSecurityConfig(s *store.MemoryStore, rootCA ca.RootCA, krw *ca.KeyReadWr
 		hosts = append(hosts, ca.CARole)
 	}
 
-	cert, err := rootCA.Signer.Sign(cfsigner.SignRequest{
+	signer, err := rootCA.Signer()
+	if err != nil {
+		return nil, err
+	}
+	cert, err := signer.Sign(cfsigner.SignRequest{
 		Request: string(csr),
 		// OU is used for Authentication of the node type. The CN has the random
 		// node ID.
@@ -395,23 +395,8 @@ func createAndWriteRootCA(rootCN string, paths ca.CertPaths, expiry time.Duratio
 		return ca.RootCA{}, err
 	}
 
-	// Convert the key given by initca to an object to create a ca.RootCA
-	parsedKey, err := helpers.ParsePrivateKeyPEM(key)
+	rootCA, err := ca.NewRootCA(cert, cert, key, ca.DefaultNodeCertExpiration, nil)
 	if err != nil {
-		log.Errorf("failed to parse private key: %v", err)
-		return ca.RootCA{}, err
-	}
-
-	// Convert the certificate into an object to create a ca.RootCA
-	parsedCert, err := helpers.ParseCertificatePEM(cert)
-	if err != nil {
-		return ca.RootCA{}, err
-	}
-
-	// Create a Signer out of the private key
-	signer, err := local.NewSigner(parsedKey, parsedCert, cfsigner.DefaultSigAlgo(parsedKey), ca.SigningPolicy(expiry))
-	if err != nil {
-		log.Errorf("failed to create signer: %v", err)
 		return ca.RootCA{}, err
 	}
 
@@ -428,23 +413,7 @@ func createAndWriteRootCA(rootCN string, paths ca.CertPaths, expiry time.Duratio
 	if err := ioutils.AtomicWriteFile(paths.Key, key, 0600); err != nil {
 		return ca.RootCA{}, err
 	}
-
-	// Create a Pool with our Root CA Certificate
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(cert) {
-		return ca.RootCA{}, errors.New("failed to append certificate to cert pool")
-	}
-
-	return ca.RootCA{
-		Signer: &ca.LocalSigner{
-			Signer: signer,
-			Cert:   cert,
-			Key:    key,
-		},
-		Certs:  cert,
-		Pool:   pool,
-		Digest: digest.FromBytes(cert),
-	}, nil
+	return rootCA, nil
 }
 
 // ReDateCert takes an existing cert and changes the not before and not after date, to make it easier

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -305,7 +305,7 @@ func genSecurityConfig(s *store.MemoryStore, rootCA ca.RootCA, krw *ca.KeyReadWr
 	}
 
 	// Append the root CA Key to the certificate, to create a valid chain
-	certChain := append(cert, rootCA.Cert...)
+	certChain := append(cert, rootCA.Certs...)
 
 	// If we were instructed to persist the files
 	if tmpDir != "" {
@@ -341,7 +341,7 @@ func genSecurityConfig(s *store.MemoryStore, rootCA ca.RootCA, krw *ca.KeyReadWr
 
 	if nonSigningRoot {
 		rootCA = ca.RootCA{
-			Cert:   rootCA.Cert,
+			Certs:  rootCA.Certs,
 			Digest: rootCA.Digest,
 			Pool:   rootCA.Pool,
 		}
@@ -438,9 +438,10 @@ func createAndWriteRootCA(rootCN string, paths ca.CertPaths, expiry time.Duratio
 	return ca.RootCA{
 		Signer: &ca.LocalSigner{
 			Signer: signer,
+			Cert:   cert,
 			Key:    key,
 		},
-		Cert:   cert,
+		Certs:  cert,
 		Pool:   pool,
 		Digest: digest.FromBytes(cert),
 	}, nil

--- a/ca/testutils/externalutils.go
+++ b/ca/testutils/externalutils.go
@@ -36,6 +36,10 @@ func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSignin
 	serverCN := "external-ca-example-server"
 	serverOU := "localhost" // Make a valid server cert for localhost.
 
+	if !rootCA.CanSign() {
+		return nil, ca.ErrNoValidSigner
+	}
+
 	// Create TLS credentials for the external CA server which we will run.
 	serverPaths := ca.CertPaths{
 		Cert: filepath.Join(basedir, "server.crt"),
@@ -120,7 +124,7 @@ func (ess *ExternalSigningServer) EnableCASigning() error {
 
 	rca := ess.handler.rootCA
 
-	rootCert, err := helpers.ParseCertificatePEM(rca.Cert)
+	rootCert, err := helpers.ParseCertificatePEM(rca.Signer.Cert)
 	if err != nil {
 		return errors.Wrap(err, "could not parse old CA certificate")
 	}

--- a/ca/testutils/externalutils.go
+++ b/ca/testutils/externalutils.go
@@ -36,8 +36,9 @@ func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSignin
 	serverCN := "external-ca-example-server"
 	serverOU := "localhost" // Make a valid server cert for localhost.
 
-	if !rootCA.CanSign() {
-		return nil, ca.ErrNoValidSigner
+	s, err := rootCA.Signer()
+	if err != nil {
+		return nil, err
 	}
 
 	// Create TLS credentials for the external CA server which we will run.
@@ -76,9 +77,9 @@ func NewExternalSigningServer(rootCA ca.RootCA, basedir string) (*ExternalSignin
 
 	mux := http.NewServeMux()
 	handler := &signHandler{
-		numIssued: &ess.NumIssued,
-		rootCA:    rootCA,
-		flaky:     &ess.flaky,
+		numIssued:  &ess.NumIssued,
+		leafSigner: s,
+		flaky:      &ess.flaky,
 	}
 	mux.Handle(signURL.Path, handler)
 	ess.handler = handler
@@ -122,13 +123,11 @@ func (ess *ExternalSigningServer) EnableCASigning() error {
 	ess.handler.mu.Lock()
 	defer ess.handler.mu.Unlock()
 
-	rca := ess.handler.rootCA
-
-	rootCert, err := helpers.ParseCertificatePEM(rca.Signer.Cert)
+	rootCert, err := helpers.ParseCertificatePEM(ess.handler.leafSigner.Cert)
 	if err != nil {
 		return errors.Wrap(err, "could not parse old CA certificate")
 	}
-	rootSigner, err := helpers.ParsePrivateKeyPEM(rca.Signer.Key)
+	rootSigner, err := helpers.ParsePrivateKeyPEM(ess.handler.leafSigner.Key)
 	if err != nil {
 		return errors.Wrap(err, "could not parse old CA key")
 	}
@@ -158,11 +157,11 @@ func (ess *ExternalSigningServer) DisableCASigning() {
 }
 
 type signHandler struct {
-	mu        sync.Mutex
-	numIssued *uint64
-	rootCA    ca.RootCA
-	flaky     *uint32
-	caSigner  signer.Signer
+	mu         sync.Mutex
+	numIssued  *uint64
+	flaky      *uint32
+	leafSigner *ca.LocalSigner
+	caSigner   signer.Signer
 }
 
 func (h *signHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -259,7 +258,7 @@ func (h *signHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Sign the requested leaf certificate.
-		certPEM, err = h.rootCA.Signer.Sign(signReq)
+		certPEM, err = h.leafSigner.Sign(signReq)
 	}
 	if err != nil {
 		cfsslErr := cfsslerrors.New(cfsslerrors.APIClientError, cfsslerrors.ServerRequestFailed)

--- a/cmd/external-ca-example/main.go
+++ b/cmd/external-ca-example/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	// And copy the Root CA certificate into the node config path for its
 	// CA.
-	ioutil.WriteFile(nodeConfigPaths.RootCA.Cert, rootCA.Cert, os.FileMode(0644))
+	ioutil.WriteFile(nodeConfigPaths.RootCA.Cert, rootCA.Certs, os.FileMode(0644))
 
 	server, err := testutils.NewExternalSigningServer(rootCA, "ca")
 	if err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -517,7 +517,7 @@ func TestForceNewCluster(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now()
 	// we don't want it too expired, because it can't have expired before the root CA cert is valid
-	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootCA.Cert, rootCA.Signer.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
+	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootCA.Signer.Cert, rootCA.Signer.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
 
 	// restart node with an expired certificate while forcing a new cluster - it should start without error and the certificate should be renewed
 	nodeID := leader.node.NodeID()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -517,7 +517,9 @@ func TestForceNewCluster(t *testing.T) {
 	require.NoError(t, err)
 	now := time.Now()
 	// we don't want it too expired, because it can't have expired before the root CA cert is valid
-	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootCA.Signer.Cert, rootCA.Signer.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
+	rootSigner, err := rootCA.Signer()
+	require.NoError(t, err)
+	expiredCertPEM := testutils.ReDateCert(t, certBytes, rootSigner.Cert, rootSigner.Key, now.Add(-1*time.Hour), now.Add(-1*time.Second))
 
 	// restart node with an expired certificate while forcing a new cluster - it should start without error and the certificate should be renewed
 	nodeID := leader.node.NodeID()

--- a/integration/node.go
+++ b/integration/node.go
@@ -47,19 +47,24 @@ func newTestNode(joinAddr, joinToken string, lateBind bool, rootCA *ca.RootCA) (
 		cfg.ListenRemoteAPI = "127.0.0.1:0"
 	}
 	if rootCA != nil {
+		signer, err := rootCA.Signer()
+		if err != nil {
+			return nil, err
+		}
 		certDir := filepath.Join(tmpDir, "certificates")
 		if err := os.MkdirAll(certDir, 0700); err != nil {
 			return nil, err
 		}
 		certPaths := ca.NewConfigPaths(certDir)
-		if err := ioutil.WriteFile(certPaths.RootCA.Cert, rootCA.Signer.Cert, 0644); err != nil {
+		if err := ioutil.WriteFile(certPaths.RootCA.Cert, signer.Cert, 0644); err != nil {
 			return nil, err
 		}
-		if err := ioutil.WriteFile(certPaths.RootCA.Key, rootCA.Signer.Key, 0600); err != nil {
+		if err := ioutil.WriteFile(certPaths.RootCA.Key, signer.Key, 0600); err != nil {
 			return nil, err
 		}
 		// generate TLS certs for this manager for bootstrapping, else the node will generate its own CA
-		_, err := rootCA.IssueAndSaveNewCertificates(ca.NewKeyReadWriter(certPaths.Node, nil, nil),
+		_, err = rootCA.IssueAndSaveNewCertificates(
+			ca.NewKeyReadWriter(certPaths.Node, nil, nil),
 			identity.NewID(), ca.ManagerRole, identity.NewID())
 		if err != nil {
 			return nil, err

--- a/integration/node.go
+++ b/integration/node.go
@@ -52,7 +52,7 @@ func newTestNode(joinAddr, joinToken string, lateBind bool, rootCA *ca.RootCA) (
 			return nil, err
 		}
 		certPaths := ca.NewConfigPaths(certDir)
-		if err := ioutil.WriteFile(certPaths.RootCA.Cert, rootCA.Cert, 0644); err != nil {
+		if err := ioutil.WriteFile(certPaths.RootCA.Cert, rootCA.Signer.Cert, 0644); err != nil {
 			return nil, err
 		}
 		if err := ioutil.WriteFile(certPaths.RootCA.Key, rootCA.Signer.Key, 0600); err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1055,7 +1055,7 @@ func defaultClusterObject(
 		},
 		RootCA: api.RootCA{
 			CAKey:      caKey,
-			CACert:     rootCA.Cert,
+			CACert:     rootCA.Certs,
 			CACertHash: rootCA.Digest.String(),
 			JoinTokens: api.JoinTokens{
 				Worker:  ca.GenerateJoinToken(rootCA),

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1033,8 +1033,8 @@ func defaultClusterObject(
 	initialUnlockKeys []*api.EncryptionKey,
 	rootCA *ca.RootCA) *api.Cluster {
 	var caKey []byte
-	if rootCA.Signer != nil {
-		caKey = rootCA.Signer.Key
+	if rcaSigner, err := rootCA.Signer(); err == nil {
+		caKey = rcaSigner.Key
 	}
 
 	return &api.Cluster{

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -485,7 +485,7 @@ func TestManagerUpdatesSecurityConfig(t *testing.T) {
 
 	newRootCert, _, err := testutils.CreateRootCertAndKey("rootOther")
 	require.NoError(t, err)
-	updatedCA := append(tc.RootCA.Cert, newRootCert...)
+	updatedCA := append(tc.RootCA.Certs, newRootCert...)
 
 	// Update the RootCA to have a bundle
 	require.NoError(t, m.raftNode.MemoryStore().Update(func(tx store.Tx) error {
@@ -496,7 +496,7 @@ func TestManagerUpdatesSecurityConfig(t *testing.T) {
 
 	// wait for the manager's security config to be updated
 	require.NoError(t, raftutils.PollFuncWithTimeout(nil, func() error {
-		if !bytes.Equal(managerSecurityConfig.RootCA().Cert, updatedCA) {
+		if !bytes.Equal(managerSecurityConfig.RootCA().Certs, updatedCA) {
 			return fmt.Errorf("root CA not updated yet")
 		}
 		return nil

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -70,7 +70,7 @@ func TestLoadSecurityConfigPartialCertsOnDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	// a new CA was generated because no existing TLS certs were present
-	require.NotEqual(t, rootCA.Cert, securityConfig.RootCA().Cert)
+	require.NotEqual(t, rootCA.Certs, securityConfig.RootCA().Certs)
 
 	// if the TLS key and cert are on disk, but there's no CA, a new CA and TLS
 	// key+cert are generated


### PR DESCRIPTION
Since in theory, we could be signing with an intermediate certificate, which should not be used as a trust root.

This is useful both for supporting offline roots, and for supporting swarm root CA rotation (in which the root we trust is still the old root, but we will be signing with a cross-signed intermediate, which can easily be switched to the new root.

For more context on how this will be used in terms of root CA rotation, please see https://github.com/docker/swarmkit/pull/2037.  ([or just the diff](https://github.com/docker/swarmkit/compare/7c78bfad7a4792f88cc050dbcf516dec9f1c9367...4d7bb0df1ff8660e7887c230b56c565063e357ef))

I made it a requirement that the signing cert has to chain up through the intermediates to the root pool, so that during root CA rotation the signing cert will actually be the cross-signed intermediate.  This doesn't have to be the case (the signing cert could be a root instead) but I thought having direct relationship between the signing cert and the root certs would be easier to validate (can use `Certificate.Verify`.  

Otherwise, the relationship to the root is indirect ; it has to have the same public key/subject as the first intermediate, and the first intermediate has to chain up to the root.  But because it doesn't chain up to the root itself, we'd have to do certificate verification (expiry, maybe path len check) ourselves.  Maybe this would be more flexible though, since we'd only be manually checking the signing cert and not the whole chain?