### PR TITLE
defaults: Add Rollback defaults

### DIFF
--- a/api/defaults/service.go
+++ b/api/defaults/service.go
@@ -32,6 +32,12 @@ var Service = api.ServiceSpec{
 		Parallelism:   1,
 		Order:         api.UpdateConfig_STOP_FIRST,
 	},
+	Rollback: &api.UpdateConfig{
+		FailureAction: api.UpdateConfig_PAUSE,
+		Monitor:       gogotypes.DurationProto(5 * time.Second),
+		Parallelism:   1,
+		Order:         api.UpdateConfig_STOP_FIRST,
+	},
 }
 
 // InterpolateService returns a ServiceSpec based on the provided spec, which
@@ -77,6 +83,15 @@ func InterpolateService(origSpec *api.ServiceSpec) *api.ServiceSpec {
 		if spec.Update.Monitor == nil {
 			spec.Update.Monitor = &gogotypes.Duration{}
 			deepcopy.Copy(spec.Update.Monitor, Service.Update.Monitor)
+		}
+	}
+
+	if spec.Rollback == nil {
+		spec.Rollback = Service.Rollback.Copy()
+	} else {
+		if spec.Rollback.Monitor == nil {
+			spec.Rollback.Monitor = &gogotypes.Duration{}
+			deepcopy.Copy(spec.Rollback.Monitor, Service.Rollback.Monitor)
 		}
 	}
 

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -155,31 +155,25 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 		u.startUpdate(ctx, service.ID)
 	}
 
-	delay := defaults.Service.Update.Delay
-	parallelism := int(defaults.Service.Update.Parallelism)
-	failureAction := defaults.Service.Update.FailureAction
-	allowedFailureFraction := defaults.Service.Update.MaxFailureRatio
-	monitoringPeriod, _ := gogotypes.DurationFromProto(defaults.Service.Update.Monitor)
-	order := defaults.Service.Update.Order
+	var monitoringPeriod time.Duration
 
 	updateConfig := service.Spec.Update
 	if service.UpdateStatus != nil && service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
+		monitoringPeriod, _ = gogotypes.DurationFromProto(defaults.Service.Rollback.Monitor)
 		updateConfig = service.Spec.Rollback
+		if updateConfig == nil {
+			updateConfig = defaults.Service.Rollback
+		}
+	} else if updateConfig == nil {
+		monitoringPeriod, _ = gogotypes.DurationFromProto(defaults.Service.Update.Monitor)
+		updateConfig = defaults.Service.Update
 	}
 
-	if updateConfig != nil {
-		failureAction = updateConfig.FailureAction
-		allowedFailureFraction = updateConfig.MaxFailureRatio
-		parallelism = int(updateConfig.Parallelism)
-		delay = updateConfig.Delay
-		order = updateConfig.Order
-
-		var err error
-		if updateConfig.Monitor != nil {
-			monitoringPeriod, err = gogotypes.DurationFromProto(updateConfig.Monitor)
-			if err != nil {
-				monitoringPeriod, _ = gogotypes.DurationFromProto(defaults.Service.Update.Monitor)
-			}
+	parallelism := int(updateConfig.Parallelism)
+	if updateConfig.Monitor != nil {
+		newMonitoringPeriod, err := gogotypes.DurationFromProto(updateConfig.Monitor)
+		if err == nil {
+			monitoringPeriod = newMonitoringPeriod
 		}
 	}
 
@@ -195,14 +189,14 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 	wg.Add(parallelism)
 	for i := 0; i < parallelism; i++ {
 		go func() {
-			u.worker(ctx, slotQueue, delay, order)
+			u.worker(ctx, slotQueue, updateConfig)
 			wg.Done()
 		}()
 	}
 
 	var failedTaskWatch chan events.Event
 
-	if failureAction != api.UpdateConfig_CONTINUE {
+	if updateConfig.FailureAction != api.UpdateConfig_CONTINUE {
 		var cancelWatch func()
 		failedTaskWatch, cancelWatch = state.Watch(
 			u.store.WatchQueue(),
@@ -234,8 +228,8 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 		if found && (startedAt.IsZero() || time.Since(startedAt) <= monitoringPeriod) {
 			failedTasks[failedTask.ID] = struct{}{}
 			totalFailures++
-			if float32(totalFailures)/float32(len(dirtySlots)) > allowedFailureFraction {
-				switch failureAction {
+			if float32(totalFailures)/float32(len(dirtySlots)) > updateConfig.MaxFailureRatio {
+				switch updateConfig.FailureAction {
 				case api.UpdateConfig_PAUSE:
 					stopped = true
 					message := fmt.Sprintf("update paused due to failure or early termination of task %s", failedTask.ID)
@@ -309,7 +303,7 @@ slotsLoop:
 	}
 }
 
-func (u *Updater) worker(ctx context.Context, queue <-chan orchestrator.Slot, delay time.Duration, order api.UpdateConfig_UpdateOrder) {
+func (u *Updater) worker(ctx context.Context, queue <-chan orchestrator.Slot, updateConfig *api.UpdateConfig) {
 	for slot := range queue {
 		// Do we have a task with the new spec in desired state = RUNNING?
 		// If so, all we have to do to complete the update is remove the
@@ -346,14 +340,14 @@ func (u *Updater) worker(ctx context.Context, queue <-chan orchestrator.Slot, de
 			}
 			updated.DesiredState = api.TaskStateReady
 
-			if err := u.updateTask(ctx, slot, updated, order); err != nil {
+			if err := u.updateTask(ctx, slot, updated, updateConfig.Order); err != nil {
 				log.G(ctx).WithError(err).WithField("task.id", updated.ID).Error("update failed")
 			}
 		}
 
-		if delay != 0 {
+		if updateConfig.Delay != 0 {
 			select {
-			case <-time.After(delay):
+			case <-time.After(updateConfig.Delay):
 			case <-u.stopChan:
 				return
 			}


### PR DESCRIPTION
Right now, the updater uses `Update` defaults for a rollback if no `Rollback` settings are provided in the service. Make the `Rollback` defaults explicit instead.