### PR TITLE
Replace the tab with 4 spaces in md files

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,7 @@ When setup correctly, you should have a GOROOT and GOPATH set in the environment
 After you set up the Go development environment, use `go get` to check out
 `swarmkit`:
 
-	go get -d github.com/docker/swarmkit
+    go get -d github.com/docker/swarmkit
 
 This command installs the source repository into the `GOPATH`.
 
@@ -26,50 +26,50 @@ Docker provides a `Makefile` as a convenience to support repeatable builds.
 `make setup` installs tools onto the `GOPATH` for use with developing
 `SwarmKit`:
 
-	make setup
+    make setup
 
 Once these commands are available in the `GOPATH`, run `make` to get a full
 build:
 
-	$ make
-	🐳 fmt
-	🐳 bin/swarmd
-	🐳 bin/swarmctl
-	🐳 bin/swarm-bench
-	🐳 bin/protoc-gen-gogoswarm
-	🐳 binaries
-	🐳 vet
-	🐳 lint
-	🐳 build
-	github.com/docker/swarmkit
-	github.com/docker/swarmkit/vendor/github.com/davecgh/go-spew/spew
-	github.com/docker/swarmkit/vendor/github.com/pmezard/go-difflib/difflib
-	github.com/docker/swarmkit/cmd/protoc-gen-gogoswarm
-	github.com/docker/swarmkit/cmd/swarm-bench
-	github.com/docker/swarmkit/cmd/swarmctl
-	github.com/docker/swarmkit/vendor/github.com/stretchr/testify/assert
-	github.com/docker/swarmkit/ca/testutils
-	github.com/docker/swarmkit/cmd/swarmd
-	github.com/docker/swarmkit/vendor/github.com/pivotal-golang/clock/fakeclock
-	github.com/docker/swarmkit/vendor/github.com/stretchr/testify/require
-	github.com/docker/swarmkit/manager/state/raft/testutils
-	github.com/docker/swarmkit/manager/testcluster
-	github.com/docker/swarmkit/protobuf/plugin/deepcopy/test
-	github.com/docker/swarmkit/protobuf/plugin/raftproxy/test
-	🐳 test
-	?       github.com/docker/swarmkit      [no test files]
-	?       github.com/docker/swarmkit      [no test files]
-	ok      github.com/docker/swarmkit/agent        2.264s
-	ok      github.com/docker/swarmkit/agent/exec   1.055s
-	ok      github.com/docker/swarmkit/agent/exec/container 1.094s
-	?       github.com/docker/swarmkit/api  [no test files]
-	?       github.com/docker/swarmkit/api/duration [no test files]
-	?       github.com/docker/swarmkit/api/timestamp        [no test files]
-	ok      github.com/docker/swarmkit/ca   15.634s
-	...
-	ok      github.com/docker/swarmkit/protobuf/plugin/raftproxy/test       1.084s
-	ok      github.com/docker/swarmkit/protobuf/ptypes      1.025s
-	?       github.com/docker/swarmkit/version      [no test files]
+    $ make
+    🐳 fmt
+    🐳 bin/swarmd
+    🐳 bin/swarmctl
+    🐳 bin/swarm-bench
+    🐳 bin/protoc-gen-gogoswarm
+    🐳 binaries
+    🐳 vet
+    🐳 lint
+    🐳 build
+    github.com/docker/swarmkit
+    github.com/docker/swarmkit/vendor/github.com/davecgh/go-spew/spew
+    github.com/docker/swarmkit/vendor/github.com/pmezard/go-difflib/difflib
+    github.com/docker/swarmkit/cmd/protoc-gen-gogoswarm
+    github.com/docker/swarmkit/cmd/swarm-bench
+    github.com/docker/swarmkit/cmd/swarmctl
+    github.com/docker/swarmkit/vendor/github.com/stretchr/testify/assert
+    github.com/docker/swarmkit/ca/testutils
+    github.com/docker/swarmkit/cmd/swarmd
+    github.com/docker/swarmkit/vendor/github.com/pivotal-golang/clock/fakeclock
+    github.com/docker/swarmkit/vendor/github.com/stretchr/testify/require
+    github.com/docker/swarmkit/manager/state/raft/testutils
+    github.com/docker/swarmkit/manager/testcluster
+    github.com/docker/swarmkit/protobuf/plugin/deepcopy/test
+    github.com/docker/swarmkit/protobuf/plugin/raftproxy/test
+    🐳 test
+    ?       github.com/docker/swarmkit      [no test files]
+    ?       github.com/docker/swarmkit      [no test files]
+    ok      github.com/docker/swarmkit/agent        2.264s
+    ok      github.com/docker/swarmkit/agent/exec   1.055s
+    ok      github.com/docker/swarmkit/agent/exec/container 1.094s
+    ?       github.com/docker/swarmkit/api  [no test files]
+    ?       github.com/docker/swarmkit/api/duration [no test files]
+    ?       github.com/docker/swarmkit/api/timestamp        [no test files]
+    ok      github.com/docker/swarmkit/ca   15.634s
+    ...
+    ok      github.com/docker/swarmkit/protobuf/plugin/raftproxy/test       1.084s
+    ok      github.com/docker/swarmkit/protobuf/ptypes      1.025s
+    ?       github.com/docker/swarmkit/version      [no test files]
 
 The above provides a repeatable build using the contents of the vendored
 `./vendor` directory. This includes formatting, vetting, linting, building,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,10 +135,10 @@ use for simple changes](https://docs.docker.com/opensource/workflow/make-a-contr
 Fork the repository and make changes on your fork in a feature branch:
 
 - If it's a bug fix branch, name it XXXX-something where XXXX is the number of
-	the issue. 
+    the issue. 
 - If it's a feature branch, create an enhancement issue to announce
-	your intentions, and name it XXXX-something where XXXX is the number of the
-	issue.
+    your intentions, and name it XXXX-something where XXXX is the number of the
+    issue.
 
 Submit unit tests for your changes. Go has a great test framework built in; use
 it! Take a look at existing tests for inspiration. [Run the full test
@@ -328,14 +328,14 @@ do need a fair way to deal with people who are making our community suck.
   hammering them in the 3 strikes process.
 
 * The rules apply equally to everyone in the community, no matter how much
-	you've contributed.
+    you've contributed.
 
 * Extreme violations of a threatening, abusive, destructive or illegal nature
-	will be addressed immediately and are not subject to 3 strikes or forgiveness.
+    will be addressed immediately and are not subject to 3 strikes or forgiveness.
 
 * Contact abuse@docker.com to report abuse or appeal violations. In the case of
-	appeals, we know that mistakes happen, and we'll work with you to come up with a
-	fair solution if there has been a misunderstanding.
+    appeals, we know that mistakes happen, and we'll work with you to come up with a
+    fair solution if there has been a misunderstanding.
 
 ## Coding Style
 

--- a/design/topology.md
+++ b/design/topology.md
@@ -32,19 +32,19 @@ The initially supported preference would is "spread".
 
 ```
 message SpreadOver {
-	string spread_descriptor = 1; // label descriptor, such as engine.labels.az
-	// TODO: support node information beyond engine and node labels
+    string spread_descriptor = 1; // label descriptor, such as engine.labels.az
+    // TODO: support node information beyond engine and node labels
 
-	// TODO: in the future, add a map that provides weights for weighted
-	// spreading.
+    // TODO: in the future, add a map that provides weights for weighted
+    // spreading.
 }
 
 message PlacementPreference {
-	oneof Preference {
-		SpreadOver spread = 1;
-	}
+    oneof Preference {
+        SpreadOver spread = 1;
+    }
 
-	Preference pref = 1;
+    Preference pref = 1;
 }
 ```
 


### PR DESCRIPTION
Spaces, it is aligned to view codes with any editor, including the web page views (such as in the GitHub code). When use tabs, the view on the page is chaos, and it is terrible to mix tabs and spaces.

Signed-off-by: yupengzte <yu.peng36@zte.com.cn>