### PR TITLE
[ca] Validate the Root CA certificate before updating the security config

### DIFF
--- a/ca/config.go
+++ b/ca/config.go
@@ -89,6 +89,39 @@ type CertificateUpdate struct {
 	Err  error
 }
 
+func validateRootCAAndTLSCert(rootCA *RootCA, externalCARootPool *x509.CertPool, tlsKeyPair *tls.Certificate) error {
+	var (
+		leafCert         *x509.Certificate
+		intermediatePool *x509.CertPool
+	)
+	for i, derBytes := range tlsKeyPair.Certificate {
+		parsed, err := x509.ParseCertificate(derBytes)
+		if err != nil {
+			return errors.Wrap(err, "could not validate new root certificates due to parse error")
+		}
+		if i == 0 {
+			leafCert = parsed
+		} else {
+			if intermediatePool == nil {
+				intermediatePool = x509.NewCertPool()
+			}
+			intermediatePool.AddCert(parsed)
+		}
+	}
+	opts := x509.VerifyOptions{
+		Roots:         rootCA.Pool,
+		Intermediates: intermediatePool,
+	}
+	if _, err := leafCert.Verify(opts); err != nil {
+		return errors.Wrap(err, "new root CA does not match existing TLS credentials")
+	}
+	opts.Roots = externalCARootPool
+	if _, err := leafCert.Verify(opts); err != nil {
+		return errors.Wrap(err, "new external root pool does not match existing TLS credentials")
+	}
+	return nil
+}
+
 // NewSecurityConfig initializes and returns a new SecurityConfig.
 func NewSecurityConfig(rootCA *RootCA, krw *KeyReadWriter, tlsKeyPair *tls.Certificate, issuerInfo *IssuerInfo) (*SecurityConfig, error) {
 	// Create the Server TLS Credentials for this node. These will not be used by workers.
@@ -155,6 +188,11 @@ func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA, externalCARootPool *x509.C
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	// refuse to update the root CA if the current TLS credentials do not validate against it
+	if err := validateRootCAAndTLSCert(rootCA, externalCARootPool, s.certificate); err != nil {
+		return err
+	}
+
 	s.rootCA = rootCA
 	s.externalCAClientRootPool = externalCARootPool
 	s.externalCA.UpdateRootCA(rootCA)
@@ -215,6 +253,13 @@ func (s *SecurityConfig) updateTLSCredentials(certificate *tls.Certificate, issu
 		})
 	}
 	return nil
+}
+
+// UpdateTLSCredentials updates the security config with an updated TLS certificate and issuer info
+func (s *SecurityConfig) UpdateTLSCredentials(certificate *tls.Certificate, issuerInfo *IssuerInfo) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.updateTLSCredentials(certificate, issuerInfo)
 }
 
 // SigningPolicy creates a policy used by the signer to ensure that the only fields
@@ -472,9 +517,7 @@ func RenewTLSConfigNow(ctx context.Context, s *SecurityConfig, connBroker *conne
 		return err
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.updateTLSCredentials(tlsKeyPair, issuerInfo)
+	return s.UpdateTLSCredentials(tlsKeyPair, issuerInfo)
 }
 
 // calculateRandomExpiry returns a random duration between 50% and 80% of the

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -433,6 +433,55 @@ func TestSecurityConfigUpdateRootCA(t *testing.T) {
 	require.Equal(t, parsedIntermediate, parsedCerts[1])
 }
 
