### PR TITLE
scheduler: Do not try to underweight nodes for global services

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -31,8 +31,11 @@ type schedulingDecision struct {
 type Scheduler struct {
 	store           *store.MemoryStore
 	unassignedTasks map[string]*api.Task
-	// preassignedTasks already have NodeID, need resource validation
-	preassignedTasks map[string]*api.Task
+	// pendingPreassignedTasks already have NodeID, need resource validation
+	pendingPreassignedTasks map[string]*api.Task
+	// preassignedTasks tracks tasks that were preassigned, including those
+	// past the pending state.
+	preassignedTasks map[string]struct{}
 	nodeSet          nodeSet
 	allTasks         map[string]*api.Task
 	pipeline         *Pipeline
@@ -46,13 +49,14 @@ type Scheduler struct {
 // New creates a new scheduler.
 func New(store *store.MemoryStore) *Scheduler {
 	return &Scheduler{
-		store:            store,
-		unassignedTasks:  make(map[string]*api.Task),
-		preassignedTasks: make(map[string]*api.Task),
-		allTasks:         make(map[string]*api.Task),
-		stopChan:         make(chan struct{}),
-		doneChan:         make(chan struct{}),
-		pipeline:         NewPipeline(),
+		store:                   store,
+		unassignedTasks:         make(map[string]*api.Task),
+		pendingPreassignedTasks: make(map[string]*api.Task),
+		preassignedTasks:        make(map[string]struct{}),
+		allTasks:                make(map[string]*api.Task),
+		stopChan:                make(chan struct{}),
+		doneChan:                make(chan struct{}),
+		pipeline:                NewPipeline(),
 	}
 }
 
@@ -77,7 +81,8 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 		}
 		// preassigned tasks need to validate resource requirement on corresponding node
 		if t.Status.State == api.TaskStatePending {
-			s.preassignedTasks[t.ID] = t
+			s.preassignedTasks[t.ID] = struct{}{}
+			s.pendingPreassignedTasks[t.ID] = t
 			continue
 		}
 
@@ -129,7 +134,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	tickRequired := false
 
 	schedule := func() {
-		if len(s.preassignedTasks) > 0 {
+		if len(s.pendingPreassignedTasks) > 0 {
 			s.processPreassignedTasks(ctx)
 		}
 		if tickRequired {
@@ -152,7 +157,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 					tickRequired = true
 				}
 			case api.EventDeleteTask:
-				if s.deleteTask(ctx, v.Task) {
+				if s.deleteTask(v.Task) {
 					// deleting tasks may free up node resource, pending tasks should be re-evaluated.
 					tickRequired = true
 				}
@@ -216,7 +221,8 @@ func (s *Scheduler) createTask(ctx context.Context, t *api.Task) bool {
 	}
 
 	if t.Status.State == api.TaskStatePending {
-		s.preassignedTasks[t.ID] = t
+		s.preassignedTasks[t.ID] = struct{}{}
+		s.pendingPreassignedTasks[t.ID] = t
 		// preassigned tasks do not contribute to running tasks count
 		return false
 	}
@@ -244,22 +250,32 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) bool {
 		if oldTask == nil {
 			return false
 		}
-		s.deleteTask(ctx, oldTask)
+
 		if t.Status.State != oldTask.Status.State &&
 			(t.Status.State == api.TaskStateFailed || t.Status.State == api.TaskStateRejected) {
-			nodeInfo, err := s.nodeSet.nodeInfo(t.NodeID)
-			if err == nil {
-				nodeInfo.taskFailed(ctx, t.ServiceID)
-				s.nodeSet.updateNode(nodeInfo)
+			// Keep track of task failures, so other nodes can be preferred
+			// for scheduling this service if it looks like the service is
+			// failing in a loop on this node. However, skip this for
+			// preassigned tasks, because the scheduler does not choose
+			// which nodes those run on.
+			if _, wasPreassigned := s.preassignedTasks[t.ID]; !wasPreassigned {
+				nodeInfo, err := s.nodeSet.nodeInfo(t.NodeID)
+				if err == nil {
+					nodeInfo.taskFailed(ctx, t.ServiceID)
+					s.nodeSet.updateNode(nodeInfo)
+				}
 			}
 		}
+
+		s.deleteTask(oldTask)
+
 		return true
 	}
 
 	if t.NodeID == "" {
 		// unassigned task
 		if oldTask != nil {
-			s.deleteTask(ctx, oldTask)
+			s.deleteTask(oldTask)
 		}
 		s.allTasks[t.ID] = t
 		s.enqueue(t)
@@ -268,10 +284,11 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) bool {
 
 	if t.Status.State == api.TaskStatePending {
 		if oldTask != nil {
-			s.deleteTask(ctx, oldTask)
+			s.deleteTask(oldTask)
 		}
+		s.preassignedTasks[t.ID] = struct{}{}
 		s.allTasks[t.ID] = t
-		s.preassignedTasks[t.ID] = t
+		s.pendingPreassignedTasks[t.ID] = t
 		// preassigned tasks do not contribute to running tasks count
 		return false
 	}
@@ -285,9 +302,10 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) bool {
 	return false
 }
 
-func (s *Scheduler) deleteTask(ctx context.Context, t *api.Task) bool {
+func (s *Scheduler) deleteTask(t *api.Task) bool {
 	delete(s.allTasks, t.ID)
 	delete(s.preassignedTasks, t.ID)
+	delete(s.pendingPreassignedTasks, t.ID)
 	nodeInfo, err := s.nodeSet.nodeInfo(t.NodeID)
 	if err == nil && nodeInfo.removeTask(t) {
 		s.nodeSet.updateNode(nodeInfo)
@@ -320,8 +338,8 @@ func (s *Scheduler) createOrUpdateNode(n *api.Node) {
 }
 
 func (s *Scheduler) processPreassignedTasks(ctx context.Context) {
-	schedulingDecisions := make(map[string]schedulingDecision, len(s.preassignedTasks))
-	for _, t := range s.preassignedTasks {
+	schedulingDecisions := make(map[string]schedulingDecision, len(s.pendingPreassignedTasks))
+	for _, t := range s.pendingPreassignedTasks {
 		newT := s.taskFitNode(ctx, t, t.NodeID)
 		if newT == nil {
 			continue
@@ -333,7 +351,7 @@ func (s *Scheduler) processPreassignedTasks(ctx context.Context) {
 
 	for _, decision := range successful {
 		if decision.new.Status.State == api.TaskStateAssigned {
-			delete(s.preassignedTasks, decision.old.ID)
+			delete(s.pendingPreassignedTasks, decision.old.ID)
 		}
 	}
 	for _, decision := range failed {
@@ -421,12 +439,7 @@ func (s *Scheduler) applySchedulingDecisions(ctx context.Context, schedulingDeci
 					t := store.GetTask(tx, taskID)
 					if t == nil {
 						// Task no longer exists
-						nodeInfo, err := s.nodeSet.nodeInfo(decision.new.NodeID)
-						if err == nil && nodeInfo.removeTask(decision.new) {
-							s.nodeSet.updateNode(nodeInfo)
-						}
-						delete(s.allTasks, decision.old.ID)
-
+						s.deleteTask(decision.new)
 						continue
 					}
 


### PR DESCRIPTION
The scheduler has simple failure loop detection that attempts to prefer
other nodes when a certain node experiences several failures in a row of
tasks from the same service. This makes sense for replicated services,
but doesn't have an effect on global services, because the node is
predetermined for each task. When this code path triggers with a global
service, it produces a confusing log message that suggests other nodes
will be preferred for this global service.

Change the scheduler to keep track of which tasks were preassigned to
nodes, and avoid tracking failures of those tasks.

Fixes #2228

cc @cpuguy83