### PR TITLE
Plugable secret backend - ensure secret driver exist

### DIFF
--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -158,6 +158,12 @@ func (s *Server) CreateSecret(ctx context.Context, request *api.CreateSecretRequ
 		return nil, err
 	}
 
+	if request.Spec.Driver != nil { // Check that the requested driver is valid
+		if _, err := s.dr.NewSecretDriver(request.Spec.Driver); err != nil {
+			return nil, err
+		}
+	}
+
 	secret := secretFromSecretSpec(request.Spec) // the store will handle name conflicts
 	err := s.store.Update(func(tx store.Tx) error {
 		return store.CreateSecret(tx, secret)

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/ca"
+	"github.com/docker/swarmkit/manager/drivers"
 	"github.com/docker/swarmkit/manager/state/raft"
 	"github.com/docker/swarmkit/manager/state/store"
 )
@@ -19,12 +20,14 @@ type Server struct {
 	raft           *raft.Node
 	securityConfig *ca.SecurityConfig
 	pg             plugingetter.PluginGetter
+	dr             *drivers.DriverProvider
 }
 
 // NewServer creates a Cluster API server.
-func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig, pg plugingetter.PluginGetter) *Server {
+func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig, pg plugingetter.PluginGetter, dr *drivers.DriverProvider) *Server {
 	return &Server{
 		store:          store,
+		dr:             dr,
 		raft:           raft,
 		securityConfig: securityConfig,
 		pg:             pg,

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -48,7 +48,7 @@ func newTestServer(t *testing.T) *testServer {
 	ts.Store = store.NewMemoryStore(&stateutils.MockProposer{})
 	assert.NotNil(t, ts.Store)
 
-	ts.Server = NewServer(ts.Store, nil, securityConfig, nil)
+	ts.Server = NewServer(ts.Store, nil, securityConfig, nil, nil)
 	assert.NotNil(t, ts.Server)
 
 	temp, err := ioutil.TempFile("", "test-socket")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -404,7 +404,7 @@ func (m *Manager) Run(parent context.Context) error {
 		return err
 	}
 
-	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.config.PluginGetter)
+	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.config.PluginGetter, drivers.New(m.config.PluginGetter))
 	baseResourceAPI := resourceapi.New(m.raftNode.MemoryStore())
 	healthServer := health.NewHealthServer()
 	localHealthServer := health.NewHealthServer()


### PR DESCRIPTION
Ensure secret driver exist before creating a secret that reference a
driver.

Since plugin getter is always nil in swarmd, it's a little hard to test
the feature on swarmd.
Waiting for moby/moby#34117 for breaking the plugin subsystem
dependencies on libcontainerd.

Signed-off-by: Liron Levin <liron@twistlock.com>