### PR TITLE
[tests] Clean up unremoved temp files from manager raft tests.

### DIFF
--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -357,7 +357,6 @@ func TestCanRemoveMember(t *testing.T) {
 
 	// Add back node 3
 	raftutils.ShutdownNode(nodes[3])
-	delete(nodes, 3)
 	nodes[3] = raftutils.NewJoinNode(t, clockSource, nodes[leader].Address, tc)
 	raftutils.WaitForCluster(t, clockSource, nodes)
 

--- a/manager/state/raft/storage_test.go
+++ b/manager/state/raft/storage_test.go
@@ -317,9 +317,7 @@ func TestRaftSnapshotForceNewCluster(t *testing.T) {
 	nodes[1].Server.Stop()
 	nodes[1].ShutdownRaft()
 	nodes[1] = raftutils.RestartNode(t, clockSource, nodes[1], true)
-	delete(nodes, 3)
-	delete(nodes, 4)
-	raftutils.WaitForCluster(t, clockSource, nodes)
+	raftutils.WaitForCluster(t, clockSource, map[uint64]*raftutils.TestNode{1: nodes[1]})
 
 	// The memberlist should contain exactly one node (self)
 	memberlist := nodes[1].GetMemberlist()

--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -262,7 +262,7 @@ func NewNode(t *testing.T, clockSource *fakeclock.FakeClock, tc *cautils.TestCA,
 
 	cfg := raft.DefaultNodeConfig()
 
-	stateDir, err := ioutil.TempDir("", "test-raft")
+	stateDir, err := ioutil.TempDir("", t.Name())
 	require.NoError(t, err, "can't create temporary state directory")
 
 	keyRotator := NewSimpleKeyRotator(raft.EncryptionKeys{CurrentDEK: []byte("current")})


### PR DESCRIPTION
We were altering the node map during the tests, so some of the replaced nodes didn't get cleaned up.  See https://github.com/docker/swarmkit/pull/2269#issuecomment-309617060