### PR TITLE
[ca][17.06] Fix the UpdateRootCA function to also update the ExternalCA's rootCA

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -157,6 +157,11 @@ func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA, externalCARootPool *x509.C
 
 	s.rootCA = rootCA
 	s.externalCAClientRootPool = externalCARootPool
+
+	s.externalCA.mu.Lock()
+	s.externalCA.rootCA = rootCA
+	s.externalCA.mu.Unlock()
+
 	return s.updateTLSCredentials(s.certificate, s.issuerInfo)
 }
 


### PR DESCRIPTION
Backport of https://github.com/docker/swarmkit/pull/2210 to the 17.06 branch.