### PR TITLE
Run CI with temporary files on a ramdisk

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -59,7 +59,10 @@ test:
         # - `checkprotos`: Build and check the proto files *only* once all
         #                  tests pass with checked-in generated code.
         # - `coverage`: Generate coverage reports.
-        - cd "$WORKDIR" && make ci
+        - sudo mkdir /tmpfs
+        - sudo mount -t tmpfs tmpfs /tmpfs
+        - sudo chown 1000:1000 /tmpfs
+        - cd "$WORKDIR" && TMPDIR=/tmpfs make ci
 
     post:
         # Report to codecov.io


### PR DESCRIPTION
This sets up a tmpfs mount to be used for temporary files created by tests.

If this works, hopefully it will fix the excessive I/O latencies that
are blocking tests for long periods and causing them to fail.

As a side effect, this also stores temporary compilation artifacts on
tmpfs.