### PR TITLE
Fix service network validation

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -433,10 +433,9 @@ func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error
 		if network == nil {
 			continue
 		}
-		if network.Spec.Internal {
+		if allocator.IsIngressNetwork(network) {
 			return grpc.Errorf(codes.InvalidArgument,
-				"Service cannot be explicitly attached to %q network which is a swarm internal network",
-				network.Spec.Annotations.Name)
+				"Service cannot be explicitly attached to the ingress network %q", network.Spec.Annotations.Name)
 		}
 	}
 	return nil


### PR DESCRIPTION
- it is checking for `Internal` instead of `Ingress`
  This is a breakage introduced in f39ead8777a6c

This was reported by @archisgore in https://github.com/docker/swarmkit/pull/2028#issuecomment-300211162