### PR TITLE
store: Remove extra panics

### DIFF
--- a/manager/state/store/nodes.go
+++ b/manager/state/store/nodes.go
@@ -136,10 +136,7 @@ func (ni nodeIndexerByHostname) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ni nodeIndexerByHostname) FromObject(obj interface{}) (bool, []byte, error) {
-	n, ok := obj.(*api.Node)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	n := obj.(*api.Node)
 
 	if n.Description == nil {
 		return false, nil, nil
@@ -159,10 +156,7 @@ func (ni nodeIndexerByRole) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ni nodeIndexerByRole) FromObject(obj interface{}) (bool, []byte, error) {
-	n, ok := obj.(*api.Node)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	n := obj.(*api.Node)
 
 	// Add the null character as a terminator
 	return true, []byte(strconv.FormatInt(int64(n.Role), 10) + "\x00"), nil
@@ -175,10 +169,7 @@ func (ni nodeIndexerByMembership) FromArgs(args ...interface{}) ([]byte, error) 
 }
 
 func (ni nodeIndexerByMembership) FromObject(obj interface{}) (bool, []byte, error) {
-	n, ok := obj.(*api.Node)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	n := obj.(*api.Node)
 
 	// Add the null character as a terminator
 	return true, []byte(strconv.FormatInt(int64(n.Spec.Membership), 10) + "\x00"), nil

--- a/manager/state/store/resources.go
+++ b/manager/state/store/resources.go
@@ -151,10 +151,7 @@ func (ri resourceIndexerByKind) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ri resourceIndexerByKind) FromObject(obj interface{}) (bool, []byte, error) {
-	r, ok := obj.(resourceEntry)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	r := obj.(resourceEntry)
 
 	// Add the null character as a terminator
 	val := r.Resource.Kind + "\x00"

--- a/manager/state/store/services.go
+++ b/manager/state/store/services.go
@@ -148,10 +148,7 @@ func (si serviceIndexerByNetwork) FromArgs(args ...interface{}) ([]byte, error) 
 }
 
 func (si serviceIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, error) {
-	s, ok := obj.(*api.Service)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	s := obj.(*api.Service)
 
 	var networkIDs [][]byte
 
@@ -176,10 +173,7 @@ func (si serviceIndexerBySecret) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (si serviceIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, error) {
-	s, ok := obj.(*api.Service)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	s := obj.(*api.Service)
 
 	container := s.Spec.Task.GetContainer()
 	if container == nil {

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -161,10 +161,7 @@ func (ti taskIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	name := naming.Task(t)
 
@@ -183,10 +180,7 @@ func (ti taskIndexerByServiceID) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerByServiceID) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
 	val := t.ServiceID + "\x00"
@@ -200,10 +194,7 @@ func (ti taskIndexerByNodeID) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerByNodeID) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
 	val := t.NodeID + "\x00"
@@ -217,10 +208,7 @@ func (ti taskIndexerBySlot) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerBySlot) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
 	val := t.ServiceID + "\x00" + strconv.FormatUint(t.Slot, 10) + "\x00"
@@ -234,10 +222,7 @@ func (ti taskIndexerByDesiredState) FromArgs(args ...interface{}) ([]byte, error
 }
 
 func (ti taskIndexerByDesiredState) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
 	return true, []byte(strconv.FormatInt(int64(t.DesiredState), 10) + "\x00"), nil
@@ -250,10 +235,7 @@ func (ti taskIndexerByNetwork) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	var networkIDs [][]byte
 
@@ -272,10 +254,7 @@ func (ti taskIndexerBySecret) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ti taskIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	container := t.Spec.GetContainer()
 	if container == nil {
@@ -299,10 +278,7 @@ func (ts taskIndexerByTaskState) FromArgs(args ...interface{}) ([]byte, error) {
 }
 
 func (ts taskIndexerByTaskState) FromObject(obj interface{}) (bool, []byte, error) {
-	t, ok := obj.(*api.Task)
-	if !ok {
-		panic("unexpected type passed to FromObject")
-	}
+	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
 	return true, []byte(strconv.FormatInt(int64(t.Status.State), 10) + "\x00"), nil


### PR DESCRIPTION
These type assertions check for failure, and panic in the failure case. A simple type assertion that doesn't check for failure would accomplish the same thing. Use these instead to simplify the code and avoid confusion.

cc @aluzzardi @cyli