### PR TITLE
[ca/node] Maybe update the root CA when renewing the TLS cert

### DIFF
--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,7 @@ import (
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
 	"github.com/pkg/errors"
@@ -497,7 +499,7 @@ func TestSecurityConfigSetWatch(t *testing.T) {
 	configWatch, configCancel := w.Watch()
 	defer configCancel()
 
-	require.NoError(t, ca.RenewTLSConfigNow(tc.Context, secConfig, tc.ConnBroker))
+	require.NoError(t, ca.RenewTLSConfigNow(tc.Context, secConfig, tc.ConnBroker, tc.Paths.RootCA))
 	select {
 	case ev := <-configWatch:
 		nodeTLSInfo, ok := ev.(*api.NodeTLSInfo)
@@ -530,7 +532,178 @@ func TestSecurityConfigSetWatch(t *testing.T) {
 
 	// ensure that we can still update tls certs and roots without error even though the watch is closed
 	require.NoError(t, secConfig.UpdateRootCA(&tc.RootCA, tc.RootCA.Pool))
-	require.NoError(t, ca.RenewTLSConfigNow(tc.Context, secConfig, tc.ConnBroker))
+	require.NoError(t, ca.RenewTLSConfigNow(tc.Context, secConfig, tc.ConnBroker, tc.Paths.RootCA))
+}
+
+// If we get an unknown authority error when trying to renew the TLS certificate, attempt to download the
+// root certificate.  If it validates against the current TLS credentials, it will be used to download
+// new ones, (only if the new certificate indicates that it's a worker, though).
+func TestRenewTLSConfigUpdatesRootOnUnknownAuthError(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "test-renew-tls-config-now-downloads-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	// make 3 CAs
+	var (
+		certs        = make([][]byte, 3)
+		keys         = make([][]byte, 3)
+		crossSigneds = make([][]byte, 3)
+		cas          = make([]ca.RootCA, 3)
+	)
+	for i := 0; i < 3; i++ {
+		certs[i], keys[i], err = testutils.CreateRootCertAndKey(fmt.Sprintf("CA%d", i))
+		require.NoError(t, err)
+		switch i {
+		case 0:
+			crossSigneds[i] = nil
+			cas[i], err = ca.NewRootCA(certs[i], certs[i], keys[i], ca.DefaultNodeCertExpiration, nil)
+			require.NoError(t, err)
+		default:
+			crossSigneds[i], err = cas[i-1].CrossSignCACertificate(certs[i])
+			require.NoError(t, err)
+			cas[i], err = ca.NewRootCA(certs[i-1], certs[i], keys[i], ca.DefaultNodeCertExpiration, crossSigneds[i])
+			require.NoError(t, err)
+		}
+	}
+
+	// the CA server is going to start off with a cert issued by the second CA, cross-signed by the first CA, and then
+	// rotate to one issued by the third CA, cross-signed by the second.
+	tc := testutils.NewTestCAFromAPIRootCA(t, tempdir, api.RootCA{
+		CACert: certs[0],
+		CAKey:  keys[0],
+		RootRotation: &api.RootRotation{
+			CACert:            certs[1],
+			CAKey:             keys[1],
+			CrossSignedCACert: crossSigneds[1],
+		},
+	}, nil)
+	defer tc.Stop()
+	require.NoError(t, tc.MemoryStore.Update(func(tx store.Tx) error {
+		cluster := store.GetCluster(tx, tc.Organization)
+		cluster.RootCA.CACert = certs[1]
+		cluster.RootCA.CAKey = keys[1]
+		cluster.RootCA.RootRotation = &api.RootRotation{
+			CACert:            certs[2],
+			CAKey:             keys[2],
+			CrossSignedCACert: crossSigneds[2],
+		}
+		return store.UpdateCluster(tx, cluster)
+	}))
+
+	paths := ca.NewConfigPaths(tempdir)
+	krw := ca.NewKeyReadWriter(paths.Node, nil, nil)
+	for i, testCase := range []struct {
+		role          api.NodeRole
+		initialRootCA *ca.RootCA
+		issuingRootCA *ca.RootCA
+		expectedRoot  []byte
+	}{
+		{
+			role:          api.NodeRoleWorker,
+			initialRootCA: &cas[0],
+			issuingRootCA: &cas[1],
+			expectedRoot:  certs[1],
+		},
+		{
+			role:          api.NodeRoleManager,
+			initialRootCA: &cas[0],
+			issuingRootCA: &cas[1],
+		},
+		// TODO(cyli): once signing root CA and serving root CA for the CA server are split up, so that the server can accept
+		// requests from certs different than the cluster root CA, add another test case to make sure that the downloaded
+		// root has to validate against both the old TLS creds and new TLS creds
+	} {
+		nodeID := fmt.Sprintf("node%d", i)
+		tlsKeyPair, issuerInfo, err := testCase.issuingRootCA.IssueAndSaveNewCertificates(krw, nodeID, ca.ManagerRole, tc.Organization)
+		require.NoError(t, err)
+		// make sure the node is added to the memory store as a worker, so when we renew the cert the test CA will answer
+		require.NoError(t, tc.MemoryStore.Update(func(tx store.Tx) error {
+			return store.CreateNode(tx, &api.Node{
+				Role: testCase.role,
+				ID:   nodeID,
+				Spec: api.NodeSpec{
+					DesiredRole:  testCase.role,
+					Membership:   api.NodeMembershipAccepted,
+					Availability: api.NodeAvailabilityActive,
+				},
+			})
+		}))
+		secConfig, err := ca.NewSecurityConfig(testCase.initialRootCA, krw, tlsKeyPair, issuerInfo)
+		require.NoError(t, err)
+
+		paths := ca.NewConfigPaths(filepath.Join(tempdir, nodeID))
+		err = ca.RenewTLSConfigNow(tc.Context, secConfig, tc.ConnBroker, paths.RootCA)
+
+		// TODO(cyli): remove this role check once the codepaths for worker and manager are the same
+		if testCase.expectedRoot != nil {
+			// only rotate if we are a worker, and if the new cert validates against the old TLS creds
+			require.NoError(t, err)
+			downloadedRoot, err := ioutil.ReadFile(paths.RootCA.Cert)
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedRoot, downloadedRoot)
+		} else {
+			require.Error(t, err)
+			require.IsType(t, x509.UnknownAuthorityError{}, err)
+			_, err = ioutil.ReadFile(paths.RootCA.Cert) // we didn't download a file
+			require.Error(t, err)
+		}
+	}
+}
+
+// If we get a not unknown authority error when trying to renew the TLS certificate, just return the
+// error and do not attempt to download the root certificate.
+func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
+	tempdir, err := ioutil.TempDir("", "test-renew-tls-config-now-downloads-root")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempdir)
+
+	cert, key, err := testutils.CreateRootCertAndKey("rootCA")
+	require.NoError(t, err)
+	rootCA, err := ca.NewRootCA(cert, cert, key, ca.DefaultNodeCertExpiration, nil)
+	require.NoError(t, err)
+
+	tc := testutils.NewTestCAFromAPIRootCA(t, tempdir, api.RootCA{
+		CACert: cert,
+		CAKey:  key,
+	}, nil)
+	defer tc.Stop()
+
+	fakeCAServer := newNonSigningCAServer(t, tc)
+	defer fakeCAServer.stop(t)
+
+	secConfig, err := tc.NewNodeConfig(ca.WorkerRole)
+	require.NoError(t, err)
+	tc.CAServer.Stop()
+
+	signErr := make(chan error)
+	go func() {
+		updates, cancel := state.Watch(tc.MemoryStore.WatchQueue(), api.EventCreateNode{})
+		defer cancel()
+		select {
+		case event := <-updates: // we want to skip the first node, which is the test CA
+			n := event.(api.EventCreateNode).Node
+			if n.Certificate.Status.State == api.IssuanceStatePending {
+				signErr <- tc.MemoryStore.Update(func(tx store.Tx) error {
+					node := store.GetNode(tx, n.ID)
+					certChain, err := rootCA.ParseValidateAndSignCSR(node.Certificate.CSR, node.Certificate.CN, ca.WorkerRole, tc.Organization)
+					if err != nil {
+						return err
+					}
+					node.Certificate.Certificate = testutils.ReDateCert(t, certChain, cert, key, time.Now().Add(-5*time.Hour), time.Now().Add(-4*time.Hour))
+					node.Certificate.Status = api.IssuanceStatus{
+						State: api.IssuanceStateIssued,
+					}
+					return store.UpdateNode(tx, node)
+				})
+				return
+			}
+		}
+	}()
+
+	err = ca.RenewTLSConfigNow(tc.Context, secConfig, fakeCAServer.getConnBroker(), tc.Paths.RootCA)
+	require.Error(t, err)
+	require.IsType(t, x509.CertificateInvalidError{}, errors.Cause(err))
+	require.NoError(t, <-signErr)
 }
 
 // enforce that no matter what order updating the root CA and updating TLS credential happens, we
