### PR TITLE
gitignore: ignore coverage.txt files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ bin/
 # ignore the obvious locations of swarmkitstate
 swarmkitstate
 bin/swarmkitstate
+
+# ignore code coverage output
+*coverage.txt


### PR DESCRIPTION
I was running `make ci` and noticed my working git directory picked up a bunch of unstaged `coverage.txt` files.

I don't think there's any value in tracking them with git if they aren't checked into the repo, so this PR adds `*coverage.txt` to the `.gitignore`

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>