### PR TITLE
[ca] Extricate `ExternalCA` from `SecurityConfig`

### DIFF
--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/pem"
@@ -1290,17 +1291,15 @@ func TestRootCAWithCrossSignedIntermediates(t *testing.T) {
 	connectToExternalRootCA, err := ca.NewRootCA(append(cautils.ECDSACertChain[2], fauxRootCert...), cautils.ECDSACertChain[1],
 		cautils.ECDSACertChainKeys[1], ca.DefaultNodeCertExpiration, cautils.ECDSACertChain[1])
 	require.NoError(t, err)
-	secConfig, cancel, err := connectToExternalRootCA.CreateSecurityConfig(tc.Context, krw, ca.CertificateRequestConfig{})
+	tlsKeyPair, _, err := connectToExternalRootCA.IssueAndSaveNewCertificates(krw, "cn", ca.ManagerRole, tc.Organization)
 	require.NoError(t, err)
-	cancel()
-
-	externalCA := secConfig.ExternalCA()
-	externalCA.UpdateURLs(tc.ExternalSigningServer.URL)
+	externalCA := ca.NewExternalCA(cautils.ECDSACertChain[1],
+		ca.NewExternalCATLSConfig([]tls.Certificate{*tlsKeyPair}, connectToExternalRootCA.Pool), tc.ExternalSigningServer.URL)
 
 	newCSR, _, err := ca.GenerateNewCSR()
 	require.NoError(t, err)
 
-	tlsCert, err = externalCA.Sign(tc.Context, ca.PrepareCSR(newCSR, "cn", ca.ManagerRole, secConfig.ClientTLSCreds.Organization()))
+	tlsCert, err = externalCA.Sign(tc.Context, ca.PrepareCSR(newCSR, "cn", ca.ManagerRole, tc.Organization))
 	require.NoError(t, err)
 
 	checkValidateAgainstAllRoots(tlsCert)

--- a/ca/config.go
+++ b/ca/config.go
@@ -157,7 +157,7 @@ func NewSecurityConfig(rootCA *RootCA, krw *KeyReadWriter, tlsKeyPair *tls.Certi
 		issuerInfo:  issuerInfo,
 		queue:       q,
 
-		externalCA:               NewExternalCA(rootCA, externalCATLSConfig),
+		externalCA:               NewExternalCA(rootCA.Intermediates, externalCATLSConfig),
 		ClientTLSCreds:           clientTLSCreds,
 		ServerTLSCreds:           serverTLSCreds,
 		externalCAClientRootPool: rootCA.Pool,
@@ -199,7 +199,7 @@ func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA, externalCARootPool *x509.C
 
 	s.rootCA = rootCA
 	s.externalCAClientRootPool = externalCARootPool
-	s.externalCA.UpdateRootCA(rootCA)
+	s.externalCA.UpdateIntermediates(rootCA.Intermediates)
 
 	return s.updateTLSCredentials(s.certificate, s.issuerInfo)
 }

--- a/ca/config.go
+++ b/ca/config.go
@@ -68,13 +68,10 @@ type SecurityConfig struct {
 	renewalMu sync.Mutex
 
 	rootCA        *RootCA
-	externalCA    *ExternalCA
 	keyReadWriter *KeyReadWriter
 
 	certificate *tls.Certificate
 	issuerInfo  *IssuerInfo
-
-	externalCAClientRootPool *x509.CertPool
 
 	ServerTLSCreds *MutableTLSCreds
 	ClientTLSCreds *MutableTLSCreds
@@ -90,7 +87,7 @@ type CertificateUpdate struct {
 	Err  error
 }
 
-func validateRootCAAndTLSCert(rootCA *RootCA, externalCARootPool *x509.CertPool, tlsKeyPair *tls.Certificate) error {
+func validateRootCAAndTLSCert(rootCA *RootCA, tlsKeyPair *tls.Certificate) error {
 	var (
 		leafCert         *x509.Certificate
 		intermediatePool *x509.CertPool
@@ -116,10 +113,6 @@ func validateRootCAAndTLSCert(rootCA *RootCA, externalCARootPool *x509.CertPool,
 	if _, err := leafCert.Verify(opts); err != nil {
 		return errors.Wrap(err, "new root CA does not match existing TLS credentials")
 	}
-	opts.Roots = externalCARootPool
-	if _, err := leafCert.Verify(opts); err != nil {
-		return errors.Wrap(err, "new external root pool does not match existing TLS credentials")
-	}
 	return nil
 }
 
@@ -139,16 +132,7 @@ func NewSecurityConfig(rootCA *RootCA, krw *KeyReadWriter, tlsKeyPair *tls.Certi
 		return nil, nil, err
 	}
 
-	// Make a new TLS config for the external CA client without a
-	// ServerName value set.
-	externalCATLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{*tlsKeyPair},
-		RootCAs:      rootCA.Pool,
-		MinVersion:   tls.VersionTLS12,
-	}
-
 	q := watch.NewQueue()
-
 	return &SecurityConfig{
 		rootCA:        rootCA,
 		keyReadWriter: krw,
@@ -157,10 +141,8 @@ func NewSecurityConfig(rootCA *RootCA, krw *KeyReadWriter, tlsKeyPair *tls.Certi
 		issuerInfo:  issuerInfo,
 		queue:       q,
 
-		externalCA:               NewExternalCA(rootCA.Intermediates, externalCATLSConfig),
-		ClientTLSCreds:           clientTLSCreds,
-		ServerTLSCreds:           serverTLSCreds,
-		externalCAClientRootPool: rootCA.Pool,
+		ClientTLSCreds: clientTLSCreds,
+		ServerTLSCreds: serverTLSCreds,
 	}, q.Close, nil
 }
 
@@ -170,11 +152,6 @@ func (s *SecurityConfig) RootCA() *RootCA {
 	defer s.mu.Unlock()
 
 	return s.rootCA
-}
-
-// ExternalCA returns the external CA.
-func (s *SecurityConfig) ExternalCA() *ExternalCA {
-	return s.externalCA
 }
 
 // KeyWriter returns the object that can write keys to disk
@@ -188,19 +165,16 @@ func (s *SecurityConfig) KeyReader() KeyReader {
 }
 
 // UpdateRootCA replaces the root CA with a new root CA
-func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA, externalCARootPool *x509.CertPool) error {
+func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// refuse to update the root CA if the current TLS credentials do not validate against it
-	if err := validateRootCAAndTLSCert(rootCA, externalCARootPool, s.certificate); err != nil {
+	if err := validateRootCAAndTLSCert(rootCA, s.certificate); err != nil {
 		return err
 	}
 
 	s.rootCA = rootCA
-	s.externalCAClientRootPool = externalCARootPool
-	s.externalCA.UpdateIntermediates(rootCA.Intermediates)
-
 	return s.updateTLSCredentials(s.certificate, s.issuerInfo)
 }
 
@@ -232,14 +206,6 @@ func (s *SecurityConfig) updateTLSCredentials(certificate *tls.Certificate, issu
 	if err := s.ClientTLSCreds.loadNewTLSConfig(clientConfig); err != nil {
 		return errors.Wrap(err, "failed to update the client credentials")
 	}
-
-	// Update the external CA to use the new client TLS
-	// config using a copy without a serverName specified.
-	s.externalCA.UpdateTLSConfig(&tls.Config{
-		Certificates: certs,
-		RootCAs:      s.externalCAClientRootPool,
-		MinVersion:   tls.VersionTLS12,
-	})
 
 	if err := s.ServerTLSCreds.loadNewTLSConfig(serverConfig); err != nil {
 		return errors.Wrap(err, "failed to update the server TLS credentials")
@@ -507,7 +473,7 @@ func updateRootThenUpdateCert(ctx context.Context, s *SecurityConfig, connBroker
 		return nil, nil, err
 	}
 	// validate against the existing security config creds
-	if err := s.UpdateRootCA(&rootCA, rootCA.Pool); err != nil {
+	if err := s.UpdateRootCA(&rootCA); err != nil {
 		return nil, nil, err
 	}
 	if err := SaveRootCA(rootCA, rootPaths); err != nil {

--- a/ca/external.go
+++ b/ca/external.go
@@ -55,9 +55,9 @@ type ExternalCA struct {
 
 // NewExternalCATLSConfig takes a TLS certificate and root pool and returns a TLS config that can be updated
 // without killing existing connections
-func NewExternalCATLSConfig(keyPair tls.Certificate, rootPool *x509.CertPool) *tls.Config {
+func NewExternalCATLSConfig(certs []tls.Certificate, rootPool *x509.CertPool) *tls.Config {
 	return &tls.Config{
-		Certificates: []tls.Certificate{keyPair},
+		Certificates: certs,
 		RootCAs:      rootPool,
 		MinVersion:   tls.VersionTLS12,
 	}
@@ -110,13 +110,6 @@ func (eca *ExternalCA) UpdateURLs(urls ...string) {
 	defer eca.mu.Unlock()
 
 	eca.urls = urls
-}
-
-// UpdateIntermediates changes the intermediates that will be appended to any certs
-func (eca *ExternalCA) UpdateIntermediates(intermediates []byte) {
-	eca.mu.Lock()
-	eca.intermediates = intermediates
-	eca.mu.Unlock()
 }
 
 // Sign signs a new certificate by proxying the given certificate signing

--- a/ca/external.go
+++ b/ca/external.go
@@ -78,19 +78,6 @@ func NewExternalCA(intermediates []byte, tlsConfig *tls.Config, urls ...string) 
 	}
 }
 
-// Copy returns a copy of the external CA that can be updated independently
-func (eca *ExternalCA) Copy() *ExternalCA {
-	eca.mu.Lock()
-	defer eca.mu.Unlock()
-
-	return &ExternalCA{
-		ExternalRequestTimeout: eca.ExternalRequestTimeout,
-		intermediates:          eca.intermediates,
-		urls:                   eca.urls,
-		client:                 eca.client,
-	}
-}
-
 // UpdateTLSConfig updates the HTTP Client for this ExternalCA by creating
 // a new client which uses the given tlsConfig.
 func (eca *ExternalCA) UpdateTLSConfig(tlsConfig *tls.Config) {

--- a/ca/external_test.go
+++ b/ca/external_test.go
@@ -36,7 +36,7 @@ func TestExternalCACrossSign(t *testing.T) {
 	cancel()
 
 	externalCA := ca.NewExternalCA(nil,
-		ca.NewExternalCATLSConfig(secConfig.ClientTLSCreds.Config().Certificates[0], tc.RootCA.Pool),
+		ca.NewExternalCATLSConfig(secConfig.ClientTLSCreds.Config().Certificates, tc.RootCA.Pool),
 		tc.ExternalSigningServer.URL)
 
 	for _, testcase := range []struct{ cert, key []byte }{
@@ -161,7 +161,7 @@ func TestExternalCACopy(t *testing.T) {
 	secConfig, err := tc.NewNodeConfig(ca.ManagerRole)
 	require.NoError(t, err)
 	externalCA1 := ca.NewExternalCA(nil,
-		ca.NewExternalCATLSConfig(secConfig.ClientTLSCreds.Config().Certificates[0], tc.RootCA.Pool))
+		ca.NewExternalCATLSConfig(secConfig.ClientTLSCreds.Config().Certificates, tc.RootCA.Pool))
 	externalCA2 := externalCA1.Copy()
 	externalCA2.UpdateURLs(tc.ExternalSigningServer.URL)
 

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -533,7 +533,7 @@ func TestCAServerUpdateRootCA(t *testing.T) {
 		require.Equal(t, testCase.rootCASigningKey, signingKey, "%d", i)
 		require.Equal(t, testCase.rootCAIntermediates, rootCA.Intermediates)
 
-		externalCA := tc.ServingSecurityConfig.ExternalCA()
+		externalCA := tc.CAServer.ExternalCA()
 		csr, _, err := ca.GenerateNewCSR()
 		require.NoError(t, err)
 		signedCert, err := externalCA.Sign(tc.Context, ca.PrepareCSR(csr, "cn", ca.ManagerRole, tc.Organization))

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -2,6 +2,7 @@ package ca_test
 
 import (
 	"bytes"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -430,6 +431,58 @@ type clusterObjToUpdate struct {
 	rootCASigningKey     []byte
 	rootCAIntermediates  []byte
 	externalCertSignedBy []byte
+}
+
+// When the SecurityConfig is updated with a new TLS keypair, the server automatically uses that keypair to contact
+// the external CA
+func TestServerExternalCAGetsTLSKeypairUpdates(t *testing.T) {
+	t.Parallel()
+
+	// this one needs the external CA server for testing
+	if !cautils.External {
+		return
+	}
+
+	tc := cautils.NewTestCA(t)
+	defer tc.Stop()
+
+	// show that we can connect to the external CA using our original creds
+	csr, _, err := ca.GenerateNewCSR()
+	require.NoError(t, err)
+	req := ca.PrepareCSR(csr, "cn", ca.ManagerRole, tc.Organization)
+
+	externalCA := tc.CAServer.ExternalCA()
+	extSignedCert, err := externalCA.Sign(tc.Context, req)
+	require.NoError(t, err)
+	require.NotNil(t, extSignedCert)
+
+	// get a new cert and make it expired
+	_, issuerInfo, err := tc.RootCA.IssueAndSaveNewCertificates(
+		tc.KeyReadWriter, tc.ServingSecurityConfig.ClientTLSCreds.NodeID(), ca.ManagerRole, tc.Organization)
+	require.NoError(t, err)
+	cert, key, err := tc.KeyReadWriter.Read()
+	require.NoError(t, err)
+
+	s, err := tc.RootCA.Signer()
+	require.NoError(t, err)
+	cert = cautils.ReDateCert(t, cert, s.Cert, s.Key, time.Now().Add(-5*time.Hour), time.Now().Add(-3*time.Hour))
+
+	// we have to create the keypair and update the security config manually, because all the renew functions check for
+	// expiry
+	tlsKeyPair, err := tls.X509KeyPair(cert, key)
+	require.NoError(t, err)
+	require.NoError(t, tc.ServingSecurityConfig.UpdateTLSCredentials(&tlsKeyPair, issuerInfo))
+
+	// show that we now cannot connect to the external CA using our original creds
+	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
+		externalCA := tc.CAServer.ExternalCA()
+		// wait for the credentials for the external CA to update
+		if _, err = externalCA.Sign(tc.Context, req); err == nil {
+			return errors.New("external CA creds haven't updated yet to be invalid")
+		}
+		return nil
+	}, 2*time.Second))
+	require.Contains(t, errors.Cause(err).Error(), "remote error: tls: bad certificate")
 }
 
 func TestCAServerUpdateRootCA(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -346,7 +346,7 @@ func (n *Node) run(ctx context.Context) (err error) {
 						log.G(ctx).WithError(err).Error("invalid new root certificate from the dispatcher")
 						continue
 					}
-					if err := securityConfig.UpdateRootCA(&newRootCA, newRootCA.Pool); err != nil {
+					if err := securityConfig.UpdateRootCA(&newRootCA); err != nil {
 						log.G(ctx).WithError(err).Error("could not use new root CA from dispatcher")
 						continue
 					}


### PR DESCRIPTION
This is the first step towards splitting the CA server's signing functionality from `SecurityConfig`, which serves more for providing creds for mTLS.  Doing so will help unify the root CA update paths in `node/node.go`.

The only node that ever needs the `ExternalCA` object is the leader that is running the CA server anyway, so it makes sense for it to go into the CA server.  This also better makes it possible at a future point to provide separate creds for contacting the external CA server if we ever needed to do so.