### PR TITLE
template: Indicate which configs contain secret data

### DIFF
--- a/template/context.go
+++ b/template/context.go
@@ -107,9 +107,10 @@ type PayloadContext struct {
 	t                 *api.Task
 	restrictedSecrets exec.SecretGetter
 	restrictedConfigs exec.ConfigGetter
+	sensitive         bool
 }
 
-func (ctx PayloadContext) secretGetter(target string) (string, error) {
+func (ctx *PayloadContext) secretGetter(target string) (string, error) {
 	if ctx.restrictedSecrets == nil {
 		return "", errors.New("secrets unavailable")
 	}
@@ -126,6 +127,7 @@ func (ctx PayloadContext) secretGetter(target string) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			ctx.sensitive = true
 			return string(secret.Spec.Data), nil
 		}
 	}
@@ -133,7 +135,7 @@ func (ctx PayloadContext) secretGetter(target string) (string, error) {
 	return "", errors.Errorf("secret target %s not found", target)
 }
 
-func (ctx PayloadContext) configGetter(target string) (string, error) {
+func (ctx *PayloadContext) configGetter(target string) (string, error) {
 	if ctx.restrictedConfigs == nil {
 		return "", errors.New("configs unavailable")
 	}
@@ -157,7 +159,7 @@ func (ctx PayloadContext) configGetter(target string) (string, error) {
 	return "", errors.Errorf("config target %s not found", target)
 }
 
-func (ctx PayloadContext) envGetter(variable string) (string, error) {
+func (ctx *PayloadContext) envGetter(variable string) (string, error) {
 	container := ctx.t.Spec.GetContainer()
 	if container == nil {
 		return "", errors.New("task is not a container")


### PR DESCRIPTION
This changes the templated ConfigGetter to include an extra method,
GetAndFlagSecretData, which returns an interpolated config and also a
flag indicating whether it contains any data from a secret. This can be
used downstream to avoid storing the config to disk.

Ideally, there would be some kind of Sensitive method on a Config object
itself, but since that type is automatically generated by protoc,
including a private field is awkward to do. Thus this approach of
returning the flag along with the config. Note that I opted for a method
that returns the config and the flag at the same time instead of a
method that just returns the flag, since a method that returns the flag
still needs to expand the config, and it seems most robust and
performant to just return the config and the flag at the same time
instead of relying on different code paths to generate consistent
results.

cc @diogomonica @cyli