### PR TITLE
[ca] Make the control API server take a security config instead of RootCA

### DIFF
--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -512,7 +512,7 @@ func TestCAServerUpdateRootCA(t *testing.T) {
 			externalCertSignedBy: cert,
 		},
 	} {
-		tc.CAServer.UpdateRootCA(context.Background(), testCase.clusterObj)
+		require.NoError(t, tc.CAServer.UpdateRootCA(context.Background(), testCase.clusterObj))
 
 		rootCA := tc.ServingSecurityConfig.RootCA()
 		require.Equal(t, testCase.rootCARoots, rootCA.Certs)

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -16,18 +16,21 @@ var (
 
 // Server is the Cluster API gRPC server.
 type Server struct {
-	store  *store.MemoryStore
-	raft   *raft.Node
-	rootCA *ca.RootCA
-	pg     plugingetter.PluginGetter
+	store          *store.MemoryStore
+	raft           *raft.Node
+	securityConfig *ca.SecurityConfig
+	scu            ca.APISecurityConfigUpdater
+	pg             plugingetter.PluginGetter
 }
 
 // NewServer creates a Cluster API server.
-func NewServer(store *store.MemoryStore, raft *raft.Node, rootCA *ca.RootCA, pg plugingetter.PluginGetter) *Server {
+func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig,
+	scu ca.APISecurityConfigUpdater, pg plugingetter.PluginGetter) *Server {
 	return &Server{
-		store:  store,
-		raft:   raft,
-		rootCA: rootCA,
-		pg:     pg,
+		store:          store,
+		raft:           raft,
+		securityConfig: securityConfig,
+		scu:            scu,
+		pg:             pg,
 	}
 }


### PR DESCRIPTION
This is also a minor refactor needed because the root CA can change over time now, so is needed for generating new join tokens and also for generating cross-signed certs when doing root rotations (when updating the swarm cluster).

We also make sure, when updating the cluster, to update the security config to reflect the latest version of the cluster to prevent join tokens from being generated using an older version of the `RootCA`.