### PR TITLE
orchestrator/global: Delete tasks when their node is deleted

### DIFF
--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -155,7 +155,7 @@ func TestDeleteNode(t *testing.T) {
 
 	deleteNode(t, store, node1)
 	// task should be set to dead
-	observedTask := testutils.WatchShutdownTask(t, watch)
+	observedTask := testutils.WatchTaskDelete(t, watch)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name1")
 	assert.Equal(t, observedTask.NodeID, "nodeid1")
 }


### PR DESCRIPTION
Currently, the global orchestrator leaves associated tasks around when
a node is deleted. There is no process for reaping these tasks, as the
task reaper keeps a certain number of global service tasks *per node*.
Instead, delete the task right away when its node is deleted. This is
similar to how the replicated orchestrator deletes tasks when scaling
down, since tasks in those slots that are no longer being used would not
end up being reaped.

Fixes #2295

cc @thaJeztah