### PR TITLE
node: Third proposed fix for cert renewal logic race

### DIFF
--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -22,6 +22,7 @@ import (
 
 	cfcsr "github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/helpers"
+	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	cautils "github.com/docker/swarmkit/ca/testutils"
@@ -41,6 +42,12 @@ import (
 func init() {
 	os.Setenv(ca.PassphraseENVVar, "")
 	os.Setenv(ca.PassphraseENVVarPrev, "")
+
+	ca.RenewTLSExponentialBackoff = events.ExponentialBackoffConfig{
+		Base:   250 * time.Millisecond,
+		Factor: 250 * time.Millisecond,
+		Max:    1 * time.Hour,
+	}
 }
 
 func checkLeafCert(t *testing.T, certBytes []byte, issuerName, cn, ou, org string, additionalDNSNames ...string) []*x509.Certificate {

--- a/ca/renewer.go
+++ b/ca/renewer.go
@@ -1,0 +1,166 @@
+package ca
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/go-events"
+	"github.com/docker/swarmkit/connectionbroker"
+	"github.com/docker/swarmkit/log"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+// RenewTLSExponentialBackoff sets the exponential backoff when trying to renew TLS certificates that have expired
+var RenewTLSExponentialBackoff = events.ExponentialBackoffConfig{
+	Base:   time.Second * 5,
+	Factor: time.Second * 5,
+	Max:    1 * time.Hour,
+}
+
+// TLSRenewer handles renewing TLS certificates, either automatically or upon
+// request.
+type TLSRenewer struct {
+	mu           sync.Mutex
+	s            *SecurityConfig
+	connBroker   *connectionbroker.Broker
+	renew        chan struct{}
+	expectedRole string
+}
+
+// NewTLSRenewer creates a new TLS renewer. It must be started with Start.
+func NewTLSRenewer(s *SecurityConfig, connBroker *connectionbroker.Broker) *TLSRenewer {
+	return &TLSRenewer{
+		s:          s,
+		connBroker: connBroker,
+		renew:      make(chan struct{}, 1),
+	}
+}
+
+// SetExpectedRole sets the expected role. If a renewal is forced, and the role
+// doesn't match this expectation, renewal will be retried with exponential
+// backoff until it does match.
+func (t *TLSRenewer) SetExpectedRole(role string) {
+	t.mu.Lock()
+	t.expectedRole = role
+	t.mu.Unlock()
+}
+
+// Renew causes the TLSRenewer to renew the certificate (nearly) right away,
+// instead of waiting for the next automatic renewal.
+func (t *TLSRenewer) Renew() {
+	select {
+	case t.renew <- struct{}{}:
+	default:
+	}
+}
+
+// Start will continuously monitor for the necessity of renewing the local certificates, either by
+// issuing them locally if key-material is available, or requesting them from a remote CA.
+func (t *TLSRenewer) Start(ctx context.Context) <-chan CertificateUpdate {
+	updates := make(chan CertificateUpdate)
+
+	go func() {
+		var (
+			retry      time.Duration
+			forceRetry bool
+		)
+		expBackoff := events.NewExponentialBackoff(RenewTLSExponentialBackoff)
+		defer close(updates)
+		for {
+			ctx = log.WithModule(ctx, "tls")
+			log := log.G(ctx).WithFields(logrus.Fields{
+				"node.id":   t.s.ClientTLSCreds.NodeID(),
+				"node.role": t.s.ClientTLSCreds.Role(),
+			})
+			// Our starting default will be 5 minutes
+			retry = 5 * time.Minute
+
+			// Since the expiration of the certificate is managed remotely we should update our
+			// retry timer on every iteration of this loop.
+			// Retrieve the current certificate expiration information.
+			validFrom, validUntil, err := readCertValidity(t.s.KeyReader())
+			if err != nil {
+				// We failed to read the expiration, let's stick with the starting default
+				log.Errorf("failed to read the expiration of the TLS certificate in: %s", t.s.KeyReader().Target())
+
+				select {
+				case updates <- CertificateUpdate{Err: errors.New("failed to read certificate expiration")}:
+				case <-ctx.Done():
+					log.Info("shutting down certificate renewal routine")
+					return
+				}
+			} else {
+				// If we have an expired certificate, try to renew immediately: the hope that this is a temporary clock skew, or
+				// we can issue our own TLS certs.
+				if validUntil.Before(time.Now()) {
+					log.Warn("the current TLS certificate is expired, so an attempt to renew it will be made immediately")
+					// retry immediately(ish) with exponential backoff
+					retry = expBackoff.Proceed(nil)
+				} else if forceRetry {
+					// A forced renewal was requested, but did not succeed yet.
+					// retry immediately(ish) with exponential backoff
+					retry = expBackoff.Proceed(nil)
+				} else {
+					// Random retry time between 50% and 80% of the total time to expiration
+					retry = calculateRandomExpiry(validFrom, validUntil)
+				}
+			}
+
+			log.WithFields(logrus.Fields{
+				"time": time.Now().Add(retry),
+			}).Debugf("next certificate renewal scheduled for %v from now", retry)
+
+			select {
+			case <-time.After(retry):
+				log.Info("renewing certificate")
+			case <-t.renew:
+				forceRetry = true
+				log.Info("forced certificate renewal")
+
+				// Pause briefly before attempting the renewal,
+				// to give the CA a chance to reconcile the
+				// desired role.
+				select {
+				case <-time.After(500 * time.Millisecond):
+				case <-ctx.Done():
+					log.Info("shutting down certificate renewal routine")
+					return
+				}
+			case <-ctx.Done():
+				log.Info("shutting down certificate renewal routine")
+				return
+			}
+
+			// ignore errors - it will just try again later
+			var certUpdate CertificateUpdate
+			if err := RenewTLSConfigNow(ctx, t.s, t.connBroker); err != nil {
+				certUpdate.Err = err
+				expBackoff.Failure(nil, nil)
+			} else {
+				newRole := t.s.ClientTLSCreds.Role()
+				t.mu.Lock()
+				expectedRole := t.expectedRole
+				t.mu.Unlock()
+				if expectedRole != "" && expectedRole != newRole {
+					expBackoff.Failure(nil, nil)
+					continue
+				}
+
+				certUpdate.Role = newRole
+				expBackoff.Success(nil)
+				forceRetry = false
+			}
+
+			select {
+			case updates <- certUpdate:
+			case <-ctx.Done():
+				log.Info("shutting down certificate renewal routine")
+				return
+			}
+		}
+	}()
+
+	return updates
+}

--- a/ca/renewer_test.go
+++ b/ca/renewer_test.go
@@ -1,0 +1,86 @@
+package ca_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func TestForceRenewTLSConfig(t *testing.T) {
+	t.Parallel()
+
+	tc := testutils.NewTestCA(t)
+	defer tc.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Get a new managerConfig with a TLS cert that has 15 minutes to live
+	nodeConfig, err := tc.WriteNewNodeConfig(ca.ManagerRole)
+	assert.NoError(t, err)
+
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	updates := renewer.Start(ctx)
+	renewer.Renew()
+	select {
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "TestForceRenewTLSConfig timed-out")
+	case certUpdate := <-updates:
+		assert.NoError(t, certUpdate.Err)
+		assert.NotNil(t, certUpdate)
+		assert.Equal(t, certUpdate.Role, ca.ManagerRole)
+	}
+}
+
+func TestForceRenewExpectedRole(t *testing.T) {
+	t.Parallel()
+
+	tc := testutils.NewTestCA(t)
+	defer tc.Stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Get a new managerConfig with a TLS cert that has 15 minutes to live
+	nodeConfig, err := tc.WriteNewNodeConfig(ca.ManagerRole)
+	assert.NoError(t, err)
+
+	go func() {
+		time.Sleep(750 * time.Millisecond)
+
+		err := tc.MemoryStore.Update(func(tx store.Tx) error {
+			node := store.GetNode(tx, nodeConfig.ClientTLSCreds.NodeID())
+			require.NotNil(t, node)
+
+			node.Spec.DesiredRole = api.NodeRoleWorker
+			node.Role = api.NodeRoleWorker
+
+			return store.UpdateNode(tx, node)
+		})
+		assert.NoError(t, err)
+	}()
+
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	updates := renewer.Start(ctx)
+	renewer.SetExpectedRole(ca.WorkerRole)
+	renewer.Renew()
+	for {
+		select {
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out")
+		case certUpdate := <-updates:
+			assert.NoError(t, certUpdate.Err)
+			assert.NotNil(t, certUpdate)
+			if certUpdate.Role == ca.WorkerRole {
+				return
+			}
+		}
+	}
+}

--- a/node/node.go
+++ b/node/node.go
@@ -133,29 +133,17 @@ type Node struct {
 	manager          *manager.Manager
 	notifyNodeChange chan *agent.NodeChanges // used by the agent to relay node updates from the dispatcher Session stream to (*Node).run
 	unlockKey        []byte
-
-	// lastNodeRole is the last-seen value of Node.Role, used to make role
-	// changes "edge triggered" and avoid renewal loops.
-	lastNodeRole lastSeenRole
-	// lastNodeDesiredRole is the last-seen value of Node.Spec.DesiredRole,
-	// used to make role changes "edge triggered" and avoid renewal loops.
-	// This exists in addition to lastNodeRole to support older CAs that
-	// only fill in the DesiredRole field.
-	lastNodeDesiredRole lastSeenRole
 }
 
 type lastSeenRole struct {
-	role *api.NodeRole
+	role api.NodeRole
 }
 
 // observe notes the latest value of this node role, and returns true if it
 // is the first seen value, or is different from the most recently seen value.
 func (l *lastSeenRole) observe(newRole api.NodeRole) bool {
-	changed := l.role == nil || *l.role != newRole
-	if l.role == nil {
-		l.role = new(api.NodeRole)
-	}
-	*l.role = newRole
+	changed := l.role != newRole
+	l.role = newRole
 	return changed
 }
 
@@ -244,6 +232,16 @@ func (n *Node) Start(ctx context.Context) error {
 	return err
 }
 
+func (n *Node) currentRole() api.NodeRole {
+	n.Lock()
+	currentRole := api.NodeRoleWorker
+	if n.role == ca.ManagerRole {
+		currentRole = api.NodeRoleManager
+	}
+	n.Unlock()
+	return currentRole
+}
+
 func (n *Node) run(ctx context.Context) (err error) {
 	defer func() {
 		n.err = err
@@ -267,6 +265,8 @@ func (n *Node) run(ctx context.Context) (err error) {
 		return err
 	}
 
+	renewer := ca.NewTLSRenewer(securityConfig, n.connBroker)
+
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("node.id", n.NodeID()))
 
 	taskDBPath := filepath.Join(n.config.StateDir, "worker/tasks.db")
@@ -282,57 +282,39 @@ func (n *Node) run(ctx context.Context) (err error) {
 
 	agentDone := make(chan struct{})
 
-	forceCertRenewal := make(chan struct{})
-	renewCert := func() {
-		for {
-			select {
-			case forceCertRenewal <- struct{}{}:
-				return
-			case <-agentDone:
-				return
-			case <-n.notifyNodeChange:
-				// consume from the channel to avoid blocking the writer
-			}
-		}
-	}
-
 	go func() {
+		// lastNodeDesiredRole is the last-seen value of Node.Spec.DesiredRole,
+		// used to make role changes "edge triggered" and avoid renewal loops.
+		lastNodeDesiredRole := lastSeenRole{role: n.currentRole()}
+
 		for {
 			select {
 			case <-agentDone:
 				return
 			case nodeChanges := <-n.notifyNodeChange:
-				n.Lock()
-				currentRole := api.NodeRoleWorker
-				if n.role == ca.ManagerRole {
-					currentRole = api.NodeRoleManager
-				}
-				n.Unlock()
+				currentRole := n.currentRole()
 
 				if nodeChanges.Node != nil {
 					// This is a bit complex to be backward compatible with older CAs that
 					// don't support the Node.Role field. They only use what's presently
 					// called DesiredRole.
-					// 1) If we haven't seen the node object before, and the desired role
-					//    is different from our current role, renew the cert. This covers
-					//    the case of starting up after a role change.
-					// 2) If we have seen the node before, the desired role is
-					//    different from our current role, and either the actual role or
-					//    desired role has changed relative to the last values we saw in
-					//    those fields, renew the cert. This covers the case of the role
-					//    changing while this node is running, but prevents getting into a
-					//    rotation loop if Node.Role isn't what we expect (because it's
-					//    unset). We may renew the certificate an extra time (first when
-					//    DesiredRole changes, and then again when Role changes).
-					// 3) If the server is sending us IssuanceStateRotate, renew the cert as
+					// 1) If DesiredRole changes, kick off a certificate renewal. The renewal
+					//    is delayed slightly to give Role time to change as well if this is
+					//    a newer CA. If the certificate we get back doesn't have the expected
+					//    role, we continue renewing with exponential backoff.
+					// 2) If the server is sending us IssuanceStateRotate, renew the cert as
 					//    requested by the CA.
-					roleChanged := n.lastNodeRole.observe(nodeChanges.Node.Role)
-					desiredRoleChanged := n.lastNodeDesiredRole.observe(nodeChanges.Node.Spec.DesiredRole)
-					if (currentRole != nodeChanges.Node.Spec.DesiredRole &&
-						((roleChanged && currentRole != nodeChanges.Node.Role) ||
-							desiredRoleChanged)) ||
-						nodeChanges.Node.Certificate.Status.State == api.IssuanceStateRotate {
-						renewCert()
+					desiredRoleChanged := lastNodeDesiredRole.observe(nodeChanges.Node.Spec.DesiredRole)
+					if desiredRoleChanged {
+						switch nodeChanges.Node.Spec.DesiredRole {
+						case api.NodeRoleManager:
+							renewer.SetExpectedRole(ca.ManagerRole)
+						case api.NodeRoleWorker:
+							renewer.SetExpectedRole(ca.WorkerRole)
+						}
+					}
+					if desiredRoleChanged || nodeChanges.Node.Certificate.Status.State == api.IssuanceStateRotate {
+						renewer.Renew()
 					}
 				}
 
@@ -364,7 +346,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 	var wg sync.WaitGroup
 	wg.Add(3)
 
-	updates := ca.RenewTLSConfig(ctx, securityConfig, n.connBroker, forceCertRenewal)
+	updates := renewer.Start(ctx)
 	go func() {
 		for certUpdate := range updates {
 			if certUpdate.Err != nil {
@@ -387,7 +369,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 	var managerErr error
 	var agentErr error
 	go func() {
-		managerErr = n.superviseManager(ctx, securityConfig, paths.RootCA, managerReady, forceCertRenewal) // store err and loop
+		managerErr = n.superviseManager(ctx, securityConfig, paths.RootCA, managerReady, renewer) // store err and loop
 		wg.Done()
 		cancel()
 	}()
@@ -869,7 +851,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 	return clearData, nil
 }
 
-func (n *Node) superviseManager(ctx context.Context, securityConfig *ca.SecurityConfig, rootPaths ca.CertPaths, ready chan struct{}, forceCertRenewal chan struct{}) error {
+func (n *Node) superviseManager(ctx context.Context, securityConfig *ca.SecurityConfig, rootPaths ca.CertPaths, ready chan struct{}, renewer *ca.TLSRenewer) error {
 	for {
 		if err := n.waitRole(ctx, ca.ManagerRole); err != nil {
 			return err
@@ -924,14 +906,7 @@ func (n *Node) superviseManager(ctx context.Context, securityConfig *ca.Security
 			log.G(ctx).Warn("failed to get worker role after manager stop, forcing certificate renewal")
 			timer.Reset(roleChangeTimeout)
 
-			select {
-			case forceCertRenewal <- struct{}{}:
-			case <-timer.C:
-				log.G(ctx).Warn("failed to trigger certificate renewal after manager stop, restarting manager")
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			}
+			renewer.Renew()
 
 			// Now that the renewal request has been sent to the
 			// renewal goroutine, wait for a change in role.


### PR DESCRIPTION
This is similar in concept to the last attempt (#2152), but moves the retries into the ca code. `RenewTLSConfig` had to be refactored to support notifying the loop of the expected role. This couldn't be passed over the channel easily, because the sending code can't block indefinitely long, and using a goroutine would let updates to the expected role race.

cc @cyli @diogomonica