### PR TITLE
raft: Actually enable CheckQuorum

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -207,6 +207,7 @@ func NewNode(opts NodeOptions) *Node {
 			MaxSizePerMsg:   cfg.MaxSizePerMsg,
 			MaxInflightMsgs: cfg.MaxInflightMsgs,
 			Logger:          cfg.Logger,
+			CheckQuorum:     cfg.CheckQuorum,
 		},
 		doneCh:              make(chan struct{}),
 		RemovedFromRaft:     make(chan struct{}),


### PR DESCRIPTION
A change to enable the CheckQuorum option was merged in September (#1564), but never actually took effect because the config structure where it was set is not used directly.

This fixes the problem to enable it.

The option is useful because it makes a leader realize that quorum is lost and start a new election. Otherwise, the leader will still try to service RPCs, and will succeed when those RPCs don't involve writes. This is confusing.