### PR TITLE
[ca] GetRemoteSignedCertificate downloads cert in Issuance or Rotate state

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -871,7 +871,7 @@ func GetRemoteSignedCertificate(ctx context.Context, csr []byte, rootCAPool *x50
 			caClient = api.NewNodeCAClient(conn.ClientConn)
 
 		// If there was no deadline exceeded error, and the certificate was issued, return
-		case err == nil && statusResponse.Status.State == api.IssuanceStateIssued:
+		case err == nil && (statusResponse.Status.State == api.IssuanceStateIssued || statusResponse.Status.State == api.IssuanceStateRotate):
 			if statusResponse.Certificate == nil {
 				conn.Close(false)
 				return nil, errors.New("no certificate in CertificateStatus response")


### PR DESCRIPTION
If a node has no registered TLS info, or has TLS info indicating that it was signed
by a different CA cert, and the cluster is in the middle of a root rotation, then
the root reconciler updates the node info to mark it as needing a rotation.

However, when a node requests a new cert, it will only download the new cert if the
issuance status is ISSUED.  If the root reconciler happens to get to the node
immediately after the CA signs it but before the node downloads it, then the node
will never download it and will poll until timeout, and then request a new certificate
instead.

Since a node only gets marked as ROTATE if it's not already in PENDING, just download
the cert even if the cluster says that the issuance state is ROTATE.  This will cut
short a lot of extra polling before the node gets a new certificate as per the ROTATE
directive.

Signed-off-by: Ying Li <ying.li@docker.com>

cc @aaronlehmann @diogomonica 

This should fix #2221.  @ijc25 Would you mind verifying?  I ran `make test` on your branch through 30 iterations and did not seem to trigger the error, although I had also included the changes from #2222 and #2223.

This is probably not super critical of a change, since triggering this issue depends on the timing of the root rotation reconciler and when a node requests a new cert vs when it polls to get the signed cert.  If this does occur in a a real cluster, the node should just re-request a new cert after the timeout.