### PR TITLE
deepcopy: Additional bounds checking in unit test

### DIFF
--- a/protobuf/plugin/deepcopy/deepcopytest.go
+++ b/protobuf/plugin/deepcopy/deepcopytest.go
@@ -69,6 +69,8 @@ func (p *test) Generate(imports generator.PluginImports, file *generator.FileDes
 
 			if f.IsBytes() {
 				if f.IsRepeated() {
+					p.P(`if len(in.`, fName, `) > 0 {`)
+					p.In()
 					fName += "[0]"
 				}
 				p.P(`if len(in.`, fName, `) > 0 {`)
@@ -81,6 +83,10 @@ func (p *test) Generate(imports generator.PluginImports, file *generator.FileDes
 				p.P(`}`)
 				p.Out()
 				p.P(`}`)
+				if f.IsRepeated() {
+					p.Out()
+					p.P(`}`)
+				}
 			}
 		}
 

--- a/protobuf/plugin/deepcopy/test/deepcopypb_test.go
+++ b/protobuf/plugin/deepcopy/test/deepcopypb_test.go
@@ -847,10 +847,12 @@ func TestRepeatedScalarCopy(t *testing.T) {
 	if &in.Field15 == &out.Field15 {
 		t.Fatalf("Field15: %#v == %#v", &in.Field15, &out.Field15)
 	}
-	if len(in.Field15[0]) > 0 {
-		in.Field15[0][0]++
-		if in.Equal(out) {
-			t.Fatalf("%#v == %#v", in, out)
+	if len(in.Field15) > 0 {
+		if len(in.Field15[0]) > 0 {
+			in.Field15[0][0]++
+			if in.Equal(out) {
+				t.Fatalf("%#v == %#v", in, out)
+			}
 		}
 	}
 


### PR DESCRIPTION
A panic was seen in this unit test. There is a missing bounds check that
needs to be added since the randomly-generated slices may have 0 length.