### PR TITLE
scheduler: Version-aware failure tracking

### DIFF
--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -15,6 +15,15 @@ type hostPortSpec struct {
 	publishedPort uint32
 }
 
+// versionedService defines a tuple that contains a service ID and a spec
+// version, so that failures can be tracked per spec version. Note that if the
+// task predates spec versioning, specVersion will contain the zero value, and
+// this will still work correctly.
+type versionedService struct {
+	serviceID   string
+	specVersion api.Version
+}
+
 // NodeInfo contains a node and some additional metadata.
 type NodeInfo struct {
 	*api.Node
@@ -24,12 +33,10 @@ type NodeInfo struct {
 	AvailableResources        *api.Resources
 	usedHostPorts             map[hostPortSpec]struct{}
 
-	// recentFailures is a map from service ID to the timestamps of the
-	// most recent failures the node has experienced from replicas of that
-	// service.
-	// TODO(aaronl): When spec versioning is supported, this should track
-	// the version of the spec that failed.
-	recentFailures map[string][]time.Time
+	// recentFailures is a map from service ID/version to the timestamps of
+	// the most recent failures the node has experienced from replicas of
+	// that service.
+	recentFailures map[versionedService][]time.Time
 }
 
 func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api.Resources) NodeInfo {
@@ -39,7 +46,7 @@ func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api
 		ActiveTasksCountByService: make(map[string]int),
 		AvailableResources:        availableResources.Copy(),
 		usedHostPorts:             make(map[hostPortSpec]struct{}),
-		recentFailures:            make(map[string][]time.Time),
+		recentFailures:            make(map[versionedService][]time.Time),
 	}
 
 	for _, t := range tasks {
@@ -149,29 +156,40 @@ func taskReservations(spec api.TaskSpec) (reservations api.Resources) {
 }
 
 // taskFailed records a task failure from a given service.
-func (nodeInfo *NodeInfo) taskFailed(ctx context.Context, serviceID string) {
+func (nodeInfo *NodeInfo) taskFailed(ctx context.Context, t *api.Task) {
 	expired := 0
 	now := time.Now()
-	for _, timestamp := range nodeInfo.recentFailures[serviceID] {
+
+	versionedService := versionedService{serviceID: t.ServiceID}
+	if t.SpecVersion != nil {
+		versionedService.specVersion = *t.SpecVersion
+	}
+
+	for _, timestamp := range nodeInfo.recentFailures[versionedService] {
 		if now.Sub(timestamp) < monitorFailures {
 			break
 		}
 		expired++
 	}
 
-	if len(nodeInfo.recentFailures[serviceID])-expired == maxFailures-1 {
-		log.G(ctx).Warnf("underweighting node %s for service %s because it experienced %d failures or rejections within %s", nodeInfo.ID, serviceID, maxFailures, monitorFailures.String())
+	if len(nodeInfo.recentFailures[versionedService])-expired == maxFailures-1 {
+		log.G(ctx).Warnf("underweighting node %s for service %s because it experienced %d failures or rejections within %s", nodeInfo.ID, t.ServiceID, maxFailures, monitorFailures.String())
 	}
 
-	nodeInfo.recentFailures[serviceID] = append(nodeInfo.recentFailures[serviceID][expired:], now)
+	nodeInfo.recentFailures[versionedService] = append(nodeInfo.recentFailures[versionedService][expired:], now)
 }
 
 // countRecentFailures returns the number of times the service has failed on
 // this node within the lookback window monitorFailures.
-func (nodeInfo *NodeInfo) countRecentFailures(now time.Time, serviceID string) int {
-	recentFailureCount := len(nodeInfo.recentFailures[serviceID])
+func (nodeInfo *NodeInfo) countRecentFailures(now time.Time, t *api.Task) int {
+	versionedService := versionedService{serviceID: t.ServiceID}
+	if t.SpecVersion != nil {
+		versionedService.specVersion = *t.SpecVersion
+	}
+
+	recentFailureCount := len(nodeInfo.recentFailures[versionedService])
 	for i := recentFailureCount - 1; i >= 0; i-- {
-		if now.Sub(nodeInfo.recentFailures[serviceID][i]) > monitorFailures {
+		if now.Sub(nodeInfo.recentFailures[versionedService][i]) > monitorFailures {
 			recentFailureCount -= i + 1
 			break
 		}

--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/constraint"
@@ -32,16 +31,6 @@ func (ns *nodeSet) nodeInfo(nodeID string) (NodeInfo, error) {
 // addOrUpdateNode sets the number of tasks for a given node. It adds the node
 // to the set if it wasn't already tracked.
 func (ns *nodeSet) addOrUpdateNode(n NodeInfo) {
-	if n.Tasks == nil {
-		n.Tasks = make(map[string]*api.Task)
-	}
-	if n.ActiveTasksCountByService == nil {
-		n.ActiveTasksCountByService = make(map[string]int)
-	}
-	if n.recentFailures == nil {
-		n.recentFailures = make(map[versionedService][]time.Time)
-	}
-
 	ns.nodes[n.ID] = n
 }
 

--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -39,7 +39,7 @@ func (ns *nodeSet) addOrUpdateNode(n NodeInfo) {
 		n.ActiveTasksCountByService = make(map[string]int)
 	}
 	if n.recentFailures == nil {
-		n.recentFailures = make(map[string][]time.Time)
+		n.recentFailures = make(map[versionedService][]time.Time)
 	}
 
 	ns.nodes[n.ID] = n

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -261,7 +261,7 @@ func (s *Scheduler) updateTask(ctx context.Context, t *api.Task) bool {
 			if _, wasPreassigned := s.preassignedTasks[t.ID]; !wasPreassigned {
 				nodeInfo, err := s.nodeSet.nodeInfo(t.NodeID)
 				if err == nil {
-					nodeInfo.taskFailed(ctx, t.ServiceID)
+					nodeInfo.taskFailed(ctx, t)
 					s.nodeSet.updateNode(nodeInfo)
 				}
 			}
@@ -536,8 +536,8 @@ func (s *Scheduler) scheduleTaskGroup(ctx context.Context, taskGroup map[string]
 	nodeLess := func(a *NodeInfo, b *NodeInfo) bool {
 		// If either node has at least maxFailures recent failures,
 		// that's the deciding factor.
-		recentFailuresA := a.countRecentFailures(now, t.ServiceID)
-		recentFailuresB := b.countRecentFailures(now, t.ServiceID)
+		recentFailuresA := a.countRecentFailures(now, t)
+		recentFailuresB := b.countRecentFailures(now, t)
 
 		if recentFailuresA >= maxFailures || recentFailuresB >= maxFailures {
 			if recentFailuresA > recentFailuresB {


### PR DESCRIPTION
This addresses a longstanding TODO which I forgot about. Currently, the scheduler tracks potential failure loops by service ID. However, if the service is updated, it won't distinguish the new version of the service from the old one. This means even if the operator fixes the underlying problem, the new tasks from the updated service will still avoid the node where the problem was detected.

Change the failure tracking to be sensitive to `SpecVersion` as well. If `SpecVersion` changes, we'll treat the task as a different kind of task for failure tracking purposes.

Also, add a periodic cleanup pass to make sure `recentFailures` doesn't grow without bound, and clean up `addOrUpdateNode` so it doesn't try to fix up uninitialized `nodeInfo` structs (which is fragile).

cc @aluzzardi 