### PR TITLE
[agent] Fix session rebuilding against a local dispatcher

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -14,9 +14,8 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
-const dispatcherRPCTimeout = 5 * time.Second
-
 var (
+	dispatcherRPCTimeout = 5 * time.Second
 	errSessionDisconnect = errors.New("agent: session disconnect") // instructed to disconnect
 	errSessionClosed     = errors.New("agent: session closed")
 )
@@ -39,12 +38,14 @@ type session struct {
 	assignments   chan *api.AssignmentsMessage
 	subscriptions chan *api.SubscriptionMessage
 
+	cancel     func()        // this is assumed to be never nil, and set whenever a session is created
 	registered chan struct{} // closed registration
 	closed     chan struct{}
 	closeOnce  sync.Once
 }
 
 func newSession(ctx context.Context, agent *Agent, delay time.Duration, sessionID string, description *api.NodeDescription) *session {
+	sessionCtx, sessionCancel := context.WithCancel(ctx)
 	s := &session{
 		agent:         agent,
 		sessionID:     sessionID,
@@ -54,6 +55,7 @@ func newSession(ctx context.Context, agent *Agent, delay time.Duration, sessionI
 		subscriptions: make(chan *api.SubscriptionMessage),
 		registered:    make(chan struct{}),
 		closed:        make(chan struct{}),
+		cancel:        sessionCancel,
 	}
 
 	// TODO(stevvooe): Need to move connection management up a level or create
@@ -69,7 +71,7 @@ func newSession(ctx context.Context, agent *Agent, delay time.Duration, sessionI
 	}
 	s.conn = cc
 
-	go s.run(ctx, delay, description)
+	go s.run(sessionCtx, delay, description)
 	return s
 }
 
@@ -114,6 +116,14 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	// Note: we don't defer cancellation of this context, because the
 	// streaming RPC is used after this function returned. We only cancel
 	// it in the timeout case to make sure the goroutine completes.
+
+	// We also fork this context again from the `run` context, because on
+	// `dispatcherRPCTimeout`, we want to cancel establishing a session and
+	// return an error.  If we cancel the `run` context instead of forking,
+	// then in `run` it's possible that we just terminate the function because
+	// `ctx` is done and hence fail to propagate the timeout error to the agent.
+	// If the error is not propogated to the agent, the agent will not close
+	// the session or rebuild a new sesssion.
 	sessionCtx, cancelSession := context.WithCancel(ctx)
 
 	// Need to run Session in a goroutine since there's no way to set a
@@ -402,10 +412,10 @@ func (s *session) sendError(err error) {
 // of event loop.
 func (s *session) close() error {
 	s.closeOnce.Do(func() {
+		s.cancel()
 		if s.conn != nil {
 			s.conn.Close(false)
 		}
-
 		close(s.closed)
 	})
 

--- a/agent/testutils/fakes.go
+++ b/agent/testutils/fakes.go
@@ -1,7 +1,10 @@
 package testutils
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -114,12 +117,16 @@ func (t *TestController) Close() error {
 	return nil
 }
 
+// SessionHandler is an injectable function that can be used handle session requests
+type SessionHandler func(*api.SessionRequest, api.Dispatcher_SessionServer) error
+
 // MockDispatcher is a fake dispatcher that one agent at a time can connect to
 type MockDispatcher struct {
 	mu             sync.Mutex
 	sessionCh      chan *api.SessionMessage
 	openSession    *api.SessionRequest
 	closedSessions []*api.SessionRequest
+	sessionHandler SessionHandler
 
 	Addr string
 }
@@ -153,6 +160,7 @@ func (m *MockDispatcher) Heartbeat(context.Context, *api.HeartbeatRequest) (*api
 // Session allows a session to be established, and sends the node info
 func (m *MockDispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_SessionServer) error {
 	m.mu.Lock()
+	handler := m.sessionHandler
 	m.openSession = r
 	m.mu.Unlock()
 	defer func() {
@@ -161,6 +169,10 @@ func (m *MockDispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Se
 		m.closedSessions = append(m.closedSessions, m.openSession)
 		m.openSession = nil
 	}()
+
+	if handler != nil {
+		return handler(r, stream)
+	}
 
 	// send the initial message first
 	if err := stream.Send(&api.SessionMessage{
@@ -200,11 +212,35 @@ func (m *MockDispatcher) SessionMessageChannel() chan<- *api.SessionMessage {
 	return m.sessionCh
 }
 
+// SetSessionHandler lets you inject a custom function to handle session requests
+func (m *MockDispatcher) SetSessionHandler(s SessionHandler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessionHandler = s
+}
+
 // NewMockDispatcher starts and returns a mock dispatcher instance that can be connected to
-func NewMockDispatcher(t *testing.T, secConfig *ca.SecurityConfig) (*MockDispatcher, func()) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	addr := l.Addr().String()
-	require.NoError(t, err)
+func NewMockDispatcher(t *testing.T, secConfig *ca.SecurityConfig, local bool) (*MockDispatcher, func()) {
+	var (
+		l       net.Listener
+		err     error
+		addr    string
+		cleanup func()
+	)
+	if local {
+		tempDir, err := ioutil.TempDir("", "local-dispatcher-socket")
+		require.NoError(t, err)
+		addr = filepath.Join(tempDir, "socket")
+		l, err = net.Listen("unix", addr)
+		require.NoError(t, err)
+		cleanup = func() {
+			os.RemoveAll(tempDir)
+		}
+	} else {
+		l, err = net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		addr = l.Addr().String()
+	}
 
 	serverOpts := []grpc.ServerOption{grpc.Creds(secConfig.ServerTLSCreds)}
 	s := grpc.NewServer(serverOpts...)
@@ -215,5 +251,11 @@ func NewMockDispatcher(t *testing.T, secConfig *ca.SecurityConfig) (*MockDispatc
 	}
 	api.RegisterDispatcherServer(s, m)
 	go s.Serve(l)
-	return m, s.Stop
+	return m, func() {
+		l.Close()
+		s.Stop()
+		if cleanup != nil {
+			cleanup()
+		}
+	}
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -318,7 +318,7 @@ func TestAgentRespectsDispatcherRootCAUpdate(t *testing.T) {
 		ca.WorkerRole, managerSecConfig.ServerTLSCreds.Organization())
 	require.NoError(t, err)
 
-	mockDispatcher, cleanup := agentutils.NewMockDispatcher(t, managerSecConfig)
+	mockDispatcher, cleanup := agentutils.NewMockDispatcher(t, managerSecConfig, false)
 	defer cleanup()
 
 	cfg := &Config{


### PR DESCRIPTION
Connections to a local dispatcher can’t really be closed, so a session can’t really be restarted because closing a session just closes the connection.  When this happens, it just starts up another session without closing the previous one.

Since we need to restart a session to push new TLS data up to the dispatcher from the agent, change "closing" a session to mean first shutting down all the clients with a context.cancel before
closing the connection.

Signed-off-by: cyli <ying.li@docker.com>