### PR TITLE
[agent/node] Bail on cert error when joining

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -206,6 +206,11 @@ func (a *Agent) run(ctx context.Context) {
 		leaving       = a.leaving
 		subscriptions = map[string]context.CancelFunc{}
 	)
+	defer func() {
+		if session != nil {
+			session.close()
+		}
+	}()
 
 	if err := a.worker.Init(ctx); err != nil {
 		log.G(ctx).WithError(err).Error("worker initialization failed")
@@ -314,6 +319,9 @@ func (a *Agent) run(ctx context.Context) {
 			if ready != nil {
 				close(ready)
 			}
+			if a.config.SessionTracker != nil {
+				a.config.SessionTracker.SessionEstablished()
+			}
 			ready = nil
 			registered = nil // we only care about this once per session
 			backoff = 0      // reset backoff
@@ -323,6 +331,10 @@ func (a *Agent) run(ctx context.Context) {
 			// but no error was sent. This must be the only place
 			// session.close is called in response to errors, for this to work.
 			if err != nil {
+				if a.config.SessionTracker != nil {
+					a.config.SessionTracker.SessionError(err)
+				}
+
 				log.G(ctx).WithError(err).Error("agent: session failed")
 				backoff = initialSessionFailureBackoff + 2*backoff
 				if backoff > maxSessionFailureBackoff {
@@ -337,6 +349,14 @@ func (a *Agent) run(ctx context.Context) {
 			// if we're here before <-registered, do nothing for that event
 			registered = nil
 		case <-session.closed:
+			if a.config.SessionTracker != nil {
+				if err := a.config.SessionTracker.SessionClosed(); err != nil {
+					log.G(ctx).WithError(err).Error("agent: exiting")
+					a.err = err
+					return
+				}
+			}
+
 			log.G(ctx).Debugf("agent: rebuild session")
 
 			// select a session registration delay from backoff range.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -207,9 +207,7 @@ func (a *Agent) run(ctx context.Context) {
 		subscriptions = map[string]context.CancelFunc{}
 	)
 	defer func() {
-		if session != nil {
-			session.close()
-		}
+		session.close()
 	}()
 
 	if err := a.worker.Init(ctx); err != nil {
@@ -385,8 +383,6 @@ func (a *Agent) run(ctx context.Context) {
 			if a.err == nil {
 				a.err = ctx.Err()
 			}
-			session.close()
-
 			return
 		}
 	}

--- a/agent/config.go
+++ b/agent/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	// NodeTLSInfo contains the starting node TLS info to bootstrap into the agent
 	NodeTLSInfo *api.NodeTLSInfo
 
-	// SessionTracker, if provided, will have its OnSessionClosed and OnSessionError methods called
+	// SessionTracker, if provided, will have its SessionClosed and SessionError methods called
 	// when sessions close and error.
 	SessionTracker SessionTracker
 }

--- a/agent/config.go
+++ b/agent/config.go
@@ -43,6 +43,10 @@ type Config struct {
 
 	// NodeTLSInfo contains the starting node TLS info to bootstrap into the agent
 	NodeTLSInfo *api.NodeTLSInfo
+
+	// SessionTracker, if provided, will have its OnSessionClosed and OnSessionError methods called
+	// when sessions close and error.
+	SessionTracker SessionTracker
 }
 
 func (c *Config) validate() error {
@@ -63,4 +67,17 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+// A SessionTracker gets notified when sessions close and error
+type SessionTracker interface {
+	// SessionClosed is called whenever a session is closed - if the function errors, the agent
+	// will exit with the returned error.  Otherwise the agent can continue and rebuild a new session.
+	SessionClosed() error
+
+	// SessionError is called whenever a session errors
+	SessionError(err error)
+
+	// SessionEstablished is called whenever a session is established
+	SessionEstablished()
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -409,7 +409,7 @@ func (s *session) sendError(err error) {
 }
 
 // close closing session. It should be called only in <-session.errs branch
-// of event loop.
+// of event loop, or when cleaning up the agent.
 func (s *session) close() error {
 	s.closeOnce.Do(func() {
 		s.cancel()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	cautils "github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/manager"
 	"github.com/docker/swarmkit/testutils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -717,4 +718,70 @@ func TestRepeatedRootRotation(t *testing.T) {
 		}
 		return nil
 	}, opsTimeout))
+}
+
+func TestNodeRejoins(t *testing.T) {
+	t.Parallel()
+	numWorker, numManager := 1, 3
+	cl := newCluster(t, numWorker, numManager)
+	defer func() {
+		require.NoError(t, cl.Stop())
+	}()
+	pollClusterReady(t, cl, numWorker, numManager)
+
+	clusterInfo, err := cl.GetClusterInfo()
+	require.NoError(t, err)
+
+	leader, err := cl.Leader()
+	require.NoError(t, err)
+
+	// Find a manager (not the leader) and the worker to shut down.
+	getNonLeaderAndWorker := func() map[string]*testNode {
+		results := make(map[string]*testNode)
+		for _, n := range cl.nodes {
+			nodeID := n.node.NodeID()
+			if n.IsManager() {
+				if nodeID != leader.node.NodeID() {
+					results[ca.ManagerRole] = n
+				}
+			} else {
+				results[ca.WorkerRole] = n
+			}
+		}
+		return results
+	}
+
+	// rejoining succeeds - (both because the certs are correct, and because node.Pause sets the JoinAddr to "")
+	for _, n := range getNonLeaderAndWorker() {
+		nodeID := n.node.NodeID()
+		require.NoError(t, n.Pause(false))
+		require.NoError(t, cl.StartNode(nodeID))
+	}
+	pollClusterReady(t, cl, numWorker, numManager)
+
+	// rejoining if the certs are wrong will fail fast so long as the join address is passed, but will keep retrying
+	// forever if the join address is not passed
+	leader, err = cl.Leader() // in case leadership changed
+	require.NoError(t, err)
+	for role, n := range getNonLeaderAndWorker() {
+		nodeID := n.node.NodeID()
+		require.NoError(t, n.Pause(false))
+
+		// generate new certs with the same node ID, role, and cluster ID, but with the wrong CA
+		paths := ca.NewConfigPaths(filepath.Join(n.config.StateDir, "certificates"))
+		newRootCA, err := ca.CreateRootCA("bad root CA")
+		require.NoError(t, err)
+		ca.SaveRootCA(newRootCA, paths.RootCA)
+		krw := ca.NewKeyReadWriter(paths.Node, nil, &manager.RaftDEKData{}) // make sure the key headers are preserved
+		_, _, err = krw.Read()
+		require.NoError(t, err)
+		_, _, err = newRootCA.IssueAndSaveNewCertificates(krw, nodeID, role, clusterInfo.ID)
+		require.NoError(t, err)
+
+		n.config.JoinAddr, err = leader.node.RemoteAPIAddr()
+		require.NoError(t, err)
+		err = cl.StartNode(nodeID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "certificate signed by unknown authority")
+	}
 }

--- a/node/node.go
+++ b/node/node.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -432,10 +434,10 @@ func (n *Node) run(ctx context.Context) (err error) {
 	}()
 
 	wg.Wait()
-	if managerErr != nil && managerErr != context.Canceled {
+	if managerErr != nil && errors.Cause(managerErr) != context.Canceled {
 		return managerErr
 	}
-	if agentErr != nil && agentErr != context.Canceled {
+	if agentErr != nil && errors.Cause(agentErr) != context.Canceled {
 		return agentErr
 	}
 	return err
@@ -516,7 +518,7 @@ waitPeer:
 	rootCA := securityConfig.RootCA()
 	issuer := securityConfig.IssuerInfo()
 
-	a, err := agent.New(&agent.Config{
+	agentConfig := &agent.Config{
 		Hostname:         n.config.Hostname,
 		ConnBroker:       n.connBroker,
 		Executor:         n.config.Executor,
@@ -529,7 +531,14 @@ waitPeer:
 			CertIssuerPublicKey: issuer.PublicKey,
 			CertIssuerSubject:   issuer.Subject,
 		},
-	})
+	}
+	// if a join address has been specified, then if the agent fails to connect due to a TLS error, fail fast - don't
+	// keep re-trying to join
+	if n.config.JoinAddr != "" {
+		agentConfig.SessionTracker = &firstSessionErrorTracker{}
+	}
+
+	a, err := agent.New(agentConfig)
 	if err != nil {
 		return err
 	}
@@ -1055,3 +1064,37 @@ func (sp sortablePeers) Less(i, j int) bool { return sp[i].NodeID < sp[j].NodeID
 func (sp sortablePeers) Len() int { return len(sp) }
 
 func (sp sortablePeers) Swap(i, j int) { sp[i], sp[j] = sp[j], sp[i] }
+
+// firstSessionErrorTracker is a utility that helps determine whether the agent should exit after
+// a TLS failure on establishing the first session.  This should only happen if a join address
+// is specified.  If establishing the first session succeeds, but later on some session fails
+// because of a TLS error, we don't want to exit the agent because a previously successful
+// session indicates that the TLS error may be a transient issue.
+type firstSessionErrorTracker struct {
+	mu               sync.Mutex
+	pastFirstSession bool
+	err              error
+}
+
+func (fs *firstSessionErrorTracker) SessionEstablished() {
+	fs.mu.Lock()
+	fs.pastFirstSession = true
+	fs.mu.Unlock()
+}
+
+func (fs *firstSessionErrorTracker) SessionError(err error) {
+	fs.mu.Lock()
+	fs.err = err
+	fs.mu.Unlock()
+}
+
+func (fs *firstSessionErrorTracker) SessionClosed() error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	// unfortunately grpc connection errors are type grpc.rpcError, which are not exposed, and we can't get at the underlying error type
+	if !fs.pastFirstSession && grpc.Code(fs.err) == codes.Internal &&
+		strings.HasPrefix(grpc.ErrorDesc(fs.err), "connection error") && strings.Contains(grpc.ErrorDesc(fs.err), "transport: x509:") {
+		return fs.err
+	}
+	return nil
+}


### PR DESCRIPTION
This is an attempt to address https://github.com/moby/moby/issues/33380.

Basically, when a join address is passed, then if there are x509 errors when connecting to that join address, the agent should bail rather than attempt to rebuild a session over and over.  This is on the assumption that a join address is only passed when attempting to join a cluster (see https://github.com/moby/moby/pull/33361).

We want to make sure that, if the join address is passed, it only fails on x509 errors if there were no previous successful sessions.  If there were previous successful sessions, this indicates that the x509 error is perhaps a result of one of the managers, as opposed to the node that is attempting to join.

Because of this, we have to keep track of how many sessions and session errors there've been on the agent, hence keeping track of state.

This is not the ideal implementation, because it is keeping track of agent lifetime state simply for the purpose of bailing early, and also because connection errors in GRPC aren't really checkable by type (since GRPC wraps and flattens all the errors down to just a description string).

An alternative solution is to load the certs and attempt to dial to the `JoinAddr` first, before even starting up the node, and see if it fails (see similar logic where we validate external CA urls: https://github.com/docker/swarmkit/blob/master/manager/controlapi/ca_rotation.go#L116).

However, this adds a certain amount of lag on every `Node` instantiation, and also is not necessarily reliable because if there are non-x509 connection errors, we'd have to either just proceed onto starting the node and just continue retrying on non-x509 errors, or we have to wait for a while until either we've connected or failed with some kind of error.

There was some discussion about changing the behavior of `Join` so that it does not try to join in the background, but will just fail after a given timeout, but as @aaronlehmann pointed out, this changes existing behavior.