### PR TITLE
[ca] Fix the UpdateRootCA function to also update the ExternalCA's rootCA

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -157,6 +157,8 @@ func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA, externalCARootPool *x509.C
 
 	s.rootCA = rootCA
 	s.externalCAClientRootPool = externalCARootPool
+	s.externalCA.UpdateRootCA(rootCA)
+
 	return s.updateTLSCredentials(s.certificate, s.issuerInfo)
 }
 


### PR DESCRIPTION
Since if it's not updated when getting a cert signed by an external CA, no intermediates are appended.

Previously the test for this (`TestRequestAndSaveNewCertificatesWithIntermediates`) passed due a combination of both this bug and a bug in how the test CA utility worked (it updated the RootCA to one without intermediates, but since updating the root CA didn't actually propagate to the external CA signing object, the external CA signer did produce a cert with intermediates).

I've updated the test CA utility and the tests as well.  I'll also open a PR against the 17.06 branch.

cc @aaronlehmann @diogomonica @jlhawn