### PR TITLE
[WIP] Respect restart policy during service reconciliation

### DIFF
--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -493,8 +493,7 @@ func (g *Orchestrator) tickTasks(ctx context.Context) {
 					return nil
 				}
 
-				if node.Spec.Availability == api.NodeAvailabilityPause ||
-					!constraint.NodeMatches(serviceEntry.constraints, node) {
+				if !constraint.NodeMatches(serviceEntry.constraints, node) {
 					t.DesiredState = api.TaskStateShutdown
 					return store.UpdateTask(tx, t)
 				}

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -187,7 +187,7 @@ func (g *Orchestrator) FixTask(ctx context.Context, batch *store.Batch, t *api.T
 		node = g.nodes[t.NodeID]
 	}
 	// if the node no longer valid, remove the task
-	if node == nil || node.Spec.Availability == api.NodeAvailabilityDrain || node.Status.State == api.NodeStatus_DOWN {
+	if node == nil || node.Spec.Availability == api.NodeAvailabilityDrain {
 		g.shutdownTask(ctx, batch, t)
 		return
 	}
@@ -295,9 +295,14 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 					continue
 				}
 
-				if node.Spec.Availability == api.NodeAvailabilityPause {
-					// the node is paused, so we won't add or update
-					// any tasks
+				if node.Spec.Availability == api.NodeAvailabilityPause ||
+					node.Status.State == api.NodeStatus_DOWN {
+					// The node is paused or down, so we
+					// won't add or update any tasks. When
+					// the node is unpaused or comes back
+					// up, it will trigger node
+					// reconciliation, correcting anything
+					// we might have skiped here.
 					continue
 				}
 
@@ -334,7 +339,7 @@ func (g *Orchestrator) reconcileServices(ctx context.Context, serviceIDs []strin
 
 // updateNode updates g.nodes based on the current node value
 func (g *Orchestrator) updateNode(node *api.Node) {
-	if node.Spec.Availability == api.NodeAvailabilityDrain || node.Status.State == api.NodeStatus_DOWN {
+	if node.Spec.Availability == api.NodeAvailabilityDrain {
 		delete(g.nodes, node.ID)
 	} else {
 		g.nodes[node.ID] = node
@@ -363,14 +368,12 @@ func (g *Orchestrator) reconcileOneNode(ctx context.Context, node *api.Node) {
 		return
 	}
 
-	if node.Status.State == api.NodeStatus_DOWN {
-		log.G(ctx).Debugf("global orchestrator: node %s is down, shutting down its tasks", node.ID)
-		g.foreachTaskFromNode(ctx, node, g.shutdownTask)
-		return
-	}
-
-	if node.Spec.Availability == api.NodeAvailabilityPause {
-		// the node is paused, so we won't add or update tasks
+	if node.Spec.Availability == api.NodeAvailabilityPause ||
+		node.Status.State == api.NodeStatus_DOWN {
+		// The node is paused or down, so we won't add or update any
+		// tasks. When the node is unpaused or comes back up, it will
+		// trigger node reconciliation, correcting anything we might
+		// have skiped here.
 		return
 	}
 

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -187,7 +187,7 @@ func (g *Orchestrator) FixTask(ctx context.Context, batch *store.Batch, t *api.T
 		node = g.nodes[t.NodeID]
 	}
 	// if the node no longer valid, remove the task
-	if t.NodeID == "" || orchestrator.InvalidNode(node) {
+	if node == nil || node.Spec.Availability == api.NodeAvailabilityDrain || node.Status.State == api.NodeStatus_DOWN {
 		g.shutdownTask(ctx, batch, t)
 		return
 	}
@@ -496,7 +496,7 @@ func (g *Orchestrator) tickTasks(ctx context.Context) {
 					return store.UpdateTask(tx, t)
 				}
 
-				return g.restarts.Restart(ctx, tx, g.cluster, service, *t)
+				return g.restarts.Restart(ctx, tx, g.cluster, service, *t, false)
 			})
 			if err != nil {
 				log.G(ctx).WithError(err).Errorf("orchestrator restartTask transaction failed")

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -414,9 +414,6 @@ func TestTaskFailure(t *testing.T) {
 	failTask(t, store, observedTask3)
 	testutils.Expect(t, watch, api.EventUpdateTask{})
 	testutils.Expect(t, watch, state.EventCommit{})
-	observedTask4 := testutils.WatchTaskUpdate(t, watch)
-	assert.Equal(t, observedTask4.DesiredState, api.TaskStateShutdown)
-	testutils.Expect(t, watch, state.EventCommit{})
 
 	// the task should not be recreated
 	select {
@@ -430,10 +427,14 @@ func TestTaskFailure(t *testing.T) {
 	testutils.Expect(t, watch, api.EventUpdateService{})
 	testutils.Expect(t, watch, state.EventCommit{})
 
-	observedTask5 := testutils.WatchTaskCreate(t, watch)
-	assert.Equal(t, observedTask5.Status.State, api.TaskStateNew)
-	assert.Equal(t, observedTask5.ServiceAnnotations.Name, "norestart")
-	assert.Equal(t, observedTask5.NodeID, "nodeid1")
+	observedTask4 := testutils.WatchTaskCreate(t, watch)
+	assert.Equal(t, observedTask4.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask4.ServiceAnnotations.Name, "norestart")
+	assert.Equal(t, observedTask4.NodeID, "nodeid1")
+
+	// old task gets shut down as the new one is created
+	observedTask5 := testutils.WatchTaskUpdate(t, watch)
+	assert.Equal(t, observedTask5.DesiredState, api.TaskStateShutdown)
 	testutils.Expect(t, watch, state.EventCommit{})
 }
 

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -216,20 +216,17 @@ func TestDrain(t *testing.T) {
 		assert.NoError(t, orchestrator.Run(ctx))
 	}()
 
-	// id2 and id5 should be killed immediately
+	// id5 should be killed immediately
 	deletion1 := testutils.WatchShutdownTask(t, watch)
-	deletion2 := testutils.WatchShutdownTask(t, watch)
 
-	assert.Regexp(t, "id(2|5)", deletion1.ID)
-	assert.Regexp(t, "id(2|5)", deletion1.NodeID)
-	assert.Regexp(t, "id(2|5)", deletion2.ID)
-	assert.Regexp(t, "id(2|5)", deletion2.NodeID)
+	assert.Equal(t, "id5", deletion1.ID)
+	assert.Equal(t, "id5", deletion1.NodeID)
 
-	// Create a new task, assigned to node id2
+	// Create a new task, assigned to node id5
 	err = s.Update(func(tx store.Tx) error {
 		task := initialTaskSet[2].Copy()
 		task.ID = "newtask"
-		task.NodeID = "id2"
+		task.NodeID = "id5"
 		assert.NoError(t, store.CreateTask(tx, task))
 		return nil
 	})
@@ -237,7 +234,7 @@ func TestDrain(t *testing.T) {
 
 	deletion3 := testutils.WatchShutdownTask(t, watch)
 	assert.Equal(t, "newtask", deletion3.ID)
-	assert.Equal(t, "id2", deletion3.NodeID)
+	assert.Equal(t, "id5", deletion3.NodeID)
 
 	// Set node id4 to the DRAINED state
 	err = s.Update(func(tx store.Tx) error {

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -15,7 +15,12 @@ type Orchestrator struct {
 	store *store.MemoryStore
 
 	reconcileServices map[string]*api.Service
-	restartTasks      map[string]struct{}
+
+	// restartTasks' keys are tasks that need to have Restart called.
+	// The value is whether to force the desired state to shutdown
+	// even when the restart policy does not call for this, for example
+	// when a node is drained.
+	restartTasks map[string]bool
 
 	// stopChan signals to the state machine to stop running.
 	stopChan chan struct{}
@@ -37,7 +42,7 @@ func NewReplicatedOrchestrator(store *store.MemoryStore) *Orchestrator {
 		stopChan:          make(chan struct{}),
 		doneChan:          make(chan struct{}),
 		reconcileServices: make(map[string]*api.Service),
-		restartTasks:      make(map[string]struct{}),
+		restartTasks:      make(map[string]bool),
 		updater:           updater,
 		restarts:          restartSupervisor,
 	}

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -284,6 +284,10 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 	assert.Equal(t, observedTask.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask.Spec.GetContainer().Image, "image1")
 
+	observedTask = testutils.WatchTaskCreate(t, watchCreate)
+	assert.Equal(t, observedTask.Status.State, api.TaskStateNew)
+	assert.Equal(t, observedTask.Spec.GetContainer().Image, "image1")
+
 	switch rollbackFailureAction {
 	case api.UpdateConfig_PAUSE:
 		// Should end up in ROLLBACK_PAUSED state

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -284,10 +284,6 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 	assert.Equal(t, observedTask.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask.Spec.GetContainer().Image, "image1")
 
-	observedTask = testutils.WatchTaskCreate(t, watchCreate)
-	assert.Equal(t, observedTask.Status.State, api.TaskStateNew)
-	assert.Equal(t, observedTask.Spec.GetContainer().Image, "image1")
-
 	switch rollbackFailureAction {
 	case api.UpdateConfig_PAUSE:
 		// Should end up in ROLLBACK_PAUSED state

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -96,7 +96,7 @@ func (r *Supervisor) waitRestart(ctx context.Context, oldDelay *delayedStart, cl
 		if service == nil {
 			return nil
 		}
-		return r.Restart(ctx, tx, cluster, service, *t)
+		return r.Restart(ctx, tx, cluster, service, *t, false)
 	})
 
 	if err != nil {
@@ -106,7 +106,7 @@ func (r *Supervisor) waitRestart(ctx context.Context, oldDelay *delayedStart, cl
 
 // Restart initiates a new task to replace t if appropriate under the service's
 // restart policy.
-func (r *Supervisor) Restart(ctx context.Context, tx store.Tx, cluster *api.Cluster, service *api.Service, t api.Task) error {
+func (r *Supervisor) Restart(ctx context.Context, tx store.Tx, cluster *api.Cluster, service *api.Service, t api.Task, forceShutdownState bool) error {
 	// TODO(aluzzardi): This function should not depend on `service`.
 
 	// Is the old task still in the process of restarting? If so, wait for
@@ -131,6 +131,11 @@ func (r *Supervisor) Restart(ctx context.Context, tx store.Tx, cluster *api.Clus
 		return errors.New("Restart called on task that was already shut down")
 	}
 
+	shouldRestart := r.shouldRestart(ctx, &t, service)
+	if !forceShutdownState && !shouldRestart {
+		return nil
+	}
+
 	t.DesiredState = api.TaskStateShutdown
 	err := store.UpdateTask(tx, &t)
 	if err != nil {
@@ -138,7 +143,7 @@ func (r *Supervisor) Restart(ctx context.Context, tx store.Tx, cluster *api.Clus
 		return err
 	}
 
-	if !r.shouldRestart(ctx, &t, service) {
+	if !shouldRestart {
 		return nil
 	}
 

--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -70,10 +70,3 @@ func IsTaskDirty(s *api.Service, t *api.Task) bool {
 	return !reflect.DeepEqual(s.Spec.Task, t.Spec) ||
 		(t.Endpoint != nil && !reflect.DeepEqual(s.Spec.Endpoint, t.Endpoint.Spec))
 }
-
-// InvalidNode is true if the node is nil, down, or drained
-func InvalidNode(n *api.Node) bool {
-	return n == nil ||
-		n.Status.State == api.NodeStatus_DOWN ||
-		n.Spec.Availability == api.NodeAvailabilityDrain
-}


### PR DESCRIPTION
Currently, service reconciliation (updating a service, leader
reelection, etc) will cause a service's tasks to be restarted even if
the restart policy says they shouldn't be. This is because the service
definition says there should be, for example, 5 replicas, and the
control loop tries to make this happen.

This experiments with the idea of keeping tasks that we don't want to
restart in the desired state "running" instead of "shutdown". This can
be a starting point for evaluating the tradeoffs and deciding if this is
a good approach.

Known caveats so far:

- Draining a node has to set the desired state of tasks on that node to
  "shutdown", regardless of the restart policy. But that means the
  orchestrator may eventually restart those tasks. So draining triggers
  the same issue we had before.
- ~~When rolling back a partial service update, tasks with the original
  service definition that happen to have failed won't be restarted. I'm
  not sure this is the correct behavior, because I would expect a service
  rollback to leave the service in a converged state.~~ -- **Fixed** by
  setting all failed tasks' desired state to `Shutdown` on a rollback.
- ~~Global services have tasks shut down on nodes that go down. This is
  necessary to prevent rolling updates from getting stuck on those
  nodes. But it means that a node going down and coming back up will
  cause a restart of its global service tasks, even if that does not
  match the restart policy.~~ -- **Fixed** by excluding tasks on down
  down nodes from the list passed to the updater instead of actually
  shutting them down.
- This breaks the constraint enforcer, which tries to shut down tasks by
  setting their observed state to `Rejected`. It expects the orchestrator to
  set the desired state to `Shutdown`, which will trigger the actual
  shutdown. It modifies observed state instead of desired state to avoid
  fighting with the orchestrator over the `DesiredState` field.

Possible solution for #932

cc @aluzzardi