### PR TITLE
dispatcher: Only mark running tasks as orphaned.

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1171,7 +1171,16 @@ func (d *Dispatcher) moveTasksToOrphaned(nodeID string) error {
 		}
 
 		for _, task := range tasks {
-			if task.Status.State < api.TaskStateOrphaned {
+			// Tasks running on an unreachable node need to be marked as
+			// orphaned since we have no idea whether the task is still running
+			// or not.
+			//
+			// This only applies for tasks that could have made progress since
+			// the agent became unreachable (assigned<->running)
+			//
+			// Tasks in a final state (e.g. rejected) *cannot* have made
+			// progress, therefore there's no point in marking them as orphaned
+			if task.Status.State >= api.TaskStateAssigned && task.Status.State <= api.TaskStateRunning {
 				task.Status.State = api.TaskStateOrphaned
 			}
 


### PR DESCRIPTION
Details in the comments.

I believe this was brought up during our conversations with @tiborvass @anusha-ragunathan @ehazlett.

This guarantees that "one off tasks" (for instance, a global service with restart policy never), once completed, will forever remain in the complete state.

Previously, completed tasks could potentially move to orphaned if a node went down for more than 24 hours.

@aaronlehmann @dongluochen Speaking of which - do you think this fixes an edge case in the "on failure" restart policy? I think without this PR, successful tasks moving to orphaned would have been rescheduled