### PR TITLE
scheduler: Fix flaky test TestSchedulerCompatiblePlatform

### DIFF
--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -1833,6 +1833,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 	}
 
 	// node with nil platform description, cannot schedule anything
+	// with a platform constraint
 	node3 := &api.Node{
 		ID: "node3",
 		Spec: api.NodeSpec{
@@ -1890,7 +1891,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assignment2 := watchAssignment(t, watch)
-	assert.Regexp(t, assignment2.NodeID, "(node1|node2)")
+	assert.Regexp(t, assignment2.NodeID, "(node2|node3)")
 
 	// add task4
 	err = s.Update(func(tx store.Tx) error {


### PR DESCRIPTION
task1 lands on node1.
task2 cannot be scheduled.
task3 can land on either node2 or node3 without creating an unbalanced situation. The lack of platform information on node3 is not a factor because task3 doesn't have platform constraints.

However, the test currently expects task3 to land on node1 or node2.

cc @nishanttotla