### PR TITLE
Fix cnmallocator darwin import

### DIFF
--- a/manager/allocator/cnmallocator/drivers_darwin.go
+++ b/manager/allocator/cnmallocator/drivers_darwin.go
@@ -3,6 +3,7 @@ package cnmallocator
 import (
 	"github.com/docker/libnetwork/drivers/overlay/ovmanager"
 	"github.com/docker/libnetwork/drivers/remote"
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 )
 
 var initializers = []initializer{
@@ -11,6 +12,6 @@ var initializers = []initializer{
 }
 
 // PredefinedNetworks returns the list of predefined network structures
-func PredefinedNetworks() []PredefinedNetworkData {
+func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
 	return nil
 }


### PR DESCRIPTION
When building on mac OS I got the following error:

```
# github.com/docker/swarmkit/manager/allocator/cnmallocator
manager/allocator/cnmallocator/drivers_darwin.go:14: undefined: PredefinedNetworkData
```

Import the type from the `networkallocator` package.