### PR TITLE
global: Allow updates of failed services with restart policy "none"

### DIFF
--- a/manager/orchestrator/testutils/testutils.go
+++ b/manager/orchestrator/testutils/testutils.go
@@ -88,7 +88,7 @@ func Expect(t *testing.T, watch chan events.Event, specifiers ...api.Event) {
 			}
 			return
 		case <-time.After(time.Second):
-			assert.FailNow(t, "no commit event")
+			assert.FailNow(t, "no matching event")
 		}
 	}
 }


### PR DESCRIPTION
There is some tension around what to do when reconciling a service whose restart policy is "none". On one hand, the restart policy says not to restart a failed task. On the other hand, the declarative state of the service says a certain number of replics of the service should run, or the task should run on all possible nodes, and a change to the spec might resolve the condition that caused the failure.

Currently, the replicated orchestrator chooses to favor the declarative state when reconciling a service. This means that on a leader change or change to the service, we effectively ignore the restart policy.

The global orchestrator, on the other hand, refuses to touch the task on any node where it has failed, if the restart policy says to do so. This can lead to very unintuitive behavior, for example setting up a service that fails because its command line is wrong, then updating the service to fix the command line, and seeing nothing happen.

I believe the replicated orchestrator's behavior is a better choice, and less confusing to users. It's very bad for a service to get into a state where it can't be updated because it has already failed on all nodes and therefore won't be touched on those nodes.

This changes the global orchestrator to behave like the replicated orchestrator, and ignore the restart policy on startup, and when the service is updated.

Note that this means that on leader changes, failed global services will be restarted, which might be contrary to expectations. But it also means that a "service update" will be able to fix a broken global service regardless of the restart policy, which is very important.

cc @aluzzardi 
cc @dongluochen (in case you're still around)