### PR TITLE
orchestrator/update: Update spec version when rolling back

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -601,7 +601,9 @@ func (u *Updater) rollbackUpdate(ctx context.Context, serviceID, message string)
 			return errors.New("cannot roll back service because no previous spec is available")
 		}
 		service.Spec = *service.PreviousSpec
+		service.SpecVersion = service.PreviousSpecVersion.Copy()
 		service.PreviousSpec = nil
+		service.PreviousSpecVersion = nil
 
 		return store.UpdateService(tx, service)
 	})


### PR DESCRIPTION
There is an oversight in this code that prevents it from changing the
spec version to match the spec that's put in place during a rollback.

This could cause a service not to get rolled back all the way.
Currently, tasks may stay on the new version until they fail and are
replaced with an older version.

cc @cpuguy83 @thaJeztah