### PR TITLE
WIP: [cli] Interactive root rotation

### DIFF
--- a/ca/reconciler.go
+++ b/ca/reconciler.go
@@ -1,0 +1,271 @@
+package ca
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"bytes"
+
+	"reflect"
+
+	"github.com/cloudflare/cfssl/helpers"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/equality"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/pkg/errors"
+)
+
+// IssuanceStateRotateBatchSize is the maximum number of nodes we'll tell to rotate their certificates in any given update
+const IssuanceStateRotateBatchSize = 30
+
+func hasIssuer(n *api.Node, info *IssuerInfo) bool {
+	if n.Description == nil || n.Description.TLSInfo == nil {
+		return false
+	}
+	return bytes.Equal(info.Subject, n.Description.TLSInfo.CertIssuerSubject) && bytes.Equal(info.PublicKey, n.Description.TLSInfo.CertIssuerPublicKey)
+}
+
+// IssuerFromAPIRootCA returns the desired issuer given an API root CA object
+func IssuerFromAPIRootCA(rootCA *api.RootCA) (*IssuerInfo, error) {
+	wantedIssuer := rootCA.CACert
+	if rootCA.RootRotation != nil {
+		wantedIssuer = rootCA.RootRotation.CACert
+	}
+	issuerCerts, err := helpers.ParseCertificatesPEM(wantedIssuer)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid certificate in cluster root CA object")
+	}
+	if len(issuerCerts) == 0 {
+		return nil, errors.Wrap(err, "invalid certificate in cluster root CA object")
+	}
+	return &IssuerInfo{
+		Subject:   issuerCerts[0].RawSubject,
+		PublicKey: issuerCerts[0].RawSubjectPublicKeyInfo,
+	}, nil
+}
+
+var errRootRotationChanged = errors.New("target root rotation has changed")
+
+// rootRotationReconciler keeps track of all the nodes in the store so that we can determine which ones need reconciliation when nodes are updated
+// or the root CA is updated.  This is meant to be used with watches on nodes and the cluster, and provides functions to be called when the
+// cluster's RootCA has changed and when a node is added, updated, or removed.
+type rootRotationReconciler struct {
+	mu                  sync.Mutex
+	clusterID           string
+	batchUpdateInterval time.Duration
+	ctx                 context.Context
+	store               *store.MemoryStore
+
+	currentRootCA    *api.RootCA
+	currentIssuer    IssuerInfo
+	allNodes         map[string]*api.Node
+	unconvergedNodes map[string]struct{}
+
+	wg     sync.WaitGroup
+	cancel func()
+}
+
+func newReconciler(ctx context.Context, clusterID string, interval time.Duration, s *store.MemoryStore, rootCA *api.RootCA, nodes []*api.Node) *rootRotationReconciler {
+	r := &rootRotationReconciler{
+		ctx:                 ctx,
+		clusterID:           clusterID,
+		store:               s,
+		batchUpdateInterval: interval,
+		allNodes:            make(map[string]*api.Node),
+		unconvergedNodes:    make(map[string]struct{}),
+	}
+	r.UpdateRootCA(rootCA)
+	r.UpdateNodes(nodes...)
+	return r
+}
+
+func (r *rootRotationReconciler) UpdateRootCA(newRootCA *api.RootCA) {
+	if newRootCA == nil {
+		return
+	}
+	issuerInfo, err := IssuerFromAPIRootCA(newRootCA)
+	if err != nil {
+		log.G(r.ctx).WithError(err).Error("unable to update process the current root CA")
+	}
+	r.mu.Lock()
+	r.currentRootCA = newRootCA
+	// check if the issuer has changed, first
+	if reflect.DeepEqual(&r.currentIssuer, issuerInfo) {
+		r.mu.Unlock()
+		return
+	}
+	// If the issuer has changed, iterate through all the nodes to figure out which ones need rotation
+	r.currentIssuer = *issuerInfo
+	r.unconvergedNodes = make(map[string]struct{})
+	var (
+		hasRootRotation bool
+		ctx             context.Context
+		wg              *sync.WaitGroup
+	)
+	if r.currentRootCA.RootRotation != nil {
+		hasRootRotation = true
+		for _, n := range r.allNodes {
+			if hasIssuer(n, &r.currentIssuer) {
+				continue
+			}
+			r.unconvergedNodes[n.ID] = struct{}{}
+		}
+		if r.cancel != nil { // there's already a loop going, so cancel it
+			r.cancel()
+			wg = &r.wg
+		}
+		ctx, r.cancel = context.WithCancel(r.ctx)
+	}
+	r.mu.Unlock()
+
+	if hasRootRotation {
+		if wg != nil {
+			wg.Wait()
+		}
+		go r.runReconcilerLoop(ctx, newRootCA)
+	}
+}
+
+func (r *rootRotationReconciler) UpdateNodes(nodes ...*api.Node) {
+	r.mu.Lock()
+	for _, n := range nodes {
+		if n == nil || n.Spec.Membership != api.NodeMembershipAccepted {
+			continue
+		}
+		r.allNodes[n.ID] = n
+		if r.currentRootCA == nil || r.currentRootCA.RootRotation == nil {
+			continue
+		}
+		if hasIssuer(n, &r.currentIssuer) {
+			delete(r.unconvergedNodes, n.ID)
+		} else {
+			r.unconvergedNodes[n.ID] = struct{}{}
+		}
+	}
+	r.mu.Unlock()
+}
+
+func (r *rootRotationReconciler) DeleteNode(node *api.Node) {
+	if node == nil {
+		return
+	}
+	r.mu.Lock()
+	delete(r.allNodes, node.ID)
+	delete(r.unconvergedNodes, node.ID)
+	r.mu.Unlock()
+}
+
+func (r *rootRotationReconciler) runReconcilerLoop(ctx context.Context, loopRootCA *api.RootCA) {
+	r.wg.Add(1)
+	defer r.wg.Done()
+	for {
+		r.mu.Lock()
+		if len(r.unconvergedNodes) == 0 {
+			r.mu.Unlock()
+
+			err := r.store.Update(func(tx store.Tx) error {
+				return r.finishRootRotation(tx, loopRootCA)
+			})
+			if err == nil {
+				log.G(r.ctx).Infof("completed root rotation on cluster %s", r.clusterID)
+				return
+			}
+			log.G(r.ctx).WithError(err).Errorf("could not complete root rotation")
+			if err == errRootRotationChanged {
+				// if the root rotation has changed, this loop will be cancelled anyway, so may as well abort early
+				return
+			}
+		} else {
+			var toUpdate []*api.Node
+			for nodeID := range r.unconvergedNodes {
+				n, ok := r.allNodes[nodeID]
+				if !ok { // should never happen
+					continue
+				}
+				iState := n.Certificate.Status.State
+				if iState != api.IssuanceStateRenew&iState && iState != api.IssuanceStatePending && iState != api.IssuanceStateRotate {
+					n = n.Copy()
+					n.Certificate.Status.State = api.IssuanceStateRotate
+					toUpdate = append(toUpdate, n)
+					if len(toUpdate) >= IssuanceStateRotateBatchSize {
+						break
+					}
+				}
+			}
+			r.mu.Unlock()
+
+			if err := r.batchUpdateNodes(toUpdate); err != nil {
+				log.G(r.ctx).WithError(err).Errorf("store error when trying to batch update %d nodes to request certificate rotation", len(toUpdate))
+			}
+		}
+
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-time.After(r.batchUpdateInterval):
+		}
+	}
+}
+
+// This function assumes that the expected root CA has root rotation.  This is intended to be used by
+// `reconcileNodeRootsAndCerts`, which uses the root CA from the `lastSeenClusterRootCA`, and checks
+// that it has a root rotation before calling this function.
+func (r *rootRotationReconciler) finishRootRotation(tx store.Tx, expectedRootCA *api.RootCA) error {
+	cluster := store.GetCluster(tx, r.clusterID)
+	if cluster == nil {
+		return fmt.Errorf("unable to get cluster %s", r.clusterID)
+	}
+
+	// If the RootCA object has changed (because another root rotation was started or because some other node
+	// had finished the root rotation), we cannot finish the root rotation that we were working on.
+	if !equality.RootCAEqualStable(expectedRootCA, &cluster.RootCA) {
+		return errRootRotationChanged
+	}
+
+	var signerCert []byte
+	if len(cluster.RootCA.RootRotation.CAKey) > 0 {
+		signerCert = cluster.RootCA.RootRotation.CACert
+	}
+	// we don't actually have to parse out the default node expiration from the cluster - we are just using
+	// the ca.RootCA object to generate new tokens and the digest
+	updatedRootCA, err := NewRootCA(cluster.RootCA.RootRotation.CACert, signerCert, cluster.RootCA.RootRotation.CAKey,
+		DefaultNodeCertExpiration, nil)
+	if err != nil {
+		return errors.Wrap(err, "invalid cluster root rotation object")
+	}
+	cluster.RootCA = api.RootCA{
+		CACert:     cluster.RootCA.RootRotation.CACert,
+		CAKey:      cluster.RootCA.RootRotation.CAKey,
+		CACertHash: updatedRootCA.Digest.String(),
+		JoinTokens: api.JoinTokens{
+			Worker:  GenerateJoinToken(&updatedRootCA),
+			Manager: GenerateJoinToken(&updatedRootCA),
+		},
+		LastForcedRotation: cluster.RootCA.LastForcedRotation,
+	}
+	return store.UpdateCluster(tx, cluster)
+}
+
+func (r *rootRotationReconciler) batchUpdateNodes(toUpdate []*api.Node) error {
+	if len(toUpdate) == 0 {
+		return nil
+	}
+	_, err := r.store.Batch(func(batch *store.Batch) error {
+		// Directly update the nodes rather than get + update, and ignore version errors.  Since
+		// `rootRotationReconciler` should be hooked up to all node update/delete/create vents, we should have
+		// close to the latest versions of all the nodes.  If not, the node will updated later and the
+		// next batch of updates should catch it.
+		for _, n := range toUpdate {
+			if err := batch.Update(func(tx store.Tx) error {
+				return store.UpdateNode(tx, n)
+			}); err != nil {
+				log.G(r.ctx).WithError(err).Debugf("unable to update node %s to request a certificate rotation")
+			}
+		}
+		return nil
+	})
+	return err
+}

