### PR TITLE
Move default swarmd.sock to /run

### DIFF
--- a/cmd/swarm-rafttool/main.go
+++ b/cmd/swarm-rafttool/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/docker/swarmkit/cmd/swarmd/defaults"
 	"github.com/spf13/cobra"
 )
 
@@ -131,7 +132,7 @@ var (
 )
 
 func init() {
-	mainCmd.PersistentFlags().StringP("state-dir", "d", "./swarmkitstate", "State directory")
+	mainCmd.PersistentFlags().StringP("state-dir", "d", defaults.StateDir, "State directory")
 	mainCmd.PersistentFlags().String("unlock-key", "", "Unlock key, if raft logs are encrypted")
 	decryptCmd.Flags().StringP("output-dir", "o", "plaintext_raft", "Output directory for decrypted raft logs")
 	mainCmd.AddCommand(

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/swarmkit/cmd/swarmctl/secret"
 	"github.com/docker/swarmkit/cmd/swarmctl/service"
 	"github.com/docker/swarmkit/cmd/swarmctl/task"
+	"github.com/docker/swarmkit/cmd/swarmd/defaults"
 	"github.com/docker/swarmkit/version"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -41,7 +42,7 @@ func defaultSocket() string {
 	if swarmSocket != "" {
 		return swarmSocket
 	}
-	return "./swarmkitstate/swarmd.sock"
+	return defaults.ControlAPISocket
 }
 
 func init() {

--- a/cmd/swarmd/defaults/defaults.go
+++ b/cmd/swarmd/defaults/defaults.go
@@ -1,0 +1,7 @@
+package defaults
+
+// ControlAPISocket is the default path where clients can contact the swarmd control API.
+var ControlAPISocket = "/var/run/swarmd.sock"
+
+// StateDir is the default path to the swarmd state directory
+var StateDir = "/var/lib/swarmd"

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -13,6 +13,7 @@ import (
 	engineapi "github.com/docker/docker/client"
 	"github.com/docker/swarmkit/agent/exec/dockerapi"
 	"github.com/docker/swarmkit/cli"
+	"github.com/docker/swarmkit/cmd/swarmd/defaults"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/docker/swarmkit/node"
@@ -228,12 +229,12 @@ var (
 func init() {
 	mainCmd.Flags().BoolP("version", "v", false, "Display the version and exit")
 	mainCmd.Flags().StringP("log-level", "l", "info", "Log level (options \"debug\", \"info\", \"warn\", \"error\", \"fatal\", \"panic\")")
-	mainCmd.Flags().StringP("state-dir", "d", "./swarmkitstate", "State directory")
+	mainCmd.Flags().StringP("state-dir", "d", defaults.StateDir, "State directory")
 	mainCmd.Flags().StringP("join-token", "", "", "Specifies the secret token required to join the cluster")
 	mainCmd.Flags().String("engine-addr", "unix:///var/run/docker.sock", "Address of engine instance of agent.")
 	mainCmd.Flags().String("hostname", "", "Override reported agent hostname")
 	mainCmd.Flags().String("listen-remote-api", "0.0.0.0:4242", "Listen address for remote API")
-	mainCmd.Flags().String("listen-control-api", "./swarmkitstate/swarmd.sock", "Listen socket for control API")
+	mainCmd.Flags().String("listen-control-api", defaults.ControlAPISocket, "Listen socket for control API")
 	mainCmd.Flags().String("listen-debug", "", "Bind the Go debug server on the provided address")
 	mainCmd.Flags().String("listen-metrics", "", "Listen address for metrics")
 	mainCmd.Flags().String("join-addr", "", "Join cluster with a node at this address")


### PR DESCRIPTION
Having this in `pwd`/swarmkitstate/ of the swarmd process is annoying if
actually trying to run as a system daemon (as I'm trying to do in #1965).

Signed-off-by: Ian Campbell <ian.campbell@docker.com>