### PR TITLE
scheduler: Clean up addOrUpdateNode

### DIFF
--- a/manager/scheduler/nodeset.go
+++ b/manager/scheduler/nodeset.go
@@ -4,7 +4,6 @@ import (
 	"container/heap"
 	"errors"
 	"strings"
-	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/constraint"
@@ -32,16 +31,6 @@ func (ns *nodeSet) nodeInfo(nodeID string) (NodeInfo, error) {
 // addOrUpdateNode sets the number of tasks for a given node. It adds the node
 // to the set if it wasn't already tracked.
 func (ns *nodeSet) addOrUpdateNode(n NodeInfo) {
-	if n.Tasks == nil {
-		n.Tasks = make(map[string]*api.Task)
-	}
-	if n.ActiveTasksCountByService == nil {
-		n.ActiveTasksCountByService = make(map[string]int)
-	}
-	if n.recentFailures == nil {
-		n.recentFailures = make(map[string][]time.Time)
-	}
-
 	ns.nodes[n.ID] = n
 }
 

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -2764,8 +2764,6 @@ func TestSchedulerHostPort(t *testing.T) {
 		// Add initial node and task
 		assert.NoError(t, store.CreateTask(tx, task1))
 		assert.NoError(t, store.CreateTask(tx, task2))
-		assert.NoError(t, store.CreateNode(tx, node1))
-		assert.NoError(t, store.CreateNode(tx, node2))
 		return nil
 	})
 	assert.NoError(t, err)
@@ -2779,6 +2777,18 @@ func TestSchedulerHostPort(t *testing.T) {
 		assert.NoError(t, scheduler.Run(ctx))
 	}()
 	defer scheduler.Stop()
+
+	// Tasks shouldn't be scheduled because there are no nodes.
+	watchAssignmentFailure(t, watch)
+	watchAssignmentFailure(t, watch)
+
+	err = s.Update(func(tx store.Tx) error {
+		// Add initial node and task
+		assert.NoError(t, store.CreateNode(tx, node1))
+		assert.NoError(t, store.CreateNode(tx, node2))
+		return nil
+	})
+	assert.NoError(t, err)
 
 	// Tasks 1 and 2 should be assigned to different nodes.
 	assignment1 := watchAssignment(t, watch)


### PR DESCRIPTION
This function previously could take an uninitialized `NodeInfo` structure and fill in whatever was missing. This is very error-prone, so remove this logic and change the only caller that relies on it to always pass in a properly initialized `NodeInfo`.

This was originally a cleanup that was part of #2253, but it turns out to fix a bad panic. Opening as a separate PR for backport.

cc @andrewhsu