--- a/ca/server.go
+++ b/ca/server.go
@@ -4,12 +4,10 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"crypto/x509"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/cloudflare/cfssl/helpers"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/equality"
 	"github.com/docker/swarmkit/identity"
@@ -67,9 +65,8 @@ type Server struct {
 	// before we update the security config with the new root CA, we need to be able to save the root certs
 	rootPaths CertPaths
 
-	// lets us know if we're already doing a reconcile loop to tell nodes to rotate their
-	// TLS certificates and watching for root rotation completion
-	rootCAReconciliationInProgress  bool
+	// lets us monitor and finish root rotations
+	rootReconciler                  *rootRotationReconciler
 	rootReconciliationRetryInterval time.Duration
 }
 
@@ -434,6 +431,7 @@ func (s *Server) Run(ctx context.Context) error {
 		},
 		api.EventCreateNode{},
 		api.EventUpdateNode{},
+		api.EventDeleteNode{},
 	)
 
 	// Do this after updateCluster has been called, so isRunning never
@@ -442,7 +440,19 @@ func (s *Server) Run(ctx context.Context) error {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	ctx = s.ctx
 	close(s.started)
+	// we need to set it on the server, because `Server.UpdateRootCA` can be called from outside the Run function
+	s.rootReconciler = newReconciler(
+		log.WithField(ctx, "method", "(*Server).rootRotationReconciler"),
+		s.securityConfig.ClientTLSCreds.Organization(),
+		s.rootReconciliationRetryInterval,
+		s.store, s.lastSeenClusterRootCA, nodes)
+	rootReconciler := s.rootReconciler
 	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.rootReconciler = nil
+		s.mu.Unlock()
+	}()
 
 	if err != nil {
 		log.G(ctx).WithFields(logrus.Fields{
@@ -461,7 +471,6 @@ func (s *Server) Run(ctx context.Context) error {
 			"method": "(*Server).Run",
 		}).WithError(err).Errorf("error attempting to reconcile certificates")
 	}
-	s.reconcileNodeRootsAndCerts()
 
 	ticker := time.NewTicker(s.reconciliationRetryInterval)
 	defer ticker.Stop()
@@ -480,13 +489,18 @@ func (s *Server) Run(ctx context.Context) error {
 			switch v := event.(type) {
 			case api.EventCreateNode:
 				s.evaluateAndSignNodeCert(ctx, v.Node)
+				rootReconciler.UpdateNodes(v.Node)
 			case api.EventUpdateNode:
 				// If this certificate is already at a final state
 				// no need to evaluate and sign it.
 				if !isFinalState(v.Node.Certificate.Status) {
 					s.evaluateAndSignNodeCert(ctx, v.Node)
 				}
+				rootReconciler.UpdateNodes(v.Node)
+			case api.EventDeleteNode:
+				rootReconciler.DeleteNode(v.Node)
 			}
+
 		case <-ticker.C:
 			for _, node := range s.pending {
 				if err := s.evaluateAndSignNodeCert(ctx, node); err != nil {
@@ -557,12 +571,16 @@ func (s *Server) isRunning() bool {
 func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster) error {
 	s.mu.Lock()
 	s.joinTokens = cluster.RootCA.JoinTokens.Copy()
+	reconciler := s.rootReconciler
 	s.mu.Unlock()
+	rCA := cluster.RootCA.Copy()
+	if reconciler != nil {
+		reconciler.UpdateRootCA(rCA)
+	}
 
 	s.secConfigMu.Lock()
 	defer s.secConfigMu.Unlock()
-	rCA := cluster.RootCA
-	rootCAChanged := len(rCA.CACert) != 0 && !equality.RootCAEqualStable(s.lastSeenClusterRootCA, &cluster.RootCA)
+	rootCAChanged := len(rCA.CACert) != 0 && !equality.RootCAEqualStable(s.lastSeenClusterRootCA, rCA)
 	externalCAChanged := !equality.ExternalCAsEqualStable(s.lastSeenExternalCAs, cluster.Spec.CAConfig.ExternalCAs)
 	logger := log.G(ctx).WithFields(logrus.Fields{
 		"cluster.id": cluster.ID,
@@ -619,7 +637,7 @@ func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster) error {
 		}
 		// only update the server cache if we've successfully updated the root CA
 		logger.Debug("Root CA updated successfully")
-		s.lastSeenClusterRootCA = cluster.RootCA.Copy()
+		s.lastSeenClusterRootCA = rCA
 	}
 
 	// we want to update if the external CA changed, or if the root CA changed because the root CA could affect what
@@ -660,9 +678,6 @@ func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster) error {
 
 		s.securityConfig.externalCA.UpdateURLs(cfsslURLs...)
 		s.lastSeenExternalCAs = cluster.Spec.CAConfig.Copy().ExternalCAs
-	}
-	if rootCAChanged && s.lastSeenClusterRootCA.RootRotation != nil {
-		s.reconcileNodeRootsAndCerts()
 	}
 	return nil
 }
@@ -825,167 +840,4 @@ func isFinalState(status api.IssuanceStatus) bool {
 	}
 
 	return false
-}
-
-// This function assumes that the expected root CA has root rotation.  This is intended to be used by
-// `reconcileNodeRootsAndCerts`, which uses the root CA from the `lastSeenClusterRootCA`, and checks
-// that it has a root rotation before calling this function.
-func (s *Server) finishRootRotation(tx store.Tx, expectedRootCA *api.RootCA) error {
-	clusterID := s.securityConfig.ClientTLSCreds.Organization()
-	cluster := store.GetCluster(tx, clusterID)
-	if cluster == nil {
-		return fmt.Errorf("unable to get cluster %s", clusterID)
-	}
-
-	// If the RootCA object has changed (because another root rotation was started or because some other node
-	// had finished the root rotation), we cannot finish the root rotation that we were working on.
-	if !equality.RootCAEqualStable(expectedRootCA, &cluster.RootCA) {
-		return errors.New("target root rotation has changed")
-	}
-
-	var signerCert []byte
-	if len(cluster.RootCA.RootRotation.CAKey) > 0 {
-		signerCert = cluster.RootCA.RootRotation.CACert
-	}
-	// we don't actually have to parse out the default node expiration from the cluster - we are just using
-	// the ca.RootCA object to generate new tokens and the digest
-	updatedRootCA, err := NewRootCA(cluster.RootCA.RootRotation.CACert, signerCert, cluster.RootCA.RootRotation.CAKey,
-		DefaultNodeCertExpiration, nil)
-	if err != nil {
-		return errors.Wrap(err, "invalid cluster root rotation object")
-	}
-	cluster.RootCA = api.RootCA{
-		CACert:     cluster.RootCA.RootRotation.CACert,
-		CAKey:      cluster.RootCA.RootRotation.CAKey,
-		CACertHash: updatedRootCA.Digest.String(),
-		JoinTokens: api.JoinTokens{
-			Worker:  GenerateJoinToken(&updatedRootCA),
-			Manager: GenerateJoinToken(&updatedRootCA),
-		},
-		LastForcedRotation: cluster.RootCA.LastForcedRotation,
-	}
-	return store.UpdateCluster(tx, cluster)
-}
-
-func (s *Server) reconcileNodeRootsAndCerts() {
-	s.mu.Lock()
-	if !s.isRunning() || s.rootCAReconciliationInProgress {
-		s.mu.Unlock()
-		return
-	}
-	ctx := s.ctx
-	s.rootCAReconciliationInProgress = true
-	s.mu.Unlock()
-
-	s.wg.Add(1)
-	logger := log.G(ctx).WithField("method", "(*Server).reconcileNodeRootsAndCerts")
-
-	go func(retryInterval time.Duration) {
-		defer func() {
-			s.wg.Done()
-			s.mu.Lock()
-			s.rootCAReconciliationInProgress = false
-			s.mu.Unlock()
-		}()
-
-		for {
-			s.secConfigMu.Lock()
-			rootCA := s.lastSeenClusterRootCA
-			s.secConfigMu.Unlock()
-			if rootCA == nil {
-				return
-			}
-
-			wantedIssuer := rootCA.CACert
-			if rootCA.RootRotation != nil {
-				wantedIssuer = rootCA.RootRotation.CACert
-			}
-			issuerCert, err := helpers.ParseCertificatePEM(wantedIssuer)
-			if err != nil {
-				logger.WithError(err).Error("invalid certificate in cluster root CA object")
-			}
-
-			// If the last seen root rotation is nil, then possibly during a leadership transfer a different manager's
-			// CA node started root rotation reconciliation and finished the root rotation, so we should also end the
-			// root reconciliation
-			if rootCA.RootRotation == nil {
-				return
-			}
-
-			var allNodes []*api.Node
-
-			s.store.View(func(tx store.ReadTx) {
-				allNodes, err = store.FindNodes(tx, store.ByMembership(api.NodeMembershipAccepted))
-			})
-			if err != nil {
-				logger.WithError(err).Error("could not find all nodes in the store")
-			}
-
-			var rootRotationDone bool
-			_, err = s.store.Batch(func(batch *store.Batch) error {
-				converged := true // this value is true if all the node certs are issued by the correct issuer
-				for _, node := range allNodes {
-					var needUpdate bool
-					err := batch.Update(func(tx store.Tx) error {
-						n := store.GetNode(tx, node.ID)
-						if n == nil || (n.Description != nil && n.Description.TLSInfo != nil &&
-							bytes.Equal(n.Description.TLSInfo.CertIssuerPublicKey, issuerCert.RawSubjectPublicKeyInfo) &&
-							bytes.Equal(n.Description.TLSInfo.CertIssuerSubject, issuerCert.RawSubject)) {
-							return nil
-						}
-						converged = false
-
-						// If we are already waiting for the node to rotate (or the node's about to get issued a new cert by us),
-						// so don't bother telling the node to rotate again.  If a cert is in renew or pending, the cert that
-						// the node will get should be issued by the correct issuer.  However, in all likelihood the node will
-						// not get a chance to report back its TLS before the reconciliation loop will mark it as rotate, and
-						// it will get a new certificate, which is fine, but results in an extra certificate renewal round.
-						issuanceState := n.Certificate.Status.State
-						if issuanceState == api.IssuanceStateRotate || issuanceState == api.IssuanceStateRenew || issuanceState == api.IssuanceStatePending {
-							return nil
-						}
-						n.Certificate.Status.State = api.IssuanceStateRotate
-						needUpdate = true
-						return store.UpdateNode(tx, n)
-					})
-					if err != nil {
-						logger.WithError(err).Debugf("could not update node %s to IssuanceStateRotate", node.ID)
-					} else if needUpdate {
-						logger.Debugf("updated node %s to IssuanceStateRotate", node.ID)
-					}
-				}
-				// It's possible that between getting all nodes and finishing root rotation, new nodes have joined.  by the time we
-				// fetch all nodes, the CA signer should have already been changed to be the desired issuer by the time we list all
-				// nodes, so any new nodes that appear after that will only get certificates signed by the correct issuer.
-				if converged {
-					// when the nodes are all converged on having TLS certificates issued by the correct entity, we can
-					// try to finish the root rotation
-					err := batch.Update(func(tx store.Tx) error {
-						return s.finishRootRotation(tx, rootCA)
-					})
-					if err != nil {
-						logger.WithError(err).Errorf("could not complete root rotation")
-					} else {
-						rootRotationDone = true
-					}
-				}
-
-				return nil
-			})
-			if err != nil {
-				logger.WithError(err).Errorf("failed to check nodes for desired certificate issuer")
-			}
-			if rootRotationDone {
-				logger.Infof("completed root rotation on cluster %s", s.securityConfig.ServerTLSCreds.Organization())
-				return
-			}
-
-			select {
-			case <-ctx.Done():
-				logger.Info("stopping incomplete root rotation reconciliation due to context being stopped")
-				return
-			case <-time.After(retryInterval):
-			}
-		}
-	}(s.rootReconciliationRetryInterval)
 }

--- a/cmd/swarmctl/cluster/inspect.go
+++ b/cmd/swarmctl/cluster/inspect.go
@@ -10,6 +10,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/cmd/swarmctl/common"
 	gogotypes "github.com/gogo/protobuf/types"
+	"github.com/opencontainers/go-digest"
 	"github.com/spf13/cobra"
 )
 
@@ -37,6 +38,11 @@ func printClusterSummary(cluster *api.Cluster) {
 			fmt.Fprintf(w, "  Certificate Validity Duration: %s\n", clusterDuration.String())
 		}
 	}
