### PR TITLE
Add support for templating Node.Hostname in docker executor

### DIFF
--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -29,8 +29,8 @@ type containerAdapter struct {
 	secrets   exec.SecretGetter
 }
 
-func newContainerAdapter(client engineapi.APIClient, task *api.Task, secrets exec.SecretGetter) (*containerAdapter, error) {
-	ctnr, err := newContainerConfig(task)
+func newContainerAdapter(client engineapi.APIClient, nodeDescription *api.NodeDescription, task *api.Task, secrets exec.SecretGetter) (*containerAdapter, error) {
+	ctnr, err := newContainerConfig(nodeDescription, task)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/exec/dockerapi/container.go
+++ b/agent/exec/dockerapi/container.go
@@ -42,12 +42,12 @@ type containerConfig struct {
 
 // newContainerConfig returns a validated container config. No methods should
 // return an error if this function returns without error.
-func newContainerConfig(t *api.Task) (*containerConfig, error) {
+func newContainerConfig(n *api.NodeDescription, t *api.Task) (*containerConfig, error) {
 	var c containerConfig
-	return &c, c.setTask(t)
+	return &c, c.setTask(n, t)
 }
 
-func (c *containerConfig) setTask(t *api.Task) error {
+func (c *containerConfig) setTask(n *api.NodeDescription, t *api.Task) error {
 	container := t.Spec.GetContainer()
 	if container == nil {
 		return exec.ErrRuntimeUnsupported
@@ -64,7 +64,7 @@ func (c *containerConfig) setTask(t *api.Task) error {
 	}
 
 	c.task = t
-	preparedSpec, err := template.ExpandContainerSpec(t)
+	preparedSpec, err := template.ExpandContainerSpec(n, t)
 	if err != nil {
 		return err
 	}

--- a/agent/exec/dockerapi/controller.go
+++ b/agent/exec/dockerapi/controller.go
@@ -41,8 +41,8 @@ type controller struct {
 var _ exec.Controller = &controller{}
 
 // newController returns a docker exec controller for the provided task.
-func newController(client engineapi.APIClient, task *api.Task, secrets exec.SecretGetter) (exec.Controller, error) {
-	adapter, err := newContainerAdapter(client, task, secrets)
+func newController(client engineapi.APIClient, nodeDescription *api.NodeDescription, task *api.Task, secrets exec.SecretGetter) (exec.Controller, error) {
+	adapter, err := newContainerAdapter(client, nodeDescription, task, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/agent/exec/dockerapi/controller_integration_test.go
+++ b/agent/exec/dockerapi/controller_integration_test.go
@@ -80,7 +80,7 @@ func TestControllerFlowIntegration(t *testing.T) {
 		return nil
 	})
 
-	ctlr, err := newController(client, task, nil)
+	ctlr, err := newController(client, nil, task, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, ctlr)
 	assert.NoError(t, ctlr.Prepare(ctx))

--- a/agent/exec/dockerapi/controller_test.go
+++ b/agent/exec/dockerapi/controller_test.go
@@ -411,11 +411,19 @@ func TestControllerRemove(t *testing.T) {
 }
 
 func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *StubAPIClient, exec.Controller, *containerConfig, func()) {
+	testNodeDescription := &api.NodeDescription{
+		Hostname: "testHostname",
+		Platform: &api.Platform{
+			OS:           "linux",
+			Architecture: "x86_64",
+		},
+	}
+
 	client := NewStubAPIClient()
-	ctlr, err := newController(client, task, nil)
+	ctlr, err := newController(client, testNodeDescription, task, nil)
 	assert.NoError(t, err)
 
-	config, err := newContainerConfig(task)
+	config, err := newContainerConfig(testNodeDescription, task)
 	assert.NoError(t, err)
 	assert.NotNil(t, config)
 

--- a/agent/exec/dockerapi/executor.go
+++ b/agent/exec/dockerapi/executor.go
@@ -11,21 +11,25 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"golang.org/x/net/context"
+	"sync"
 )
 
 type executor struct {
 	client           engineapi.APIClient
 	secrets          exec.SecretsManager
 	genericResources []*api.GenericResource
+	mutex            sync.Mutex // This mutex protects the following node field
+	node             *api.NodeDescription
 }
 
 // NewExecutor returns an executor from the docker client.
 func NewExecutor(client engineapi.APIClient, genericResources []*api.GenericResource) exec.Executor {
-	return &executor{
+	var executor = &executor{
 		client:           client,
 		secrets:          secrets.NewManager(),
 		genericResources: genericResources,
 	}
+	return executor
 }
 
 // Describe returns the underlying node description from the docker client.
@@ -111,6 +115,11 @@ func (e *executor) Describe(ctx context.Context) (*api.NodeDescription, error) {
 		},
 	}
 
+	// Save the node information in the executor field
+	e.mutex.Lock()
+	e.node = description
+	e.mutex.Unlock()
+
 	return description, nil
 }
 
@@ -120,7 +129,11 @@ func (e *executor) Configure(ctx context.Context, node *api.Node) error {
 
 // Controller returns a docker container controller.
 func (e *executor) Controller(t *api.Task) (exec.Controller, error) {
-	ctlr, err := newController(e.client, t, secrets.Restrict(e.secrets, t))
+	// Get the node description from the executor field
+	e.mutex.Lock()
+	nodeDescription := e.node
+	e.mutex.Unlock()
+	ctlr, err := newController(e.client, nodeDescription, t, secrets.Restrict(e.secrets, t))
 	if err != nil {
 		return nil, err
 	}

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -128,7 +128,13 @@ func validateContainerSpec(taskSpec api.TaskSpec) error {
 	// Building a empty/dummy Task to validate the templating and
 	// the resulting container spec as well. This is a *best effort*
 	// validation.
-	container, err := template.ExpandContainerSpec(&api.Task{
+	container, err := template.ExpandContainerSpec(&api.NodeDescription{
+		Hostname: "nodeHostname",
+		Platform: &api.Platform{
+			OS:           "os",
+			Architecture: "architecture",
+		},
+	}, &api.Task{
 		Spec:      taskSpec,
 		ServiceID: "serviceid",
 		Slot:      1,

--- a/template/getter.go
+++ b/template/getter.go
@@ -9,11 +9,12 @@ import (
 type templatedSecretGetter struct {
 	dependencies exec.DependencyGetter
 	t            *api.Task
+	node         *api.NodeDescription
 }
 
 // NewTemplatedSecretGetter returns a SecretGetter that evaluates templates.
-func NewTemplatedSecretGetter(dependencies exec.DependencyGetter, t *api.Task) exec.SecretGetter {
-	return templatedSecretGetter{dependencies: dependencies, t: t}
+func NewTemplatedSecretGetter(dependencies exec.DependencyGetter, t *api.Task, node *api.NodeDescription) exec.SecretGetter {
+	return templatedSecretGetter{dependencies: dependencies, t: t, node: node}
 }
 
 func (t templatedSecretGetter) Get(secretID string) (*api.Secret, error) {
@@ -31,7 +32,7 @@ func (t templatedSecretGetter) Get(secretID string) (*api.Secret, error) {
 		return secret, err
 	}
 
-	newSpec, err := ExpandSecretSpec(secret, t.t, t.dependencies)
+	newSpec, err := ExpandSecretSpec(secret, t.node, t.t, t.dependencies)
 	if err != nil {
 		return secret, errors.Wrapf(err, "failed to expand templated secret %s", secretID)
 	}
@@ -44,11 +45,12 @@ func (t templatedSecretGetter) Get(secretID string) (*api.Secret, error) {
 type templatedConfigGetter struct {
 	dependencies exec.DependencyGetter
 	t            *api.Task
+	node         *api.NodeDescription
 }
 
 // NewTemplatedConfigGetter returns a ConfigGetter that evaluates templates.
-func NewTemplatedConfigGetter(dependencies exec.DependencyGetter, t *api.Task) exec.ConfigGetter {
-	return templatedConfigGetter{dependencies: dependencies, t: t}
+func NewTemplatedConfigGetter(dependencies exec.DependencyGetter, t *api.Task, node *api.NodeDescription) exec.ConfigGetter {
+	return templatedConfigGetter{dependencies: dependencies, t: t, node: node}
 }
 
 func (t templatedConfigGetter) Get(configID string) (*api.Config, error) {
@@ -66,7 +68,7 @@ func (t templatedConfigGetter) Get(configID string) (*api.Config, error) {
 		return config, err
 	}
 
-	newSpec, err := ExpandConfigSpec(config, t.t, t.dependencies)
+	newSpec, err := ExpandConfigSpec(config, t.node, t.t, t.dependencies)
 	if err != nil {
 		return config, errors.Wrapf(err, "failed to expand templated config %s", configID)
 	}
@@ -82,10 +84,10 @@ type templatedDependencyGetter struct {
 }
 
 // NewTemplatedDependencyGetter returns a DependencyGetter that evaluates templates.
-func NewTemplatedDependencyGetter(dependencies exec.DependencyGetter, t *api.Task) exec.DependencyGetter {
+func NewTemplatedDependencyGetter(dependencies exec.DependencyGetter, t *api.Task, node *api.NodeDescription) exec.DependencyGetter {
 	return templatedDependencyGetter{
-		secrets: NewTemplatedSecretGetter(dependencies, t),
-		configs: NewTemplatedConfigGetter(dependencies, t),
+		secrets: NewTemplatedSecretGetter(dependencies, t, node),
+		configs: NewTemplatedConfigGetter(dependencies, t, node),
 	}
 }
 

--- a/template/getter_test.go
+++ b/template/getter_test.go
@@ -31,6 +31,7 @@ func TestTemplatedSecret(t *testing.T) {
 		desc        string
 		secretSpec  api.SecretSpec
 		task        *api.Task
+		node        *api.NodeDescription
 		expected    string
 		expectedErr string
 	}
@@ -43,14 +44,20 @@ func TestTemplatedSecret(t *testing.T) {
 					"SERVICE_NAME={{.Service.Name}}\n" +
 					"TASK_ID={{.Task.ID}}\n" +
 					"TASK_NAME={{.Task.Name}}\n" +
-					"NODE_ID={{.Node.ID}}\n"),
+					"NODE_ID={{.Node.ID}}\n" +
+					"NODE_HOSTNAME={{.Node.Hostname}}\n" +
+					"NODE_OS={{.Node.Platform.OS}}\n" +
+					"NODE_ARCHITECTURE={{.Node.Platform.Architecture}}"),
 				Templating: &api.Driver{Name: "golang"},
 			},
 			expected: "SERVICE_ID=serviceID\n" +
 				"SERVICE_NAME=serviceName\n" +
 				"TASK_ID=taskID\n" +
 				"TASK_NAME=serviceName.10.taskID\n" +
-				"NODE_ID=nodeID\n",
+				"NODE_ID=nodeID\n" +
+				"NODE_HOSTNAME=myhostname\n" +
+				"NODE_OS=testOS\n" +
+				"NODE_ARCHITECTURE=testArchitecture",
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{
@@ -64,6 +71,11 @@ func TestTemplatedSecret(t *testing.T) {
 						},
 					},
 				}
+			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				n.Hostname = "myhostname"
+				n.Platform.OS = "testOS"
+				n.Platform.Architecture = "testArchitecture"
 			}),
 		},
 		{
@@ -98,6 +110,9 @@ func TestTemplatedSecret(t *testing.T) {
 						},
 					},
 				}
+			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
 			}),
 		},
 		{
@@ -135,6 +150,9 @@ func TestTemplatedSecret(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test expansion of secret not available to task",
@@ -157,6 +175,9 @@ func TestTemplatedSecret(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test expansion of config not available to task",
@@ -178,6 +199,9 @@ func TestTemplatedSecret(t *testing.T) {
 						},
 					},
 				}
+			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
 			}),
 		},
 		{
@@ -209,6 +233,9 @@ func TestTemplatedSecret(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test env",
@@ -234,6 +261,9 @@ func TestTemplatedSecret(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 	}
 
@@ -244,7 +274,7 @@ func TestTemplatedSecret(t *testing.T) {
 		dependencyManager.Secrets().Add(*templatedSecret, *referencedSecret)
 		dependencyManager.Configs().Add(*referencedConfig)
 
-		templatedDependencies := NewTemplatedDependencyGetter(agent.Restrict(dependencyManager, testCase.task), testCase.task)
+		templatedDependencies := NewTemplatedDependencyGetter(agent.Restrict(dependencyManager, testCase.task), testCase.task, testCase.node)
 		expandedSecret, err := templatedDependencies.Secrets().Get("templatedsecret")
 
 		if testCase.expectedErr != "" {
@@ -281,6 +311,7 @@ func TestTemplatedConfig(t *testing.T) {
 		task        *api.Task
 		expected    string
 		expectedErr string
+		node        *api.NodeDescription
 	}
 
 	testCases := []testCase{
@@ -291,14 +322,20 @@ func TestTemplatedConfig(t *testing.T) {
 					"SERVICE_NAME={{.Service.Name}}\n" +
 					"TASK_ID={{.Task.ID}}\n" +
 					"TASK_NAME={{.Task.Name}}\n" +
-					"NODE_ID={{.Node.ID}}\n"),
+					"NODE_ID={{.Node.ID}}\n" +
+					"NODE_HOSTNAME={{.Node.Hostname}}\n" +
+					"NODE_OS={{.Node.Platform.OS}}\n" +
+					"NODE_ARCHITECTURE={{.Node.Platform.Architecture}}"),
 				Templating: &api.Driver{Name: "golang"},
 			},
 			expected: "SERVICE_ID=serviceID\n" +
 				"SERVICE_NAME=serviceName\n" +
 				"TASK_ID=taskID\n" +
 				"TASK_NAME=serviceName.10.taskID\n" +
-				"NODE_ID=nodeID\n",
+				"NODE_ID=nodeID\n" +
+				"NODE_HOSTNAME=myhostname\n" +
+				"NODE_OS=testOS\n" +
+				"NODE_ARCHITECTURE=testArchitecture",
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{
@@ -312,6 +349,11 @@ func TestTemplatedConfig(t *testing.T) {
 						},
 					},
 				}
+			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				n.Hostname = "myhostname"
+				n.Platform.OS = "testOS"
+				n.Platform.Architecture = "testArchitecture"
 			}),
 		},
 		{
@@ -349,6 +391,9 @@ func TestTemplatedConfig(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test expansion of config, by target",
@@ -383,6 +428,9 @@ func TestTemplatedConfig(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test expansion of secret not available to task",
@@ -405,6 +453,9 @@ func TestTemplatedConfig(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test expansion of config not available to task",
@@ -426,6 +477,9 @@ func TestTemplatedConfig(t *testing.T) {
 						},
 					},
 				}
+			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
 			}),
 		},
 		{
@@ -457,6 +511,9 @@ func TestTemplatedConfig(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 		{
 			desc: "Test env",
@@ -482,6 +539,9 @@ func TestTemplatedConfig(t *testing.T) {
 					},
 				}
 			}),
+			node: modifyNode(func(n *api.NodeDescription) {
+				// use default values
+			}),
 		},
 	}
 
@@ -492,7 +552,7 @@ func TestTemplatedConfig(t *testing.T) {
 		dependencyManager.Configs().Add(*templatedConfig, *referencedConfig)
 		dependencyManager.Secrets().Add(*referencedSecret)
 
-		templatedDependencies := NewTemplatedDependencyGetter(agent.Restrict(dependencyManager, testCase.task), testCase.task)
+		templatedDependencies := NewTemplatedDependencyGetter(agent.Restrict(dependencyManager, testCase.task), testCase.task, testCase.node)
 		expandedConfig, err := templatedDependencies.Configs().Get("templatedconfig")
 
 		if testCase.expectedErr != "" {


### PR DESCRIPTION
At the moment we can only use NodeID as a template variable. The hostname is better for some kind of application and it's also more flexible and human readable. See #1951 or moby/moby#32561 for related proposals.

This PR is built on the previous work done by @gianarb
