### PR TITLE
allocator: Fix events watch leak

### DIFF
--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -51,13 +51,6 @@ type taskBallot struct {
 
 // allocActor controls the various phases in the lifecycle of one kind of allocator.
 type allocActor struct {
-	// Channel through which the allocator gets all the events
-	// that it is interested in.
-	ch chan events.Event
-
-	// cancel unregisters the watcher.
-	cancel func()
-
 	// Task voter identity of the allocator.
 	taskVoter string
 
@@ -90,7 +83,10 @@ func New(store *store.MemoryStore, pg plugingetter.PluginGetter) (*Allocator, er
 func (a *Allocator) Run(ctx context.Context) error {
 	// Setup cancel context for all goroutines to use.
 	ctx, cancel := context.WithCancel(ctx)
-	var wg sync.WaitGroup
+	var (
+		wg     sync.WaitGroup
+		actors []func() error
+	)
 
 	defer func() {
 		cancel()
@@ -98,26 +94,8 @@ func (a *Allocator) Run(ctx context.Context) error {
 		close(a.doneChan)
 	}()
 
-	var actors []func() error
-	watch, watchCancel := state.Watch(a.store.WatchQueue(),
-		api.EventCreateNetwork{},
-		api.EventDeleteNetwork{},
-		api.EventCreateService{},
-		api.EventUpdateService{},
-		api.EventDeleteService{},
-		api.EventCreateTask{},
-		api.EventUpdateTask{},
-		api.EventDeleteTask{},
-		api.EventCreateNode{},
-		api.EventUpdateNode{},
-		api.EventDeleteNode{},
-		state.EventCommit{},
-	)
-
 	for _, aa := range []allocActor{
 		{
-			ch:        watch,
-			cancel:    watchCancel,
 			taskVoter: networkVoter,
 			init:      a.doNetworkInit,
 			action:    a.doNetworkAlloc,
@@ -127,8 +105,8 @@ func (a *Allocator) Run(ctx context.Context) error {
 			a.registerToVote(aa.taskVoter)
 		}
 
-		// Copy the iterated value for variable capture.
-		aaCopy := aa
+		// Assign a pointer for variable capture
+		aaPtr := &aa
 		actor := func() error {
 			wg.Add(1)
 			defer wg.Done()
@@ -136,19 +114,19 @@ func (a *Allocator) Run(ctx context.Context) error {
 			// init might return an allocator specific context
 			// which is a child of the passed in context to hold
 			// allocator specific state
-			if err := aaCopy.init(ctx); err != nil {
-				// Stop the watches for this allocator
-				// if we are failing in the init of
-				// this allocator.
-				aa.cancel()
+			watch, watchCancel, err := a.init(ctx, aaPtr)
+			if err != nil {
 				return err
 			}
 
 			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				a.run(ctx, aaCopy)
-			}()
+			go func(watch <-chan events.Event, watchCancel func()) {
+				defer func() {
+					wg.Done()
+					watchCancel()
+				}()
+				a.run(ctx, *aaPtr, watch)
+			}(watch, watchCancel)
 			return nil
 		}
 
@@ -172,10 +150,34 @@ func (a *Allocator) Stop() {
 	<-a.doneChan
 }
 
-func (a *Allocator) run(ctx context.Context, aa allocActor) {
+func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
+	watch, watchCancel := state.Watch(a.store.WatchQueue(),
+		api.EventCreateNetwork{},
+		api.EventDeleteNetwork{},
+		api.EventCreateService{},
+		api.EventUpdateService{},
+		api.EventDeleteService{},
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+		api.EventCreateNode{},
+		api.EventUpdateNode{},
+		api.EventDeleteNode{},
+		state.EventCommit{},
+	)
+
+	if err := aa.init(ctx); err != nil {
+		watchCancel()
+		return nil, nil, err
+	}
+
+	return watch, watchCancel, nil
+}
+
+func (a *Allocator) run(ctx context.Context, aa allocActor, watch <-chan events.Event) {
 	for {
 		select {
-		case ev, ok := <-aa.ch:
+		case ev, ok := <-watch:
 			if !ok {
 				return
 			}


### PR DESCRIPTION
The allocator starts a watch on events and never shuts it down. If this node loses leadership, events will continue to pile up in that queue forever, leading to memory exhaustion.

Fix this by giving the watch a well-defined lifecycle. Return it along with a cancel function from an init() method to make it clear it must be cancelled, instead of sticking the cancel function value in a struct where there is no clear responsibilty for calling it.

In the future, we might consider changing `Watch` to run a callback function, so shutting down the watch is mandatory (similar to what we do with store transactions).

cc @briantd @jakegdocker