### PR TITLE
Better Architecture comparison for Platform filter

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -244,11 +244,29 @@ func (f *PlatformFilter) Check(n *NodeInfo) bool {
 		return true
 	}
 	// check if the platform for the node is supported
-	nodePlatform := n.Description.Platform
-	for _, p := range f.supportedPlatforms {
-		if (p.Architecture == "" || p.Architecture == nodePlatform.Architecture) && (p.OS == "" || p.OS == nodePlatform.OS) {
-			return true
+	if n.Description != nil {
+		if nodePlatform := n.Description.Platform; nodePlatform != nil {
+			for _, p := range f.supportedPlatforms {
+				if f.platformEqual(*p, *nodePlatform) {
+					return true
+				}
+			}
 		}
+	}
+	return false
+}
+
+func (f *PlatformFilter) platformEqual(imgPlatform, nodePlatform api.Platform) bool {
+	// normalize "x86_64" architectures to "amd64"
+	if imgPlatform.Architecture == "x86_64" {
+		imgPlatform.Architecture = "amd64"
+	}
+	if nodePlatform.Architecture == "x86_64" {
+		nodePlatform.Architecture = "amd64"
+	}
+
+	if (imgPlatform.Architecture == "" || imgPlatform.Architecture == nodePlatform.Architecture) && (imgPlatform.OS == "" || imgPlatform.OS == nodePlatform.OS) {
+		return true
 	}
 	return false
 }

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -1728,7 +1728,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 			Placement: &api.Placement{
 				Platforms: []*api.Platform{
 					{
-						Architecture: "intel",
+						Architecture: "arm",
 						OS:           "linux",
 					},
 				},
@@ -1788,7 +1788,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 						OS:           "linux",
 					},
 					{
-						Architecture: "amd64",
+						Architecture: "x86_64",
 						OS:           "windows",
 					},
 				},
@@ -1808,7 +1808,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 		},
 		Description: &api.NodeDescription{
 			Platform: &api.Platform{
-				Architecture: "amd64",
+				Architecture: "x86_64",
 				OS:           "linux",
 			},
 		},
@@ -1832,6 +1832,20 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 		},
 	}
 
+	// node with nil platform description, cannot schedule anything
+	node3 := &api.Node{
+		ID: "node3",
+		Spec: api.NodeSpec{
+			Annotations: api.Annotations{
+				Name: "node3",
+			},
+		},
+		Status: api.NodeStatus{
+			State: api.NodeStatus_READY,
+		},
+		Description: &api.NodeDescription{},
+	}
+
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 	defer s.Close()
@@ -1841,6 +1855,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 		assert.NoError(t, store.CreateTask(tx, task1))
 		assert.NoError(t, store.CreateNode(tx, node1))
 		assert.NoError(t, store.CreateNode(tx, node2))
+		assert.NoError(t, store.CreateNode(tx, node3))
 		return nil
 	})
 	assert.NoError(t, err)
@@ -1866,7 +1881,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	failure := watchAssignmentFailure(t, watch)
-	assert.Equal(t, "no suitable node (unsupported platform on 2 nodes)", failure.Status.Message)
+	assert.Equal(t, "no suitable node (unsupported platform on 3 nodes)", failure.Status.Message)
 
 	// add task3
 	err = s.Update(func(tx store.Tx) error {


### PR DESCRIPTION
I noticed that doing `Architecture` comparisons on the Platform filter is likely to cause issues.

For instance, I saw that the docker-in-docker dev container reports node info as `linux`/`x86_64` and the `alpine:latest@sha256:c0537ff6a5218ef531ece93d4984efc99bbf3f7497c0a7726c88e2bb7584dc96` image I downloaded reports its platform info as `linux`/`amd64`. The image can still run.

This means that the platform filter, as implemented now, will kick off an image that is capable of running on a node. I think this mismatch is a bug, but I don't think we lose by disabling Architecture comparisons, at least for now.

cc @aluzzardi @aaronlehmann @friism 

Signed-off-by: Nishant Totla <nishanttotla@gmail.com>