### PR TITLE
Make deepcopy actually deep

### DIFF
--- a/api/ca.pb.go
+++ b/api/ca.pb.go
@@ -215,6 +215,10 @@ func (m *IssueNodeCertificateRequest) CopyFrom(src interface{}) {
 
 	o := src.(*IssueNodeCertificateRequest)
 	*m = *o
+	if o.CSR != nil {
+		m.CSR = make([]byte, len(o.CSR))
+		copy(m.CSR, o.CSR)
+	}
 }
 
 func (m *IssueNodeCertificateResponse) Copy() *IssueNodeCertificateResponse {
@@ -255,6 +259,10 @@ func (m *GetRootCACertificateResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetRootCACertificateResponse)
 	*m = *o
+	if o.Certificate != nil {
+		m.Certificate = make([]byte, len(o.Certificate))
+		copy(m.Certificate, o.Certificate)
+	}
 }
 
 func (m *GetUnlockKeyRequest) Copy() *GetUnlockKeyRequest {
@@ -280,6 +288,10 @@ func (m *GetUnlockKeyResponse) CopyFrom(src interface{}) {
 
 	o := src.(*GetUnlockKeyResponse)
 	*m = *o
+	if o.UnlockKey != nil {
+		m.UnlockKey = make([]byte, len(o.UnlockKey))
+		copy(m.UnlockKey, o.UnlockKey)
+	}
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Version, &o.Version)
 }
 

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -357,6 +357,10 @@ func (m *LogMessage) CopyFrom(src interface{}) {
 		m.Timestamp = &google_protobuf.Timestamp{}
 		github_com_docker_swarmkit_api_deepcopy.Copy(m.Timestamp, o.Timestamp)
 	}
+	if o.Data != nil {
+		m.Data = make([]byte, len(o.Data))
+		copy(m.Data, o.Data)
+	}
 }
 
 func (m *SubscribeLogsRequest) Copy() *SubscribeLogsRequest {

--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -1097,6 +1097,10 @@ func (m *SecretSpec) CopyFrom(src interface{}) {
 	o := src.(*SecretSpec)
 	*m = *o
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Annotations, &o.Annotations)
+	if o.Data != nil {
+		m.Data = make([]byte, len(o.Data))
+		copy(m.Data, o.Data)
+	}
 }
 
 func (m *NodeSpec) Marshal() (dAtA []byte, err error) {

--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -2531,6 +2531,10 @@ func (m *AcceptancePolicy_RoleAdmissionPolicy_Secret) CopyFrom(src interface{}) 
 
 	o := src.(*AcceptancePolicy_RoleAdmissionPolicy_Secret)
 	*m = *o
+	if o.Data != nil {
+		m.Data = make([]byte, len(o.Data))
+		copy(m.Data, o.Data)
+	}
 }
 
 func (m *ExternalCA) Copy() *ExternalCA {
@@ -2553,6 +2557,10 @@ func (m *ExternalCA) CopyFrom(src interface{}) {
 		}
 	}
 
