### PR TITLE
manager: Fix hanging Stop method

### DIFF
--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -361,7 +361,7 @@ func (n *Node) JoinAndStart(ctx context.Context) (err error) {
 		if err != nil {
 			n.stopMu.Lock()
 			// to shutdown transport
-			close(n.stopped)
+			n.cancelFunc()
 			n.stopMu.Unlock()
 			n.done()
 		} else {


### PR DESCRIPTION
If `raftNode.JoinAndStart` failed, `Stop` will block forever because it waits for the manager to start up.

To fix this, close the "started" channel even if Run exits early due to an error. Fix the way the collector is initialized so its `Stop` method won't hang either.

Add a test that makes sure the node shuts down cleanly after a failed manager initialization.

cc @cyli