### PR TITLE
Ensure controlapi Server always has an up to date allocator

### DIFF
--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -107,7 +107,7 @@ func validateNetworkSpec(spec *api.NetworkSpec, a *allocator.Allocator, pg plugi
 // - Returns `InvalidArgument` if the NetworkSpec is malformed.
 // - Returns an error if the creation fails.
 func (s *Server) CreateNetwork(ctx context.Context, request *api.CreateNetworkRequest) (*api.CreateNetworkResponse, error) {
-	if err := validateNetworkSpec(request.Spec, s.a, s.pg); err != nil {
+	if err := validateNetworkSpec(request.Spec, *(s.a), s.pg); err != nil {
 		return nil, err
 	}
 

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -21,14 +21,15 @@ type Server struct {
 	raft           *raft.Node
 	securityConfig *ca.SecurityConfig
 	scu            ca.APISecurityConfigUpdater
-	a              *allocator.Allocator
+	a              **allocator.Allocator
 	pg             plugingetter.PluginGetter
 }
 
 // NewServer creates a Cluster API server.
 func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig,
-	scu ca.APISecurityConfigUpdater, a *allocator.Allocator, pg plugingetter.PluginGetter) *Server {
+	scu ca.APISecurityConfigUpdater, a **allocator.Allocator, pg plugingetter.PluginGetter) *Server {
 	return &Server{
+		a:              a,
 		store:          store,
 		raft:           raft,
 		securityConfig: securityConfig,

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	cautils "github.com/docker/swarmkit/ca/testutils"
+	"github.com/docker/swarmkit/manager/allocator"
 	"github.com/docker/swarmkit/manager/state/store"
 	stateutils "github.com/docker/swarmkit/manager/state/testutils"
 	"github.com/stretchr/testify/assert"
@@ -48,7 +49,8 @@ func newTestServer(t *testing.T) *testServer {
 	ts.Store = store.NewMemoryStore(&stateutils.MockProposer{})
 	assert.NotNil(t, ts.Store)
 
-	ts.Server = NewServer(ts.Store, nil, securityConfig, ca.NewServer(ts.Store, securityConfig, tc.Paths.RootCA), nil, nil)
+	var a *allocator.Allocator
+	ts.Server = NewServer(ts.Store, nil, securityConfig, ca.NewServer(ts.Store, securityConfig, tc.Paths.RootCA), &a, nil)
 	assert.NotNil(t, ts.Server)
 
 	temp, err := ioutil.TempFile("", "test-socket")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -396,7 +396,7 @@ func (m *Manager) Run(parent context.Context) error {
 		return err
 	}
 
-	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.caserver, m.allocator, m.config.PluginGetter)
+	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.caserver, &m.allocator, m.config.PluginGetter)
 	baseWatchAPI := watchapi.NewServer(m.raftNode.MemoryStore())
 	baseResourceAPI := resourceapi.New(m.raftNode.MemoryStore())
 	healthServer := health.NewHealthServer()

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -187,6 +187,18 @@ func TestManager(t *testing.T) {
 		)
 	}))
 	controlClient = api.NewControlClient(controlConn)
+	_, err = controlClient.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
+		Spec: &api.NetworkSpec{
+			Annotations: api.Annotations{
+				Name: "test-network-bad-driver",
+			},
+			DriverConfig: &api.Driver{
+				Name: "invalid-must-never-exist",
+			},
+		},
+	})
+	assert.Error(t, err)
+
 	_, err = controlClient.RemoveNode(context.Background(),
 		&api.RemoveNodeRequest{
 			NodeID: agentID,


### PR DESCRIPTION
Currently the allocator is only created when a node becomes the leader, which
is (almost always) after the controlapi.NewServer call. Hence the server is
always being passed a m.allocator which is nil.

In addition the server wasn't actually remembering the allocator it was passed.

Add a second layer of indirection to the allocator stashed by the controlapi
Server, so it will always see the latest version of m.allocator.

This stops #2230 from happening, but is really only a stopgap until a more
satisfactory solution can be found.

This regression was made by me in fb74191488a7 ("Convert NetworkAllocator to an
interface"). Add a call to CreateNetwork to TestManager intended to exercise
the code path through validateNetwork to allocator.IsBuiltinNetworkDriver.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>