### PR TITLE
taskreaper: Clean up Watch code

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1033,7 +1033,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	}(m.constraintEnforcer)
 
 	go func(taskReaper *taskreaper.TaskReaper) {
-		taskReaper.Run()
+		taskReaper.Run(ctx)
 	}(m.taskReaper)
 
 	go func(orchestrator *replicated.Orchestrator) {

--- a/manager/orchestrator/replicated/task_reaper_test.go
+++ b/manager/orchestrator/replicated/task_reaper_test.go
@@ -75,7 +75,7 @@ func TestTaskHistory(t *testing.T) {
 	go func() {
 		assert.NoError(t, orchestrator.Run(ctx))
 	}()
-	go taskReaper.Run()
+	go taskReaper.Run(ctx)
 
 	observedTask1 := testutils.WatchTaskCreate(t, watch)
 	assert.Equal(t, observedTask1.Status.State, api.TaskStateNew)


### PR DESCRIPTION
It is not necessary to create a watch in the `New` function. Creating it in `Run` is more consistent with other parts of the code, and makes the lifecycle of the watch clearer.

This is not a functional change, but it may help prevent adding bugs in the future.

Also, thread through a context to use for logging.