### PR TITLE
raft: Don't log errors removing members based on snapshot

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -698,9 +698,7 @@ func (n *Node) restoreFromSnapshot(ctx context.Context, data []byte) error {
 
 	for _, removedMember := range snapCluster.Removed {
 		n.cluster.RemoveMember(removedMember)
-		if err := n.transport.RemovePeer(removedMember); err != nil {
-			log.G(ctx).WithError(err).Errorf("failed to remove peer %x from transport", removedMember)
-		}
+		n.transport.RemovePeer(removedMember)
 		delete(oldMembers, removedMember)
 	}
 


### PR DESCRIPTION
When we remove the peers on the snapshot's Removed list from from the
transport, we may have already removed them in the past, or never even
been in contact with these peers. We shouldn't log an error if it turns
out these peers are not known by the transport. This avoids a misleading
error message.

@cyli