### PR TITLE
dispatcher: Make debug log clear that dispatcher committed the task status

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -631,7 +631,7 @@ func (d *Dispatcher) processUpdates(ctx context.Context) {
 					logger.WithError(err).Error("failed to update task status")
 					return nil
 				}
-				logger.Debug("task status updated")
+				logger.Debug("dispatcher committed status update to store")
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION
Changes the debug message to make it clearer that swarmkit agent actively noticed the task status update and that the dispatcher is now committing that state to the store. I'm still familiarizing myself to the swarmkit architecture and lexicon so please let me know if this can be improved.
 
Closes #2208 

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>