### PR TITLE
orchestrator/global: Don't create tasks on down nodes

### DIFF
--- a/manager/orchestrator/testutils/testutils.go
+++ b/manager/orchestrator/testutils/testutils.go
@@ -72,7 +72,7 @@ func WatchShutdownTask(t *testing.T, watch chan events.Event) *api.Task {
 				assert.FailNow(t, "got EventCreateTask when expecting EventUpdateTask", fmt.Sprint(event))
 			}
 		case <-time.After(time.Second):
-			assert.FailNow(t, "no task deletion")
+			assert.FailNow(t, "no task shutdown")
 		}
 	}
 }


### PR DESCRIPTION
The global orchestrator shuts down tasks on drained nodes. This makes
sense - it's consistent with the replicated orchestrator shutting down
tasks in the same situation (as part of a possible restart), and it
prevents rolling updates from getting stuck when it hits a node that's
down. But the global orchestrator will still try to create tasks on down
nodes when it reconciles a service. This is very inconsistent.

Change the global orchestrator to treat down nodes like drained nodes -
all their tasks get shut down immediately, and they get ignored by
reconciliation until they become ready again.

cc @cyli @aluzzardi