### PR TITLE
Fixing error with host network mode on upgrade from pre 17.06 versions

### DIFF
--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -52,7 +52,7 @@ func TestAllocator(t *testing.T) {
 			Annotations: api.Annotations{
 				Name: "swarm-macvlan",
 			},
-			DriverConfig: &api.Driver{Name: "mac-vlan"},
+			DriverConfig: &api.Driver{Name: "macvlan"},
 		},
 	}
 
@@ -233,9 +233,8 @@ func TestAllocator(t *testing.T) {
 	})
 	assert.NotNil(t, ps)
 	assert.NotNil(t, sn)
-	assert.Nil(t, ps.IPAM, "Non nil IPAMOptions for predefined network")
-	assert.Nil(t, sn.IPAM, "Non nil IPAMOptions for predefined network")
-
+	assert.NotNil(t, ps.IPAM)
+	assert.NotNil(t, sn.IPAM)
 	// Verify no allocation was done for tasks on node-local networks
 	var (
 		tp1 *api.Task

--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -142,6 +142,10 @@ func (na *cnmNetworkAllocator) Allocate(n *api.Network) error {
 		n.DriverState = &api.Driver{
 			Name: d.name,
 		}
+		// In order to support backward compatibility with older daemon
+		// versions which assumes the network attachment to contains
+		// non nil IPAM attribute, passing an empty object
+		n.IPAM = &api.IPAMOptions{Driver: &api.Driver{}}
 	} else {
 		nw.pools, err = na.allocatePools(n)
 		if err != nil {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -945,18 +945,19 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			if err := store.CreateNetwork(tx, newIngressNetwork()); err != nil {
 				log.G(ctx).WithError(err).Error("failed to create default ingress network")
 			}
-			// Create now the static predefined node-local networks which
-			// are known to be present in each cluster node. This is needed
-			// in order to allow running services on the predefined docker
-			// networks like `bridge` and `host`.
-			log.G(ctx).Info("Creating node-local predefined networks")
-			for _, p := range allocator.PredefinedNetworks() {
+		}
+		// Create now the static predefined if the store does not contain predefined
+		//networks like bridge/host node-local networks which
+		// are known to be present in each cluster node. This is needed
+		// in order to allow running services on the predefined docker
+		// networks like `bridge` and `host`.
+		for _, p := range allocator.PredefinedNetworks() {
+			if store.GetNetwork(tx, p.Name) == nil {
 				if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil {
 					log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 				}
 			}
 		}
-
 		return nil
 	})
 


### PR DESCRIPTION
This commit contains the following fixes:
1) On upgrade from pre 17.06 version services created with net=host
were failing because the swarm was not aware of host network being
created. The fix added takes care of this by creating network if
the store does not contain predefined networks

2) On a cluster with upgraded 17.06 version of docker swarm manager
the daemon panics while trying to access IPAM driver in the createNetworkRequest on
the nodes with pre 17.06 versions. In order to avoid panics empty struct is passed
with network attachment. This does not have any function impact.

Signed-off-by: Abhinandan Prativadi <abhi@docker.com>