### PR TITLE
updater: Fix rollback regression

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -155,18 +155,23 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 		u.startUpdate(ctx, service.ID)
 	}
 
-	var monitoringPeriod time.Duration
+	var (
+		monitoringPeriod time.Duration
+		updateConfig     *api.UpdateConfig
+	)
 
-	updateConfig := service.Spec.Update
 	if service.UpdateStatus != nil && service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
 		monitoringPeriod, _ = gogotypes.DurationFromProto(defaults.Service.Rollback.Monitor)
 		updateConfig = service.Spec.Rollback
 		if updateConfig == nil {
 			updateConfig = defaults.Service.Rollback
 		}
-	} else if updateConfig == nil {
+	} else {
 		monitoringPeriod, _ = gogotypes.DurationFromProto(defaults.Service.Update.Monitor)
-		updateConfig = defaults.Service.Update
+		updateConfig = service.Spec.Update
+		if updateConfig == nil {
+			updateConfig = defaults.Service.Update
+		}
 	}
 
 	parallelism := int(updateConfig.Parallelism)

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -340,7 +340,6 @@ func TestUpdaterFailureAction(t *testing.T) {
 
 	assert.Equal(t, 0, v2Counter)
 	assert.Equal(t, instances, v3Counter)
-
 }
 
 func TestUpdaterTaskTimeout(t *testing.T) {


### PR DESCRIPTION
When Monitor is not explicitly set in the spec, we're supposed to use the default. This regressed in #2080.

cc @cyli @dongluochen