### PR TITLE
[CI] Fetch origin before diffing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -49,6 +49,7 @@ dependencies:
 test:
     pre:
         # Ensure validation of dependencies
+        - cd "$WORKDIR" && git fetch origin
         - cd "$WORKDIR" && if test -n "`git diff --stat=1000 origin/master | grep -E \"^[[:space:]]*vendor\"`"; then make dep-validate; fi
 
     override:


### PR DESCRIPTION
It turns out that origin/master may not be up to date in CircleCI
checkouts. Fetch origin so that diffing for the vendor check can be done
correctly.

Note that this doesn't help the case of PRs against branches other than
master, but the worst case is that those will waste a few seconds doing
unnecessary vendor validation. Since those PRs are relatively rare, that
seems fine.