### PR TITLE
raft: Check for leader before returning quorum loss error

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1370,10 +1370,6 @@ func (n *Node) getLeaderConn() (*grpc.ClientConn, error) {
 // LeaderConn returns current connection to cluster leader or raftselector.ErrIsLeader
 // if current machine is leader.
 func (n *Node) LeaderConn(ctx context.Context) (*grpc.ClientConn, error) {
-	if atomic.LoadUint32(&n.ticksWithNoLeader) > lostQuorumTimeout {
-		return nil, errLostQuorum
-	}
-
 	cc, err := n.getLeaderConn()
 	if err == nil {
 		return cc, nil
@@ -1381,6 +1377,10 @@ func (n *Node) LeaderConn(ctx context.Context) (*grpc.ClientConn, error) {
 	if err == raftselector.ErrIsLeader {
 		return nil, err
 	}
+	if atomic.LoadUint32(&n.ticksWithNoLeader) > lostQuorumTimeout {
+		return nil, errLostQuorum
+	}
+
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
 	for {


### PR DESCRIPTION
If the leader comes back after an extended period of quorum loss, we may
not realize this until a tick has elapsed. API calls may fail even
though there actually is a leader at that point in time. To solve this,
optimistically try to get the leader connection, and only check
ticksWithNoLeader if this fails.

cc @cyli