### PR TITLE
Reuse allocator.IsIngressNetworkNeeded in controlapi

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -560,7 +560,8 @@ func taskUpdateEndpoint(t *api.Task, endpoint *api.Endpoint) {
 	t.Endpoint = endpoint.Copy()
 }
 
-func isIngressNetworkNeeded(s *api.Service) bool {
+// IsIngressNetworkNeeded checks whether the service requires the routing-mesh
+func IsIngressNetworkNeeded(s *api.Service) bool {
 	if s == nil {
 		return false
 	}
@@ -590,7 +591,7 @@ func (a *Allocator) taskCreateNetworkAttachments(t *api.Task, s *api.Service) {
 	}
 
 	var networks []*api.NetworkAttachment
-	if isIngressNetworkNeeded(s) {
+	if IsIngressNetworkNeeded(s) {
 		networks = append(networks, &api.NetworkAttachment{Network: a.netCtx.ingressNetwork})
 	}
 
@@ -770,7 +771,7 @@ func (a *Allocator) allocateService(ctx context.Context, s *api.Service) error {
 		// The service is trying to expose ports to the external
 		// world. Automatically attach the service to the ingress
 		// network only if it is not already done.
-		if isIngressNetworkNeeded(s) {
+		if IsIngressNetworkNeeded(s) {
 			if nc.ingressNetwork == nil {
 				return fmt.Errorf("ingress network is missing")
 			}
@@ -803,7 +804,7 @@ func (a *Allocator) allocateService(ctx context.Context, s *api.Service) error {
 	// If the service doesn't expose ports any more and if we have
 	// any lingering virtual IP references for ingress network
 	// clean them up here.
-	if !isIngressNetworkNeeded(s) {
+	if !IsIngressNetworkNeeded(s) {
 		if s.Endpoint != nil {
 			for i, vip := range s.Endpoint.VirtualIPs {
 				if vip.NetworkID == nc.ingressNetwork.ID {

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -219,7 +219,7 @@ func (s *Server) removeIngressNetwork(id string) error {
 			return grpc.Errorf(codes.Internal, "could not find services using network %s: %v", id, err)
 		}
 		for _, srv := range services {
-			if doesServiceNeedIngress(srv) {
+			if allocator.IsIngressNetworkNeeded(srv) {
 				return grpc.Errorf(codes.FailedPrecondition, "ingress network cannot be removed because service %s depends on it", srv.ID)
 			}
 		}

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -458,36 +458,6 @@ func (s *Server) checkSecretExistence(tx store.Tx, spec *api.ServiceSpec) error 
 	return nil
 }
 
-func doesServiceNeedIngress(srv *api.Service) bool {
-	// Only VIP mode with target ports needs routing mesh.
-	// If no endpoint is specified, it defaults to VIP mode but no target ports
-	// are specified, so the service does not need the routing mesh.
-	if srv.Spec.Endpoint == nil || srv.Spec.Endpoint.Mode != api.ResolutionModeVirtualIP {
-		return false
-	}
-	// Go through the ports' config
-	for _, p := range srv.Spec.Endpoint.Ports {
-		if p.PublishMode != api.PublishModeIngress {
-			continue
-		}
-		if p.PublishedPort != 0 {
-			return true
-		}
-	}
-	// Go through the ports' state
-	if srv.Endpoint != nil {
-		for _, p := range srv.Endpoint.Ports {
-			if p.PublishMode != api.PublishModeIngress {
-				continue
-			}
-			if p.PublishedPort != 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // CreateService creates and returns a Service based on the provided ServiceSpec.
 // - Returns `InvalidArgument` if the ServiceSpec is malformed.
 // - Returns `Unimplemented` if the ServiceSpec references unimplemented features.
@@ -514,7 +484,7 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 		SpecVersion: &api.Version{},
 	}
 
-	if doesServiceNeedIngress(service) {
+	if allocator.IsIngressNetworkNeeded(service) {
 		if _, err := allocator.GetIngressNetwork(s.store); err == allocator.ErrNoIngress {
 			return nil, grpc.Errorf(codes.FailedPrecondition, "service needs ingress network, but no ingress network is present")
 		}
@@ -658,7 +628,7 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 			service.UpdateStatus = nil
 		}
 
-		if doesServiceNeedIngress(service) {
+		if allocator.IsIngressNetworkNeeded(service) {
 			if _, err := allocator.GetIngressNetwork(s.store); err == allocator.ErrNoIngress {
 				return grpc.Errorf(codes.FailedPrecondition, "service needs ingress network, but no ingress network is present")
 			}


### PR DESCRIPTION
Signed-off-by: Alessandro Boch <aboch@docker.com>