### PR TITLE
Plugable secret backend

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -421,10 +421,18 @@ func TestAssignmentsSecretDriver(t *testing.T) {
 	t.Parallel()
 
 	const (
-		secretDriver       = "secret-driver"
-		existingSecretName = "existing-secret"
-		secretValue        = "custom-secret-value"
+		secretDriver        = "secret-driver"
+		existingSecretName  = "existing-secret"
+		serviceName         = "service-name"
+		serviceHostname     = "service-hostname"
+		serviceEndpointMode = 2
 	)
+	secretValue := []byte("custom-secret-value")
+	serviceLabels := map[string]string{
+		"label-name": "label-value",
+	}
+
+	portConfig := drivers.PortConfig{Name: "port", PublishMode: 5, TargetPort: 80, Protocol: 10, PublishedPort: 8080}
 
 	responses := map[string]*drivers.SecretsProviderResponse{
 		existingSecretName: {Value: secretValue},
@@ -437,7 +445,13 @@ func TestAssignmentsSecretDriver(t *testing.T) {
 		var request drivers.SecretsProviderRequest
 		assert.NoError(t, err)
 		assert.NoError(t, json.Unmarshal(body, &request))
-		response := responses[request.Name]
+		response := responses[request.SecretName]
+		assert.Equal(t, serviceName, request.ServiceName)
+		assert.Equal(t, serviceHostname, request.ServiceHostname)
+		assert.Equal(t, int32(serviceEndpointMode), request.ServiceEndpointSpec.Mode)
+		assert.Len(t, request.ServiceEndpointSpec.Ports, 1)
+		assert.EqualValues(t, portConfig, request.ServiceEndpointSpec.Ports[0])
+		assert.EqualValues(t, serviceLabels, request.ServiceLabels)
 		assert.NotNil(t, response)
 		resp, err := json.Marshal(response)
 		assert.NoError(t, err)
@@ -465,12 +479,31 @@ func TestAssignmentsSecretDriver(t *testing.T) {
 		},
 	}
 	spec := taskSpecFromDependencies(secret, config)
+	spec.GetContainer().Hostname = serviceHostname
 	task := &api.Task{
 		NodeID:       nodeID,
 		ID:           "secretTask",
 		Status:       api.TaskStatus{State: api.TaskStateReady},
 		DesiredState: api.TaskStateNew,
 		Spec:         spec,
+		Endpoint: &api.Endpoint{
+			Spec: &api.EndpointSpec{
+				Mode: serviceEndpointMode,
+				Ports: []*api.PortConfig{
+					{
+						Name:          portConfig.Name,
+						PublishedPort: portConfig.PublishedPort,
+						Protocol:      api.PortConfig_Protocol(portConfig.Protocol),
+						TargetPort:    portConfig.TargetPort,
+						PublishMode:   api.PortConfig_PublishMode(portConfig.PublishMode),
+					},
+				},
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name:   serviceName,
+			Labels: serviceLabels,
+		},
 	}
 
 	err = gd.Store.Update(func(tx store.Tx) error {
@@ -491,7 +524,7 @@ func TestAssignmentsSecretDriver(t *testing.T) {
 	_, _, secretChanges := splitChanges(resp.Changes)
 	assert.Len(t, secretChanges, 1)
 	for _, s := range secretChanges {
-		assert.Equal(t, secretValue, string(s.Spec.Data))
+		assert.Equal(t, secretValue, s.Spec.Data)
 	}
 }
 

--- a/manager/drivers/secrets.go
+++ b/manager/drivers/secrets.go
@@ -26,12 +26,45 @@ func NewSecretDriver(plugin plugingetter.CompatPlugin) *SecretDriver {
 }
 
 // Get gets a secret from the secret provider
-func (d *SecretDriver) Get(spec *api.SecretSpec) ([]byte, error) {
+func (d *SecretDriver) Get(spec *api.SecretSpec, task *api.Task) ([]byte, error) {
 	if spec == nil {
-		return nil, fmt.Errorf("spec is nil")
+		return nil, fmt.Errorf("secret spec is nil")
 	}
+	if task == nil {
+		return nil, fmt.Errorf("task is nil")
+	}
+
 	var secretResp SecretsProviderResponse
-	secretReq := &SecretsProviderRequest{Name: spec.Annotations.Name}
+	secretReq := &SecretsProviderRequest{
+		SecretName:    spec.Annotations.Name,
+		ServiceName:   task.ServiceAnnotations.Name,
+		ServiceLabels: task.ServiceAnnotations.Labels,
+	}
+	container := task.Spec.GetContainer()
+	if container != nil {
+		secretReq.ServiceHostname = container.Hostname
+	}
+
+	if task.Endpoint != nil && task.Endpoint.Spec != nil {
+		secretReq.ServiceEndpointSpec = &EndpointSpec{
+			Mode: int32(task.Endpoint.Spec.Mode),
+		}
+		for _, p := range task.Endpoint.Spec.Ports {
+			if p == nil {
+				continue
+			}
+			secretReq.ServiceEndpointSpec.Ports =
+				append(secretReq.ServiceEndpointSpec.Ports,
+					PortConfig{
+						Name:          p.Name,
+						Protocol:      int32(p.Protocol),
+						PublishedPort: p.PublishedPort,
+						TargetPort:    p.TargetPort,
+						PublishMode:   int32(p.PublishMode),
+					})
+		}
+	}
+
 	err := d.plugin.Client().Call(SecretsProviderAPI, secretReq, &secretResp)
 	if err != nil {
 		return nil, err
@@ -40,16 +73,38 @@ func (d *SecretDriver) Get(spec *api.SecretSpec) ([]byte, error) {
 		return nil, fmt.Errorf(secretResp.Err)
 	}
 	// Assign the secret value
-	return []byte(secretResp.Value), nil
+	return secretResp.Value, nil
 }
 
 // SecretsProviderRequest is the secrets provider request.
 type SecretsProviderRequest struct {
-	Name string `json:"name"` // Name is the name of the secret plugin
+	SecretName          string            `json:",omitempty"` // SecretName is the name of the secret to request from the plugin
+	ServiceHostname     string            `json:",omitempty"` // ServiceHostname is the hostname of the service, can be used for x509 certificate
+	ServiceName         string            `json:",omitempty"` // ServiceName is the name of the service that requested the secret
+	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata
+	ServiceEndpointSpec *EndpointSpec     `json:",omitempty"` // ServiceEndpointSpec holds the specification for endpoints
 }
 
 // SecretsProviderResponse is the secrets provider response.
 type SecretsProviderResponse struct {
-	Value string `json:"value"` // Value is the value of the secret
-	Err   string `json:"err"`   // Err is the error response of the plugin
+	Value []byte `json:",omitempty"` // Value is the value of the secret
+	Err   string `json:",omitempty"` // Err is the error response of the plugin
+}
+
+// EndpointSpec represents the spec of an endpoint.
+type EndpointSpec struct {
+	Mode  int32        `json:",omitempty"`
+	Ports []PortConfig `json:",omitempty"`
+}
+
+// PortConfig represents the config of a port.
+type PortConfig struct {
+	Name     string `json:",omitempty"`
+	Protocol int32  `json:",omitempty"`
+	// TargetPort is the port inside the container
+	TargetPort uint32 `json:",omitempty"`
+	// PublishedPort is the port on the swarm hosts
+	PublishedPort uint32 `json:",omitempty"`
+	// PublishMode is the mode in which port is published
+	PublishMode int32 `json:",omitempty"`
 }


### PR DESCRIPTION
This commit extends SwarmKit secret management with pluggable secret
backends support.

Following previous commits:

docker/swarmkit@eebac27
moby/moby@08f7cf0

Added the following parameters to the plugin request:
```
- ServiceSpec.TaskSpec.ContainerSpec.Hostname - for use in a x509
certificate
- ServiceSpec.EndpointSpec - has desired DNS domains that might be
suitable for an external x509 certificate
- ServiceSpec.Annotations.Name - name of the service
- ServiceSpec.Annotations.Labels - captures environment names, and other
metadata
```

Signed-off-by: Liron Levin <liron@twistlock.com>