### PR TITLE
controlapi: Allow network attachments to be changed

### DIFF
--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -627,8 +627,6 @@ func TestUpdateService(t *testing.T) {
 
 }
 
-// TODO(dongluochen): Network update is not supported yet and it's blocked
-// from controlapi. This test should be removed once network update is supported.
 func TestServiceUpdateRejectNetworkChange(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Stop()
@@ -655,7 +653,7 @@ func TestServiceUpdateRejectNetworkChange(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), errNetworkUpdateNotSupported.Error()))
 
-	// Use TaskSpec.Networks
+	// Changes to TaskSpec.Networks are allowed
 	spec = createSpec("name2", "image", 1)
 	spec.Task.Networks = []*api.NetworkAttachmentConfig{
 		{
@@ -676,8 +674,7 @@ func TestServiceUpdateRejectNetworkChange(t *testing.T) {
 		Spec:           &service.Spec,
 		ServiceVersion: &service.Meta.Version,
 	})
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), errNetworkUpdateNotSupported.Error()))
+	assert.NoError(t, err)
 
 	// Migrate networks from ServiceSpec.Networks to TaskSpec.Networks
 	spec = createSpec("name3", "image", 1)


### PR DESCRIPTION
We disallow changing network attachments, because in the past this wouldn't trigger rolling updates properly. However, this restriction predates the movement of `Networks` from `Spec` to `TaskSpec`. It should be fine to update `TaskSpec.Networks`, since the criteria for a rolling update is the `TaskSpec` in the task not matching the service.

Change controlapi to allow the `Networks` field in `TaskSpec` to be updated. It's also okay to change the field in `Spec` if the one in `TaskSpec` is also being changed at the same time - for example, if migrating data from the legacy `Spec.Networks` field to `Spec.Task.Networks`.

This is difficult to fully test inside swarmkit, but I am including an integration test in the corresponding docker PR.

Fixes #1029

cc @dhiltgen @mavenugo