### PR TITLE
Add filtering for log plugins

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -128,7 +128,7 @@ func (f *PluginFilter) SetTask(t *api.Task) bool {
 		}
 	}
 
-	if (c != nil && volumeTemplates) || len(t.Networks) > 0 {
+	if (c != nil && volumeTemplates) || len(t.Networks) > 0 || t.Spec.LogDriver != nil {
 		f.t = t
 		return true
 	}
@@ -153,7 +153,7 @@ func (f *PluginFilter) Check(n *NodeInfo) bool {
 	if container != nil {
 		for _, mount := range container.Mounts {
 			if referencesVolumePlugin(mount) {
-				if !f.pluginExistsOnNode("Volume", mount.VolumeOptions.DriverConfig.Name, nodePlugins) {
+				if _, exists := f.pluginExistsOnNode("Volume", mount.VolumeOptions.DriverConfig.Name, nodePlugins); !exists {
 					return false
 				}
 			}
@@ -163,22 +163,34 @@ func (f *PluginFilter) Check(n *NodeInfo) bool {
 	// Check if all network plugins required by task are installed on node
 	for _, tn := range f.t.Networks {
 		if tn.Network != nil && tn.Network.DriverState != nil && tn.Network.DriverState.Name != "" {
-			if !f.pluginExistsOnNode("Network", tn.Network.DriverState.Name, nodePlugins) {
+			if _, exists := f.pluginExistsOnNode("Network", tn.Network.DriverState.Name, nodePlugins); !exists {
 				return false
 			}
+		}
+	}
+
+	if f.t.Spec.LogDriver != nil {
+		// If there are no log driver types in the list at all, most likely this is
+		// an older daemon that did not report this information. In this case don't filter
+		if typeFound, exists := f.pluginExistsOnNode("Log", f.t.Spec.LogDriver.Name, nodePlugins); !exists && typeFound {
+			return false
 		}
 	}
 	return true
 }
 
 // pluginExistsOnNode returns true if the (pluginName, pluginType) pair is present in nodePlugins
-func (f *PluginFilter) pluginExistsOnNode(pluginType string, pluginName string, nodePlugins []api.PluginDescription) bool {
+func (f *PluginFilter) pluginExistsOnNode(pluginType string, pluginName string, nodePlugins []api.PluginDescription) (bool, bool) {
+	var typeFound bool
+
 	for _, np := range nodePlugins {
 		if pluginType != np.Type {
 			continue
 		}
+		typeFound = true
+
 		if pluginName == np.Name {
-			return true
+			return true, true
 		}
 		// This does not use the reference package to avoid the
 		// overhead of parsing references as part of the scheduling
@@ -186,10 +198,10 @@ func (f *PluginFilter) pluginExistsOnNode(pluginType string, pluginName string, 
 		// strict subset of the reference grammar that is always
 		// name:tag.
 		if strings.HasPrefix(np.Name, pluginName) && np.Name[len(pluginName):] == ":latest" {
-			return true
+			return true, true
 		}
 	}
-	return false
+	return typeFound, false
 }
 
 // Explain returns an explanation of a failure.


### PR DESCRIPTION
Docker added support for logging plugins, this makes sure swarmkit can
filter nodes for task scheduling based on available log plugins.