### PR TITLE
[ca] Fix data race with the reconciler's WaitGroup

### DIFF
--- a/ca/reconciler.go
+++ b/ca/reconciler.go
@@ -85,6 +85,7 @@ func (r *rootRotationReconciler) UpdateRootCA(newRootCA *api.RootCA) {
 			if waitForPrevLoop {
 				r.wg.Wait()
 			}
+			r.wg.Add(1)
 			go r.runReconcilerLoop(loopCtx, newRootCA)
 		}
 	}()
@@ -151,7 +152,6 @@ func (r *rootRotationReconciler) DeleteNode(node *api.Node) {
 }
 
 func (r *rootRotationReconciler) runReconcilerLoop(ctx context.Context, loopRootCA *api.RootCA) {
-	r.wg.Add(1)
 	defer r.wg.Done()
 	for {
 		r.mu.Lock()


### PR DESCRIPTION
Do not call WaitGroup.Add from within the reconciler loop goroutine, since WaitGroup.Add must be called before WaitGroup.Wait is called, and calling it from within the goroutine is racy because it means that the WaitGroup.Wait could be called before the goroutine is actually started.

Signed-off-by: cyli <ying.li@docker.com>