### PR TITLE
[ca] Refactor SecurityConfig to automatically create a watch.Queue

### DIFF
--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -1290,8 +1290,9 @@ func TestRootCAWithCrossSignedIntermediates(t *testing.T) {
 	connectToExternalRootCA, err := ca.NewRootCA(append(cautils.ECDSACertChain[2], fauxRootCert...), cautils.ECDSACertChain[1],
 		cautils.ECDSACertChainKeys[1], ca.DefaultNodeCertExpiration, cautils.ECDSACertChain[1])
 	require.NoError(t, err)
-	secConfig, err := connectToExternalRootCA.CreateSecurityConfig(tc.Context, krw, ca.CertificateRequestConfig{})
+	secConfig, cancel, err := connectToExternalRootCA.CreateSecurityConfig(tc.Context, krw, ca.CertificateRequestConfig{})
 	require.NoError(t, err)
+	cancel()
 
 	externalCA := secConfig.ExternalCA()
 	externalCA.UpdateURLs(tc.ExternalSigningServer.URL)

--- a/ca/external_test.go
+++ b/ca/external_test.go
@@ -29,9 +29,10 @@ func TestExternalCACrossSign(t *testing.T) {
 	defer tc.Stop()
 	paths := ca.NewConfigPaths(tc.TempDir)
 
-	secConfig, err := tc.RootCA.CreateSecurityConfig(tc.Context,
+	secConfig, cancel, err := tc.RootCA.CreateSecurityConfig(tc.Context,
 		ca.NewKeyReadWriter(paths.Node, nil, nil), ca.CertificateRequestConfig{})
 	require.NoError(t, err)
+	cancel()
 	externalCA := secConfig.ExternalCA()
 	externalCA.UpdateURLs(tc.ExternalSigningServer.URL)
 

--- a/manager/controlapi/ca_rotation_test.go
+++ b/manager/controlapi/ca_rotation_test.go
@@ -63,8 +63,9 @@ func getSecurityConfig(t *testing.T, localRootCA *ca.RootCA, cluster *api.Cluste
 	require.NoError(t, err)
 	defer os.RemoveAll(tempdir)
 	paths := ca.NewConfigPaths(tempdir)
-	secConfig, err := localRootCA.CreateSecurityConfig(context.Background(), ca.NewKeyReadWriter(paths.Node, nil, nil), ca.CertificateRequestConfig{})
+	secConfig, cancel, err := localRootCA.CreateSecurityConfig(context.Background(), ca.NewKeyReadWriter(paths.Node, nil, nil), ca.CertificateRequestConfig{})
 	require.NoError(t, err)
+	cancel()
 
 	require.NoError(t, ca.NewServer(store.NewMemoryStore(nil), secConfig, paths.RootCA).UpdateRootCA(context.Background(), cluster))
 	return secConfig


### PR DESCRIPTION
Rather than use `SetWatch`.  This returns the `watch.Queue.Close` function as a cleanup function whenever a security config is created.

cc @aaronlehmann @diogomonica 