### PR TITLE
orchestrator: Check that service's SpecVersion exists before dereferencing

### DIFF
--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -63,7 +63,7 @@ func IsTaskDirty(s *api.Service, t *api.Task) bool {
 	// If the spec version matches, we know the task is not dirty. However,
 	// if it does not match, that doesn't mean the task is dirty, since
 	// only a portion of the spec is included in the comparison.
-	if t.SpecVersion != nil && *s.SpecVersion == *t.SpecVersion {
+	if t.SpecVersion != nil && s.SpecVersion != nil && *s.SpecVersion == *t.SpecVersion {
 		return false
 	}
 


### PR DESCRIPTION
`IsTaskDirty` assumed that if a task had a `SpecVersion`, the corresponding service must also have a `SpecVersion`, since that is where the task's field is copied from. However, there are mixed-version scenarios where a service could get updated by a manager running an older version of swarmkit than the manager that created the task. Add a check to avoid a crash in this case.