### PR TITLE
Tasks should be removed when a node doesn't matches service constraint

### DIFF
--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -440,13 +440,10 @@ func (g *Orchestrator) reconcileServicesOneNode(ctx context.Context, serviceIDs 
 				continue
 			}
 
-			if !constraint.NodeMatches(service.constraints, node) {
-				continue
-			}
-
-			// if restart policy considers this node has finished its task
+			// if the node doesn't match the constraints for the service,
+			// or restart policy considers this node has finished its task
 			// it should remove all running tasks
-			if completed[serviceID] {
+			if !constraint.NodeMatches(service.constraints, node) || completed[serviceID] {
 				g.removeTasks(ctx, batch, tasks[serviceID])
 				continue
 			}


### PR DESCRIPTION
In https://github.com/docker/docker/issues/31377#issuecomment-288367101, a task from a global service is stuck at `pending` state. Reconciliation should clean up such tasks. 

```
root@manager1:~# docker service ps consulagent
ID            NAME                                   IMAGE                        NODE         DESIRED STATE  CURRENT STATE            ERROR  PORTS
nrv6ofiwlsbz  consulagent.dqxztwj3rrycomdvy7y4xkstd  127.0.0.1:5000/consul:x.x.x  manager3     Running        Pending 19 minutes ago
5umgd96jc4np  consulagent.d2swwbt2n2j58dyzwjs2xc8f7  127.0.0.1:5000/consul:x.x.x  node2        Running        Running 19 minutes ago
kgs950z3hvdo  consulagent.vae6tkmhc9mapv9fcck38nu5m  127.0.0.1:5000/consul:x.x.x  node1        Shutdown       Shutdown 18 minutes ago
qzvs3jg10u5m  consulagent.d2swwbt2n2j58dyzwjs2xc8f7  127.0.0.1:5000/consul:x.x.x  node2        Shutdown       Shutdown 19 minutes ago
```

Signed-off-by: Dong Chen <dongluo.chen@docker.com>