### PR TITLE
Temporarily vendor fork of etcd

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.0
 github.com/grpc-ecosystem/go-grpc-prometheus 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
 
 # etcd/raft
-github.com/coreos/etcd 824277cb3a577a0e8c829ca9ec557b973fe06d20
+github.com/coreos/etcd ea5389a79f40206170582c1ea076191b8622cb8e https://github.com/aaronlehmann/etcd # for https://github.com/coreos/etcd/pull/7830
 github.com/coreos/go-systemd v12
 github.com/coreos/pkg v3
 github.com/prometheus/client_golang 52437c81da6b127a9925d17eb3a382a2e5fd395e

--- a/vendor/github.com/coreos/etcd/raft/raft.go
+++ b/vendor/github.com/coreos/etcd/raft/raft.go
@@ -1154,6 +1154,10 @@ func (r *raft) addNode(id uint64) {
 	}
 
 	r.setProgress(id, 0, r.raftLog.lastIndex()+1)
+	// When a node is first added, we should mark it as recently active.
+	// Otherwise, CheckQuorum may cause us to step down if it is invoked
+	// before the added node has a chance to communicate with us.
+	r.prs[id].RecentActive = true
 }
 
 func (r *raft) removeNode(id uint64) {


### PR DESCRIPTION
Now that we are using CheckQuorum, it is causing some spurious leader
elections that are leading to test failures in both SwarmKit and Docker
integration tests.

I submitted this change upstream, but it hasn't been reviewed yet. I'd
like to temporarily vendor a fork that has the change. First, this will
unblock vendoring swarmkit from the master branch. Also, it will give us
a chance to test the change more broadly. Finally, we probably don't
want to vendor the master branch of etcd, so without this temporary
fork, we'd have to wait for a release that includes this change.