### PR TITLE
Removing creation of predefined networks on swarm manager

### DIFF
--- a/manager/allocator/cnmallocator/drivers_darwin.go
+++ b/manager/allocator/cnmallocator/drivers_darwin.go
@@ -15,3 +15,8 @@ var initializers = []initializer{
 func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
 	return nil
 }
+
+// IsPredefinedNetwork checks if the network is a host/bridge network
+func IsPredefinedNetwork(target string) bool {
+	return false
+}

--- a/manager/allocator/cnmallocator/drivers_network_linux.go
+++ b/manager/allocator/cnmallocator/drivers_network_linux.go
@@ -26,3 +26,13 @@ func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
 		{Name: "host", Driver: "host"},
 	}
 }
+
+// IsPredefinedNetwork checks if the network is a host/bridge network
+func IsPredefinedNetwork(target string) bool {
+	for _, p := range PredefinedNetworks() {
+		if target == p.Name {
+			return true
+		}
+	}
+	return false
+}

--- a/manager/allocator/cnmallocator/drivers_network_windows.go
+++ b/manager/allocator/cnmallocator/drivers_network_windows.go
@@ -15,3 +15,8 @@ var initializers = []initializer{
 func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
 	return nil
 }
+
+// IsPredefinedNetwork checks if the network is a host/bridge network
+func IsPredefinedNetwork(target string) bool {
+	return false
+}

--- a/manager/allocator/cnmallocator/drivers_unsupported.go
+++ b/manager/allocator/cnmallocator/drivers_unsupported.go
@@ -12,3 +12,8 @@ const initializers = nil
 func PredefinedNetworks() []networkallocator.PredefinedNetworkData {
 	return nil
 }
+
+// IsPredefinedNetwork checks if the network is a host/bridge network
+func IsPredefinedNetwork(target string) bool {
+	return false
+}

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -1191,3 +1191,8 @@ func GetIngressNetwork(s *store.MemoryStore) (*api.Network, error) {
 	}
 	return nil, ErrNoIngress
 }
+
+// IsPredefinedNetwork checks if the network is a host/bridge network
+func IsPredefinedNetwork(target string) bool {
+	return cnmallocator.IsPredefinedNetwork(target)
+}

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -435,6 +435,9 @@ func validateConfigRefsSpec(spec api.TaskSpec) error {
 
 func (s *Server) validateNetworks(networks []*api.NetworkAttachmentConfig) error {
 	for _, na := range networks {
+		if allocator.IsPredefinedNetwork(na.Target) {
+			continue
+		}
 		var network *api.Network
 		s.store.View(func(tx store.ReadTx) {
 			network = store.GetNetwork(tx, na.Target)


### PR DESCRIPTION
From 17.06 we started supporting service creation on host and bridge
predefined networks in addition to user defined local scope networks.
Since the task allocation involves creation of networks in the swarm
manager a network id is generated on the manager to create predefined networks.
But this network id is not visible with the api to fetch networks. Since
the task template which is part of a servicespec holds this network id
its hard to correlate the network id to network name by the api consumer.
So for predefined networks a predefined network id would make it easier
to correlate and update the service spec.
Corresponding moby PR: moby/moby#34278