### PR TITLE
Update Controller task when TaskManager task is changed

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -204,6 +204,10 @@ func (tm *taskManager) run(ctx context.Context) {
 			task = task.Copy()
 			task.Status = tm.task.Status // overwrite our status, as it is canonical.
 			tm.task = task
+			// update the Controller's view of the task
+			if err := tm.ctlr.Update(ctx, task); err != nil {
+				log.G(ctx).WithError(err).Error("Controller task update failed")
+			}
 			updated = true
 
 			// we have accepted the task update

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -90,7 +90,7 @@ func TestTaskManager(t *testing.T) {
 				"start":   1,
 				"wait":    1,
 				"prepare": 1,
-				"update":  2}, ctlr.calls)
+				"update":  4}, ctlr.calls)
 			return
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())


### PR DESCRIPTION
Before this change, the Controller for a task was left with an old reference whenever the Taskmanager's copy of the task was changed. Now, call `Update` on the controller whenever we change the task like this.

This is needed because currently, service logs hangs if a container backing a task is deleted. The docker controller calls a `waitReady` method, which waits for a task to be running and ready for API calls. If inspecting the container returns `Unknown Container`, the container is assumed to not have been created yet. This is a problem, because deleting a container also causes an inspect to return `Unknown Container`; the only way to differentiate the two is to inspect the task state. If the task state is greater than `Shutdown`, the container can be assumed lost and the logs call can be aborted.

The whole second paragraph requires changes in `docker/docker`, but because the task object is never updated, we cannot know the task status, and the fix is not possible. We must do this at the controller level, because we do want to return logs for shutdown containers to the client if possible (so the manager should dispatch a subscription for the task), and only the worker can know if the container backing a task is still available.

Signed-off-by: Drew Erny <drew.erny@docker.com>