+
+	if len(cluster.Spec.CAConfig.SigningCACert) > 0 {
+		fmt.Fprintf(w, "  Desired CA Cert Digest: %s\n", digest.FromBytes(cluster.Spec.CAConfig.SigningCACert).String())
+	}
+	fmt.Fprintf(w, "  ForceRotate number: %d\n", cluster.Spec.CAConfig.ForceRotate)
 	if len(cluster.Spec.CAConfig.ExternalCAs) > 0 {
 		fmt.Fprintln(w, "  External CAs:")
 		for _, ca := range cluster.Spec.CAConfig.ExternalCAs {

--- a/cmd/swarmctl/cluster/root_rotation.go
+++ b/cmd/swarmctl/cluster/root_rotation.go
@@ -1,0 +1,201 @@
+package cluster
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/docker/docker/cli/command"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/progress"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/ca"
+	digest "github.com/opencontainers/go-digest"
+	"golang.org/x/net/context"
+)
+
+const (
+	certsRotatedStr = "  nodes rotated TLS certificates"
+	rootsRotatedStr = "   nodes rotated CA certificates"
+)
+
+// rootRotationProgress outputs progress information for convergence of a root rotation.
+func rootRotationProgress(ctx context.Context, client api.ControlClient, clusterID string, progressWriter io.WriteCloser) error {
+	defer progressWriter.Close()
+
+	progressOut := streamformatter.NewJSONStreamFormatter().NewProgressOutput(progressWriter, false)
+
+	sigint := make(chan os.Signal, 1)
+	signal.Notify(sigint, os.Interrupt)
+	defer signal.Stop(sigint)
+
+	var (
+		updater     *rootRotationProgressUpdater
+		converged   bool
+		convergedAt time.Time
+		monitor     = 3 * time.Second
+	)
+
+	for {
+		clusterResp, err := client.GetCluster(ctx, &api.GetClusterRequest{ClusterID: clusterID})
+		if err != nil {
+			return err
+		}
+
+		issuerInfo, err := ca.IssuerFromAPIRootCA(&clusterResp.Cluster.RootCA)
+		if err != nil {
+			return err
+		}
+		desiredTLSInfo := api.NodeTLSInfo{
+			TrustRoot:           clusterResp.Cluster.RootCA.CACert,
+			CertIssuerPublicKey: issuerInfo.PublicKey,
+			CertIssuerSubject:   issuerInfo.Subject,
+		}
+
+		if updater == nil {
+			updater = &rootRotationProgressUpdater{
+				progressOut: progressOut,
+			}
+		}
+
+		if converged && time.Since(convergedAt) >= monitor {
+			return nil
+		}
+
+		nodesListResp, err := client.ListNodes(ctx, &api.ListNodesRequest{})
+		if err != nil {
+			return err
+		}
+
+		updater.update(&desiredTLSInfo, nodesListResp.Nodes, clusterResp.Cluster.RootCA.RootRotation == nil)
+		converged = updater.done
+		if converged {
+			if convergedAt.IsZero() {
+				convergedAt = time.Now()
+			}
+			wait := monitor - time.Since(convergedAt)
+			if wait >= 0 {
+				progressOut.WriteProgress(progress.Progress{
+					// Ideally this would have no ID, but
+					// the progress rendering code behaves
+					// poorly on an "action" with no ID. It
+					// returns the cursor to the beginning
+					// of the line, so the first character
+					// may be difficult to read. Then the
+					// output is overwritten by the shell
+					// prompt when the command finishes.
+					ID:     "verify",
+					Action: fmt.Sprintf("Waiting %d seconds to verify that the roots are stable...", wait/time.Second+1),
+				})
+			}
+		} else {
+			if !convergedAt.IsZero() {
+				progressOut.WriteProgress(progress.Progress{
+					ID:     "verify",
+					Action: "detected another root rotation change",
+				})
+			}
+			convergedAt = time.Time{}
+		}
+
+		select {
+		case <-time.After(200 * time.Millisecond):
+		case <-sigint:
+			if !converged {
+				progress.Message(progressOut, "", "Operation continuing in background.")
+				progress.Message(progressOut, "", "Use `swarmctl cluster inspect default` to check progress.")
+			}
+			return nil
+		}
+	}
+}
+
+type rootRotationProgressUpdater struct {
+	progressOut progress.Output
+	initialized bool
+	done        bool
+}
+
+func (r *rootRotationProgressUpdater) update(desiredTLSInfo *api.NodeTLSInfo, nodes []*api.Node, rootRotationDone bool) {
+	// write the current desired root cert
+	r.progressOut.WriteProgress(progress.Progress{
+		ID:     "desired root digest",
+		Action: digest.FromBytes(desiredTLSInfo.TrustRoot).String(),
+	})
+
+	if !r.initialized {
+		// draw 2 progress bars, 1 for nodes with the correct cert, 1 for nodes with the correct trust root
+		progress.Update(r.progressOut, certsRotatedStr, " ")
+		progress.Update(r.progressOut, rootsRotatedStr, " ")
+		r.initialized = true
+	}
+
+	// If we had reached a converged state, check if we are still converged.
+	var certsRight, trustRootsRight int64
+	for _, n := range nodes {
+		if n.Description == nil || n.Description.TLSInfo == nil {
+			continue
+		}
+
+		if bytes.Equal(n.Description.TLSInfo.CertIssuerPublicKey, desiredTLSInfo.CertIssuerPublicKey) &&
+			bytes.Equal(n.Description.TLSInfo.CertIssuerSubject, desiredTLSInfo.CertIssuerSubject) {
+			certsRight++
+		}
+
+		if bytes.Equal(n.Description.TLSInfo.TrustRoot, desiredTLSInfo.TrustRoot) {
+			trustRootsRight++
+		}
+	}
+
+	total := int64(len(nodes))
+	certsAction := fmt.Sprintf("%d/%d done", certsRight, total)
+	r.progressOut.WriteProgress(progress.Progress{
+		ID:         certsRotatedStr,
+		Action:     certsAction,
+		Current:    certsRight,
+		Total:      total,
+		HideCounts: true,
+	})
+
+	if certsRight == total && rootRotationDone {
+		rootsAction := fmt.Sprintf("%d/%d done", trustRootsRight, total)
+		r.progressOut.WriteProgress(progress.Progress{
+			ID:         rootsRotatedStr,
+			Action:     rootsAction,
+			Current:    trustRootsRight,
+			Total:      total,
+			HideCounts: true,
+		})
+		r.done = certsRight == total && trustRootsRight == total
+	} else {
+		rootsAction := fmt.Sprintf("%d/%d done", 0, total)
+		r.progressOut.WriteProgress(progress.Progress{
+			ID:         rootsRotatedStr,
+			Action:     rootsAction,
+			Current:    0,
+			Total:      total,
+			HideCounts: true,
+		})
+		r.done = false
+	}
+}
+
+// WaitOnRootRotation waits for the root rotation to converge. It outputs a progress bar.
+func WaitOnRootRotation(ctx context.Context, client api.ControlClient, clusterID string) error {
+	errChan := make(chan error, 1)
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		errChan <- rootRotationProgress(ctx, client, clusterID, pipeWriter)
+	}()
+
+	err := jsonmessage.DisplayJSONMessagesToStream(pipeReader, command.NewOutStream(os.Stdout), nil)
+	if err == nil {
+		err = <-errChan
+	}
+	return err
+}

