### PR TITLE
Minor doc changes.

### DIFF
--- a/identity/doc.go
+++ b/identity/doc.go
@@ -1,6 +1,6 @@
-// Package identity provides functionality for generating and manager
-// identifiers within swarm. This includes entity identification, such as that
-// of Service, Task and Network but also cryptographically-secure Node identity.
+// Package identity provides functionality for generating and managing
+// identifiers within a swarm. This includes entity identification, such as for
+// Services, Tasks and Networks but also cryptographically-secure Node identities.
 //
 // Random Identifiers
 //

--- a/manager/allocator/doc.go
+++ b/manager/allocator/doc.go
@@ -3,16 +3,16 @@
 // manages a set of independent allocator processes which can mostly
 // execute concurrently with only a minimal need for coordination.
 //
-// One of the instances where it needs coordination is when to move a
-// task to ALLOCATED state. Since a task can move to ALLOCATED state
-// only when all task allocators have completed their service of
-// allocation, they all have to agree on that. The way this achieved
-// in `allocator` is by creating a `taskBallot` to which all task
-// allocators register themselves as mandatory voters. For each task
-// that needs allocation, each allocator independently votes to indicate
-// the completion of their allocation. Once all registered voters have
-// voted then the task is moved to ALLOCATED state.
+// One of the instances where it needs coordination is when deciding to
+// move a task to the PENDING state. Since a task can move to the
+// PENDING state only when all the task allocators have completed,
+// they must cooperate. The way `allocator` achieves this is by creating
+// a `taskBallot` to which all task allocators register themselves as
+// mandatory voters. For each task that needs allocation, each allocator
+// independently votes to indicate the completion of their allocation.
+// Once all registered voters have voted then the task is moved to the
+// PENDING state.
 //
-// Other than the coordination needed for task ALLOCATED state, all
+// Other than the coordination needed for task PENDING state, all
 // the allocators function fairly independently.
 package allocator

--- a/manager/state/store/doc.go
+++ b/manager/state/store/doc.go
@@ -1,16 +1,16 @@
-// Package state provides interfaces to work with swarm cluster state.
+// Package store provides interfaces to work with swarm cluster state.
 //
-// The primary interface is Store, which abstracts storage of this cluster
-// state. Store exposes a transactional interface for both reads and writes.
+// The primary interface is MemoryStore, which abstracts storage of this cluster
+// state. MemoryStore exposes a transactional interface for both reads and writes.
 // To perform a read transaction, View accepts a callback function that it
 // will invoke with a ReadTx object that gives it a consistent view of the
 // state. Similarly, Update accepts a callback function that it will invoke with
 // a Tx object that allows reads and writes to happen without interference from
 // other transactions.
 //
-// This is an example of making an update to a Store:
+// This is an example of making an update to a MemoryStore:
 //
-//	err := store.Update(func(tx state.Tx) {
+//	err := store.Update(func(tx store.Tx) {
 //		if err := tx.Nodes().Update(newNode); err != nil {
 //			return err
 //		}
@@ -20,8 +20,8 @@
 //		return fmt.Errorf("transaction failed: %v", err)
 //	}
 //
-// WatchableStore is a version of Store that exposes watch functionality.
-// These expose a publish/subscribe queue where code can subscribe to
+// MemoryStore exposes watch functionality.
+// It exposes a publish/subscribe queue where code can subscribe to
 // changes of interest. This can be combined with the ViewAndWatch function to
 // "fork" a store, by making a snapshot and then applying future changes
 // to keep the copy in sync. This approach lets consumers of the data
@@ -29,4 +29,4 @@
 // strategies. It can lead to more efficient code because data consumers
 // don't necessarily have to lock the main data store if they are
 // maintaining their own copies of the state.
-package state
+package store


### PR DESCRIPTION
WatchableStore mentioned in manager/state/doc.go does not seem to exist.
MemoryStore fits the old description. I assume this was missed in a
rename.

Signed-off-by: Alexander Midlash <amidlash@docker.com>