### PR TITLE
[ca] Separate `CreateRootCA` from saving root CA

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -745,7 +745,7 @@ func GetRemoteCA(ctx context.Context, d digest.Digest, connBroker *connectionbro
 
 // CreateRootCA creates a Certificate authority for a new Swarm Cluster, potentially
 // overwriting any existing CAs.
-func CreateRootCA(rootCN string, paths CertPaths) (RootCA, error) {
+func CreateRootCA(rootCN string) (RootCA, error) {
 	// Create a simple CSR for the CA using the default CA validator and policy
 	req := cfcsr.CertificateRequest{
 		CN:         rootCN,
@@ -761,11 +761,6 @@ func CreateRootCA(rootCN string, paths CertPaths) (RootCA, error) {
 
 	rootCA, err := NewRootCA(cert, cert, key, DefaultNodeCertExpiration, nil)
 	if err != nil {
-		return RootCA{}, err
-	}
-
-	// save the cert to disk
-	if err := saveRootCA(rootCA, paths); err != nil {
 		return RootCA{}, err
 	}
 
@@ -872,7 +867,8 @@ func readCertValidity(kr KeyReader) (time.Time, time.Time, error) {
 
 }
 
-func saveRootCA(rootCA RootCA, paths CertPaths) error {
+// SaveRootCA saves a RootCA object to disk
+func SaveRootCA(rootCA RootCA, paths CertPaths) error {
 	// Make sure the necessary dirs exist and they are writable
 	err := os.MkdirAll(filepath.Dir(paths.Cert), 0755)
 	if err != nil {

--- a/ca/config.go
+++ b/ca/config.go
@@ -276,7 +276,7 @@ func DownloadRootCA(ctx context.Context, paths CertPaths, token string, connBrok
 	}
 
 	// Save root CA certificate to disk
-	if err = saveRootCA(rootCA, paths); err != nil {
+	if err = SaveRootCA(rootCA, paths); err != nil {
 		return RootCA{}, err
 	}
 

--- a/ca/transport_test.go
+++ b/ca/transport_test.go
@@ -17,7 +17,7 @@ func TestNewMutableTLS(t *testing.T) {
 	paths := NewConfigPaths(tempdir)
 	krw := NewKeyReadWriter(paths.Node, nil, nil)
 
-	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	rootCA, err := CreateRootCA("rootCN")
 	require.NoError(t, err)
 
 	cert, err := rootCA.IssueAndSaveNewCertificates(krw, "CN", ManagerRole, "org")
@@ -38,7 +38,7 @@ func TestGetAndValidateCertificateSubject(t *testing.T) {
 	paths := NewConfigPaths(tempdir)
 	krw := NewKeyReadWriter(paths.Node, nil, nil)
 
-	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	rootCA, err := CreateRootCA("rootCN")
 	require.NoError(t, err)
 
 	cert, err := rootCA.IssueAndSaveNewCertificates(krw, "CN", ManagerRole, "org")
@@ -58,7 +58,7 @@ func TestLoadNewTLSConfig(t *testing.T) {
 	paths := NewConfigPaths(tempdir)
 	krw := NewKeyReadWriter(paths.Node, nil, nil)
 
-	rootCA, err := CreateRootCA("rootCN", paths.RootCA)
+	rootCA, err := CreateRootCA("rootCN")
 	require.NoError(t, err)
 
 	// Create two different certs and two different TLS configs

--- a/cmd/external-ca-example/main.go
+++ b/cmd/external-ca-example/main.go
@@ -21,9 +21,12 @@ func main() {
 	}
 
 	// Initialize the Root CA.
-	rootCA, err := ca.CreateRootCA("external-ca-example", rootPaths)
+	rootCA, err := ca.CreateRootCA("external-ca-example")
 	if err != nil {
-		logrus.Fatalf("unable to initialize Root CA: %s", err)
+		logrus.Fatalf("unable to initialize Root CA: %s", err.Error())
+	}
+	if err := ca.SaveRootCA(rootCA, rootPaths); err != nil {
+		logrus.Fatalf("unable to save Root CA: %s", err.Error())
 	}
 
 	// Create the initial manager node credentials.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -489,10 +489,7 @@ func TestForceNewCluster(t *testing.T) {
 	t.Parallel()
 
 	// create an external CA so that we can use it to generate expired certificates
-	tempDir, err := ioutil.TempDir("", "external-ca")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-	rootCA, err := ca.CreateRootCA("externalRoot", ca.NewConfigPaths(tempDir).RootCA)
+	rootCA, err := ca.CreateRootCA("externalRoot")
 	require.NoError(t, err)
 
 	// start a new cluster with the external CA bootstrapped

--- a/node/node.go
+++ b/node/node.go
@@ -600,8 +600,11 @@ func (n *Node) loadSecurityConfig(ctx context.Context) (*ca.SecurityConfig, erro
 				n.unlockKey = encryption.GenerateSecretKey()
 			}
 			krw = ca.NewKeyReadWriter(paths.Node, n.unlockKey, &manager.RaftDEKData{})
-			rootCA, err = ca.CreateRootCA(ca.DefaultRootCN, paths.RootCA)
+			rootCA, err = ca.CreateRootCA(ca.DefaultRootCN)
 			if err != nil {
+				return nil, err
+			}
+			if err := ca.SaveRootCA(rootCA, paths.RootCA); err != nil {
 				return nil, err
 			}
 			log.G(ctx).Debug("generated CA key and certificate")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -55,8 +55,9 @@ func TestLoadSecurityConfigPartialCertsOnDisk(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	paths := ca.NewConfigPaths(filepath.Join(tempdir, "certificates"))
-	rootCA, err := ca.CreateRootCA(ca.DefaultRootCN, paths.RootCA)
+	rootCA, err := ca.CreateRootCA(ca.DefaultRootCN)
 	require.NoError(t, err)
+	require.NoError(t, ca.SaveRootCA(rootCA, paths.RootCA))
 
 	node, err := New(&Config{
 		StateDir: tempdir,
@@ -105,8 +106,10 @@ func TestLoadSecurityConfigLoadFromDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load successfully with valid passphrase
-	rootCA, err := ca.CreateRootCA(ca.DefaultRootCN, paths.RootCA)
+	rootCA, err := ca.CreateRootCA(ca.DefaultRootCN)
 	require.NoError(t, err)
+	require.NoError(t, ca.SaveRootCA(rootCA, paths.RootCA))
+
 	krw := ca.NewKeyReadWriter(paths.Node, []byte("passphrase"), nil)
 	require.NoError(t, err)
 	_, err = rootCA.IssueAndSaveNewCertificates(krw, identity.NewID(), ca.WorkerRole, identity.NewID())
@@ -134,8 +137,9 @@ func TestLoadSecurityConfigLoadFromDisk(t *testing.T) {
 	require.Equal(t, ErrInvalidUnlockKey, err)
 
 	// Invalid CA
-	rootCA, err = ca.CreateRootCA(ca.DefaultRootCN, paths.RootCA)
+	rootCA, err = ca.CreateRootCA(ca.DefaultRootCN)
 	require.NoError(t, err)
+	require.NoError(t, ca.SaveRootCA(rootCA, paths.RootCA))
 	node, err = New(&Config{
 		StateDir:  tempdir,
 		JoinAddr:  peer.Addr,


### PR DESCRIPTION
This is a minor refactor that would be useful when autogenerating Root CAs as part of root rotation (if the user wants swarm to just generate a key and cert for them)