### PR TITLE
allocator: Various cleanups

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -346,7 +346,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		}
 
 		if !nc.nwkAllocator.ServiceNeedsAllocation(s) {
-			if nc.nwkAllocator.PortsAllocatedInHostPublishMode(s) {
+			if !nc.nwkAllocator.HostPublishPortsNeedUpdate(s) {
 				break
 			}
 			updatePortsInHostPublishMode(s)

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -303,10 +303,10 @@ func (na *NetworkAllocator) IsTaskAllocated(t *api.Task) bool {
 	return true
 }
 
-// PortsAllocatedInHostPublishMode returns if the passed service has its published ports in
-// host (non ingress) mode allocated
-func (na *NetworkAllocator) PortsAllocatedInHostPublishMode(s *api.Service) bool {
-	return na.portAllocator.portsAllocatedInHostPublishMode(s)
+// HostPublishPortsNeedUpdate returns true if the passed service needs
+// allocations for its published ports in host (non ingress) mode
+func (na *NetworkAllocator) HostPublishPortsNeedUpdate(s *api.Service) bool {
+	return na.portAllocator.hostPublishPortsNeedUpdate(s)
 }
 
 // ServiceAllocationOpts is struct used for functional options in IsServiceAllocated

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -153,7 +153,7 @@ func (na *NetworkAllocator) Deallocate(n *api.Network) error {
 // IP and ports needed by the service.
 func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 	if err = na.portAllocator.serviceAllocatePorts(s); err != nil {
-		return
+		return err
 	}
 	defer func() {
 		if err != nil {
@@ -183,55 +183,54 @@ func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 		}
 
 		delete(na.services, s.ID)
-		return
+		return nil
 	}
 
 	specNetworks := serviceNetworks(s)
 
 	// Allocate VIPs for all the pre-populated endpoint attachments
 	eVIPs := s.Endpoint.VirtualIPs[:0]
+
+vipLoop:
 	for _, eAttach := range s.Endpoint.VirtualIPs {
-		match := false
 		for _, nAttach := range specNetworks {
 			if nAttach.Target == eAttach.NetworkID {
-				match = true
 				if err = na.allocateVIP(eAttach); err != nil {
-					return
+					return err
 				}
 				eVIPs = append(eVIPs, eAttach)
-				break
+				continue vipLoop
 			}
 		}
-		//If the network of the VIP is not part of the service spec,
-		//deallocate the vip
-		if !match {
-			na.deallocateVIP(eAttach)
-		}
+		// If the network of the VIP is not part of the service spec,
+		// deallocate the vip
+		na.deallocateVIP(eAttach)
 	}
-	s.Endpoint.VirtualIPs = eVIPs
 
-outer:
+networkLoop:
 	for _, nAttach := range specNetworks {
 		for _, vip := range s.Endpoint.VirtualIPs {
 			if vip.NetworkID == nAttach.Target {
-				continue outer
+				continue networkLoop
 			}
 		}
 
 		vip := &api.Endpoint_VirtualIP{NetworkID: nAttach.Target}
 		if err = na.allocateVIP(vip); err != nil {
-			return
+			return err
 		}
 
-		s.Endpoint.VirtualIPs = append(s.Endpoint.VirtualIPs, vip)
+		eVIPs = append(eVIPs, vip)
 	}
 
-	if len(s.Endpoint.VirtualIPs) > 0 {
+	if len(eVIPs) > 0 {
 		na.services[s.ID] = struct{}{}
 	} else {
 		delete(na.services, s.ID)
 	}
-	return
+
+	s.Endpoint.VirtualIPs = eVIPs
+	return nil
 }
 
 // ServiceDeallocate de-allocates all the network resources such as
@@ -338,34 +337,30 @@ func (na *NetworkAllocator) ServiceNeedsAllocation(s *api.Service, flags ...func
 			return true
 		}
 
+		// If the spec has networks which don't have a corresponding VIP,
+		// the service needs to be allocated.
+	networkLoop:
 		for _, net := range specNetworks {
-			match := false
 			for _, vip := range s.Endpoint.VirtualIPs {
 				if vip.NetworkID == net.Target {
-					match = true
-					break
+					continue networkLoop
 				}
 			}
-			if !match {
-				return true
-			}
+			return true
 		}
 	}
 
-	//If the spec no longer has networks attached and has a vip allocated
-	//from previous spec the service needs to updated
+	// If the spec no longer has networks attached and has a vip allocated
+	// from previous spec the service needs to allocated.
 	if s.Endpoint != nil {
+	vipLoop:
 		for _, vip := range s.Endpoint.VirtualIPs {
-			match := false
 			for _, net := range specNetworks {
 				if vip.NetworkID == net.Target {
-					match = true
-					break
+					continue vipLoop
 				}
 			}
-			if !match {
-				return true
-			}
+			return true
 		}
 	}
 

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -186,11 +186,7 @@ func (na *NetworkAllocator) ServiceAllocate(s *api.Service) (err error) {
 		return
 	}
 
-	// Always prefer NetworkAttachmentConfig in the TaskSpec
-	specNetworks := s.Spec.Task.Networks
-	if len(specNetworks) == 0 && s != nil && len(s.Spec.Networks) != 0 {
-		specNetworks = s.Spec.Networks
-	}
+	specNetworks := serviceNetworks(s)
 
 	// Allocate VIPs for all the pre-populated endpoint attachments
 	eVIPs := s.Endpoint.VirtualIPs[:0]
@@ -326,11 +322,7 @@ func (na *NetworkAllocator) ServiceNeedsAllocation(s *api.Service, flags ...func
 		flag(&options)
 	}
 
-	// Always prefer NetworkAttachmentConfig in the TaskSpec
-	specNetworks := s.Spec.Task.Networks
-	if len(specNetworks) == 0 && len(s.Spec.Networks) != 0 {
-		specNetworks = s.Spec.Networks
-	}
+	specNetworks := serviceNetworks(s)
 
 	// If endpoint mode is VIP and allocator does not have the
 	// service in VIP allocated set then it needs to be allocated.
@@ -884,4 +876,12 @@ func initializeDrivers(reg *drvregistry.DrvRegistry) error {
 		}
 	}
 	return nil
+}
+
+func serviceNetworks(s *api.Service) []*api.NetworkAttachmentConfig {
+	// Always prefer NetworkAttachmentConfig in the TaskSpec
+	if len(s.Spec.Task.Networks) == 0 && len(s.Spec.Networks) != 0 {
+		return s.Spec.Networks
+	}
+	return s.Spec.Task.Networks
 }

--- a/manager/allocator/networkallocator/portallocator.go
+++ b/manager/allocator/networkallocator/portallocator.go
@@ -269,9 +269,9 @@ func (pa *portAllocator) serviceDeallocatePorts(s *api.Service) {
 	s.Endpoint.Ports = nil
 }
 
-func (pa *portAllocator) portsAllocatedInHostPublishMode(s *api.Service) bool {
+func (pa *portAllocator) hostPublishPortsNeedUpdate(s *api.Service) bool {
 	if s.Endpoint == nil && s.Spec.Endpoint == nil {
-		return true
+		return false
 	}
 
 	portStates := allocatedPorts{}
@@ -288,13 +288,13 @@ func (pa *portAllocator) portsAllocatedInHostPublishMode(s *api.Service) bool {
 			if portConfig.PublishMode == api.PublishModeHost &&
 				portConfig.PublishedPort != 0 {
 				if portStates.delState(portConfig) == nil {
-					return false
+					return true
 				}
 			}
 		}
 	}
 
-	return true
+	return false
 }
 
 func (pa *portAllocator) isPortsAllocated(s *api.Service) bool {

--- a/manager/allocator/networkallocator/portallocator_test.go
+++ b/manager/allocator/networkallocator/portallocator_test.go
@@ -264,7 +264,7 @@ func TestServiceAllocatePorts(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestPortsAllocatedInHostPublishMode(t *testing.T) {
+func TestHostPublishPortsNeedUpdate(t *testing.T) {
 	pa, err := newPortAllocator()
 	assert.NoError(t, err)
 
@@ -282,7 +282,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 				},
 				Endpoint: nil,
 			},
-			expect: true,
+			expect: false,
 		},
 		{
 			// non host mode does not impact
@@ -301,7 +301,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 				},
 				Endpoint: nil,
 			},
-			expect: true,
+			expect: false,
 		},
 		{
 			// publish mode is different
@@ -330,7 +330,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 					},
 				},
 			},
