### PR TITLE
[store] Change the `Restore` action on objects to update instead of delete/create

### DIFF
--- a/manager/state/store/clusters.go
+++ b/manager/state/store/clusters.go
@@ -43,21 +43,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			clusters, err := FindClusters(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Clusters))
+			for i, x := range snapshot.Clusters {
+				toStoreObj[i] = x
 			}
-			for _, n := range clusters {
-				if err := DeleteCluster(tx, n.ID); err != nil {
-					return err
-				}
-			}
-			for _, n := range snapshot.Clusters {
-				if err := CreateCluster(tx, n); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableCluster, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/configs.go
+++ b/manager/state/store/configs.go
@@ -37,21 +37,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			configs, err := FindConfigs(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Configs))
+			for i, x := range snapshot.Configs {
+				toStoreObj[i] = x
 			}
-			for _, s := range configs {
-				if err := DeleteConfig(tx, s.ID); err != nil {
-					return err
-				}
-			}
-			for _, s := range snapshot.Configs {
-				if err := CreateConfig(tx, s); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableConfig, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/networks.go
+++ b/manager/state/store/networks.go
@@ -37,21 +37,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			networks, err := FindNetworks(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Networks))
+			for i, x := range snapshot.Networks {
+				toStoreObj[i] = x
 			}
-			for _, n := range networks {
-				if err := DeleteNetwork(tx, n.ID); err != nil {
-					return err
-				}
-			}
-			for _, n := range snapshot.Networks {
-				if err := CreateNetwork(tx, n); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableNetwork, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/nodes.go
+++ b/manager/state/store/nodes.go
@@ -47,21 +47,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			nodes, err := FindNodes(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Nodes))
+			for i, x := range snapshot.Nodes {
+				toStoreObj[i] = x
 			}
-			for _, n := range nodes {
-				if err := DeleteNode(tx, n.ID); err != nil {
-					return err
-				}
-			}
-			for _, n := range snapshot.Nodes {
-				if err := CreateNode(tx, n); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableNode, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/object.go
+++ b/manager/state/store/object.go
@@ -13,3 +13,46 @@ type ObjectStoreConfig struct {
 	Restore          func(Tx, *api.StoreSnapshot) error
 	ApplyStoreAction func(Tx, api.StoreAction) error
 }
+
+// RestoreTable takes a list of new objects of a particular type (e.g. clusters,
+// nodes, etc., which conform to the StoreObject interface) and replaces the
+// existing objects in the store of that type with the new objects.
+func RestoreTable(tx Tx, table string, newObjects []api.StoreObject) error {
+	checkType := func(by By) error {
+		return nil
+	}
+	var oldObjects []api.StoreObject
+	appendResult := func(o api.StoreObject) {
+		oldObjects = append(oldObjects, o)
+	}
+
+	err := tx.find(table, All, checkType, appendResult)
+	if err != nil {
+		return nil
+	}
+
+	updated := make(map[string]struct{})
+
+	for _, o := range newObjects {
+		objectID := o.GetID()
+		if existing := tx.lookup(table, indexID, objectID); existing != nil {
+			if err := tx.update(table, o); err != nil {
+				return err
+			}
+			updated[objectID] = struct{}{}
+		} else {
+			if err := tx.create(table, o); err != nil {
+				return err
+			}
+		}
+	}
+	for _, o := range oldObjects {
+		objectID := o.GetID()
+		if _, ok := updated[objectID]; !ok {
+			if err := tx.delete(table, objectID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/manager/state/store/secrets.go
+++ b/manager/state/store/secrets.go
@@ -37,21 +37,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			secrets, err := FindSecrets(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Secrets))
+			for i, x := range snapshot.Secrets {
+				toStoreObj[i] = x
 			}
-			for _, s := range secrets {
-				if err := DeleteSecret(tx, s.ID); err != nil {
-					return err
-				}
-			}
-			for _, s := range snapshot.Secrets {
-				if err := CreateSecret(tx, s); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableSecret, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/services.go
+++ b/manager/state/store/services.go
@@ -58,21 +58,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			services, err := FindServices(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Services))
+			for i, x := range snapshot.Services {
+				toStoreObj[i] = x
 			}
-			for _, s := range services {
-				if err := DeleteService(tx, s.ID); err != nil {
-					return err
-				}
-			}
-			for _, s := range snapshot.Services {
-				if err := CreateService(tx, s); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableService, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -82,21 +82,11 @@ func init() {
 			return err
 		},
 		Restore: func(tx Tx, snapshot *api.StoreSnapshot) error {
-			tasks, err := FindTasks(tx, All)
-			if err != nil {
-				return err
+			toStoreObj := make([]api.StoreObject, len(snapshot.Tasks))
+			for i, x := range snapshot.Tasks {
+				toStoreObj[i] = x
 			}
-			for _, t := range tasks {
-				if err := DeleteTask(tx, t.ID); err != nil {
-					return err
-				}
-			}
-			for _, t := range snapshot.Tasks {
-				if err := CreateTask(tx, t); err != nil {
-					return err
-				}
-			}
-			return nil
+			return RestoreTable(tx, tableTask, toStoreObj)
 		},
 		ApplyStoreAction: func(tx Tx, sa api.StoreAction) error {
 			switch v := sa.Target.(type) {


### PR DESCRIPTION
Since if the object already exists, the event produced should be an update and not a delete/create.

This is probably the cause of https://github.com/moby/moby/pull/33541, where an unlock key change is sometimes is not picked up by a snapshot restore from another node.

cc @aaronlehmann 

Also, :( generics