### PR TITLE
BackPort: Fixing error with host network mode on upgrade from pre 17.06 versions

### DIFF
--- a/manager/allocator/networkallocator/networkallocator.go
+++ b/manager/allocator/networkallocator/networkallocator.go
@@ -152,6 +152,8 @@ func (na *NetworkAllocator) Allocate(n *api.Network) error {
 		n.DriverState = &api.Driver{
 			Name: d.name,
 		}
+		//populate for backward compatibility
+		n.IPAM = &api.IPAMOptions{Driver: &api.Driver{}}
 	} else {
 		nw.pools, err = na.allocatePools(n)
 		if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -955,6 +955,16 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 					log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 				}
 			}
+		} else {
+			// If it is already part of cluster, check if the store contains predefined
+			//networks like bridge/host and add it if not present.
+			for _, p := range networkallocator.PredefinedNetworks() {
+				if store.GetNetwork(tx, p.Name) == nil {
+					if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil {
+						log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
+					}
+				}
+			}
 		}
 
 		return nil


### PR DESCRIPTION
This commit contains the following fixes:
1) On upgrade from pre 17.06 version services created with net=host
were failing because the swarm was not aware of host network being
created. The fix added takes care of this by creating network if
the store does not contain predefined networks

2) On a cluster with upgraded 17.06 version of docker swarm manager
the daemon panics while trying to access IPAM driver in the createNetworkRequest on
the nodes with pre 17.06 versions. In order to avoid panics empty struct is passed
with network attachment. This does not have any function impact.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>