### PR TITLE
[tests] Cleanup and better logging

### DIFF
--- a/ca/external.go
+++ b/ca/external.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/csr"
 	"github.com/cloudflare/cfssl/signer"
+	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
@@ -126,7 +127,7 @@ func (eca *ExternalCA) Sign(ctx context.Context, req signer.SignRequest) (cert [
 		if err == nil {
 			return append(cert, intermediates...), err
 		}
-		logrus.Debugf("unable to proxy certificate signing request to %s: %s", url, err)
+		log.G(ctx).Debugf("unable to proxy certificate signing request to %s: %s", url, err)
 	}
 
 	return nil, err

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -152,18 +152,7 @@ func pollServiceReady(t *testing.T, c *testCluster, sid string, replicas int) {
 }
 
 func newCluster(t *testing.T, numWorker, numManager int) *testCluster {
-	// Get name of caller
-	var testName string
-	pc, _, _, ok := runtime.Caller(1)
-	if ok {
-		funcName := runtime.FuncForPC(pc).Name()
-		splitted := strings.Split(funcName, ".")
-		if len(splitted) > 1 {
-			testName = splitted[len(splitted)-1]
-		}
-	}
-
-	cl := newTestCluster(testName)
+	cl := newTestCluster(t.Name())
 	for i := 0; i < numManager; i++ {
 		require.NoError(t, cl.AddManager(false, nil), "manager number %d", i+1)
 	}
@@ -190,7 +179,7 @@ func TestServiceCreateLateBind(t *testing.T) {
 
 	numWorker, numManager := 3, 3
 
-	cl := newTestCluster("TestServiceCreateLateBind")
+	cl := newTestCluster(t.Name())
 	for i := 0; i < numManager; i++ {
 		require.NoError(t, cl.AddManager(true, nil), "manager number %d", i+1)
 	}
@@ -501,7 +490,7 @@ func TestForceNewCluster(t *testing.T) {
 
 	// start a new cluster with the external CA bootstrapped
 	numWorker, numManager := 0, 1
-	cl := newTestCluster("TestForceNewCluster")
+	cl := newTestCluster(t.Name())
 	defer func() {
 		require.NoError(t, cl.Stop())
 	}()


### PR DESCRIPTION
This PR includes some test cleanups discovered while debugging #2221:

1. The goroutine that updates to the RootCA of the testing CA server never actually terminates after a test, because the context is never canceled.  This makes sure that goroutine is cleaned up.

1. One of the fake CA servers is never stopped after a test - added a defer stop.

1. Similar to how the integration tests log the test names, do the same for the testing CA so we can tell which logs belong to which test.

cc @aaronlehmann @ijc25 This does not actually fix the stated issue above, but would be helpful for debugging and may reduce some resource consumption for running the tests.