### PR TITLE
store: Simplify Batch

### DIFF
--- a/ca/reconciler.go
+++ b/ca/reconciler.go
@@ -241,7 +241,7 @@ func (r *rootRotationReconciler) batchUpdateNodes(toUpdate []*api.Node) error {
 	if len(toUpdate) == 0 {
 		return nil
 	}
-	_, err := r.store.Batch(func(batch *store.Batch) error {
+	err := r.store.Batch(func(batch *store.Batch) error {
 		// Directly update the nodes rather than get + update, and ignore version errors.  Since
 		// `rootRotationReconciler` should be hooked up to all node update/delete/create events, we should have
 		// close to the latest versions of all the nodes.  If not, the node will updated later and the

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -1305,7 +1305,7 @@ func TestRootRotationReconciliationThrottled(t *testing.T) {
 	}()
 
 	// create twice the batch size of nodes
-	_, err = tc.MemoryStore.Batch(func(batch *store.Batch) error {
+	err = tc.MemoryStore.Batch(func(batch *store.Batch) error {
 		for i := len(nodes); i < ca.IssuanceStateRotateMaxBatchSize*2; i++ {
 			nodeID := fmt.Sprintf("%d", i)
 			err := batch.Update(func(tx store.Tx) error {

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -95,7 +95,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 		if !na.IsAllocated(nc.ingressNetwork) {
 			if err := a.allocateNetwork(ctx, nc.ingressNetwork); err != nil {
 				log.G(ctx).WithError(err).Error("failed allocating ingress network during init")
-			} else if _, err := a.store.Batch(func(batch *store.Batch) error {
+			} else if err := a.store.Batch(func(batch *store.Batch) error {
 				if err := a.commitAllocatedNetwork(ctx, batch, nc.ingressNetwork); err != nil {
 					log.G(ctx).WithError(err).Error("failed committing allocation of ingress network during init")
 				}
@@ -134,7 +134,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 		allocatedNetworks = append(allocatedNetworks, n)
 	}
 
-	if _, err := a.store.Batch(func(batch *store.Batch) error {
+	if err := a.store.Batch(func(batch *store.Batch) error {
 		for _, n := range allocatedNetworks {
 			if err := a.commitAllocatedNetwork(ctx, batch, n); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed committing allocation of network %s during init", n.ID)
@@ -175,7 +175,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 		allocatedServices = append(allocatedServices, s)
 	}
 
-	if _, err := a.store.Batch(func(batch *store.Batch) error {
+	if err := a.store.Batch(func(batch *store.Batch) error {
 		for _, s := range allocatedServices {
 			if err := a.commitAllocatedService(ctx, batch, s); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed committing allocation of service %s during init", s.ID)
@@ -239,7 +239,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 		}
 	}
 
-	if _, err := a.store.Batch(func(batch *store.Batch) error {
+	if err := a.store.Batch(func(batch *store.Batch) error {
 		for _, t := range allocatedTasks {
 			if err := a.commitAllocatedTask(ctx, batch, t); err != nil {
 				log.G(ctx).WithError(err).Errorf("failed committing allocation of task %s during init", t.ID)
@@ -275,7 +275,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 			break
 		}
 
-		if _, err := a.store.Batch(func(batch *store.Batch) error {
+		if err := a.store.Batch(func(batch *store.Batch) error {
 			return a.commitAllocatedNetwork(ctx, batch, n)
 		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to commit allocation for network %s", n.ID)
@@ -326,7 +326,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 			break
 		}
 
-		if _, err := a.store.Batch(func(batch *store.Batch) error {
+		if err := a.store.Batch(func(batch *store.Batch) error {
 			return a.commitAllocatedService(ctx, batch, s)
 		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to commit allocation for service %s", s.ID)
@@ -357,7 +357,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 			}
 		}
 
-		if _, err := a.store.Batch(func(batch *store.Batch) error {
+		if err := a.store.Batch(func(batch *store.Batch) error {
 			return a.commitAllocatedService(ctx, batch, s)
 		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to commit allocation during update for service %s", s.ID)
@@ -447,7 +447,7 @@ func (a *Allocator) doNodeAlloc(ctx context.Context, ev events.Event) {
 			return
 		}
 
-		if _, err := a.store.Batch(func(batch *store.Batch) error {
+		if err := a.store.Batch(func(batch *store.Batch) error {
 			return a.commitAllocatedNode(ctx, batch, node)
 		}); err != nil {
 			log.G(ctx).WithError(err).Errorf("Failed to commit allocation of network resources for node %s", node.ID)
@@ -489,7 +489,7 @@ func (a *Allocator) allocateNodes(ctx context.Context) error {
 		allocatedNodes = append(allocatedNodes, node)
 	}
 
-	if _, err := a.store.Batch(func(batch *store.Batch) error {
+	if err := a.store.Batch(func(batch *store.Batch) error {
 		for _, node := range allocatedNodes {
 			if err := a.commitAllocatedNode(ctx, batch, node); err != nil {
 				log.G(ctx).WithError(err).Errorf("Failed to commit allocation of network resources for node %s", node.ID)
@@ -523,7 +523,7 @@ func (a *Allocator) deallocateNodes(ctx context.Context) error {
 				log.G(ctx).WithError(err).Errorf("Failed freeing network resources for node %s", node.ID)
 			}
 			node.Attachment = nil
-			if _, err := a.store.Batch(func(batch *store.Batch) error {
+			if err := a.store.Batch(func(batch *store.Batch) error {
 				return a.commitAllocatedNode(ctx, batch, node)
 			}); err != nil {
 				log.G(ctx).WithError(err).Errorf("Failed to commit deallocation of network resources for node %s", node.ID)
@@ -977,22 +977,25 @@ func (a *Allocator) procUnallocatedNetworks(ctx context.Context) {
 		return
 	}
 
-	committed, err := a.store.Batch(func(batch *store.Batch) error {
+	err := a.store.Batch(func(batch *store.Batch) error {
 		for _, n := range allocatedNetworks {
 			if err := a.commitAllocatedNetwork(ctx, batch, n); err != nil {
 				log.G(ctx).WithError(err).Debugf("Failed to commit allocation of unallocated network %s", n.ID)
 				continue
 			}
+			delete(nc.unallocatedNetworks, n.ID)
 		}
 		return nil
 	})
 
 	if err != nil {
 		log.G(ctx).WithError(err).Error("Failed to commit allocation of unallocated networks")
-	}
-
-	for _, n := range allocatedNetworks[:committed] {
-		delete(nc.unallocatedNetworks, n.ID)
+		// We optimistically removed these from nc.unallocatedNetworks
+		// above in anticipation of successfully committing the batch,
+		// but since the transaction has failed, we requeue them here.
+		for _, n := range allocatedNetworks {
+			nc.unallocatedNetworks[n.ID] = n
+		}
 	}
 }
 
@@ -1013,22 +1016,25 @@ func (a *Allocator) procUnallocatedServices(ctx context.Context) {
 		return
 	}
 
-	committed, err := a.store.Batch(func(batch *store.Batch) error {
+	err := a.store.Batch(func(batch *store.Batch) error {
 		for _, s := range allocatedServices {
 			if err := a.commitAllocatedService(ctx, batch, s); err != nil {
 				log.G(ctx).WithError(err).Debugf("Failed to commit allocation of unallocated service %s", s.ID)
 				continue
 			}
+			delete(nc.unallocatedServices, s.ID)
 		}
 		return nil
 	})
 
 	if err != nil {
 		log.G(ctx).WithError(err).Error("Failed to commit allocation of unallocated services")
-	}
-
-	for _, s := range allocatedServices[:committed] {
-		delete(nc.unallocatedServices, s.ID)
+		// We optimistically removed these from nc.unallocatedServices
+		// above in anticipation of successfully committing the batch,
+		// but since the transaction has failed, we requeue them here.
+		for _, s := range allocatedServices {
+			nc.unallocatedServices[s.ID] = s
+		}
 	}
 }
 
@@ -1058,14 +1064,14 @@ func (a *Allocator) procTasksNetwork(ctx context.Context, onRetry bool) {
 		return
 	}
 
-	committed, err := a.store.Batch(func(batch *store.Batch) error {
+	err := a.store.Batch(func(batch *store.Batch) error {
 		for _, t := range allocatedTasks {
 			err := a.commitAllocatedTask(ctx, batch, t)
-
 			if err != nil {
 				log.G(ctx).WithError(err).Error("task allocation commit failure")
 				continue
 			}
+			delete(toAllocate, t.ID)
 		}
 
 		return nil
@@ -1073,10 +1079,12 @@ func (a *Allocator) procTasksNetwork(ctx context.Context, onRetry bool) {
 
 	if err != nil {
 		log.G(ctx).WithError(err).Error("failed a store batch operation while processing tasks")
-	}
-
-	for _, t := range allocatedTasks[:committed] {
-		delete(toAllocate, t.ID)
+		// We optimistically removed these from toAllocate above in
+		// anticipation of successfully committing the batch, but since
+		// the transaction has failed, we requeue them here.
+		for _, t := range allocatedTasks {
+			toAllocate[t.ID] = t
+		}
 	}
 }
 

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -333,7 +333,7 @@ func (d *Dispatcher) markNodesUnknown(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get list of nodes")
 	}
-	_, err = d.store.Batch(func(batch *store.Batch) error {
+	err = d.store.Batch(func(batch *store.Batch) error {
 		for _, n := range nodes {
 			err := batch.Update(func(tx store.Tx) error {
 				// check if node is still here
@@ -600,7 +600,7 @@ func (d *Dispatcher) processUpdates(ctx context.Context) {
 		"method": "(*Dispatcher).processUpdates",
 	})
 
-	_, err := d.store.Batch(func(batch *store.Batch) error {
+	err := d.store.Batch(func(batch *store.Batch) error {
 		for taskID, status := range taskUpdates {
 			err := batch.Update(func(tx store.Tx) error {
 				logger := log.WithField("task.id", taskID)
@@ -951,7 +951,7 @@ func (d *Dispatcher) Assignments(r *api.AssignmentsRequest, stream api.Dispatche
 }
 
 func (d *Dispatcher) moveTasksToOrphaned(nodeID string) error {
-	_, err := d.store.Batch(func(batch *store.Batch) error {
+	err := d.store.Batch(func(batch *store.Batch) error {
 		var (
 			tasks []*api.Task
 			err   error

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -129,7 +129,7 @@ func (ce *ConstraintEnforcer) rejectNoncompliantTasks(node *api.Node) {
 	}
 
 	if len(removeTasks) != 0 {
-		_, err := ce.store.Batch(func(batch *store.Batch) error {
+		err := ce.store.Batch(func(batch *store.Batch) error {
 			for _, t := range removeTasks {
 				err := batch.Update(func(tx store.Tx) error {
 					t = store.GetTask(tx, t.ID)

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -249,7 +249,7 @@ func (g *Orchestrator) removeTasksFromNode(ctx context.Context, node *api.Node) 
 		return
 	}
 
-	_, err = g.store.Batch(func(batch *store.Batch) error {
+	err = g.store.Batch(func(batch *store.Batch) error {
 		for _, t := range tasks {
 			// Global orchestrator only removes tasks from globalServices
 			if _, exists := g.globalServices[t.ServiceID]; exists {
@@ -296,7 +296,7 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 
 	updates := make(map[*api.Service][]orchestrator.Slot)
 
-	_, err := g.store.Batch(func(batch *store.Batch) error {
+	err := g.store.Batch(func(batch *store.Batch) error {
 		for _, serviceID := range serviceIDs {
 			var updateTasks []orchestrator.Slot
 
@@ -433,7 +433,7 @@ func (g *Orchestrator) reconcileServicesOneNode(ctx context.Context, serviceIDs 
 		}
 	}
 
-	_, err = g.store.Batch(func(batch *store.Batch) error {
+	err = g.store.Batch(func(batch *store.Batch) error {
 		for _, serviceID := range serviceIDs {
 			service, exists := g.globalServices[serviceID]
 			if !exists {
@@ -505,7 +505,7 @@ func (g *Orchestrator) tickTasks(ctx context.Context) {
 	if len(g.restartTasks) == 0 {
 		return
 	}
-	_, err := g.store.Batch(func(batch *store.Batch) error {
+	err := g.store.Batch(func(batch *store.Batch) error {
 		for taskID := range g.restartTasks {
 			err := batch.Update(func(tx store.Tx) error {
 				t := store.GetTask(tx, taskID)

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -108,7 +108,7 @@ func (r *Orchestrator) reconcile(ctx context.Context, service *api.Service) {
 		log.G(ctx).Debugf("Service %s was scaled up from %d to %d instances", service.ID, numSlots, specifiedSlots)
 		// Update all current tasks then add missing tasks
 		r.updater.Update(ctx, r.cluster, service, slotsSlice)
-		_, err = r.store.Batch(func(batch *store.Batch) error {
+		err = r.store.Batch(func(batch *store.Batch) error {
 			r.addTasks(ctx, batch, service, runningSlots, deadSlots, specifiedSlots-uint64(numSlots))
 			r.deleteTasksMap(ctx, batch, deadSlots)
 			return nil
@@ -155,7 +155,7 @@ func (r *Orchestrator) reconcile(ctx context.Context, service *api.Service) {
 		}
 
 		r.updater.Update(ctx, r.cluster, service, sortedSlots[:specifiedSlots])
-		_, err = r.store.Batch(func(batch *store.Batch) error {
+		err = r.store.Batch(func(batch *store.Batch) error {
 			r.deleteTasksMap(ctx, batch, deadSlots)
 			r.deleteTasks(ctx, batch, sortedSlots[specifiedSlots:])
 			return nil
@@ -165,7 +165,7 @@ func (r *Orchestrator) reconcile(ctx context.Context, service *api.Service) {
 		}
 
 	case specifiedSlots == uint64(numSlots):
-		_, err = r.store.Batch(func(batch *store.Batch) error {
+		err = r.store.Batch(func(batch *store.Batch) error {
 			r.deleteTasksMap(ctx, batch, deadSlots)
 			return nil
 		})

--- a/manager/orchestrator/replicated/tasks.go
+++ b/manager/orchestrator/replicated/tasks.go
@@ -45,7 +45,7 @@ func (r *Orchestrator) handleTaskEvent(ctx context.Context, event events.Event) 
 
 func (r *Orchestrator) tickTasks(ctx context.Context) {
 	if len(r.restartTasks) > 0 {
-		_, err := r.store.Batch(func(batch *store.Batch) error {
+		err := r.store.Batch(func(batch *store.Batch) error {
 			for taskID := range r.restartTasks {
 				err := batch.Update(func(tx store.Tx) error {
 					// TODO(aaronl): optimistic update?

--- a/manager/orchestrator/service.go
+++ b/manager/orchestrator/service.go
@@ -41,7 +41,7 @@ func DeleteServiceTasks(ctx context.Context, s *store.MemoryStore, service *api.
 		return
 	}
 
-	_, err = s.Batch(func(batch *store.Batch) error {
+	err = s.Batch(func(batch *store.Batch) error {
 		for _, t := range tasks {
 			err := batch.Update(func(tx store.Tx) error {
 				if err := store.DeleteTask(tx, t.ID); err != nil {

--- a/manager/orchestrator/taskinit/init.go
+++ b/manager/orchestrator/taskinit/init.go
@@ -21,7 +21,7 @@ type InitHandler interface {
 // CheckTasks fixes tasks in the store before orchestrator runs. The previous leader might
 // not have finished processing their updates and left them in an inconsistent state.
 func CheckTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, initHandler InitHandler, startSupervisor *restart.Supervisor) error {
-	_, err := s.Batch(func(batch *store.Batch) error {
+	err := s.Batch(func(batch *store.Batch) error {
 		tasks, err := store.FindTasks(readTx, store.All)
 		if err != nil {
 			return err

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -378,7 +378,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 	startThenStop := false
 	var delayStartCh <-chan struct{}
 	// Atomically create the updated task and bring down the old one.
-	_, err := u.store.Batch(func(batch *store.Batch) error {
+	err := u.store.Batch(func(batch *store.Batch) error {
 		err := batch.Update(func(tx store.Tx) error {
 			if store.GetService(tx, updated.ServiceID) == nil {
 				return errors.New("service was deleted")
@@ -431,7 +431,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 				u.updatedTasksMu.Unlock()
 
 				if startThenStop {
-					_, err := u.store.Batch(func(batch *store.Batch) error {
+					err := u.store.Batch(func(batch *store.Batch) error {
 						_, err := u.removeOldTasks(ctx, batch, slot)
 						if err != nil {
 							log.G(ctx).WithError(err).WithField("task.id", updated.ID).Warning("failed to remove old task after starting replacement")
@@ -457,7 +457,7 @@ func (u *Updater) useExistingTask(ctx context.Context, slot orchestrator.Slot, e
 	}
 	if len(removeTasks) != 0 || existing.DesiredState != api.TaskStateRunning {
 		var delayStartCh <-chan struct{}
-		_, err := u.store.Batch(func(batch *store.Batch) error {
+		err := u.store.Batch(func(batch *store.Batch) error {
 			var oldTask *api.Task
 			if len(removeTasks) != 0 {
 				var err error

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -394,7 +394,7 @@ func (s *Scheduler) applySchedulingDecisions(ctx context.Context, schedulingDeci
 	successful = make([]schedulingDecision, 0, len(schedulingDecisions))
 
 	// Apply changes to master store
-	applied, err := s.store.Batch(func(batch *store.Batch) error {
+	err := s.store.Batch(func(batch *store.Batch) error {
 		for len(schedulingDecisions) > 0 {
 			err := batch.Update(func(tx store.Tx) error {
 				// Update exactly one task inside this Update
@@ -452,8 +452,8 @@ func (s *Scheduler) applySchedulingDecisions(ctx context.Context, schedulingDeci
 
 	if err != nil {
 		log.G(ctx).WithError(err).Error("scheduler tick transaction failed")
-		failed = append(failed, successful[applied:]...)
-		successful = successful[:applied]
+		failed = append(failed, successful...)
+		successful = nil
 	}
 	return
 }

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -348,9 +348,6 @@ type Batch struct {
 	store *MemoryStore
 	// applied counts the times Update has run successfully
 	applied int
-	// committed is the number of times Update had run successfully as of
-	// the time pending changes were committed.
-	committed int
 	// transactionSizeEstimate is the running count of the size of the
 	// current transaction.
 	transactionSizeEstimate int
@@ -434,8 +431,6 @@ func (batch *Batch) commit() error {
 		return batch.err
 	}
 
-	batch.committed = batch.applied
-
 	for _, c := range batch.tx.changelist {
 		batch.store.queue.Publish(c)
 	}
@@ -461,9 +456,9 @@ func (batch *Batch) commit() error {
 // excessive time, or producing a transaction that exceeds the maximum
 // size.
 //
-// Batch returns the number of calls to batch.Update whose changes were
-// successfully committed to the store.
-func (s *MemoryStore) Batch(cb func(*Batch) error) (int, error) {
+// If Batch returns an error, no guarantees are made about how many updates
+// were committed successfully.
+func (s *MemoryStore) Batch(cb func(*Batch) error) error {
 	s.updateLock.Lock()
 
 	batch := Batch{
@@ -474,12 +469,12 @@ func (s *MemoryStore) Batch(cb func(*Batch) error) (int, error) {
 	if err := cb(&batch); err != nil {
 		batch.tx.memDBTx.Abort()
 		s.updateLock.Unlock()
-		return batch.committed, err
+		return err
 	}
 
 	err := batch.commit()
 	s.updateLock.Unlock()
-	return batch.committed, err
+	return err
 }
 
 func (tx *tx) init(memDBTx *memdb.Txn, curVersion *api.Version) {

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1028,7 +1028,7 @@ func TestBatch(t *testing.T) {
 	defer cancel()
 
 	// Create 405 nodes. Should get split across 3 transactions.
-	committed, err := s.Batch(func(batch *Batch) error {
+	err := s.Batch(func(batch *Batch) error {
 		for i := 0; i != 2*MaxChangesPerTransaction+5; i++ {
 			n := &api.Node{
 				ID: "id" + strconv.Itoa(i),
@@ -1048,7 +1048,6 @@ func TestBatch(t *testing.T) {
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, 2*MaxChangesPerTransaction+5, committed)
 
 	for i := 0; i != MaxChangesPerTransaction; i++ {
 		event := <-watch
@@ -1090,7 +1089,7 @@ func TestBatchFailure(t *testing.T) {
 	defer cancel()
 
 	// Return an error partway through a transaction.
-	committed, err := s.Batch(func(batch *Batch) error {
+	err := s.Batch(func(batch *Batch) error {
 		for i := 0; ; i++ {
 			n := &api.Node{
 				ID: "id" + strconv.Itoa(i),
@@ -1111,7 +1110,6 @@ func TestBatchFailure(t *testing.T) {
 		}
 	})
 	assert.Error(t, err)
-	assert.Equal(t, MaxChangesPerTransaction, committed)
 
 	for i := 0; i != MaxChangesPerTransaction; i++ {
 		event := <-watch
@@ -1188,7 +1186,7 @@ func TestWatchFrom(t *testing.T) {
 
 	// Create a few nodes, 2 per transaction
 	for i := 0; i != 5; i++ {
-		committed, err := s.Batch(func(batch *Batch) error {
+		err := s.Batch(func(batch *Batch) error {
 			node := &api.Node{
 				ID: "id" + strconv.Itoa(i),
 				Spec: api.NodeSpec{
@@ -1218,7 +1216,6 @@ func TestWatchFrom(t *testing.T) {
 			return nil
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 2, committed)
 	}
 
 	// Try to watch from an invalid index


### PR DESCRIPTION
Currently `Batch` returns the number of updates it was able to commit
successfully, but this isn't really actionable. Either it committed
everything successfully, or the node lost leadership and it doesn't
matter what was committed and what wasn't (the new leader will pick up
from where we left off). A compliant caller of Batch would have to do a
bunch of accounting keep its internal state in sync with what Batch was
able to commit. This turns out not to matter in the current
implementation. Most uses of Batch ignored the first return value.

Change `Batch` to only return an error.

Fixes #2111

This is an alternative to #2110 

cc @ijc25 @dongluochen @aboch @yongtang