-			expect: false,
+			expect: true,
 		},
 		{
 			input: &api.Service{
@@ -359,7 +359,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 					},
 				},
 			},
-			expect: true,
+			expect: false,
 		},
 		{
 			// published port not specified
@@ -389,7 +389,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 					},
 				},
 			},
-			expect: true,
+			expect: false,
 		},
 		{
 			// one published port not specified, the other specified
@@ -431,7 +431,7 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 					},
 				},
 			},
-			expect: false,
+			expect: true,
 		},
 		{
 			// one published port not specified, the other specified
@@ -474,12 +474,12 @@ func TestPortsAllocatedInHostPublishMode(t *testing.T) {
 					},
 				},
 			},
-			expect: true,
+			expect: false,
 		},
 	}
 	for _, singleTest := range testCases {
-		expect := pa.portsAllocatedInHostPublishMode(singleTest.input)
-		assert.Equal(t, expect, singleTest.expect)
+		actual := pa.hostPublishPortsNeedUpdate(singleTest.input)
+		assert.Equal(t, singleTest.expect, actual)
 	}
 }
 


### PR DESCRIPTION
This PR has a few small cleanups for the allocator code.

It may be easiest to review commit-by-commit.

```
    allocator: Rename PortsAllocatedInHostPublishMode

    Rename to HostPublishPortsNeedUpdate, and invert the logic. This better
    matches ServiceNeedsAllocation and is a clearer description of what the
    function is used for.
```

```
    allocator: Factor specNetworks assignment into a function
```

```
    allocator: Standardize on label/continue syntax when comparing VIPs with networks

    Also, return explicit error values instead of relying on the named
    return variable.
```

```
    allocator: Make updatePortsInHostPublishMode check for host publish mode, not ingress

    This will make things easier if/when we add another publish mode.

    Also, update the Spec on s.Endpoint whether or not the new value is nil.
```

One thing I would still like to clean up is the way ports are checked for being up-to-date, and updated in `s.Endpoint`. This is a fairly big and risky cleanup and I haven't tackled it here. I filed #2143 for my thoughts about what the result should look like.

cc @aboch @yongtang @abhinandanpb @dongluochen