### PR TITLE
Allow different services to use the same host-mode port

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -3,7 +3,6 @@ package controlapi
 import (
 	"errors"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -489,18 +488,32 @@ func (s *Server) checkPortConflicts(spec *api.ServiceSpec, serviceID string) err
 		return nil
 	}
 
-	pcToString := func(pc *api.PortConfig) string {
-		port := strconv.FormatUint(uint64(pc.PublishedPort), 10)
-		return port + "/" + pc.Protocol.String()
+	type portSpec struct {
+		protocol      api.PortConfig_Protocol
+		publishedPort uint32
 	}
 
-	reqPorts := make(map[string]bool)
-	for _, pc := range spec.Endpoint.Ports {
-		if pc.PublishedPort > 0 {
-			reqPorts[pcToString(pc)] = true
+	pcToStruct := func(pc *api.PortConfig) portSpec {
+		return portSpec{
+			protocol:      pc.Protocol,
+			publishedPort: pc.PublishedPort,
 		}
 	}
-	if len(reqPorts) == 0 {
+
+	ingressPorts := make(map[portSpec]struct{})
+	hostModePorts := make(map[portSpec]struct{})
+	for _, pc := range spec.Endpoint.Ports {
+		if pc.PublishedPort == 0 {
+			continue
+		}
+		switch pc.PublishMode {
+		case api.PublishModeIngress:
+			ingressPorts[pcToStruct(pc)] = struct{}{}
+		case api.PublishModeHost:
+			hostModePorts[pcToStruct(pc)] = struct{}{}
+		}
+	}
+	if len(ingressPorts) == 0 && len(hostModePorts) == 0 {
 		return nil
 	}
 
@@ -516,6 +529,31 @@ func (s *Server) checkPortConflicts(spec *api.ServiceSpec, serviceID string) err
 		return err
 	}
 
+	isPortInUse := func(pc *api.PortConfig, service *api.Service) error {
+		if pc.PublishedPort == 0 {
+			return nil
+		}
+
+		switch pc.PublishMode {
+		case api.PublishModeHost:
+			if _, ok := ingressPorts[pcToStruct(pc)]; ok {
+				return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s) as a host-published port", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
+			}
+
+			// Multiple services with same port in host publish mode can
+			// coexist - this is handled by the scheduler.
+			return nil
+		case api.PublishModeIngress:
+			_, ingressConflict := ingressPorts[pcToStruct(pc)]
+			_, hostModeConflict := hostModePorts[pcToStruct(pc)]
+			if ingressConflict || hostModeConflict {
+				return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s) as an ingress port", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
+			}
+		}
+
+		return nil
+	}
+
 	for _, service := range services {
 		// If service ID is the same (and not "") then this is an update
 		if serviceID != "" && serviceID == service.ID {
@@ -523,15 +561,15 @@ func (s *Server) checkPortConflicts(spec *api.ServiceSpec, serviceID string) err
 		}
 		if service.Spec.Endpoint != nil {
 			for _, pc := range service.Spec.Endpoint.Ports {
-				if reqPorts[pcToString(pc)] {
-					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s)", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
+				if err := isPortInUse(pc, service); err != nil {
+					return err
 				}
 			}
 		}
 		if service.Endpoint != nil {
 			for _, pc := range service.Endpoint.Ports {
-				if reqPorts[pcToString(pc)] {
-					return grpc.Errorf(codes.InvalidArgument, "port '%d' is already in use by service '%s' (%s)", pc.PublishedPort, service.Spec.Annotations.Name, service.ID)
+				if err := isPortInUse(pc, service); err != nil {
+					return err
 				}
 			}
 		}

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -546,6 +546,56 @@ func TestCreateService(t *testing.T) {
 	}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
 	assert.NoError(t, err)
+
+	// ensure no port conflict when host ports overlap
+	spec = createSpec("name8", "image", 1)
+	spec.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeHost, PublishedPort: uint32(9101), TargetPort: uint32(9101), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	r, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, r.Service.ID)
+
+	spec2 = createSpec("name9", "image", 1)
+	spec2.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeHost, PublishedPort: uint32(9101), TargetPort: uint32(9101), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
+	assert.NoError(t, err)
+
+	// ensure port conflict when host ports overlaps with ingress port (host port first)
+	spec = createSpec("name10", "image", 1)
+	spec.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeHost, PublishedPort: uint32(9102), TargetPort: uint32(9102), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	r, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, r.Service.ID)
+
+	spec2 = createSpec("name11", "image", 1)
+	spec2.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeIngress, PublishedPort: uint32(9102), TargetPort: uint32(9102), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+
+	// ensure port conflict when host ports overlaps with ingress port (ingress port first)
+	spec = createSpec("name12", "image", 1)
+	spec.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeIngress, PublishedPort: uint32(9103), TargetPort: uint32(9103), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	r, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, r.Service.ID)
+
+	spec2 = createSpec("name13", "image", 1)
+	spec2.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
+		{PublishMode: api.PublishModeHost, PublishedPort: uint32(9103), TargetPort: uint32(9103), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
+	}}
+	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }
 
 func TestSecretValidation(t *testing.T) {

--- a/manager/scheduler/pipeline.go
+++ b/manager/scheduler/pipeline.go
@@ -14,6 +14,7 @@ var (
 		&PluginFilter{},
 		&ConstraintFilter{},
 		&PlatformFilter{},
+		&HostPortFilter{},
 	}
 )
 

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -2438,3 +2438,146 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints bool) {
 		s.Close()
 	}
 }
