### PR TITLE
node: Alternate fix for cert renewal logic race

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -542,7 +542,7 @@ func RenewTLSConfig(ctx context.Context, s *SecurityConfig, connBroker *connecti
 				expBackoff.Failure(nil, nil)
 			} else {
 				certUpdate.Role = s.ClientTLSCreds.Role()
-				expBackoff = events.NewExponentialBackoff(RenewTLSExponentialBackoff)
+				expBackoff.Success(nil)
 				forceRetry = false
 			}
 

--- a/node/node.go
+++ b/node/node.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
 	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/agent"
 	"github.com/docker/swarmkit/agent/exec"
 	"github.com/docker/swarmkit/api"
@@ -36,8 +37,9 @@ import (
 )
 
 const (
-	stateFilename     = "state.json"
-	roleChangeTimeout = 16 * time.Second
+	stateFilename           = "state.json"
+	roleChangeTimeout       = 16 * time.Second
+	initialCertRenewalDelay = 500 * time.Millisecond
 )
 
 var (
@@ -47,6 +49,12 @@ var (
 
 	// ErrInvalidUnlockKey is returned when we can't decrypt the TLS certificate
 	ErrInvalidUnlockKey = errors.New("node is locked, and needs a valid unlock key")
+
+	certRenewalBackoffConfig = events.ExponentialBackoffConfig{
+		Base:   2 * time.Second,
+		Factor: 5 * time.Second,
+		Max:    1 * time.Hour,
+	}
 )
 
 // Config provides values for a Node.
@@ -133,30 +141,28 @@ type Node struct {
 	manager          *manager.Manager
 	notifyNodeChange chan *agent.NodeChanges // used by the agent to relay node updates from the dispatcher Session stream to (*Node).run
 	unlockKey        []byte
-
-	// lastNodeRole is the last-seen value of Node.Role, used to make role
-	// changes "edge triggered" and avoid renewal loops.
-	lastNodeRole lastSeenRole
-	// lastNodeDesiredRole is the last-seen value of Node.Spec.DesiredRole,
-	// used to make role changes "edge triggered" and avoid renewal loops.
-	// This exists in addition to lastNodeRole to support older CAs that
-	// only fill in the DesiredRole field.
-	lastNodeDesiredRole lastSeenRole
 }
 
 type lastSeenRole struct {
-	role *api.NodeRole
+	mu   sync.Mutex
+	role api.NodeRole
 }
 
 // observe notes the latest value of this node role, and returns true if it
 // is the first seen value, or is different from the most recently seen value.
 func (l *lastSeenRole) observe(newRole api.NodeRole) bool {
-	changed := l.role == nil || *l.role != newRole
-	if l.role == nil {
-		l.role = new(api.NodeRole)
-	}
-	*l.role = newRole
+	l.mu.Lock()
+	changed := l.role != newRole
+	l.role = newRole
+	l.mu.Unlock()
 	return changed
+}
+
+func (l *lastSeenRole) peek() api.NodeRole {
+	l.mu.Lock()
+	role := l.role
+	l.mu.Unlock()
+	return role
 }
 
 // RemoteAPIAddr returns address on which remote manager api listens.
@@ -244,6 +250,16 @@ func (n *Node) Start(ctx context.Context) error {
 	return err
 }
 
+func (n *Node) currentRole() api.NodeRole {
+	n.Lock()
+	currentRole := api.NodeRoleWorker
+	if n.role == ca.ManagerRole {
+		currentRole = api.NodeRoleManager
+	}
+	n.Unlock()
+	return currentRole
+}
+
 func (n *Node) run(ctx context.Context) (err error) {
 	defer func() {
 		n.err = err
@@ -267,6 +283,12 @@ func (n *Node) run(ctx context.Context) (err error) {
 		return err
 	}
 
+	// lastNodeDesiredRole is the last-seen value of Node.Spec.DesiredRole,
+	// used to make role changes "edge triggered" and avoid renewal loops.
+	lastNodeDesiredRole := lastSeenRole{role: n.currentRole()}
+
+	certRenewalBackoff := events.NewExponentialBackoff(certRenewalBackoffConfig)
+
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("node.id", n.NodeID()))
 
 	taskDBPath := filepath.Join(n.config.StateDir, "worker/tasks.db")
@@ -283,17 +305,34 @@ func (n *Node) run(ctx context.Context) (err error) {
 	agentDone := make(chan struct{})
 
 	forceCertRenewal := make(chan struct{})
-	renewCert := func() {
-		for {
-			select {
-			case forceCertRenewal <- struct{}{}:
-				return
-			case <-agentDone:
-				return
-			case <-n.notifyNodeChange:
-				// consume from the channel to avoid blocking the writer
-			}
+	renewCertNow := func() {
+		select {
+		case forceCertRenewal <- struct{}{}:
+		case <-agentDone:
 		}
+	}
+	renewCertForRoleChange := func() {
+		delay := certRenewalBackoff.Proceed(nil)
+		if delay == 0 {
+			// Wait for the role to be reconciled
+			delay = initialCertRenewalDelay
+		}
+		select {
+		case <-time.After(delay):
+		case <-agentDone:
+			return
+		}
+
+		if n.currentRole() == lastNodeDesiredRole.peek() {
+			// We've already received a certificate with the role we
+			// were anticipating, so there's nothing to do.
+			certRenewalBackoff.Success(nil)
+			return
+		}
+
+		certRenewalBackoff.Failure(nil, nil)
+
+		renewCertNow()
 	}
 
 	go func() {
@@ -302,37 +341,25 @@ func (n *Node) run(ctx context.Context) (err error) {
 			case <-agentDone:
 				return
 			case nodeChanges := <-n.notifyNodeChange:
-				n.Lock()
-				currentRole := api.NodeRoleWorker
-				if n.role == ca.ManagerRole {
-					currentRole = api.NodeRoleManager
-				}
-				n.Unlock()
+				currentRole := n.currentRole()
 
 				if nodeChanges.Node != nil {
 					// This is a bit complex to be backward compatible with older CAs that
 					// don't support the Node.Role field. They only use what's presently
 					// called DesiredRole.
-					// 1) If we haven't seen the node object before, and the desired role
-					//    is different from our current role, renew the cert. This covers
-					//    the case of starting up after a role change.
-					// 2) If we have seen the node before, the desired role is
-					//    different from our current role, and either the actual role or
-					//    desired role has changed relative to the last values we saw in
-					//    those fields, renew the cert. This covers the case of the role
-					//    changing while this node is running, but prevents getting into a
-					//    rotation loop if Node.Role isn't what we expect (because it's
-					//    unset). We may renew the certificate an extra time (first when
-					//    DesiredRole changes, and then again when Role changes).
-					// 3) If the server is sending us IssuanceStateRotate, renew the cert as
+					// 1) If DesiredRole changes, kick off a certificate renewal. The renewal
+					//    is delayed slightly to give Role time to change as well if this is
+					//    a newer CA. If the certificate we get back doesn't have the expected
+					//    role, we continue renewing with exponential backoff.
+					// 2) If the server is sending us IssuanceStateRotate, renew the cert as
 					//    requested by the CA.
-					roleChanged := n.lastNodeRole.observe(nodeChanges.Node.Role)
-					desiredRoleChanged := n.lastNodeDesiredRole.observe(nodeChanges.Node.Spec.DesiredRole)
-					if (currentRole != nodeChanges.Node.Spec.DesiredRole &&
-						((roleChanged && currentRole != nodeChanges.Node.Role) ||
-							desiredRoleChanged)) ||
-						nodeChanges.Node.Certificate.Status.State == api.IssuanceStateRotate {
-						renewCert()
+					desiredRoleChanged := lastNodeDesiredRole.observe(nodeChanges.Node.Spec.DesiredRole)
+					if desiredRoleChanged {
+						// Reset backoff
+						certRenewalBackoff.Success(nil)
+						go renewCertForRoleChange()
+					} else if nodeChanges.Node.Certificate.Status.State == api.IssuanceStateRotate {
+						go renewCertNow()
 					}
 				}
 
@@ -375,6 +402,13 @@ func (n *Node) run(ctx context.Context) (err error) {
 			n.role = certUpdate.Role
 			n.roleCond.Broadcast()
 			n.Unlock()
+
+			lastDesiredRole := lastNodeDesiredRole.peek()
+			if n.currentRole() == lastDesiredRole {
+				certRenewalBackoff.Success(nil)
+			} else {
+				go renewCertForRoleChange()
+			}
 		}
 
 		wg.Done()


### PR DESCRIPTION
As suggested by @cyli, this tries to fix the race by repeatedly renewing the certificate until we get a role that matches DesiredRole.

This is an alternative to #2149

The main weird thing about this is that I'm running `renewCertNow` and `renewCertForRoleChange` as goroutines to avoid a deadlock. It's possible that multiple instances can run at once. This can theoretically lead to some weird behavior, like duplicated renewals, or extra backoff when none is necessary. However, changing the code to only allow one to run at once seems like it would add some extra complexity. I don't see anything bad that can happen from having multiple of these goroutines running at once, but on the other hand, determinism is nice. I'd appreciate input on this aspect.

cc @cyli @diogomonica