### PR TITLE
fix typos in manager/controlapi

### DIFF
--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -38,7 +38,7 @@ func validateClusterSpec(spec *api.ClusterSpec) error {
 	}
 
 	// Validate that AcceptancePolicies only include Secrets that are bcrypted
-	// TODO(diogo): Add a global list of acceptace algorithms. We only support bcrypt for now.
+	// TODO(diogo): Add a global list of acceptance algorithms. We only support bcrypt for now.
 	if len(spec.AcceptancePolicy.Policies) > 0 {
 		for _, policy := range spec.AcceptancePolicy.Policies {
 			if policy.Secret != nil && strings.ToLower(policy.Secret.Alg) != "bcrypt" {

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -621,7 +621,7 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 			service.Spec = *request.Spec.Copy()
 			// Set spec version. Note that this will not match the
 			// service's Meta.Version after the store update. The
-			// versionsfor the spec and the service itself are not
+			// versions for the spec and the service itself are not
 			// meant to be directly comparable.
 			service.SpecVersion = service.Meta.Version.Copy()
 


### PR DESCRIPTION
Just fix some typos.

Signed-off-by: fate-grand-order <chenjg@harmonycloud.cn>