### PR TITLE
orchestrator/update: Only shut down old tasks on success

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -430,7 +430,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 				u.updatedTasks[updated.ID] = time.Now()
 				u.updatedTasksMu.Unlock()
 
-				if startThenStop {
+				if startThenStop && updated.Status.State == api.TaskStateRunning {
 					err := u.store.Batch(func(batch *store.Batch) error {
 						_, err := u.removeOldTasks(ctx, batch, slot)
 						if err != nil {


### PR DESCRIPTION
In start-then-stop mode, the updater waits for a verdict on the startup
of a new task, and then shuts down the tasks that this new task was
meant to replace. It should really only shut down the old task if the
new task successfully reached running. The thinking here was probably
that a task which fails on startup would briefly enter the running state
before failing, so there isn't much point in distinguishing between
running and some terminal state. However, if a health check is being
used, the task may never enter the running state. This can also happen
when a task is rejected by a node.

See https://github.com/moby/moby/issues/34111 for a repro case.

cc @sirlatrom @cpuguy83