### PR TITLE
[tests] No local signer for test CA if external CA is desired

### DIFF
--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -144,12 +144,28 @@ func NewTestCAFromAPIRootCA(t *testing.T, tempBaseDir string, apiRootCA api.Root
 
 	if External {
 		// Start the CA API server - ensure that the external server doesn't have any intermediates
-		externalSigningServer, err = NewExternalSigningServer(rootCA, tempBaseDir)
-		assert.NoError(t, err)
+		var extRootCA ca.RootCA
+		if apiRootCA.RootRotation != nil {
+			extRootCA, err = ca.NewRootCA(
+				apiRootCA.RootRotation.CACert, apiRootCA.RootRotation.CACert, apiRootCA.RootRotation.CAKey, ca.DefaultNodeCertExpiration, nil)
+			// remove the key from the API root CA so that once the CA server starts up, it won't have a local signer
+			apiRootCA.RootRotation.CAKey = nil
+		} else {
+			extRootCA, err = ca.NewRootCA(
+				apiRootCA.CACert, apiRootCA.CACert, apiRootCA.CAKey, ca.DefaultNodeCertExpiration, nil)
+			// remove the key from the API root CA so that once the CA server starts up, it won't have a local signer
+			apiRootCA.CAKey = nil
+		}
+		require.NoError(t, err)
+
+		externalSigningServer, err = NewExternalSigningServer(extRootCA, tempBaseDir)
+		require.NoError(t, err)
+
 		externalCAs = []*api.ExternalCA{
 			{
 				Protocol: api.ExternalCA_CAProtocolCFSSL,
 				URL:      externalSigningServer.URL,
+				CACert:   extRootCA.Certs,
 			},
 		}
 	}


### PR DESCRIPTION
Ensure that the test CA, if an external CA is desired, does not have a local signer.

Signed-off-by: Ying Li <ying.li@docker.com>

This also does is not a fix for #2221, but is more correct behavior.  I added https://github.com/docker/swarmkit/pull/2210/files#diff-70b482ef8a125f8723ff2f77b65299faR146 as a comment and never followed through on it in #2210.