### PR TITLE
[dispatcher] Maybe prevent missing a network key update

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1145,6 +1145,9 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 		return err
 	}
 
+	clusterUpdatesCh, clusterCancel := d.clusterUpdateQueue.Watch()
+	defer clusterCancel()
+
 	if err := stream.Send(&api.SessionMessage{
 		SessionID:            sessionID,
 		Node:                 nodeObj,
@@ -1154,9 +1157,6 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 	}); err != nil {
 		return err
 	}
-
-	clusterUpdatesCh, clusterCancel := d.clusterUpdateQueue.Watch()
-	defer clusterCancel()
 
 	// disconnectNode is a helper forcibly shutdown connection
 	disconnectNode := func() error {


### PR DESCRIPTION
In the dispatcher, start watching for cluster changes before sending the first
session message, because it's possible to miss a cluster update just between when
the message is being sent and when we start watching for cluster updates.

Signed-off-by: cyli <ying.li@docker.com>

cc @aaronlehmann 