### PR TITLE
[ca] Include a signing profile for cross-signing CA certs externally

### DIFF
--- a/ca/external.go
+++ b/ca/external.go
@@ -23,6 +23,9 @@ import (
 	"golang.org/x/net/context/ctxhttp"
 )
 
+// ExternalCrossSignProfile is the profile that we will be sending cross-signing CSR sign requests with
+const ExternalCrossSignProfile = "CA"
+
 // ErrNoExternalCAURLs is an error used it indicate that an ExternalCA is
 // configured with no URLs to which it can proxy certificate signing requests.
 var ErrNoExternalCAURLs = errors.New("no external CA URLs")
@@ -157,6 +160,7 @@ func (eca *ExternalCA) CrossSignRootCA(ctx context.Context, rca RootCA) ([]byte,
 			CN:    rootCert.Subject.CommonName,
 			Names: cfCSRObj.Names,
 		},
+		Profile: ExternalCrossSignProfile,
 	}
 	// cfssl actually ignores non subject alt name extensions in the CSR, so we have to add the CA extension in the signing
 	// request as well


### PR DESCRIPTION
When we make an external CA request to cross-sign a certificate, include a particular signing profile that can be implemented by the external CA.

This way it will be easier for them to implement extra policies.

This is not urgent, but would be good to make this part of the input external CAs that interact with swarm should expect.

cc @diogomonica @aaronlehmann @jlhawn 