+// You can't update the root CA to one that doesn't match the TLS certificates
+func TestSecurityConfigUpdateRootCAUpdateConsistentWithTLSCertificates(t *testing.T) {
+	t.Parallel()
+	if testutils.External {
+		return // we don't care about external CAs at all
+	}
+	tempdir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	krw := ca.NewKeyReadWriter(ca.NewConfigPaths(tempdir).Node, nil, nil)
+
+	rootCA, err := ca.CreateRootCA("rootcn")
+	require.NoError(t, err)
+	tlsKeyPair, issuerInfo, err := rootCA.IssueAndSaveNewCertificates(krw, "cn", "ou", "org")
+	require.NoError(t, err)
+
+	otherRootCA, err := ca.CreateRootCA("otherCN")
+	require.NoError(t, err)
+	_, otherIssuerInfo, err := otherRootCA.IssueAndSaveNewCertificates(krw, "cn", "ou", "org")
+	require.NoError(t, err)
+	intermediate, err := rootCA.CrossSignCACertificate(otherRootCA.Certs)
+	require.NoError(t, err)
+	otherTLSCert, otherTLSKey, err := krw.Read()
+	require.NoError(t, err)
+	otherTLSKeyPair, err := tls.X509KeyPair(append(otherTLSCert, intermediate...), otherTLSKey)
+	require.NoError(t, err)
+
+	// Note - the validation only happens on UpdateRootCA for now, because the assumption is
+	// that something else does the validation when loading the security config for the first
+	// time and when getting new TLS credentials
+
+	secConfig, err := ca.NewSecurityConfig(&rootCA, krw, tlsKeyPair, issuerInfo)
+	require.NoError(t, err)
+
+	// can't update the root CA or external pool to one that doesn't match the tls certs
+	require.Error(t, secConfig.UpdateRootCA(&otherRootCA, rootCA.Pool))
+	require.Error(t, secConfig.UpdateRootCA(&rootCA, otherRootCA.Pool))
+
+	// can update the secConfig's root CA to one that does match the certs
+	combinedRootCA, err := ca.NewRootCA(append(otherRootCA.Certs, rootCA.Certs...), nil, nil,
+		ca.DefaultNodeCertExpiration, nil)
+	require.NoError(t, err)
+	require.NoError(t, secConfig.UpdateRootCA(&combinedRootCA, combinedRootCA.Pool))
+
+	// if there are intermediates, we can update to a root CA that signed the intermediate
+	require.NoError(t, secConfig.UpdateTLSCredentials(&otherTLSKeyPair, otherIssuerInfo))
+	require.NoError(t, secConfig.UpdateRootCA(&rootCA, rootCA.Pool))
+
+}
+
 func TestSecurityConfigSetWatch(t *testing.T) {
 	tc := testutils.NewTestCA(t)
 	defer tc.Stop()

--- a/node/node.go
+++ b/node/node.go
@@ -346,12 +346,12 @@ func (n *Node) run(ctx context.Context) (err error) {
 						log.G(ctx).WithError(err).Error("invalid new root certificate from the dispatcher")
 						continue
 					}
-					if err := ca.SaveRootCA(newRootCA, paths.RootCA); err != nil {
-						log.G(ctx).WithError(err).Error("could not save new root certificate from the dispatcher")
-						continue
-					}
 					if err := securityConfig.UpdateRootCA(&newRootCA, newRootCA.Pool); err != nil {
 						log.G(ctx).WithError(err).Error("could not use new root CA from dispatcher")
+						continue
+					}
+					if err := ca.SaveRootCA(newRootCA, paths.RootCA); err != nil {
+						log.G(ctx).WithError(err).Error("could not save new root certificate from the dispatcher")
 						continue
 					}
 				}


### PR DESCRIPTION
Validate the Root CA certificate before updating the security config with
a new RootCA, to be sure that the root CA certificate matches the TLS
credentials already in the SecurityConfig.

This will prevent, for instance, a manager from telling an agent to load
an invalid root certificate, as can happen if an agent connects to a
manager that is being caught up via raft and hence might be replaying
old root rotations.

Signed-off-by: Ying Li <ying.li@docker.com>

Without this change, a manager that is catching up (for instance if it has been promoted, or if it was behind) and replying raft messages might tell all the nodes connected to it to update their root CA to an older version.  This will also prevent that manager from updating to an outdated root CA as it's catching up.

This is not the most ideal change, since we're only validating when updating the root CA in the security config, but would be a quick patch to fix the issue if we want to try to get this into 17.06.

Otherwise, maybe it'd make sense to refactor `SecurityConfig` a bit to store the `x509.Certificate` and key instead of just the `tls.Certificate`, so that validation for everything can be moved into the `SecurityConfig`?

cc @aaronlehmann @diogomonica 