### PR TITLE
Avoid writing to Network.Spec in allocatePools

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -790,17 +790,15 @@ func (na *NetworkAllocator) allocatePools(n *api.Network) (map[string]string, er
 
 	pools := make(map[string]string)
 
-	if n.Spec.IPAM == nil {
-		n.Spec.IPAM = &api.IPAMOptions{}
-	}
-
-	ipamConfigs := make([]*api.IPAMConfig, len(n.Spec.IPAM.Configs))
-	copy(ipamConfigs, n.Spec.IPAM.Configs)
+	var ipamConfigs []*api.IPAMConfig
 
 	// If there is non-nil IPAM state always prefer those subnet
 	// configs over Spec configs.
 	if n.IPAM != nil {
 		ipamConfigs = n.IPAM.Configs
+	} else if n.Spec.IPAM != nil {
+		ipamConfigs = make([]*api.IPAMConfig, len(n.Spec.IPAM.Configs))
+		copy(ipamConfigs, n.Spec.IPAM.Configs)
 	}
 
 	// Append an empty slot for subnet allocation if there are no


### PR DESCRIPTION
A NetworkSpec should never be updated by the core. Avoid updating it in even a
trivial manner by restructuring the creation of ipamConfigs. I also happen to
find the new logic easier to grok.

This is largely benign right now but never writing to Network.Spec will make
changes in #2108 easier to reason about.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>