### PR TITLE
[controlapi] Redact the cluster spec CA signing certificate when getting the cluster info

### DIFF
--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -247,6 +247,11 @@ func redactClusters(clusters []*api.Cluster) []*api.Cluster {
 		// Do not copy secret keys
 		redactedSpec := cluster.Spec.Copy()
 		redactedSpec.CAConfig.SigningCAKey = nil
+		// the cert is not a secret, but if API users get the cluster spec and then update,
+		// then because the cert is included but not the key, the user can get update errors
+		// or unintended consequences (such as telling swarm to forget about the key so long
+		// as there is a corresponding external CA)
+		redactedSpec.CAConfig.SigningCACert = nil
 
 		redactedRootCA := cluster.RootCA.Copy()
 		redactedRootCA.CAKey = nil


### PR DESCRIPTION
Not because it's a secret, but otherwise the user flow of getting and updating the cluster spec would be problematic because the key is redacted but the cert is not - the user would be responsible for having to remove the cert instead to make sure this doesn't change the swarm CA key.

cc @aaronlehmann @andrewhsu @jlhawn