+
+func TestSchedulerHostPort(t *testing.T) {
+	ctx := context.Background()
+	node1 := &api.Node{
+		ID: "nodeid1",
+		Spec: api.NodeSpec{
+			Annotations: api.Annotations{
+				Name: "node1",
+			},
+		},
+		Status: api.NodeStatus{
+			State: api.NodeStatus_READY,
+		},
+	}
+	node2 := &api.Node{
+		ID: "nodeid2",
+		Spec: api.NodeSpec{
+			Annotations: api.Annotations{
+				Name: "node2",
+			},
+		},
+		Status: api.NodeStatus{
+			State: api.NodeStatus_READY,
+		},
+	}
+
+	task1 := &api.Task{
+		ID:           "id1",
+		DesiredState: api.TaskStateRunning,
+		Spec: api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{},
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name: "name1",
+		},
+		Status: api.TaskStatus{
+			State: api.TaskStatePending,
+		},
+		Endpoint: &api.Endpoint{
+			Ports: []*api.PortConfig{
+				{
+					PublishMode:   api.PublishModeHost,
+					PublishedPort: 58,
+					Protocol:      api.ProtocolTCP,
+				},
+			},
+		},
+	}
+	task2 := &api.Task{
+		ID:           "id2",
+		DesiredState: api.TaskStateRunning,
+		Spec: api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{},
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name: "name2",
+		},
+		Status: api.TaskStatus{
+			State: api.TaskStatePending,
+		},
+		Endpoint: &api.Endpoint{
+			Ports: []*api.PortConfig{
+				{
+					PublishMode:   api.PublishModeHost,
+					PublishedPort: 58,
+					Protocol:      api.ProtocolUDP,
+				},
+			},
+		},
+	}
+	task3 := &api.Task{
+		ID:           "id3",
+		DesiredState: api.TaskStateRunning,
+		Spec: api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{},
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name: "name3",
+		},
+		Status: api.TaskStatus{
+			State: api.TaskStatePending,
+		},
+		Endpoint: &api.Endpoint{
+			Ports: []*api.PortConfig{
+				{
+					PublishMode:   api.PublishModeHost,
+					PublishedPort: 58,
+					Protocol:      api.ProtocolUDP,
+				},
+				{
+					PublishMode:   api.PublishModeHost,
+					PublishedPort: 58,
+					Protocol:      api.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	s := store.NewMemoryStore(nil)
+	assert.NotNil(t, s)
+	defer s.Close()
+
+	err := s.Update(func(tx store.Tx) error {
+		// Add initial node and task
+		assert.NoError(t, store.CreateTask(tx, task1))
+		assert.NoError(t, store.CreateTask(tx, task2))
+		assert.NoError(t, store.CreateNode(tx, node1))
+		assert.NoError(t, store.CreateNode(tx, node2))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	scheduler := New(s)
+
+	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	defer cancel()
+
+	go func() {
+		assert.NoError(t, scheduler.Run(ctx))
+	}()
+	defer scheduler.Stop()
+
+	// Tasks 1 and 2 should be assigned to different nodes.
+	assignment1 := watchAssignment(t, watch)
+	assignment2 := watchAssignment(t, watch)
+	assert.True(t, assignment1 != assignment2)
+
+	// Task 3 should not be schedulable.
+	err = s.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateTask(tx, task3))
+		return nil
+	})
+	assert.NoError(t, err)
+
+	failure := watchAssignmentFailure(t, watch)
+	assert.Equal(t, "no suitable node (host-mode port already in use on 2 nodes)", failure.Status.Message)
+}


### PR DESCRIPTION
Relax the validation in controlapi to allow two services to use the same host-mode published port.

Add a scheduler filter so that tasks from these services land on different nodes.

cc @aboch @pvnovarese @aluzzardi @dongluochen