### PR TITLE
store: Fix type wrappers for Resource and Extension types

### DIFF
--- a/manager/state/store/extensions.go
+++ b/manager/state/store/extensions.go
@@ -18,16 +18,16 @@ func init() {
 				indexID: {
 					Name:    indexID,
 					Unique:  true,
-					Indexer: api.ExtensionIndexerByID{},
+					Indexer: extensionIndexerByID{},
 				},
 				indexName: {
 					Name:    indexName,
 					Unique:  true,
-					Indexer: api.ExtensionIndexerByName{},
+					Indexer: extensionIndexerByName{},
 				},
 				indexCustom: {
 					Name:         indexCustom,
-					Indexer:      api.ExtensionCustomIndexer{},
+					Indexer:      extensionCustomIndexer{},
 					AllowMissing: true,
 				},
 			},
@@ -74,6 +74,10 @@ func init() {
 
 type extensionEntry struct {
 	*api.Extension
+}
+
+func (e extensionEntry) CopyStoreObject() api.StoreObject {
+	return extensionEntry{Extension: e.Extension.Copy()}
 }
 
 // CreateExtension adds a new extension to the store.
@@ -147,4 +151,40 @@ func FindExtensions(tx ReadTx, by By) ([]*api.Extension, error) {
 
 	err := tx.find(tableExtension, by, checkType, appendResult)
 	return extensionList, err
+}
+
+type extensionIndexerByID struct{}
+
+func (indexer extensionIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionIndexerByID{}.FromArgs(args...)
+}
+func (indexer extensionIndexerByID) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionIndexerByID{}.PrefixFromArgs(args...)
+}
+func (indexer extensionIndexerByID) FromObject(obj interface{}) (bool, []byte, error) {
+	return api.ExtensionIndexerByID{}.FromObject(obj.(extensionEntry).Extension)
+}
+
+type extensionIndexerByName struct{}
+
+func (indexer extensionIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionIndexerByName{}.FromArgs(args...)
+}
+func (indexer extensionIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionIndexerByName{}.PrefixFromArgs(args...)
+}
+func (indexer extensionIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+	return api.ExtensionIndexerByName{}.FromObject(obj.(extensionEntry).Extension)
+}
+
+type extensionCustomIndexer struct{}
+
+func (indexer extensionCustomIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionCustomIndexer{}.FromArgs(args...)
+}
+func (indexer extensionCustomIndexer) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ExtensionCustomIndexer{}.PrefixFromArgs(args...)
+}
+func (indexer extensionCustomIndexer) FromObject(obj interface{}) (bool, [][]byte, error) {
+	return api.ExtensionCustomIndexer{}.FromObject(obj.(extensionEntry).Extension)
 }

--- a/manager/state/store/resources.go
+++ b/manager/state/store/resources.go
@@ -16,12 +16,12 @@ func init() {
 				indexID: {
 					Name:    indexID,
 					Unique:  true,
-					Indexer: api.ResourceIndexerByID{},
+					Indexer: resourceIndexerByID{},
 				},
 				indexName: {
 					Name:    indexName,
 					Unique:  true,
-					Indexer: api.ResourceIndexerByName{},
+					Indexer: resourceIndexerByName{},
 				},
 				indexKind: {
 					Name:    indexKind,
@@ -29,7 +29,7 @@ func init() {
 				},
 				indexCustom: {
 					Name:         indexCustom,
-					Indexer:      api.ResourceCustomIndexer{},
+					Indexer:      resourceCustomIndexer{},
 					AllowMissing: true,
 				},
 			},
@@ -76,6 +76,10 @@ func init() {
 
 type resourceEntry struct {
 	*api.Resource
+}
+
+func (r resourceEntry) CopyStoreObject() api.StoreObject {
+	return resourceEntry{Resource: r.Resource.Copy()}
 }
 
 func confirmExtension(tx Tx, r *api.Resource) error {
@@ -159,4 +163,40 @@ func (ri resourceIndexerByKind) FromObject(obj interface{}) (bool, []byte, error
 	// Add the null character as a terminator
 	val := r.Resource.Kind + "\x00"
 	return true, []byte(val), nil
+}
+
+type resourceIndexerByID struct{}
+
+func (indexer resourceIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceIndexerByID{}.FromArgs(args...)
+}
+func (indexer resourceIndexerByID) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceIndexerByID{}.PrefixFromArgs(args...)
+}
+func (indexer resourceIndexerByID) FromObject(obj interface{}) (bool, []byte, error) {
+	return api.ResourceIndexerByID{}.FromObject(obj.(resourceEntry).Resource)
+}
+
+type resourceIndexerByName struct{}
+
+func (indexer resourceIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceIndexerByName{}.FromArgs(args...)
+}
+func (indexer resourceIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceIndexerByName{}.PrefixFromArgs(args...)
+}
+func (indexer resourceIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+	return api.ResourceIndexerByName{}.FromObject(obj.(resourceEntry).Resource)
+}
+
+type resourceCustomIndexer struct{}
+
+func (indexer resourceCustomIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceCustomIndexer{}.FromArgs(args...)
+}
+func (indexer resourceCustomIndexer) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+	return api.ResourceCustomIndexer{}.PrefixFromArgs(args...)
+}
+func (indexer resourceCustomIndexer) FromObject(obj interface{}) (bool, [][]byte, error) {
+	return api.ResourceCustomIndexer{}.FromObject(obj.(resourceEntry).Resource)
 }


### PR DESCRIPTION
The `Resource` and `Extension` types still use wrappers around the protobuf
type. This will be necessary for future changes (#1999) that reference the
relevant extension inside the `resourceEntry`, and reference indexer
objects in the `extensionEntry`. The use of wrappers isn't working
correctly in the current state, because `CopyStoreObject` is returning the
base protobuf type, and stripping the wrapper before anything is saved
in the store. Fix this by defining a custom `CopyStoreObject` for each of
these types. Also, wrap the indexers.