### PR TITLE
Generic resource cli

### DIFF
--- a/api/genericresource/parse.go
+++ b/api/genericresource/parse.go
@@ -1,6 +1,7 @@
 package genericresource
 
 import (
+	"encoding/csv"
 	"fmt"
 	"strconv"
 	"strings"
@@ -12,35 +13,82 @@ func newParseError(format string, args ...interface{}) error {
 	return fmt.Errorf("could not parse GenericResource: "+format, args...)
 }
 
-// Parse parses the GenericResource resources given by the arguments
-func Parse(cmd string) ([]*api.GenericResource, error) {
-	var rs []*api.GenericResource
+func namedResourceVal(res string) (int64, error) {
+	return strconv.ParseInt(res, 10, 64)
+}
 
-	for _, term := range strings.Split(cmd, ";") {
+func allNamedResources(res []string) bool {
+	for _, v := range res {
+		if _, err := namedResourceVal(v); err == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+// ParseCmd parses the Generic Resource command line argument
+// and returns a list of *api.GenericResource
+func ParseCmd(cmd string) ([]*api.GenericResource, error) {
+	if strings.Contains(cmd, "\n") {
+		return nil, newParseError("unexpected '\n' character")
+	}
+
+	r := csv.NewReader(strings.NewReader(cmd))
+	records, err := r.ReadAll()
+
+	if err != nil {
+		return nil, newParseError("%v", err)
+	}
+
+	if len(records) != 1 {
+		return nil, newParseError("found multiple records while parsing cmd %v", records)
+	}
+
+	return Parse(records[0])
+}
+
+// Parse parses a table of GenericResource resources
+func Parse(cmds []string) ([]*api.GenericResource, error) {
+	tokens := make(map[string][]string)
+
+	for _, term := range cmds {
 		kva := strings.Split(term, "=")
 		if len(kva) != 2 {
-			return nil, newParseError("incorrect term %s, missing '=' or malformed expr", term)
+			return nil, newParseError("incorrect term %s, missing"+
+				"'=' or malformed expression", term)
 		}
 
 		key := strings.TrimSpace(kva[0])
 		val := strings.TrimSpace(kva[1])
 
-		u, err := strconv.ParseInt(val, 10, 64)
-		if err == nil {
-			if u < 0 {
-				return nil, newParseError("cannot ask for negative resource %s", key)
+		tokens[key] = append(tokens[key], val)
+	}
+
+	var rs []*api.GenericResource
+	for k, v := range tokens {
+		if len(v) == 1 {
+			u, err := namedResourceVal(v[0])
+			if err != nil {
+				goto ParseNamed
 			}
-			rs = append(rs, NewDiscrete(key, u))
+
+			if u < 0 {
+				return nil, newParseError("cannot ask for"+
+					"negative resource %s", k)
+			}
+
+			rs = append(rs, NewDiscrete(k, u))
 			continue
 		}
 
-		if len(val) > 2 && val[0] == '{' && val[len(val)-1] == '}' {
-			val = val[1 : len(val)-1]
-			rs = append(rs, NewSet(key, strings.Split(val, ",")...)...)
+	ParseNamed:
+		if allNamedResources(v) {
+			rs = append(rs, NewSet(k, v...)...)
 			continue
 		}
 
-		return nil, newParseError("could not parse expression '%s'", term)
+		return nil, newParseError("malformed expression '%s=%s'", k, v)
 	}
 
 	return rs, nil

--- a/api/genericresource/parse_test.go
+++ b/api/genericresource/parse_test.go
@@ -7,17 +7,26 @@ import (
 )
 
 func TestParseDiscrete(t *testing.T) {
-	res, err := Parse("apple=3")
+	res, err := ParseCmd("apple=3")
 	assert.NoError(t, err)
 	assert.Equal(t, len(res), 1)
 
 	apples := GetResource("apple", res)
 	assert.Equal(t, len(apples), 1)
 	assert.Equal(t, apples[0].GetDiscreteResourceSpec().Value, int64(3))
+
+	_, err = ParseCmd("apple=3\napple=4")
+	assert.Error(t, err)
+
+	_, err = ParseCmd("apple=3,apple=4")
+	assert.Error(t, err)
+
+	_, err = ParseCmd("apple=-3")
+	assert.Error(t, err)
 }
 
 func TestParseStr(t *testing.T) {
-	res, err := Parse("orange={red,green,blue}")
+	res, err := ParseCmd("orange=red,orange=green,orange=blue")
 	assert.NoError(t, err)
 	assert.Equal(t, len(res), 3)
 
@@ -29,7 +38,7 @@ func TestParseStr(t *testing.T) {
 }
 
 func TestParseDiscreteAndStr(t *testing.T) {
-	res, err := Parse("orange={red,green,blue};apple=3")
+	res, err := ParseCmd("orange=red,orange=green,orange=blue,apple=3")
 	assert.NoError(t, err)
 	assert.Equal(t, len(res), 4)
 

--- a/cmd/swarmctl/service/flagparser/flags.go
+++ b/cmd/swarmctl/service/flagparser/flags.go
@@ -32,7 +32,7 @@ func AddServiceFlags(flags *pflag.FlagSet) {
 	flags.String("memory-limit", "", "memory limit (e.g. 512m)")
 	flags.String("cpu-reservation", "", "number of CPU cores reserved (e.g. 0.5)")
 	flags.String("cpu-limit", "", "CPU cores limit (e.g. 0.5)")
-	flags.String("generic-resources", "", "user defined resources request (e.g. gpu=3;fpga=1)")
+	flags.String("generic-resources", "", "user defined resources request (e.g. gpu=3,fpga=1)")
 
 	flags.Uint64("update-parallelism", 0, "task update parallelism (0 = all at once)")
 	flags.String("update-delay", "0s", "delay between task updates (0s = none)")

--- a/cmd/swarmctl/service/flagparser/resource.go
+++ b/cmd/swarmctl/service/flagparser/resource.go
@@ -104,7 +104,7 @@ func parseResource(flags *pflag.FlagSet, spec *api.ServiceSpec) error {
 		if err != nil {
 			return err
 		}
-		spec.Task.Resources.Reservations.Generic, err = genericresource.Parse(cmd)
+		spec.Task.Resources.Reservations.Generic, err = genericresource.ParseCmd(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -168,7 +168,7 @@ var (
 				if err != nil {
 					return err
 				}
-				resources, err = genericresource.Parse(genericResources)
+				resources, err = genericresource.ParseCmd(genericResources)
 				if err != nil {
 					return err
 				}
@@ -287,7 +287,7 @@ func init() {
 	mainCmd.Flags().String("listen-debug", "", "Bind the Go debug server on the provided address")
 	mainCmd.Flags().String("listen-metrics", "", "Listen address for metrics")
 	mainCmd.Flags().String("join-addr", "", "Join cluster with a node at this address")
-	mainCmd.Flags().String("generic-node-resources", "", "user defined resources (e.g. fpga=2;gpu={UUID1,UUID2,UUID3})")
+	mainCmd.Flags().String("generic-node-resources", "", "user defined resources (e.g. fpga=2,gpu=UUID1,gpu=UUID2,gpu=UUID3)")
 	mainCmd.Flags().Bool("force-new-cluster", false, "Force the creation of a new cluster from data directory")
 	mainCmd.Flags().Uint32("heartbeat-tick", 1, "Defines the heartbeat interval (in seconds) for raft member health-check")
 	mainCmd.Flags().Uint32("election-tick", 3, "Defines the amount of ticks (in seconds) needed without a Leader to trigger a new election")

--- a/design/generic_resources.md
+++ b/design/generic_resources.md
@@ -93,7 +93,7 @@ of resources, ...) and should not be addressed in this PR.
 $ # Single resource
 $ swarmctl service create --name nginx --image nginx:latest --generic-resources "banana=2"
 $ # Multiple resources
-$ swarmctl service create --name nginx --image nginx:latest --generic-resources "banana=2;apple=3"
+$ swarmctl service create --name nginx --image nginx:latest --generic-resources "banana=2,apple=3"
 ```
 
 ### Generic Resource advertising
@@ -103,7 +103,7 @@ It is the scheduler's job to decide which resource to assign and keep track of w
 owns which resource.
 
 ```
-$ swarmd -d $DIR --join-addr $IP --join-token $TOKEN --generic-node-resources "banana={blue,red,green};apple=8"
+$ swarmd -d $DIR --join-addr $IP --join-token $TOKEN --generic-node-resources "banana=blue,banana=red,banana=green,apple=8"
 ```
 
 ### Generic Resource communication
@@ -142,7 +142,7 @@ Plugins:
   Volume                  : [local nvidia-docker]
 Engine Version            : 1.13.1
 
-$ swarmctl service create --name nginx --image nginx:latest --generic-resources "banana=2;apple=2"
+$ swarmctl service create --name nginx --image nginx:latest --generic-resources "banana=2,apple=2"
 $ swarmctl service inspect nginx
 ID                       : abxelhl822d8zyjqam3m3szb0
 Name                     : nginx
@@ -161,7 +161,7 @@ Task ID                      Service    Slot    Image           Desired State   
 
 $ # ssh to the node
 $ docker inspect $CONTAINER_ID --format '{{.Config.Env}}' | tr -s ' ' '\n'
-[DOCKER_RESOURCE_BANANA=2
+[DOCKER_RESOURCE_BANANA=red,blue
 DOCKER_RESOURCE_APPLE=2
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 NGINX_VERSION=1.13.0-1~stretch


### PR DESCRIPTION
Signed-off-by: Renaud Gaubert rgaubert@nvidia.com

*What I did:*
Changed the CLI format of Generic Resources as suggested by @thaJeztah in docker/cli/pull/429
From `--generic-resources "apple=2;orange={blue,red,green}"`
To `--generic-resources "apple=2,orange=blue,orange=red,orange=green"`


This new format albeit a bit more verbose is the CSV format and is already used for `--mount`

- See [here](https://github.com/moby/moby/issues/33439) for tracking
- See [here](https://github.com/docker/swarmkit/blob/master/design/generic_resources.md) for design document

*How to verify it:*

```
$ swarmd ... --generic-resources "apple=2,orange=blue,orange=red,orange=green"
$ swarmct service create ... --generic-resources "orange=2,apple=2"
```

ping @aaronlehmann 