@@ -586,7 +759,7 @@ func TestRenewTLSConfigUpdateRootCARace(t *testing.T) {
 
 		go func() {
 			defer close(done2)
-			require.NoError(t, ca.RenewTLSConfigNow(ctx, secConfig, tc.ConnBroker))
+			require.NoError(t, ca.RenewTLSConfigNow(ctx, secConfig, tc.ConnBroker, tc.Paths.RootCA))
 		}()
 
 		<-done1
@@ -647,7 +820,7 @@ func TestRenewTLSConfigWorker(t *testing.T) {
 	c := nodeConfig.ClientTLSCreds
 	writeAlmostExpiringCertToDisk(t, tc, c.NodeID(), c.Role(), c.Organization())
 
-	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker, tc.Paths.RootCA)
 	updates := renewer.Start(ctx)
 	select {
 	case <-time.After(10 * time.Second):
@@ -683,7 +856,7 @@ func TestRenewTLSConfigManager(t *testing.T) {
 	c := nodeConfig.ClientTLSCreds
 	writeAlmostExpiringCertToDisk(t, tc, c.NodeID(), c.Role(), c.Organization())
 
-	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker, tc.Paths.RootCA)
 	updates := renewer.Start(ctx)
 	select {
 	case <-time.After(10 * time.Second):
@@ -727,7 +900,7 @@ func TestRenewTLSConfigWithNoNode(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker, tc.Paths.RootCA)
 	updates := renewer.Start(ctx)
 	select {
 	case <-time.After(10 * time.Second):

--- a/ca/renewer.go
+++ b/ca/renewer.go
@@ -27,14 +27,16 @@ type TLSRenewer struct {
 	connBroker   *connectionbroker.Broker
 	renew        chan struct{}
 	expectedRole string
+	rootPaths    CertPaths
 }
 
 // NewTLSRenewer creates a new TLS renewer. It must be started with Start.
-func NewTLSRenewer(s *SecurityConfig, connBroker *connectionbroker.Broker) *TLSRenewer {
+func NewTLSRenewer(s *SecurityConfig, connBroker *connectionbroker.Broker, rootPaths CertPaths) *TLSRenewer {
 	return &TLSRenewer{
 		s:          s,
 		connBroker: connBroker,
 		renew:      make(chan struct{}, 1),
+		rootPaths:  rootPaths,
 	}
 }
 
@@ -135,7 +137,7 @@ func (t *TLSRenewer) Start(ctx context.Context) <-chan CertificateUpdate {
 
 			// ignore errors - it will just try again later
 			var certUpdate CertificateUpdate
-			if err := RenewTLSConfigNow(ctx, t.s, t.connBroker); err != nil {
+			if err := RenewTLSConfigNow(ctx, t.s, t.connBroker, t.rootPaths); err != nil {
 				certUpdate.Err = err
 				expBackoff.Failure(nil, nil)
 			} else {

--- a/ca/renewer_test.go
+++ b/ca/renewer_test.go
@@ -26,7 +26,7 @@ func TestForceRenewTLSConfig(t *testing.T) {
 	nodeConfig, err := tc.WriteNewNodeConfig(ca.ManagerRole)
 	assert.NoError(t, err)
 
-	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker, tc.Paths.RootCA)
 	updates := renewer.Start(ctx)
 	renewer.Renew()
 	select {
@@ -67,7 +67,7 @@ func TestForceRenewExpectedRole(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker)
+	renewer := ca.NewTLSRenewer(nodeConfig, tc.ConnBroker, tc.Paths.RootCA)
 	updates := renewer.Start(ctx)
 	renewer.SetExpectedRole(ca.WorkerRole)
 	renewer.Renew()

--- a/ca/server.go
+++ b/ca/server.go
@@ -624,10 +624,6 @@ func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster) error {
 		if err != nil {
 			return errors.Wrap(err, "invalid Root CA object in cluster")
 		}
-		if err := SaveRootCA(updatedRootCA, s.rootPaths); err != nil {
-			return errors.Wrap(err, "unable to save new root CA certificates")
-		}
-
 		externalCARootPool := updatedRootCA.Pool
 		if rCA.RootRotation != nil {
 			// the external CA has to trust the new CA cert
@@ -639,6 +635,9 @@ func (s *Server) UpdateRootCA(ctx context.Context, cluster *api.Cluster) error {
 		// Attempt to update our local RootCA with the new parameters
 		if err := s.securityConfig.UpdateRootCA(&updatedRootCA, externalCARootPool); err != nil {
 			return errors.Wrap(err, "updating Root CA failed")
+		}
+		if err := SaveRootCA(updatedRootCA, s.rootPaths); err != nil {
+			return errors.Wrap(err, "unable to save new root CA certificates")
 		}
 		// only update the server cache if we've successfully updated the root CA
 		logger.Debugf("Root CA %s successfully", setOrUpdate)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -698,7 +698,7 @@ func (m *Manager) updateKEK(ctx context.Context, cluster *api.Cluster) error {
 
 			connBroker := connectionbroker.New(remotes.NewRemotes())
 			connBroker.SetLocalConn(conn)
-			if err := ca.RenewTLSConfigNow(ctx, securityConfig, connBroker); err != nil {
+			if err := ca.RenewTLSConfigNow(ctx, securityConfig, connBroker, m.config.RootCAPaths); err != nil {
 				logger.WithError(err).Error("failed to download new TLS certificate after locking the cluster")
 			}
 		}()

--- a/node/node.go
+++ b/node/node.go
@@ -281,7 +281,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 		return err
 	}
 
-	renewer := ca.NewTLSRenewer(securityConfig, n.connBroker)
+	renewer := ca.NewTLSRenewer(securityConfig, n.connBroker, paths.RootCA)
 
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("node.id", n.NodeID()))
 


### PR DESCRIPTION
When renewing the TLS certificate, if we get an x509.UnknownAuthorityError,
try to update the root CA such that it validates against the old TLS creds
before renewing again.

This can help with edge cases where a manager might have been demoted, and
thus not be able to push the latest root certificate to its agent, but
the node needs to renew the TLS cert to get one for the worker role (but
root rotation has already finished, and hence any certificate it gets will
no longer have the intermediate and won't validate).

Signed-off-by: Ying Li <ying.li@docker.com>

Still needs test.  The ideal scenario @aaronlehmann and I discussed was to separate the Root CA used to sign new certs from the root CA the node itself uses to validate incoming connections and external servers, but that may be a bigger change.

This functionality may still be useful, however, to account for edge cases.