+	if o.CACert != nil {
+		m.CACert = make([]byte, len(o.CACert))
+		copy(m.CACert, o.CACert)
+	}
 }
 
 func (m *CAConfig) Copy() *CAConfig {
@@ -2762,6 +2770,14 @@ func (m *RootCA) CopyFrom(src interface{}) {
 
 	o := src.(*RootCA)
 	*m = *o
+	if o.CAKey != nil {
+		m.CAKey = make([]byte, len(o.CAKey))
+		copy(m.CAKey, o.CAKey)
+	}
+	if o.CACert != nil {
+		m.CACert = make([]byte, len(o.CACert))
+		copy(m.CACert, o.CACert)
+	}
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.JoinTokens, &o.JoinTokens)
 	if o.RootRotation != nil {
 		m.RootRotation = &RootRotation{}
@@ -2782,7 +2798,15 @@ func (m *Certificate) CopyFrom(src interface{}) {
 
 	o := src.(*Certificate)
 	*m = *o
+	if o.CSR != nil {
+		m.CSR = make([]byte, len(o.CSR))
+		copy(m.CSR, o.CSR)
+	}
 	github_com_docker_swarmkit_api_deepcopy.Copy(&m.Status, &o.Status)
+	if o.Certificate != nil {
+		m.Certificate = make([]byte, len(o.Certificate))
+		copy(m.Certificate, o.Certificate)
+	}
 }
 
 func (m *EncryptionKey) Copy() *EncryptionKey {
@@ -2798,6 +2822,10 @@ func (m *EncryptionKey) CopyFrom(src interface{}) {
 
 	o := src.(*EncryptionKey)
 	*m = *o
+	if o.Key != nil {
+		m.Key = make([]byte, len(o.Key))
+		copy(m.Key, o.Key)
+	}
 }
 
 func (m *ManagerStatus) Copy() *ManagerStatus {
@@ -2920,6 +2948,14 @@ func (m *MaybeEncryptedRecord) CopyFrom(src interface{}) {
 
 	o := src.(*MaybeEncryptedRecord)
 	*m = *o
+	if o.Data != nil {
+		m.Data = make([]byte, len(o.Data))
+		copy(m.Data, o.Data)
+	}
+	if o.Nonce != nil {
+		m.Nonce = make([]byte, len(o.Nonce))
+		copy(m.Nonce, o.Nonce)
+	}
 }
 
 func (m *RootRotation) Copy() *RootRotation {
@@ -2935,6 +2971,18 @@ func (m *RootRotation) CopyFrom(src interface{}) {
 
 	o := src.(*RootRotation)
 	*m = *o
+	if o.CACert != nil {
+		m.CACert = make([]byte, len(o.CACert))
+		copy(m.CACert, o.CACert)
+	}
+	if o.CAKey != nil {
+		m.CAKey = make([]byte, len(o.CAKey))
+		copy(m.CAKey, o.CAKey)
+	}
+	if o.CrossSignedCACert != nil {
+		m.CrossSignedCACert = make([]byte, len(o.CrossSignedCACert))
+		copy(m.CrossSignedCACert, o.CrossSignedCACert)
+	}
 }
 
 func (m *Version) Marshal() (dAtA []byte, err error) {

--- a/protobuf/plugin/deepcopy/test/deepcopy.pb.go
+++ b/protobuf/plugin/deepcopy/test/deepcopy.pb.go
@@ -578,6 +578,10 @@ func (m *BasicScalar) CopyFrom(src interface{}) {
 
 	o := src.(*BasicScalar)
 	*m = *o
+	if o.Field15 != nil {
+		m.Field15 = make([]byte, len(o.Field15))
+		copy(m.Field15, o.Field15)
+	}
 }
 
 func (m *RepeatedScalar) Copy() *RepeatedScalar {
@@ -665,7 +669,12 @@ func (m *RepeatedScalar) CopyFrom(src interface{}) {
 
 	if o.Field15 != nil {
 		m.Field15 = make([][]byte, len(o.Field15))
-		copy(m.Field15, o.Field15)
+		for i := range m.Field15 {
+			if o.Field15[i] != nil {
+				m.Field15[i] = make([]byte, len(o.Field15[i]))
+				copy(m.Field15[i], o.Field15[i])
+			}
+		}
 	}
 
 }
@@ -949,7 +958,11 @@ func (m *OneOf) CopyFrom(src interface{}) {
 			m.Fields = &v
 		case *OneOf_Field7:
 			v := OneOf_Field7{
-				Field7: o.GetField7(),
+				Field7: make([]byte, len(o.GetField7())),
+			}
+			if o.GetField7() != nil {
+				v.Field7 = make([]byte, len(o.GetField7()))
+				copy(v.Field7, o.GetField7())
 			}
 			m.Fields = &v
 		case *OneOf_Field8:

--- a/protobuf/plugin/deepcopy/test/deepcopypb_test.go
+++ b/protobuf/plugin/deepcopy/test/deepcopypb_test.go
@@ -781,6 +781,12 @@ func TestBasicScalarCopy(t *testing.T) {
 	if &in.Field15 == &out.Field15 {
 		t.Fatalf("Field15: %#v == %#v", &in.Field15, &out.Field15)
 	}
+	if len(in.Field15) > 0 {
+		in.Field15[0]++
+		if in.Equal(out) {
+			t.Fatalf("%#v == %#v", in, out)
+		}
+	}
 
 	in = nil
 	out = in.Copy()
@@ -840,6 +846,12 @@ func TestRepeatedScalarCopy(t *testing.T) {
 	}
 	if &in.Field15 == &out.Field15 {
 		t.Fatalf("Field15: %#v == %#v", &in.Field15, &out.Field15)
+	}
+	if len(in.Field15[0]) > 0 {
+		in.Field15[0][0]++
+		if in.Equal(out) {
+			t.Fatalf("%#v == %#v", in, out)
+		}
 	}
 
 	in = nil
@@ -1027,38 +1039,23 @@ func TestOneOfCopy(t *testing.T) {
 	if !in.Equal(out) {
 		t.Fatalf("%#v != %#v", in, out)
 	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
+	if len(in.GetField7()) > 0 {
+		in.GetField7()[0]++
+		if in.Equal(out) {
+			t.Fatalf("%#v == %#v", in, out)
+		}
 	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
+	if in.GetField8() != nil && in.GetField8() == out.GetField8() {
+		t.Fatalf("GetField8(): %#v == %#v", in.GetField8(), out.GetField8())
 	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
+	if in.GetField9() != nil && in.GetField9() == out.GetField9() {
+		t.Fatalf("GetField9(): %#v == %#v", in.GetField9(), out.GetField9())
 	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
+	if in.GetField10() != nil && in.GetField10() == out.GetField10() {
+		t.Fatalf("GetField10(): %#v == %#v", in.GetField10(), out.GetField10())
 	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
-	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
-	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
-	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
-	}
-	if &in.Fields == &out.Fields {
-		t.Fatalf("Fields: %#v == %#v", &in.Fields, &out.Fields)
-	}
-	if &in.FieldsTwo == &out.FieldsTwo {
-		t.Fatalf("FieldsTwo: %#v == %#v", &in.FieldsTwo, &out.FieldsTwo)
-	}
-	if &in.FieldsTwo == &out.FieldsTwo {
-		t.Fatalf("FieldsTwo: %#v == %#v", &in.FieldsTwo, &out.FieldsTwo)
+	if in.GetField11() != nil && in.GetField11() == out.GetField11() {
+		t.Fatalf("GetField11(): %#v == %#v", in.GetField11(), out.GetField11())
 	}
 
 	in = nil


### PR DESCRIPTION
deepcopy was treating "bytes" as a scalar value and relying on a direct assignment. It's necessary to copy the underlying bytes as well.