### PR TITLE
Avoid nil Allocator in controlapi

### DIFF
--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -946,7 +946,7 @@ func (na *cnmNetworkAllocator) IsVIPOnIngressNetwork(vip *api.Endpoint_VirtualIP
 }
 
 // IsBuiltInDriver returns whether the passed driver is an internal network driver
-func (na *cnmNetworkAllocator) IsBuiltInDriver(name string) bool {
+func IsBuiltInDriver(name string) bool {
 	n := strings.ToLower(name)
 	for _, d := range initializers {
 		if n == d.ntype {

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -1073,8 +1073,8 @@ func (a *Allocator) procTasksNetwork(ctx context.Context, onRetry bool) {
 }
 
 // IsBuiltInNetworkDriver returns whether the passed driver is an internal network driver
-func (a *Allocator) IsBuiltInNetworkDriver(name string) bool {
-	return a.netCtx.nwkAllocator.IsBuiltInDriver(name)
+func IsBuiltInNetworkDriver(name string) bool {
+	return cnmallocator.IsBuiltInDriver(name)
 }
 
 // PredefinedNetworks returns the list of predefined network structures for a given network model

--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -31,13 +31,6 @@ func OnInit(options *ServiceAllocationOpts) {
 // NetworkAllocator provides network model specific allocation functionality.
 type NetworkAllocator interface {
 	//
-	// Drivers
-	//
-
-	// IsBuiltInDriver returns whether the passed driver is an internal network driver
-	IsBuiltInDriver(name string) bool
-
-	//
 	// Network Allocation
 	//
 

--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -93,7 +93,7 @@ func validateConfigOrSecretAnnotations(m api.Annotations) error {
 	return nil
 }
 
-func validateDriver(driver *api.Driver, a *allocator.Allocator, pg plugingetter.PluginGetter, pluginType string) error {
+func validateDriver(driver *api.Driver, pg plugingetter.PluginGetter, pluginType string) error {
 	if driver == nil {
 		// It is ok to not specify the driver. We will choose
 		// a default driver.
@@ -111,7 +111,7 @@ func validateDriver(driver *api.Driver, a *allocator.Allocator, pg plugingetter.
 			return nil
 		}
 	default:
-		if a.IsBuiltInNetworkDriver(driver.Name) {
+		if allocator.IsBuiltInNetworkDriver(driver.Name) {
 			return nil
 		}
 	}

--- a/manager/controlapi/common.go
+++ b/manager/controlapi/common.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/libnetwork/driverapi"
 	"github.com/docker/libnetwork/ipamapi"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/allocator"
@@ -110,10 +111,11 @@ func validateDriver(driver *api.Driver, pg plugingetter.PluginGetter, pluginType
 		if strings.ToLower(driver.Name) == ipamapi.DefaultIPAM {
 			return nil
 		}
-	default:
+	case driverapi.NetworkPluginEndpointType:
 		if allocator.IsBuiltInNetworkDriver(driver.Name) {
 			return nil
 		}
+	default:
 	}
 
 	if pg == nil {

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -51,14 +51,14 @@ func validateIPAMConfiguration(ipamConf *api.IPAMConfig) error {
 	return nil
 }
 
-func validateIPAM(ipam *api.IPAMOptions, a *allocator.Allocator, pg plugingetter.PluginGetter) error {
+func validateIPAM(ipam *api.IPAMOptions, pg plugingetter.PluginGetter) error {
 	if ipam == nil {
 		// It is ok to not specify any IPAM configurations. We
 		// will choose good defaults.
 		return nil
 	}
 
-	if err := validateDriver(ipam.Driver, a, pg, ipamapi.PluginEndpointType); err != nil {
+	if err := validateDriver(ipam.Driver, pg, ipamapi.PluginEndpointType); err != nil {
 		return err
 	}
 
@@ -71,7 +71,7 @@ func validateIPAM(ipam *api.IPAMOptions, a *allocator.Allocator, pg plugingetter
 	return nil
 }
 
-func validateNetworkSpec(spec *api.NetworkSpec, a *allocator.Allocator, pg plugingetter.PluginGetter) error {
+func validateNetworkSpec(spec *api.NetworkSpec, pg plugingetter.PluginGetter) error {
 	if spec == nil {
 		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
@@ -92,11 +92,11 @@ func validateNetworkSpec(spec *api.NetworkSpec, a *allocator.Allocator, pg plugi
 		return grpc.Errorf(codes.PermissionDenied, "label %s is for internally created predefined networks and cannot be applied by users",
 			networkallocator.PredefinedLabel)
 	}
-	if err := validateDriver(spec.DriverConfig, a, pg, driverapi.NetworkPluginEndpointType); err != nil {
+	if err := validateDriver(spec.DriverConfig, pg, driverapi.NetworkPluginEndpointType); err != nil {
 		return err
 	}
 
-	if err := validateIPAM(spec.IPAM, a, pg); err != nil {
+	if err := validateIPAM(spec.IPAM, pg); err != nil {
 		return err
 	}
 
@@ -107,7 +107,7 @@ func validateNetworkSpec(spec *api.NetworkSpec, a *allocator.Allocator, pg plugi
 // - Returns `InvalidArgument` if the NetworkSpec is malformed.
 // - Returns an error if the creation fails.
 func (s *Server) CreateNetwork(ctx context.Context, request *api.CreateNetworkRequest) (*api.CreateNetworkResponse, error) {
-	if err := validateNetworkSpec(request.Spec, s.a, s.pg); err != nil {
+	if err := validateNetworkSpec(request.Spec, s.pg); err != nil {
 		return nil, err
 	}
 

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -25,7 +25,7 @@ func createNetworkSpec(name string) *api.NetworkSpec {
 // createInternalNetwork creates an internal network for testing. it is the same
 // as Server.CreateNetwork except without the label check.
 func (s *Server) createInternalNetwork(ctx context.Context, request *api.CreateNetworkRequest) (*api.CreateNetworkResponse, error) {
-	if err := validateNetworkSpec(request.Spec, nil, nil); err != nil {
+	if err := validateNetworkSpec(request.Spec, nil); err != nil {
 		return nil, err
 	}
 
@@ -85,9 +85,9 @@ func createServiceInNetwork(t *testing.T, ts *testServer, name, image string, nw
 }
 
 func TestValidateDriver(t *testing.T) {
-	assert.NoError(t, validateDriver(nil, nil, nil, ""))
+	assert.NoError(t, validateDriver(nil, nil, ""))
 
-	err := validateDriver(&api.Driver{Name: ""}, nil, nil, "")
+	err := validateDriver(&api.Driver{Name: ""}, nil, "")
 	assert.Error(t, err)
 	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
 }
@@ -172,7 +172,7 @@ func TestRemoveNetwork(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Stop()
 	nr, err := ts.Client.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
-		Spec: createNetworkSpec("testnet2"),
+		Spec: createNetworkSpec("testnet3"),
 	})
 	assert.NoError(t, err)
 	assert.NotEqual(t, nr.Network, nil)
@@ -193,6 +193,19 @@ func TestRemoveNetworkWithAttachedService(t *testing.T) {
 	assert.NotEqual(t, nr.Network.ID, "")
 	createServiceInNetwork(t, ts, "name", "image", nr.Network.ID, 1)
 	_, err = ts.Client.RemoveNetwork(context.Background(), &api.RemoveNetworkRequest{NetworkID: nr.Network.ID})
+	assert.Error(t, err)
+}
+
+func TestCreateNetworkInvalidDriver(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+	spec := createNetworkSpec("baddrivernet")
+	spec.DriverConfig = &api.Driver{
+		Name: "invalid-must-never-exist",
+	}
+	_, err := ts.Client.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
+		Spec: spec,
+	})
 	assert.Error(t, err)
 }
 

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/ca"
-	"github.com/docker/swarmkit/manager/allocator"
 	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/manager/state/store"
 )
@@ -21,13 +20,12 @@ type Server struct {
 	raft           *raft.Node
 	securityConfig *ca.SecurityConfig
 	scu            ca.APISecurityConfigUpdater
-	a              *allocator.Allocator
 	pg             plugingetter.PluginGetter
 }
 
 // NewServer creates a Cluster API server.
 func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig,
-	scu ca.APISecurityConfigUpdater, a *allocator.Allocator, pg plugingetter.PluginGetter) *Server {
+	scu ca.APISecurityConfigUpdater, pg plugingetter.PluginGetter) *Server {
 	return &Server{
 		store:          store,
 		raft:           raft,

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -48,7 +48,7 @@ func newTestServer(t *testing.T) *testServer {
 	ts.Store = store.NewMemoryStore(&stateutils.MockProposer{})
 	assert.NotNil(t, ts.Store)
 
-	ts.Server = NewServer(ts.Store, nil, securityConfig, ca.NewServer(ts.Store, securityConfig, tc.Paths.RootCA), nil, nil)
+	ts.Server = NewServer(ts.Store, nil, securityConfig, ca.NewServer(ts.Store, securityConfig, tc.Paths.RootCA), nil)
 	assert.NotNil(t, ts.Server)
 
 	temp, err := ioutil.TempFile("", "test-socket")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -396,7 +396,7 @@ func (m *Manager) Run(parent context.Context) error {
 		return err
 	}
 
-	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.caserver, m.allocator, m.config.PluginGetter)
+	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.caserver, m.config.PluginGetter)
 	baseWatchAPI := watchapi.NewServer(m.raftNode.MemoryStore())
 	baseResourceAPI := resourceapi.New(m.raftNode.MemoryStore())
 	healthServer := health.NewHealthServer()

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -187,6 +187,18 @@ func TestManager(t *testing.T) {
 		)
 	}))
 	controlClient = api.NewControlClient(controlConn)
+	_, err = controlClient.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
+		Spec: &api.NetworkSpec{
+			Annotations: api.Annotations{
+				Name: "test-network-bad-driver",
+			},
+			DriverConfig: &api.Driver{
+				Name: "invalid-must-never-exist",
+			},
+		},
+	})
+	assert.Error(t, err)
+
 	_, err = controlClient.RemoveNode(context.Background(),
 		&api.RemoveNodeRequest{
 			NodeID: agentID,


### PR DESCRIPTION
At the point at which the controlapi server is created the allocator has not yet been created, and hence is nil.
    
Since CNM is currently the only actual choice do as with `PredefinedNetworks` and hardcode the use of the CNM backend, this will be reworked once there is a second choice.
    
Fixes #2230. Add a call to NetworkCreate in TestManager and a test to controlapi specifically to trigger this code path. The latter tests controlapi in isolation, while the former would catch e.g. a race or initialisation order issue in a manager.
    
Also, in controlapi tests, change a `testnet2` into a 3 in `TestRemoveNetwork` to avoid (harmless) duplication.
    
Signed-off-by: Ian Campbell <ian.campbell@docker.com>

Also, only call `IsBuiltInNetworkDriver` for Network plugin type.

Replaces #2231.