### PR TITLE
Only filter on plugins if running with docker engine

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -128,6 +128,12 @@ func (f *PluginFilter) SetTask(t *api.Task) bool {
 // Check returns true if the task can be scheduled into the given node.
 // TODO(amitshukla): investigate storing Plugins as a map so it can be easily probed
 func (f *PluginFilter) Check(n *NodeInfo) bool {
+	if n.Description == nil || n.Description.Engine == nil {
+		// If the node is not running Engine, plugins are not
+		// supported.
+		return true
+	}
+
 	// Get list of plugins on the node
 	nodePlugins := n.Description.Engine.Plugins
 


### PR DESCRIPTION
If there is no engine description then this assumes that all drivers etc are built-in and thus always available, and when they are not proper errors will be generated and propagated.
    
This avoids the need in https://github.com/docker/swarmkit/pull/1965 to populate a spurious `api.NodeDescription.Engine` field (spurious because there is no engine in this case).
    
Signed-off-by: Ian Campbell <ian.campbell@docker.com>

The `api.NodeDescription.Engine` field is https://github.com/ijc25/swarmkit/blob/42f853a3c262666e29d4c0bd3ea301d5e736bc82/agent/exec/containerd/executor.go#L93...L101 in the current PR (but I expect that link to break when I next force push there) it is the `executor.Describe` method and is just:
```
		// Possibly this should have a Containerd entry
		// instead. There is some code which
		// `desc.Engine.Plugins` to be non-nil see
		// `PluginFilter.Check` in
		// `manager/scheduler/filter.go`
		Engine: &api.EngineDescription{
			Labels:  map[string]string{},
			Plugins: []api.PluginDescription{},
		},
```