### PR TITLE
dispatcher: Clean up leftover task and node updates

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -148,8 +148,6 @@ func New(cluster Cluster, c *Config) *Dispatcher {
 		downNodes:             newNodeStore(defaultNodeDownPeriod, 0, 1, 0),
 		store:                 cluster.MemoryStore(),
 		cluster:               cluster,
-		taskUpdates:           make(map[string]*api.TaskStatus),
-		nodeUpdates:           make(map[string]nodeUpdate),
 		processUpdatesTrigger: make(chan struct{}, 1),
 		config:                c,
 	}
@@ -181,6 +179,14 @@ func getWeightedPeers(cluster Cluster) []*api.WeightedPeer {
 // Run runs dispatcher tasks which should be run on leader dispatcher.
 // Dispatcher can be stopped with cancelling ctx or calling Stop().
 func (d *Dispatcher) Run(ctx context.Context) error {
+	d.taskUpdatesLock.Lock()
+	d.taskUpdates = make(map[string]*api.TaskStatus)
+	d.taskUpdatesLock.Unlock()
+
+	d.nodeUpdatesLock.Lock()
+	d.nodeUpdates = make(map[string]nodeUpdate)
+	d.nodeUpdatesLock.Unlock()
+
 	d.mu.Lock()
 	if d.isRunning() {
 		d.mu.Unlock()


### PR DESCRIPTION
The leader sets timers that trigger when nodes' heartbeat timeouts
expire. These timers may trigger after another node takes over as the
leader. In that case, they add updates to nodeUpdates that are acted on
when this node becomes the leader again. That's bad because it means
other nodes will immediately be marked as "DOWN" instead of being in the
UNKNOWN state for the ~15 second grace period.

Reset nodeUpdates and taskUpdates when the dispatcher starts up, so
stale data is not a factor.

I found I could reproduce this reliably by running a cluster of three
managers, and using ^Z to suspend the leader. After repeating this a few
times, nodes would start to get marked DOWN immediately after a leader
change.