--- a/cmd/swarmctl/cluster/update.go
+++ b/cmd/swarmctl/cluster/update.go
@@ -101,6 +101,10 @@ var (
 			}
 			spec.TaskDefaults.LogDriver = driver
 
+			if flags.Changed("rotate-ca") {
+				spec.CAConfig.ForceRotate++
+			}
+
 			r, err := c.UpdateCluster(common.Context(cmd), &api.UpdateClusterRequest{
 				ClusterID:      cluster.ID,
 				ClusterVersion: &cluster.Meta.Version,
@@ -114,6 +118,10 @@ var (
 
 			if rotation.ManagerUnlockKey {
 				return displayUnlockKey(cmd)
+			}
+
+			if flags.Changed("rotate-ca") {
+				WaitOnRootRotation(common.Context(cmd), c, cluster.ID)
 			}
 			return nil
 		},
@@ -131,4 +139,5 @@ func init() {
 	updateCmd.Flags().String("rotate-join-token", "", "Rotate join token for worker or manager")
 	updateCmd.Flags().Bool("rotate-unlock-key", false, "Rotate manager unlock key")
 	updateCmd.Flags().Bool("autolock", false, "Enable or disable manager autolocking (requiring an unlock key to start a stopped manager)")
+	updateCmd.Flags().Bool("rotate-ca", false, "Rotate the root CA certificate and key for the cluster")
 }

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -214,3 +214,16 @@ func updateNode(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
+
+func getCluster(ctx context.Context, c api.ControlClient) (*api.Cluster, error) {
+	rl, err := c.ListClusters(ctx, &api.ListClustersRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(rl.Clusters) == 0 {
+		return nil, fmt.Errorf("no clusters found")
+	}
+
+	return rl.Clusters[0], nil
+}

--- a/cmd/swarmctl/node/list.go
+++ b/cmd/swarmctl/node/list.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"text/tabwriter"
 
+	"reflect"
+
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/cmd/swarmctl/common"
 	"github.com/spf13/cobra"
 )
@@ -38,13 +41,27 @@ var (
 
 			var output func(n *api.Node)
 
+			cluster, err := getCluster(common.Context(cmd), c)
+			if err != nil {
+				return err
+			}
+			clusterIssuer, err := ca.IssuerFromAPIRootCA(&cluster.RootCA)
+			if err != nil {
+				return err
+			}
+			desiredTLSInfo := &api.NodeTLSInfo{
+				CertIssuerPublicKey: clusterIssuer.PublicKey,
+				CertIssuerSubject:   clusterIssuer.Subject,
+				TrustRoot:           cluster.RootCA.CACert,
+			}
+
 			if !quiet {
 				w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 				defer func() {
 					// Ignore flushing errors - there's nothing we can do.
 					_ = w.Flush()
 				}()
-				common.PrintHeader(w, "ID", "Name", "Membership", "Status", "Availability", "Manager Status")
+				common.PrintHeader(w, "ID", "Name", "Membership", "Status", "Availability", "Manager Status", "TLS Status")
 				output = func(n *api.Node) {
 					spec := &n.Spec
 					name := spec.Annotations.Name
@@ -64,14 +81,21 @@ var (
 					if reachability == "" && spec.DesiredRole == api.NodeRoleManager {
 						reachability = "UNKNOWN"
 					}
+					tlsStatus := "OUTDATED"
+					if n.Description == nil || n.Description.TLSInfo == nil {
+						tlsStatus = "UNKNOWN"
+					} else if reflect.DeepEqual(n.Description.TLSInfo, desiredTLSInfo) {
+						tlsStatus = "CURRENT"
+					}
 
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						n.ID,
 						name,
 						membership,
 						n.Status.State.String(),
 						availability,
 						reachability,
+						tlsStatus,
 					)
 				}
 			} else {

--- a/integration/api.go
+++ b/integration/api.go
@@ -131,6 +131,12 @@ func (a *dummyAPI) ListClusters(ctx context.Context, r *api.ListClustersRequest)
 	return cli.ListClusters(ctx, r)
 }
 
-func (a *dummyAPI) UpdateCluster(context.Context, *api.UpdateClusterRequest) (*api.UpdateClusterResponse, error) {
-	panic("not implemented")
+func (a *dummyAPI) UpdateCluster(ctx context.Context, r *api.UpdateClusterRequest) (*api.UpdateClusterResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, opsTimeout)
+	defer cancel()
+	cli, err := a.c.RandomManager().ControlClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cli.UpdateCluster(ctx, r)
 }

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -12,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+
+	"reflect"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cloudflare/cfssl/helpers"
@@ -98,6 +101,9 @@ func pollClusterReady(t *testing.T, c *testCluster, numWorker, numManager int) {
 				if n.ManagerStatus != nil {
 					return fmt.Errorf("worker node %s should not have manager status, returned %s", n.ID, n.ManagerStatus)
 				}
+			}
+			if n.Description.TLSInfo == nil {
+				return fmt.Errorf("node %s has not reported its TLS info yet", n.ID)
 			}
 		}
 		if !leaderFound {
@@ -546,4 +552,179 @@ func TestForceNewCluster(t *testing.T) {
 	require.NoError(t, leader.Pause(true))
 	require.NoError(t, ioutil.WriteFile(managerCertFile, expiredCertPEM, 0644))
 	require.Error(t, cl.StartNode(nodeID))
+}
+
+func pollRootRotationDone(t *testing.T, cl *testCluster) {
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
+		clusterInfo, err := cl.GetClusterInfo()
+		if err != nil {
+			return err
+		}
+		if clusterInfo.RootCA.RootRotation != nil {
+			return errors.New("root rotation not done")
+		}
+		return nil
+	}, opsTimeout))
+}
+
+func TestSuccessfulRootRotation(t *testing.T) {
+	t.Parallel()
+	numWorker, numManager := 2, 3
+	cl := newCluster(t, numWorker, numManager)
+	defer func() {
+		require.NoError(t, cl.Stop())
+	}()
+	pollClusterReady(t, cl, numWorker, numManager)
+
+	// Take down one of managers and both workers, so we can't actually ever finish root rotation.
+	resp, err := cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})
+	require.NoError(t, err)
+	var (
+		downManagerID string
+		downWorkerIDs []string
+		oldTLSInfo    *api.NodeTLSInfo
+	)
+	for _, n := range resp.Nodes {
+		if oldTLSInfo != nil {
+			require.Equal(t, oldTLSInfo, n.Description.TLSInfo)
+		} else {
+			oldTLSInfo = n.Description.TLSInfo
+		}
+		if n.Role == api.NodeRoleManager {
+			if !n.ManagerStatus.Leader && downManagerID == "" {
+				downManagerID = n.ID
+				require.NoError(t, cl.nodes[n.ID].Pause(false))
+			}
+			continue
+		}
+		downWorkerIDs = append(downWorkerIDs, n.ID)
+		require.NoError(t, cl.nodes[n.ID].Pause(false))
+	}
+
+	// perform a root rotation, and wait until all the nodes that are up have newly issued certs
+	newRootCert, newRootKey, err := cautils.CreateRootCertAndKey("newRootCN")
+	require.NoError(t, err)
+	require.NoError(t, cl.RotateRootCA(newRootCert, newRootKey))
+
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
+		resp, err := cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})
+		if err != nil {
+			return err
+		}
+		for _, n := range resp.Nodes {
+			isDown := n.ID == downManagerID || n.ID == downWorkerIDs[0] || n.ID == downWorkerIDs[1]
+			if reflect.DeepEqual(n.Description.TLSInfo, oldTLSInfo) != isDown {
+				return fmt.Errorf("expected TLS info to have changed: %v", !isDown)
+			}
+		}
+
+		// root rotation isn't done
+		clusterInfo, err := cl.GetClusterInfo()
+		if err != nil {
+			return err
+		}
+		require.NotNil(t, clusterInfo.RootCA.RootRotation) // if root rotation is already done, fail and finish the test here
+		return nil
+	}, opsTimeout))
+
+	// Kill the leader, and bring the other manager back to show that a new
+	// leader can pick up the reconciliation loop and complete the root rotation.
+	// Bring one worker back, kill the other worker, and add a new worker - show
+	// that we can converge on a root rotation.
+	downLeader, err := cl.Leader()
+	require.NoError(t, err)
+	leaderID := downLeader.node.NodeID()
+
+	require.NoError(t, cl.StartNode(downManagerID))
+	require.NoError(t, cl.StartNode(downWorkerIDs[0]))
+	require.NoError(t, cl.RemoveNode(downWorkerIDs[1], false))
+	require.NoError(t, cl.AddAgent())
+	require.NoError(t, downLeader.Pause(false))
+
+	// we can finish root rotation even though the previous leader was down because it had
+	// already rotated its cert
+	pollRootRotationDone(t, cl)
+
+	// bring the previous leader back up so it can get the new root
+	require.NoError(t, cl.StartNode(leaderID))
+
+	// wait until all the nodes have gotten their new certs and trust roots
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
+		resp, err = cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})
+		if err != nil {
+			return err
+		}
+		var newTLSInfo *api.NodeTLSInfo
+		for _, n := range resp.Nodes {
+			if newTLSInfo == nil {
+				newTLSInfo = n.Description.TLSInfo
+				if bytes.Equal(newTLSInfo.CertIssuerPublicKey, oldTLSInfo.CertIssuerPublicKey) ||
+					bytes.Equal(newTLSInfo.CertIssuerSubject, oldTLSInfo.CertIssuerSubject) {
+					return errors.New("expecting the issuer to have changed")
+				}
+				if !bytes.Equal(newTLSInfo.TrustRoot, newRootCert) {
+					return errors.New("expecting the the root certificate to have changed")
+				}
+			} else if !reflect.DeepEqual(newTLSInfo, n.Description.TLSInfo) {
+				return fmt.Errorf("the nodes have not converged yet, particularly %s", n.ID)
+			}
+
+			if n.Certificate.Status.State != api.IssuanceStateIssued {
+				return errors.New("nodes have yet to finish renewing their TLS certificates")
+			}
+		}
+		return nil
+	}, opsTimeout))
+}
+
+func TestRepeatedRootRotation(t *testing.T) {
+	t.Parallel()
+	numWorker, numManager := 3, 1
+	cl := newCluster(t, numWorker, numManager)
+	defer func() {
+		require.NoError(t, cl.Stop())
+	}()
+	pollClusterReady(t, cl, numWorker, numManager)
+
+	resp, err := cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})
+	require.NoError(t, err)
+	var oldTLSInfo *api.NodeTLSInfo
+	for _, n := range resp.Nodes {
+		if oldTLSInfo != nil {
+			require.Equal(t, oldTLSInfo, n.Description.TLSInfo)
+		} else {
+			oldTLSInfo = n.Description.TLSInfo
+		}
+	}
+
+	// perform multiple root rotations, wait a second between each
+	var newRootCert, newRootKey []byte
+	for i := 0; i < 3; i++ {
+		newRootCert, newRootKey, err = cautils.CreateRootCertAndKey("newRootCN")
+		require.NoError(t, err)
+		require.NoError(t, cl.RotateRootCA(newRootCert, newRootKey))
+		time.Sleep(time.Second)
+	}
+
+	pollRootRotationDone(t, cl)
+
+	// wait until all the nodes are stabilized back to the latest issuer
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
+		resp, err = cl.api.ListNodes(context.Background(), &api.ListNodesRequest{})
+		if err != nil {
+			return nil
+		}
+		for _, n := range resp.Nodes {
+			if reflect.DeepEqual(n.Description.TLSInfo, oldTLSInfo) {
+				return errors.New("nodes have not changed TLS info")
+			}
+			if n.Certificate.Status.State != api.IssuanceStateIssued {
+				return errors.New("nodes have yet to finish renewing their TLS certificates")
+			}
+			if !bytes.Equal(n.Description.TLSInfo.TrustRoot, newRootCert) {
+				return errors.New("nodes do not all trust the new root yet")
+			}
+		}
+		return nil
+	}, opsTimeout))
 }

--- a/integration/node.go
+++ b/integration/node.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"google.golang.org/grpc"
 
@@ -115,6 +116,10 @@ func (n *testNode) stop() error {
 	defer cancel()
 	isManager := n.IsManager()
 	if err := n.node.Stop(ctx); err != nil {
+		// if the error is from trying to stop an already stopped stopped node, ignore the error
+		if strings.Contains(err.Error(), "node: not started") {
+			return nil
+		}
 		// TODO(aaronl): This stack dumping may be removed in the
 		// future once context deadline issues while shutting down
 		// nodes are resolved.


### PR DESCRIPTION
This is based on https://github.com/docker/docker/pull/31144.

Todo:
- [ ] what should the command line flags for accepting a cert and key, and accepting a cert + external CAs look like?
- [ ] should we be adding the progress bar to `cluster inspect` or add a new command to resume checking root CA progress?

Basic root rotation:  https://asciinema.org/a/ddsnrnzob16v3ampmbqjf3j55
Root rotation when there's another root rotation:  https://asciinema.org/a/19ah16sg29it0fyeellflpe68

This is stacked on top of #2100 

cc @diogomonica @aaronlehmann