### PR TITLE
Allow secret references to be full paths

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -2,7 +2,6 @@ package controlapi
 
 import (
 	"errors"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -368,11 +367,9 @@ func validateSecretRefsSpec(spec api.TaskSpec) error {
 		// If this is a file target, we will ensure filename uniqueness
 		if secretRef.GetFile() != nil {
 			fileName := secretRef.GetFile().Name
-			// Validate the file name
-			if fileName == "" || fileName != filepath.Base(filepath.Clean(fileName)) {
+			if fileName == "" {
 				return grpc.Errorf(codes.InvalidArgument, "malformed file secret reference, invalid target file name provided")
 			}
-
 			// If this target is already in use, we have conflicting targets
 			if prevSecretName, ok := existingTargets[fileName]; ok {
 				return grpc.Errorf(codes.InvalidArgument, "secret references '%s' and '%s' have a conflicting target: '%s'", prevSecretName, secretRef.SecretName, fileName)

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -602,7 +602,10 @@ func TestSecretValidation(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 
 	// Test secret References with valid filenames
-	validFileNames := []string{"file.txt", ".file.txt", "_file-txt_.txt"}
+	// Note: "../secretfile.txt", "../../secretfile.txt" will be rejected
+	// by the executor, but controlapi presently doesn't reject those names.
+	// Such validation would be platform-specific.
+	validFileNames := []string{"file.txt", ".file.txt", "_file-txt_.txt", "../secretfile.txt", "../../secretfile.txt", "file../.txt", "subdir/file.txt", "/file.txt"}
 	for i, validName := range validFileNames {
 		secretRef := createSecret(t, ts, validName, validName)
 

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -595,14 +595,11 @@ func TestSecretValidation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test secret References with invalid filenames
-	invalidFileNames := []string{"../secretfile.txt", "../../secretfile.txt", "file../.txt", "subdir/file.txt"}
-	for i, invalidName := range invalidFileNames {
-		secretRef := createSecret(t, ts, invalidName, invalidName)
+	secretRefBlank := createSecret(t, ts, "", "")
 
-		serviceSpec = createServiceSpecWithSecrets(fmt.Sprintf("invalid%v", i), secretRef)
-		_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
-	}
+	serviceSpec = createServiceSpecWithSecrets("invalid-blank", secretRefBlank)
+	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 
 	// Test secret References with valid filenames
 	validFileNames := []string{"file.txt", ".file.txt", "_file-txt_.txt"}


### PR DESCRIPTION
This removes the limitation of forcing secrets to be in `/var/run/secrets` and allows arbitrary paths.  Note: these are still bind mounted and on tmpfs.

Refs https://github.com/docker/docker/pull/32336#issuecomment-293035306