### PR TITLE
Fix dependency validation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,7 @@ dependencies:
 test:
     pre:
         # Ensure validation of dependencies
-        - if test -n "`git diff --stat=1000 origin/master | grep -E \"^[[:space:]]*vendor\"`"; then make dep-validate; fi
+        - cd "$WORKDIR" && if test -n "`git diff --stat=1000 origin/master | grep -E \"^[[:space:]]*vendor\"`"; then make dep-validate; fi
 
     override:
         # Run all tests in a single pass to ensure we don't move to the next


### PR DESCRIPTION
Our circle.yml is set up so that we have to cd into $WORKDIR for each
step. If we run "make dep-validate" in the default working directory,
where there also happens to be a checkout of the source tree, really
weird things happen.

cc @ijc25