### PR TITLE
agent: avoid race condition after failing task startup

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -426,14 +426,19 @@ func (w *worker) Listen(ctx context.Context, reporter StatusReporter) {
 }
 
 func (w *worker) startTask(ctx context.Context, tx *bolt.Tx, task *api.Task) error {
-	w.taskevents.Publish(task.Copy())
 	_, err := w.taskManager(ctx, tx, task) // side-effect taskManager creation.
 
 	if err != nil {
 		log.G(ctx).WithError(err).Error("failed to start taskManager")
+		// we ignore this error: it gets reported in the taskStatus within
+		// `newTaskManager`. We log it here and move on. If their is an
+		// attempted restart, the lack of taskManager will have this retry
+		// again.
+		return nil
 	}
 
-	// TODO(stevvooe): Add start method for taskmanager
+	// only publish if controller resolution was successful.
+	w.taskevents.Publish(task.Copy())
 	return nil
 }
 
@@ -464,7 +469,7 @@ func (w *worker) newTaskManager(ctx context.Context, tx *bolt.Tx, task *api.Task
 	}
 
 	if err != nil {
-		log.G(ctx).Error("controller resolution failed")
+		log.G(ctx).WithError(err).Error("controller resolution failed")
 		return nil, err
 	}
 
@@ -568,9 +573,14 @@ func (w *worker) Subscribe(ctx context.Context, subscription *api.SubscriptionMe
 		case v := <-ch:
 			task := v.(*api.Task)
 			if match(task) {
-				w.mu.Lock()
-				go w.taskManagers[task.ID].Logs(ctx, *subscription.Options, publisher)
-				w.mu.Unlock()
+				w.mu.RLock()
+				tm, ok := w.taskManagers[task.ID]
+				w.mu.RUnlock()
+				if !ok {
+					continue
+				}
+
+				go tm.Logs(ctx, *subscription.Options, publisher)
 			}
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
This moves the publish of a task manager creation event to after the
successful resolution of a task manager, ensuring that it will be there
when later resolved for log subscriptions.

Before, we correctly ignored the error, but it was not reported via the
correct log messagses. We have added the proper `WithError` to the log
message to ensure traceability.

It is unclear whether or not this early mount validation, the cause of
the controller resolution failure, is valid or not. We should really be
deferring to the "runtime" to make that determination and fail at
startup, but this PR should allow this to work gracefully.

Signed-off-by: Stephen J Day <stephen.day@docker.com>

Closes https://github.com/docker/swarmkit/issues/2147