### PR TITLE
make create secret return conflict

### DIFF
--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -173,7 +173,7 @@ func (s *Server) CreateSecret(ctx context.Context, request *api.CreateSecretRequ
 
 	switch err {
 	case store.ErrNameConflict:
-		return nil, grpc.Errorf(codes.AlreadyExists, "secret %s already exists", request.Spec.Annotations.Name)
+		return nil, grpc.Errorf(codes.AlreadyExists, "name %s conflicts with an existing secret", request.Spec.Annotations.Name)
 	case nil:
 		secret.Spec.Data = nil // clean the actual secret data so it's never returned
 		log.G(ctx).WithFields(logrus.Fields{


### PR DESCRIPTION
This PR try to fix: https://github.com/docker/docker/issues/31909

Currently secret creation returns `rpc error: code = 6 desc = secret xxx already exists` if there is already has a secret named xxx. Then this error in docker daemon will return an status code of 500. I think this is a 409 code, so there is some kind of improper.

However, like `create service`, it returns `rpc error: code = 2 desc = name conflicts with an existing object` if there is already a service named xxx.

And in docker daemon side, for errors returned to client side, according to https://github.com/docker/docker/blob/master/api/server/httputils/errors.go#L61, it returns a 409.

As a result, I think we just need to add a string of `conflict` in the error message.

Signed-off-by: allencloud <allen.sun@daocloud.io>