### PR TITLE
Stabilize the api proto descriptors in swarmkit

### DIFF
--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -30,3 +30,7 @@ plugins = ["grpc", "deepcopy", "storeobject", "raftproxy", "authenticatedwrapper
   "google/protobuf/field_mask.proto" = "github.com/gogo/protobuf/types"
   "google/protobuf/timestamp.proto" = "github.com/gogo/protobuf/types"
   "google/protobuf/duration.proto" = "github.com/gogo/protobuf/types"
+
+[[descriptors]]
+prefix = "github.com/docker/swarmkit/api"
+target = "api/api.pb.txt"

--- a/api/README.md
+++ b/api/README.md
@@ -6,3 +6,19 @@ $ make generate
 ```
 
 Click [here](https://github.com/google/protobuf) for more information about protobuf.
+
+The `api.pb.txt` file contains merged descriptors of all defined services and messages.
+Definitions present here are considered frozen after the release.
+
+At release time, the current `api.pb.txt` file will be moved into place to
+freeze the API changes for the minor version. For example, when 1.0.0 is
+released, `api.pb.txt` should be moved to `1.0.txt`. Notice that we leave off
+the patch number, since the API will be completely locked down for a given
+patch series.
+
+We may find that by default, protobuf descriptors are too noisy to lock down
+API changes. In that case, we may filter out certain fields in the descriptors,
+possibly regenerating for old versions.
+
+This process is similar to the [process used to ensure backwards compatibility
+in Go](https://github.com/golang/go/tree/master/api).

--- a/api/api.pb.txt
+++ b/api/api.pb.txt
@@ -1,0 +1,9717 @@
+file {
+  name: "google/protobuf/timestamp.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Timestamp"
+    field {
+      name: "seconds"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "seconds"
+    }
+    field {
+      name: "nanos"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "nanos"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "TimestampProto"
+    java_multiple_files: true
+    go_package: "github.com/golang/protobuf/ptypes/timestamp"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/duration.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Duration"
+    field {
+      name: "seconds"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "seconds"
+    }
+    field {
+      name: "nanos"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "nanos"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "DurationProto"
+    java_multiple_files: true
+    go_package: "github.com/golang/protobuf/ptypes/duration"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/descriptor.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "FileDescriptorSet"
+    field {
+      name: "file"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FileDescriptorProto"
+      json_name: "file"
+    }
+  }
+  message_type {
+    name: "FileDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "package"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "package"
+    }
+    field {
+      name: "dependency"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "dependency"
+    }
+    field {
+      name: "public_dependency"
+      number: 10
+      label: LABEL_REPEATED
+      type: TYPE_INT32
+      json_name: "publicDependency"
+    }
+    field {
+      name: "weak_dependency"
+      number: 11
+      label: LABEL_REPEATED
+      type: TYPE_INT32
+      json_name: "weakDependency"
+    }
+    field {
+      name: "message_type"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.DescriptorProto"
+      json_name: "messageType"
+    }
+    field {
+      name: "enum_type"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumDescriptorProto"
+      json_name: "enumType"
+    }
+    field {
+      name: "service"
+      number: 6
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.ServiceDescriptorProto"
+      json_name: "service"
+    }
+    field {
+      name: "extension"
+      number: 7
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FieldDescriptorProto"
+      json_name: "extension"
+    }
+    field {
+      name: "options"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FileOptions"
+      json_name: "options"
+    }
+    field {
+      name: "source_code_info"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.SourceCodeInfo"
+      json_name: "sourceCodeInfo"
+    }
+    field {
+      name: "syntax"
+      number: 12
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "syntax"
+    }
+  }
+  message_type {
+    name: "DescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "field"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FieldDescriptorProto"
+      json_name: "field"
+    }
+    field {
+      name: "extension"
+      number: 6
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FieldDescriptorProto"
+      json_name: "extension"
+    }
+    field {
+      name: "nested_type"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.DescriptorProto"
+      json_name: "nestedType"
+    }
+    field {
+      name: "enum_type"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumDescriptorProto"
+      json_name: "enumType"
+    }
+    field {
+      name: "extension_range"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.DescriptorProto.ExtensionRange"
+      json_name: "extensionRange"
+    }
+    field {
+      name: "oneof_decl"
+      number: 8
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.OneofDescriptorProto"
+      json_name: "oneofDecl"
+    }
+    field {
+      name: "options"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.MessageOptions"
+      json_name: "options"
+    }
+    field {
+      name: "reserved_range"
+      number: 9
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.DescriptorProto.ReservedRange"
+      json_name: "reservedRange"
+    }
+    field {
+      name: "reserved_name"
+      number: 10
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "reservedName"
+    }
+    nested_type {
+      name: "ExtensionRange"
+      field {
+        name: "start"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "start"
+      }
+      field {
+        name: "end"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "end"
+      }
+    }
+    nested_type {
+      name: "ReservedRange"
+      field {
+        name: "start"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "start"
+      }
+      field {
+        name: "end"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "end"
+      }
+    }
+  }
+  message_type {
+    name: "FieldDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "number"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "number"
+    }
+    field {
+      name: "label"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.FieldDescriptorProto.Label"
+      json_name: "label"
+    }
+    field {
+      name: "type"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.FieldDescriptorProto.Type"
+      json_name: "type"
+    }
+    field {
+      name: "type_name"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "typeName"
+    }
+    field {
+      name: "extendee"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "extendee"
+    }
+    field {
+      name: "default_value"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "defaultValue"
+    }
+    field {
+      name: "oneof_index"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "oneofIndex"
+    }
+    field {
+      name: "json_name"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "jsonName"
+    }
+    field {
+      name: "options"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.FieldOptions"
+      json_name: "options"
+    }
+    enum_type {
+      name: "Type"
+      value {
+        name: "TYPE_DOUBLE"
+        number: 1
+      }
+      value {
+        name: "TYPE_FLOAT"
+        number: 2
+      }
+      value {
+        name: "TYPE_INT64"
+        number: 3
+      }
+      value {
+        name: "TYPE_UINT64"
+        number: 4
+      }
+      value {
+        name: "TYPE_INT32"
+        number: 5
+      }
+      value {
+        name: "TYPE_FIXED64"
+        number: 6
+      }
+      value {
+        name: "TYPE_FIXED32"
+        number: 7
+      }
+      value {
+        name: "TYPE_BOOL"
+        number: 8
+      }
+      value {
+        name: "TYPE_STRING"
+        number: 9
+      }
+      value {
+        name: "TYPE_GROUP"
+        number: 10
+      }
+      value {
+        name: "TYPE_MESSAGE"
+        number: 11
+      }
+      value {
+        name: "TYPE_BYTES"
+        number: 12
+      }
+      value {
+        name: "TYPE_UINT32"
+        number: 13
+      }
+      value {
+        name: "TYPE_ENUM"
+        number: 14
+      }
+      value {
+        name: "TYPE_SFIXED32"
+        number: 15
+      }
+      value {
+        name: "TYPE_SFIXED64"
+        number: 16
+      }
+      value {
+        name: "TYPE_SINT32"
+        number: 17
+      }
+      value {
+        name: "TYPE_SINT64"
+        number: 18
+      }
+    }
+    enum_type {
+      name: "Label"
+      value {
+        name: "LABEL_OPTIONAL"
+        number: 1
+      }
+      value {
+        name: "LABEL_REQUIRED"
+        number: 2
+      }
+      value {
+        name: "LABEL_REPEATED"
+        number: 3
+      }
+    }
+  }
+  message_type {
+    name: "OneofDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "options"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.OneofOptions"
+      json_name: "options"
+    }
+  }
+  message_type {
+    name: "EnumDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumValueDescriptorProto"
+      json_name: "value"
+    }
+    field {
+      name: "options"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumOptions"
+      json_name: "options"
+    }
+  }
+  message_type {
+    name: "EnumValueDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "number"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "number"
+    }
+    field {
+      name: "options"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumValueOptions"
+      json_name: "options"
+    }
+  }
+  message_type {
+    name: "ServiceDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "method"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.MethodDescriptorProto"
+      json_name: "method"
+    }
+    field {
+      name: "options"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.ServiceOptions"
+      json_name: "options"
+    }
+  }
+  message_type {
+    name: "MethodDescriptorProto"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "input_type"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "inputType"
+    }
+    field {
+      name: "output_type"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "outputType"
+    }
+    field {
+      name: "options"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.MethodOptions"
+      json_name: "options"
+    }
+    field {
+      name: "client_streaming"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "clientStreaming"
+    }
+    field {
+      name: "server_streaming"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "serverStreaming"
+    }
+  }
+  message_type {
+    name: "FileOptions"
+    field {
+      name: "java_package"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "javaPackage"
+    }
+    field {
+      name: "java_outer_classname"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "javaOuterClassname"
+    }
+    field {
+      name: "java_multiple_files"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "javaMultipleFiles"
+    }
+    field {
+      name: "java_generate_equals_and_hash"
+      number: 20
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      options {
+        deprecated: true
+      }
+      json_name: "javaGenerateEqualsAndHash"
+    }
+    field {
+      name: "java_string_check_utf8"
+      number: 27
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "javaStringCheckUtf8"
+    }
+    field {
+      name: "optimize_for"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.FileOptions.OptimizeMode"
+      default_value: "SPEED"
+      json_name: "optimizeFor"
+    }
+    field {
+      name: "go_package"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "goPackage"
+    }
+    field {
+      name: "cc_generic_services"
+      number: 16
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "ccGenericServices"
+    }
+    field {
+      name: "java_generic_services"
+      number: 17
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "javaGenericServices"
+    }
+    field {
+      name: "py_generic_services"
+      number: 18
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "pyGenericServices"
+    }
+    field {
+      name: "deprecated"
+      number: 23
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "cc_enable_arenas"
+      number: 31
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "ccEnableArenas"
+    }
+    field {
+      name: "objc_class_prefix"
+      number: 36
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "objcClassPrefix"
+    }
+    field {
+      name: "csharp_namespace"
+      number: 37
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "csharpNamespace"
+    }
+    field {
+      name: "swift_prefix"
+      number: 39
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "swiftPrefix"
+    }
+    field {
+      name: "php_class_prefix"
+      number: 40
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "phpClassPrefix"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    enum_type {
+      name: "OptimizeMode"
+      value {
+        name: "SPEED"
+        number: 1
+      }
+      value {
+        name: "CODE_SIZE"
+        number: 2
+      }
+      value {
+        name: "LITE_RUNTIME"
+        number: 3
+      }
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+    reserved_range {
+      start: 38
+      end: 39
+    }
+  }
+  message_type {
+    name: "MessageOptions"
+    field {
+      name: "message_set_wire_format"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "messageSetWireFormat"
+    }
+    field {
+      name: "no_standard_descriptor_accessor"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "noStandardDescriptorAccessor"
+    }
+    field {
+      name: "deprecated"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "map_entry"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "mapEntry"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+    reserved_range {
+      start: 8
+      end: 9
+    }
+    reserved_range {
+      start: 9
+      end: 10
+    }
+  }
+  message_type {
+    name: "FieldOptions"
+    field {
+      name: "ctype"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.FieldOptions.CType"
+      default_value: "STRING"
+      json_name: "ctype"
+    }
+    field {
+      name: "packed"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "packed"
+    }
+    field {
+      name: "jstype"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.FieldOptions.JSType"
+      default_value: "JS_NORMAL"
+      json_name: "jstype"
+    }
+    field {
+      name: "lazy"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "lazy"
+    }
+    field {
+      name: "deprecated"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "weak"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "weak"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    enum_type {
+      name: "CType"
+      value {
+        name: "STRING"
+        number: 0
+      }
+      value {
+        name: "CORD"
+        number: 1
+      }
+      value {
+        name: "STRING_PIECE"
+        number: 2
+      }
+    }
+    enum_type {
+      name: "JSType"
+      value {
+        name: "JS_NORMAL"
+        number: 0
+      }
+      value {
+        name: "JS_STRING"
+        number: 1
+      }
+      value {
+        name: "JS_NUMBER"
+        number: 2
+      }
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+    reserved_range {
+      start: 4
+      end: 5
+    }
+  }
+  message_type {
+    name: "OneofOptions"
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+  }
+  message_type {
+    name: "EnumOptions"
+    field {
+      name: "allow_alias"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "allowAlias"
+    }
+    field {
+      name: "deprecated"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+    reserved_range {
+      start: 5
+      end: 6
+    }
+  }
+  message_type {
+    name: "EnumValueOptions"
+    field {
+      name: "deprecated"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+  }
+  message_type {
+    name: "ServiceOptions"
+    field {
+      name: "deprecated"
+      number: 33
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+  }
+  message_type {
+    name: "MethodOptions"
+    field {
+      name: "deprecated"
+      number: 33
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      default_value: "false"
+      json_name: "deprecated"
+    }
+    field {
+      name: "idempotency_level"
+      number: 34
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".google.protobuf.MethodOptions.IdempotencyLevel"
+      default_value: "IDEMPOTENCY_UNKNOWN"
+      json_name: "idempotencyLevel"
+    }
+    field {
+      name: "uninterpreted_option"
+      number: 999
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption"
+      json_name: "uninterpretedOption"
+    }
+    enum_type {
+      name: "IdempotencyLevel"
+      value {
+        name: "IDEMPOTENCY_UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "NO_SIDE_EFFECTS"
+        number: 1
+      }
+      value {
+        name: "IDEMPOTENT"
+        number: 2
+      }
+    }
+    extension_range {
+      start: 1000
+      end: 536870912
+    }
+  }
+  message_type {
+    name: "UninterpretedOption"
+    field {
+      name: "name"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.UninterpretedOption.NamePart"
+      json_name: "name"
+    }
+    field {
+      name: "identifier_value"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "identifierValue"
+    }
+    field {
+      name: "positive_int_value"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "positiveIntValue"
+    }
+    field {
+      name: "negative_int_value"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "negativeIntValue"
+    }
+    field {
+      name: "double_value"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_DOUBLE
+      json_name: "doubleValue"
+    }
+    field {
+      name: "string_value"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "stringValue"
+    }
+    field {
+      name: "aggregate_value"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "aggregateValue"
+    }
+    nested_type {
+      name: "NamePart"
+      field {
+        name: "name_part"
+        number: 1
+        label: LABEL_REQUIRED
+        type: TYPE_STRING
+        json_name: "namePart"
+      }
+      field {
+        name: "is_extension"
+        number: 2
+        label: LABEL_REQUIRED
+        type: TYPE_BOOL
+        json_name: "isExtension"
+      }
+    }
+  }
+  message_type {
+    name: "SourceCodeInfo"
+    field {
+      name: "location"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.SourceCodeInfo.Location"
+      json_name: "location"
+    }
+    nested_type {
+      name: "Location"
+      field {
+        name: "path"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        options {
+          packed: true
+        }
+        json_name: "path"
+      }
+      field {
+        name: "span"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        options {
+          packed: true
+        }
+        json_name: "span"
+      }
+      field {
+        name: "leading_comments"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "leadingComments"
+      }
+      field {
+        name: "trailing_comments"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "trailingComments"
+      }
+      field {
+        name: "leading_detached_comments"
+        number: 6
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "leadingDetachedComments"
+      }
+    }
+  }
+  message_type {
+    name: "GeneratedCodeInfo"
+    field {
+      name: "annotation"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.GeneratedCodeInfo.Annotation"
+      json_name: "annotation"
+    }
+    nested_type {
+      name: "Annotation"
+      field {
+        name: "path"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_INT32
+        options {
+          packed: true
+        }
+        json_name: "path"
+      }
+      field {
+        name: "source_file"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "sourceFile"
+      }
+      field {
+        name: "begin"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "begin"
+      }
+      field {
+        name: "end"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "end"
+      }
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "DescriptorProtos"
+    optimize_for: SPEED
+    go_package: "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor"
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.Reflection"
+  }
+}
+file {
+  name: "gogoproto/gogo.proto"
+  package: "gogoproto"
+  dependency: "google/protobuf/descriptor.proto"
+  extension {
+    name: "goproto_enum_prefix"
+    extendee: ".google.protobuf.EnumOptions"
+    number: 62001
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoEnumPrefix"
+  }
+  extension {
+    name: "goproto_enum_stringer"
+    extendee: ".google.protobuf.EnumOptions"
+    number: 62021
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoEnumStringer"
+  }
+  extension {
+    name: "enum_stringer"
+    extendee: ".google.protobuf.EnumOptions"
+    number: 62022
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "enumStringer"
+  }
+  extension {
+    name: "enum_customname"
+    extendee: ".google.protobuf.EnumOptions"
+    number: 62023
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "enumCustomname"
+  }
+  extension {
+    name: "enumdecl"
+    extendee: ".google.protobuf.EnumOptions"
+    number: 62024
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "enumdecl"
+  }
+  extension {
+    name: "enumvalue_customname"
+    extendee: ".google.protobuf.EnumValueOptions"
+    number: 66001
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "enumvalueCustomname"
+  }
+  extension {
+    name: "goproto_getters_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63001
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoGettersAll"
+  }
+  extension {
+    name: "goproto_enum_prefix_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63002
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoEnumPrefixAll"
+  }
+  extension {
+    name: "goproto_stringer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63003
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoStringerAll"
+  }
+  extension {
+    name: "verbose_equal_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63004
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "verboseEqualAll"
+  }
+  extension {
+    name: "face_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63005
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "faceAll"
+  }
+  extension {
+    name: "gostring_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63006
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "gostringAll"
+  }
+  extension {
+    name: "populate_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63007
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "populateAll"
+  }
+  extension {
+    name: "stringer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63008
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stringerAll"
+  }
+  extension {
+    name: "onlyone_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63009
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "onlyoneAll"
+  }
+  extension {
+    name: "equal_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63013
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "equalAll"
+  }
+  extension {
+    name: "description_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63014
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "descriptionAll"
+  }
+  extension {
+    name: "testgen_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63015
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "testgenAll"
+  }
+  extension {
+    name: "benchgen_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63016
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "benchgenAll"
+  }
+  extension {
+    name: "marshaler_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63017
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "marshalerAll"
+  }
+  extension {
+    name: "unmarshaler_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63018
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unmarshalerAll"
+  }
+  extension {
+    name: "stable_marshaler_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63019
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stableMarshalerAll"
+  }
+  extension {
+    name: "sizer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63020
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "sizerAll"
+  }
+  extension {
+    name: "goproto_enum_stringer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63021
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoEnumStringerAll"
+  }
+  extension {
+    name: "enum_stringer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63022
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "enumStringerAll"
+  }
+  extension {
+    name: "unsafe_marshaler_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63023
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unsafeMarshalerAll"
+  }
+  extension {
+    name: "unsafe_unmarshaler_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63024
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unsafeUnmarshalerAll"
+  }
+  extension {
+    name: "goproto_extensions_map_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63025
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoExtensionsMapAll"
+  }
+  extension {
+    name: "goproto_unrecognized_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63026
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoUnrecognizedAll"
+  }
+  extension {
+    name: "gogoproto_import"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63027
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "gogoprotoImport"
+  }
+  extension {
+    name: "protosizer_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63028
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "protosizerAll"
+  }
+  extension {
+    name: "compare_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63029
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "compareAll"
+  }
+  extension {
+    name: "typedecl_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63030
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "typedeclAll"
+  }
+  extension {
+    name: "enumdecl_all"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63031
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "enumdeclAll"
+  }
+  extension {
+    name: "goproto_registration"
+    extendee: ".google.protobuf.FileOptions"
+    number: 63032
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoRegistration"
+  }
+  extension {
+    name: "goproto_getters"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64001
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoGetters"
+  }
+  extension {
+    name: "goproto_stringer"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64003
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoStringer"
+  }
+  extension {
+    name: "verbose_equal"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64004
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "verboseEqual"
+  }
+  extension {
+    name: "face"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64005
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "face"
+  }
+  extension {
+    name: "gostring"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64006
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "gostring"
+  }
+  extension {
+    name: "populate"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64007
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "populate"
+  }
+  extension {
+    name: "stringer"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 67008
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stringer"
+  }
+  extension {
+    name: "onlyone"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64009
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "onlyone"
+  }
+  extension {
+    name: "equal"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64013
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "equal"
+  }
+  extension {
+    name: "description"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64014
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "description"
+  }
+  extension {
+    name: "testgen"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64015
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "testgen"
+  }
+  extension {
+    name: "benchgen"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64016
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "benchgen"
+  }
+  extension {
+    name: "marshaler"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64017
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "marshaler"
+  }
+  extension {
+    name: "unmarshaler"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64018
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unmarshaler"
+  }
+  extension {
+    name: "stable_marshaler"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64019
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stableMarshaler"
+  }
+  extension {
+    name: "sizer"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64020
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "sizer"
+  }
+  extension {
+    name: "unsafe_marshaler"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64023
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unsafeMarshaler"
+  }
+  extension {
+    name: "unsafe_unmarshaler"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64024
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "unsafeUnmarshaler"
+  }
+  extension {
+    name: "goproto_extensions_map"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64025
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoExtensionsMap"
+  }
+  extension {
+    name: "goproto_unrecognized"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64026
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "goprotoUnrecognized"
+  }
+  extension {
+    name: "protosizer"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64028
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "protosizer"
+  }
+  extension {
+    name: "compare"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64029
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "compare"
+  }
+  extension {
+    name: "typedecl"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 64030
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "typedecl"
+  }
+  extension {
+    name: "nullable"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65001
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "nullable"
+  }
+  extension {
+    name: "embed"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65002
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "embed"
+  }
+  extension {
+    name: "customtype"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65003
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "customtype"
+  }
+  extension {
+    name: "customname"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65004
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "customname"
+  }
+  extension {
+    name: "jsontag"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65005
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "jsontag"
+  }
+  extension {
+    name: "moretags"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65006
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "moretags"
+  }
+  extension {
+    name: "casttype"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65007
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "casttype"
+  }
+  extension {
+    name: "castkey"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65008
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "castkey"
+  }
+  extension {
+    name: "castvalue"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65009
+    label: LABEL_OPTIONAL
+    type: TYPE_STRING
+    json_name: "castvalue"
+  }
+  extension {
+    name: "stdtime"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65010
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stdtime"
+  }
+  extension {
+    name: "stdduration"
+    extendee: ".google.protobuf.FieldOptions"
+    number: 65011
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    json_name: "stdduration"
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "GoGoProtos"
+  }
+}
+file {
+  name: "github.com/docker/swarmkit/api/types.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "google/protobuf/timestamp.proto"
+  dependency: "google/protobuf/duration.proto"
+  dependency: "gogoproto/gogo.proto"
+  message_type {
+    name: "Version"
+    field {
+      name: "index"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "index"
+    }
+  }
+  message_type {
+    name: "IndexEntry"
+    field {
+      name: "key"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "key"
+    }
+    field {
+      name: "val"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "val"
+    }
+  }
+  message_type {
+    name: "Annotations"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "labels"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations.LabelsEntry"
+      json_name: "labels"
+    }
+    field {
+      name: "indices"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IndexEntry"
+      options {
+        65001: 0
+      }
+      json_name: "indices"
+    }
+    nested_type {
+      name: "LabelsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "NamedGenericResource"
+    field {
+      name: "kind"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "kind"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "value"
+    }
+  }
+  message_type {
+    name: "DiscreteGenericResource"
+    field {
+      name: "kind"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "kind"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "value"
+    }
+  }
+  message_type {
+    name: "GenericResource"
+    field {
+      name: "named_resource_spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NamedGenericResource"
+      oneof_index: 0
+      json_name: "namedResourceSpec"
+    }
+    field {
+      name: "discrete_resource_spec"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.DiscreteGenericResource"
+      oneof_index: 0
+      json_name: "discreteResourceSpec"
+    }
+    oneof_decl {
+      name: "resource"
+    }
+  }
+  message_type {
+    name: "Resources"
+    field {
+      name: "nano_cpus"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      options {
+        65004: "NanoCPUs"
+      }
+      json_name: "nanoCpus"
+    }
+    field {
+      name: "memory_bytes"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "memoryBytes"
+    }
+    field {
+      name: "generic"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.GenericResource"
+      json_name: "generic"
+    }
+  }
+  message_type {
+    name: "ResourceRequirements"
+    field {
+      name: "limits"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resources"
+      json_name: "limits"
+    }
+    field {
+      name: "reservations"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resources"
+      json_name: "reservations"
+    }
+  }
+  message_type {
+    name: "Platform"
+    field {
+      name: "architecture"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "architecture"
+    }
+    field {
+      name: "os"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "OS"
+      }
+      json_name: "os"
+    }
+  }
+  message_type {
+    name: "PluginDescription"
+    field {
+      name: "type"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "type"
+    }
+    field {
+      name: "name"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+  }
+  message_type {
+    name: "EngineDescription"
+    field {
+      name: "engine_version"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "engineVersion"
+    }
+    field {
+      name: "labels"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EngineDescription.LabelsEntry"
+      json_name: "labels"
+    }
+    field {
+      name: "plugins"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PluginDescription"
+      options {
+        65001: 0
+      }
+      json_name: "plugins"
+    }
+    nested_type {
+      name: "LabelsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "NodeDescription"
+    field {
+      name: "hostname"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "hostname"
+    }
+    field {
+      name: "platform"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Platform"
+      json_name: "platform"
+    }
+    field {
+      name: "resources"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resources"
+      json_name: "resources"
+    }
+    field {
+      name: "engine"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EngineDescription"
+      json_name: "engine"
+    }
+    field {
+      name: "tls_info"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeTLSInfo"
+      options {
+        65004: "TLSInfo"
+      }
+      json_name: "tlsInfo"
+    }
+  }
+  message_type {
+    name: "NodeTLSInfo"
+    field {
+      name: "trust_root"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "trustRoot"
+    }
+    field {
+      name: "cert_issuer_subject"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "certIssuerSubject"
+    }
+    field {
+      name: "cert_issuer_public_key"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "certIssuerPublicKey"
+    }
+  }
+  message_type {
+    name: "RaftMemberStatus"
+    field {
+      name: "leader"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "leader"
+    }
+    field {
+      name: "reachability"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.RaftMemberStatus.Reachability"
+      json_name: "reachability"
+    }
+    field {
+      name: "message"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "message"
+    }
+    enum_type {
+      name: "Reachability"
+      value {
+        name: "UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "UNREACHABLE"
+        number: 1
+      }
+      value {
+        name: "REACHABLE"
+        number: 2
+      }
+    }
+  }
+  message_type {
+    name: "NodeStatus"
+    field {
+      name: "state"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeStatus.State"
+      json_name: "state"
+    }
+    field {
+      name: "message"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "message"
+    }
+    field {
+      name: "addr"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+    enum_type {
+      name: "State"
+      value {
+        name: "UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "DOWN"
+        number: 1
+      }
+      value {
+        name: "READY"
+        number: 2
+      }
+      value {
+        name: "DISCONNECTED"
+        number: 3
+      }
+    }
+  }
+  message_type {
+    name: "Image"
+    field {
+      name: "reference"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "reference"
+    }
+  }
+  message_type {
+    name: "Mount"
+    field {
+      name: "type"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.Mount.Type"
+      json_name: "type"
+    }
+    field {
+      name: "source"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "source"
+    }
+    field {
+      name: "target"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "target"
+    }
+    field {
+      name: "readonly"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      options {
+        65004: "ReadOnly"
+      }
+      json_name: "readonly"
+    }
+    field {
+      name: "bind_options"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Mount.BindOptions"
+      json_name: "bindOptions"
+    }
+    field {
+      name: "volume_options"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Mount.VolumeOptions"
+      json_name: "volumeOptions"
+    }
+    field {
+      name: "tmpfs_options"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Mount.TmpfsOptions"
+      json_name: "tmpfsOptions"
+    }
+    nested_type {
+      name: "BindOptions"
+      field {
+        name: "propagation"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.Mount.BindOptions.Propagation"
+        json_name: "propagation"
+      }
+      enum_type {
+        name: "Propagation"
+        value {
+          name: "RPRIVATE"
+          number: 0
+          options {
+            66001: "MountPropagationRPrivate"
+          }
+        }
+        value {
+          name: "PRIVATE"
+          number: 1
+          options {
+            66001: "MountPropagationPrivate"
+          }
+        }
+        value {
+          name: "RSHARED"
+          number: 2
+          options {
+            66001: "MountPropagationRShared"
+          }
+        }
+        value {
+          name: "SHARED"
+          number: 3
+          options {
+            66001: "MountPropagationShared"
+          }
+        }
+        value {
+          name: "RSLAVE"
+          number: 4
+          options {
+            66001: "MountPropagationRSlave"
+          }
+        }
+        value {
+          name: "SLAVE"
+          number: 5
+          options {
+            66001: "MountPropagationSlave"
+          }
+        }
+        options {
+          62001: 0
+          62023: "MountPropagation"
+        }
+      }
+    }
+    nested_type {
+      name: "VolumeOptions"
+      field {
+        name: "nocopy"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+        options {
+          65004: "NoCopy"
+        }
+        json_name: "nocopy"
+      }
+      field {
+        name: "labels"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.Mount.VolumeOptions.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "driver_config"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.Driver"
+        json_name: "driverConfig"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+    nested_type {
+      name: "TmpfsOptions"
+      field {
+        name: "size_bytes"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT64
+        json_name: "sizeBytes"
+      }
+      field {
+        name: "mode"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_UINT32
+        options {
+          65003: "os.FileMode"
+          65001: 0
+        }
+        json_name: "mode"
+      }
+    }
+    enum_type {
+      name: "Type"
+      value {
+        name: "BIND"
+        number: 0
+        options {
+          66001: "MountTypeBind"
+        }
+      }
+      value {
+        name: "VOLUME"
+        number: 1
+        options {
+          66001: "MountTypeVolume"
+        }
+      }
+      value {
+        name: "TMPFS"
+        number: 2
+        options {
+          66001: "MountTypeTmpfs"
+        }
+      }
+      options {
+        62001: 0
+        62023: "MountType"
+      }
+    }
+  }
+  message_type {
+    name: "RestartPolicy"
+    field {
+      name: "condition"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.RestartPolicy.RestartCondition"
+      json_name: "condition"
+    }
+    field {
+      name: "delay"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "delay"
+    }
+    field {
+      name: "max_attempts"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "maxAttempts"
+    }
+    field {
+      name: "window"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "window"
+    }
+    enum_type {
+      name: "RestartCondition"
+      value {
+        name: "NONE"
+        number: 0
+        options {
+          66001: "RestartOnNone"
+        }
+      }
+      value {
+        name: "ON_FAILURE"
+        number: 1
+        options {
+          66001: "RestartOnFailure"
+        }
+      }
+      value {
+        name: "ANY"
+        number: 2
+        options {
+          66001: "RestartOnAny"
+        }
+      }
+      options {
+        62001: 0
+        62023: "RestartCondition"
+      }
+    }
+  }
+  message_type {
+    name: "UpdateConfig"
+    field {
+      name: "parallelism"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "parallelism"
+    }
+    field {
+      name: "delay"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      options {
+        65011: 1
+        65001: 0
+      }
+      json_name: "delay"
+    }
+    field {
+      name: "failure_action"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.UpdateConfig.FailureAction"
+      json_name: "failureAction"
+    }
+    field {
+      name: "monitor"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "monitor"
+    }
+    field {
+      name: "max_failure_ratio"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_FLOAT
+      json_name: "maxFailureRatio"
+    }
+    field {
+      name: "order"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.UpdateConfig.UpdateOrder"
+      json_name: "order"
+    }
+    enum_type {
+      name: "FailureAction"
+      value {
+        name: "PAUSE"
+        number: 0
+      }
+      value {
+        name: "CONTINUE"
+        number: 1
+      }
+      value {
+        name: "ROLLBACK"
+        number: 2
+      }
+    }
+    enum_type {
+      name: "UpdateOrder"
+      value {
+        name: "STOP_FIRST"
+        number: 0
+      }
+      value {
+        name: "START_FIRST"
+        number: 1
+      }
+    }
+  }
+  message_type {
+    name: "UpdateStatus"
+    field {
+      name: "state"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.UpdateStatus.UpdateState"
+      json_name: "state"
+    }
+    field {
+      name: "started_at"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "startedAt"
+    }
+    field {
+      name: "completed_at"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "completedAt"
+    }
+    field {
+      name: "message"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "message"
+    }
+    enum_type {
+      name: "UpdateState"
+      value {
+        name: "UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "UPDATING"
+        number: 1
+      }
+      value {
+        name: "PAUSED"
+        number: 2
+      }
+      value {
+        name: "COMPLETED"
+        number: 3
+      }
+      value {
+        name: "ROLLBACK_STARTED"
+        number: 4
+      }
+      value {
+        name: "ROLLBACK_PAUSED"
+        number: 5
+      }
+      value {
+        name: "ROLLBACK_COMPLETED"
+        number: 6
+      }
+    }
+  }
+  message_type {
+    name: "ContainerStatus"
+    field {
+      name: "container_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "containerId"
+    }
+    field {
+      name: "pid"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      options {
+        65004: "PID"
+      }
+      json_name: "pid"
+    }
+    field {
+      name: "exit_code"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "exitCode"
+    }
+  }
+  message_type {
+    name: "PortStatus"
+    field {
+      name: "ports"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PortConfig"
+      json_name: "ports"
+    }
+  }
+  message_type {
+    name: "TaskStatus"
+    field {
+      name: "timestamp"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "timestamp"
+    }
+    field {
+      name: "state"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.TaskState"
+      json_name: "state"
+    }
+    field {
+      name: "message"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "message"
+    }
+    field {
+      name: "err"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "err"
+    }
+    field {
+      name: "container"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ContainerStatus"
+      oneof_index: 0
+      json_name: "container"
+    }
+    field {
+      name: "port_status"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PortStatus"
+      json_name: "portStatus"
+    }
+    field {
+      name: "applied_by"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "appliedBy"
+    }
+    field {
+      name: "applied_at"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "appliedAt"
+    }
+    oneof_decl {
+      name: "runtime_status"
+    }
+  }
+  message_type {
+    name: "NetworkAttachmentConfig"
+    field {
+      name: "target"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "target"
+    }
+    field {
+      name: "aliases"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "aliases"
+    }
+    field {
+      name: "addresses"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "addresses"
+    }
+    field {
+      name: "driver_attachment_opts"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachmentConfig.DriverAttachmentOptsEntry"
+      json_name: "driverAttachmentOpts"
+    }
+    nested_type {
+      name: "DriverAttachmentOptsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "IPAMConfig"
+    field {
+      name: "family"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.IPAMConfig.AddressFamily"
+      json_name: "family"
+    }
+    field {
+      name: "subnet"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "subnet"
+    }
+    field {
+      name: "range"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "range"
+    }
+    field {
+      name: "gateway"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "gateway"
+    }
+    field {
+      name: "reserved"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IPAMConfig.ReservedEntry"
+      json_name: "reserved"
+    }
+    nested_type {
+      name: "ReservedEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+    enum_type {
+      name: "AddressFamily"
+      value {
+        name: "UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "IPV4"
+        number: 4
+      }
+      value {
+        name: "IPV6"
+        number: 6
+      }
+    }
+  }
+  message_type {
+    name: "PortConfig"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "protocol"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.PortConfig.Protocol"
+      json_name: "protocol"
+    }
+    field {
+      name: "target_port"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT32
+      json_name: "targetPort"
+    }
+    field {
+      name: "published_port"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT32
+      json_name: "publishedPort"
+    }
+    field {
+      name: "publish_mode"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.PortConfig.PublishMode"
+      json_name: "publishMode"
+    }
+    enum_type {
+      name: "Protocol"
+      value {
+        name: "TCP"
+        number: 0
+        options {
+          66001: "ProtocolTCP"
+        }
+      }
+      value {
+        name: "UDP"
+        number: 1
+        options {
+          66001: "ProtocolUDP"
+        }
+      }
+      options {
+        62001: 0
+      }
+    }
+    enum_type {
+      name: "PublishMode"
+      value {
+        name: "INGRESS"
+        number: 0
+        options {
+          66001: "PublishModeIngress"
+        }
+      }
+      value {
+        name: "HOST"
+        number: 1
+        options {
+          66001: "PublishModeHost"
+        }
+      }
+      options {
+        62023: "PublishMode"
+        62001: 0
+      }
+    }
+  }
+  message_type {
+    name: "Driver"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "options"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver.OptionsEntry"
+      json_name: "options"
+    }
+    nested_type {
+      name: "OptionsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "IPAMOptions"
+    field {
+      name: "driver"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "driver"
+    }
+    field {
+      name: "configs"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IPAMConfig"
+      json_name: "configs"
+    }
+  }
+  message_type {
+    name: "Peer"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "addr"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+  }
+  message_type {
+    name: "WeightedPeer"
+    field {
+      name: "peer"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Peer"
+      json_name: "peer"
+    }
+    field {
+      name: "weight"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "weight"
+    }
+  }
+  message_type {
+    name: "IssuanceStatus"
+    field {
+      name: "state"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.IssuanceStatus.State"
+      json_name: "state"
+    }
+    field {
+      name: "err"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "err"
+    }
+    enum_type {
+      name: "State"
+      value {
+        name: "UNKNOWN"
+        number: 0
+        options {
+          66001: "IssuanceStateUnknown"
+        }
+      }
+      value {
+        name: "RENEW"
+        number: 1
+        options {
+          66001: "IssuanceStateRenew"
+        }
+      }
+      value {
+        name: "PENDING"
+        number: 2
+        options {
+          66001: "IssuanceStatePending"
+        }
+      }
+      value {
+        name: "ISSUED"
+        number: 3
+        options {
+          66001: "IssuanceStateIssued"
+        }
+      }
+      value {
+        name: "FAILED"
+        number: 4
+        options {
+          66001: "IssuanceStateFailed"
+        }
+      }
+      value {
+        name: "ROTATE"
+        number: 5
+        options {
+          66001: "IssuanceStateRotate"
+        }
+      }
+      options {
+        62001: 0
+      }
+    }
+  }
+  message_type {
+    name: "AcceptancePolicy"
+    field {
+      name: "policies"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.AcceptancePolicy.RoleAdmissionPolicy"
+      json_name: "policies"
+    }
+    nested_type {
+      name: "RoleAdmissionPolicy"
+      field {
+        name: "role"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.NodeRole"
+        json_name: "role"
+      }
+      field {
+        name: "autoaccept"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+        json_name: "autoaccept"
+      }
+      field {
+        name: "secret"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.AcceptancePolicy.RoleAdmissionPolicy.Secret"
+        json_name: "secret"
+      }
+      nested_type {
+        name: "Secret"
+        field {
+          name: "data"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_BYTES
+          json_name: "data"
+        }
+        field {
+          name: "alg"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "alg"
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ExternalCA"
+    field {
+      name: "protocol"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.ExternalCA.CAProtocol"
+      json_name: "protocol"
+    }
+    field {
+      name: "url"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "URL"
+      }
+      json_name: "url"
+    }
+    field {
+      name: "options"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ExternalCA.OptionsEntry"
+      json_name: "options"
+    }
+    field {
+      name: "ca_cert"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CACert"
+      }
+      json_name: "caCert"
+    }
+    nested_type {
+      name: "OptionsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+    enum_type {
+      name: "CAProtocol"
+      value {
+        name: "CFSSL"
+        number: 0
+        options {
+          66001: "CAProtocolCFSSL"
+        }
+      }
+    }
+  }
+  message_type {
+    name: "CAConfig"
+    field {
+      name: "node_cert_expiry"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "nodeCertExpiry"
+    }
+    field {
+      name: "external_cas"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ExternalCA"
+      options {
+        65004: "ExternalCAs"
+      }
+      json_name: "externalCas"
+    }
+    field {
+      name: "signing_ca_cert"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "SigningCACert"
+      }
+      json_name: "signingCaCert"
+    }
+    field {
+      name: "signing_ca_key"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "SigningCAKey"
+      }
+      json_name: "signingCaKey"
+    }
+    field {
+      name: "force_rotate"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "forceRotate"
+    }
+  }
+  message_type {
+    name: "OrchestrationConfig"
+    field {
+      name: "task_history_retention_limit"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "taskHistoryRetentionLimit"
+    }
+  }
+  message_type {
+    name: "TaskDefaults"
+    field {
+      name: "log_driver"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "logDriver"
+    }
+  }
+  message_type {
+    name: "DispatcherConfig"
+    field {
+      name: "heartbeat_period"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "heartbeatPeriod"
+    }
+  }
+  message_type {
+    name: "RaftConfig"
+    field {
+      name: "snapshot_interval"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "snapshotInterval"
+    }
+    field {
+      name: "keep_old_snapshots"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "keepOldSnapshots"
+    }
+    field {
+      name: "log_entries_for_slow_followers"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "logEntriesForSlowFollowers"
+    }
+    field {
+      name: "heartbeat_tick"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT32
+      json_name: "heartbeatTick"
+    }
+    field {
+      name: "election_tick"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT32
+      json_name: "electionTick"
+    }
+  }
+  message_type {
+    name: "EncryptionConfig"
+    field {
+      name: "auto_lock_managers"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "autoLockManagers"
+    }
+  }
+  message_type {
+    name: "SpreadOver"
+    field {
+      name: "spread_descriptor"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "spreadDescriptor"
+    }
+  }
+  message_type {
+    name: "PlacementPreference"
+    field {
+      name: "spread"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SpreadOver"
+      oneof_index: 0
+      json_name: "spread"
+    }
+    oneof_decl {
+      name: "Preference"
+    }
+  }
+  message_type {
+    name: "Placement"
+    field {
+      name: "constraints"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "constraints"
+    }
+    field {
+      name: "preferences"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PlacementPreference"
+      json_name: "preferences"
+    }
+    field {
+      name: "platforms"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Platform"
+      json_name: "platforms"
+    }
+  }
+  message_type {
+    name: "JoinTokens"
+    field {
+      name: "worker"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "worker"
+    }
+    field {
+      name: "manager"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "manager"
+    }
+  }
+  message_type {
+    name: "RootCA"
+    field {
+      name: "ca_key"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CAKey"
+      }
+      json_name: "caKey"
+    }
+    field {
+      name: "ca_cert"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CACert"
+      }
+      json_name: "caCert"
+    }
+    field {
+      name: "ca_cert_hash"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "CACertHash"
+      }
+      json_name: "caCertHash"
+    }
+    field {
+      name: "join_tokens"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.JoinTokens"
+      options {
+        65001: 0
+      }
+      json_name: "joinTokens"
+    }
+    field {
+      name: "root_rotation"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RootRotation"
+      json_name: "rootRotation"
+    }
+    field {
+      name: "last_forced_rotation"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "lastForcedRotation"
+    }
+  }
+  message_type {
+    name: "Certificate"
+    field {
+      name: "role"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeRole"
+      json_name: "role"
+    }
+    field {
+      name: "csr"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CSR"
+      }
+      json_name: "csr"
+    }
+    field {
+      name: "status"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IssuanceStatus"
+      options {
+        65001: 0
+      }
+      json_name: "status"
+    }
+    field {
+      name: "certificate"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "certificate"
+    }
+    field {
+      name: "cn"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "CN"
+      }
+      json_name: "cn"
+    }
+  }
+  message_type {
+    name: "EncryptionKey"
+    field {
+      name: "subsystem"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "subsystem"
+    }
+    field {
+      name: "algorithm"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.EncryptionKey.Algorithm"
+      json_name: "algorithm"
+    }
+    field {
+      name: "key"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "key"
+    }
+    field {
+      name: "lamport_time"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "lamportTime"
+    }
+    enum_type {
+      name: "Algorithm"
+      value {
+        name: "AES_128_GCM"
+        number: 0
+      }
+      options {
+        62001: 0
+      }
+    }
+  }
+  message_type {
+    name: "ManagerStatus"
+    field {
+      name: "raft_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "raftId"
+    }
+    field {
+      name: "addr"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+    field {
+      name: "leader"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "leader"
+    }
+    field {
+      name: "reachability"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.RaftMemberStatus.Reachability"
+      json_name: "reachability"
+    }
+  }
+  message_type {
+    name: "FileTarget"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "uid"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "UID"
+      }
+      json_name: "uid"
+    }
+    field {
+      name: "gid"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "GID"
+      }
+      json_name: "gid"
+    }
+    field {
+      name: "mode"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT32
+      options {
+        65003: "os.FileMode"
+        65001: 0
+      }
+      json_name: "mode"
+    }
+  }
+  message_type {
+    name: "SecretReference"
+    field {
+      name: "secret_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "secretId"
+    }
+    field {
+      name: "secret_name"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "secretName"
+    }
+    field {
+      name: "file"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.FileTarget"
+      oneof_index: 0
+      json_name: "file"
+    }
+    oneof_decl {
+      name: "target"
+    }
+  }
+  message_type {
+    name: "ConfigReference"
+    field {
+      name: "config_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "configId"
+    }
+    field {
+      name: "config_name"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "configName"
+    }
+    field {
+      name: "file"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.FileTarget"
+      oneof_index: 0
+      json_name: "file"
+    }
+    oneof_decl {
+      name: "target"
+    }
+  }
+  message_type {
+    name: "BlacklistedCertificate"
+    field {
+      name: "expiry"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "expiry"
+    }
+  }
+  message_type {
+    name: "HealthConfig"
+    field {
+      name: "test"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "test"
+    }
+    field {
+      name: "interval"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "interval"
+    }
+    field {
+      name: "timeout"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "timeout"
+    }
+    field {
+      name: "retries"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "retries"
+    }
+    field {
+      name: "start_period"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "startPeriod"
+    }
+  }
+  message_type {
+    name: "MaybeEncryptedRecord"
+    field {
+      name: "algorithm"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.MaybeEncryptedRecord.Algorithm"
+      json_name: "algorithm"
+    }
+    field {
+      name: "data"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "data"
+    }
+    field {
+      name: "nonce"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "nonce"
+    }
+    enum_type {
+      name: "Algorithm"
+      value {
+        name: "NONE"
+        number: 0
+        options {
+          66001: "NotEncrypted"
+        }
+      }
+      value {
+        name: "SECRETBOX_SALSA20_POLY1305"
+        number: 1
+        options {
+          66001: "NACLSecretboxSalsa20Poly1305"
+        }
+      }
+    }
+  }
+  message_type {
+    name: "RootRotation"
+    field {
+      name: "ca_cert"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CACert"
+      }
+      json_name: "caCert"
+    }
+    field {
+      name: "ca_key"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CAKey"
+      }
+      json_name: "caKey"
+    }
+    field {
+      name: "cross_signed_ca_cert"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CrossSignedCACert"
+      }
+      json_name: "crossSignedCaCert"
+    }
+  }
+  message_type {
+    name: "Privileges"
+    field {
+      name: "credential_spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Privileges.CredentialSpec"
+      json_name: "credentialSpec"
+    }
+    field {
+      name: "selinux_context"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Privileges.SELinuxContext"
+      options {
+        65004: "SELinuxContext"
+      }
+      json_name: "selinuxContext"
+    }
+    nested_type {
+      name: "CredentialSpec"
+      field {
+        name: "file"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        oneof_index: 0
+        json_name: "file"
+      }
+      field {
+        name: "registry"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        oneof_index: 0
+        json_name: "registry"
+      }
+      oneof_decl {
+        name: "source"
+      }
+    }
+    nested_type {
+      name: "SELinuxContext"
+      field {
+        name: "disable"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+        json_name: "disable"
+      }
+      field {
+        name: "user"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "user"
+      }
+      field {
+        name: "role"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "role"
+      }
+      field {
+        name: "type"
+        number: 4
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "type"
+      }
+      field {
+        name: "level"
+        number: 5
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "level"
+      }
+    }
+  }
+  enum_type {
+    name: "ResourceType"
+    value {
+      name: "TASK"
+      number: 0
+    }
+    value {
+      name: "SECRET"
+      number: 1
+    }
+    value {
+      name: "CONFIG"
+      number: 2
+    }
+  }
+  enum_type {
+    name: "TaskState"
+    value {
+      name: "NEW"
+      number: 0
+      options {
+        66001: "TaskStateNew"
+      }
+    }
+    value {
+      name: "PENDING"
+      number: 64
+      options {
+        66001: "TaskStatePending"
+      }
+    }
+    value {
+      name: "ASSIGNED"
+      number: 192
+      options {
+        66001: "TaskStateAssigned"
+      }
+    }
+    value {
+      name: "ACCEPTED"
+      number: 256
+      options {
+        66001: "TaskStateAccepted"
+      }
+    }
+    value {
+      name: "PREPARING"
+      number: 320
+      options {
+        66001: "TaskStatePreparing"
+      }
+    }
+    value {
+      name: "READY"
+      number: 384
+      options {
+        66001: "TaskStateReady"
+      }
+    }
+    value {
+      name: "STARTING"
+      number: 448
+      options {
+        66001: "TaskStateStarting"
+      }
+    }
+    value {
+      name: "RUNNING"
+      number: 512
+      options {
+        66001: "TaskStateRunning"
+      }
+    }
+    value {
+      name: "COMPLETE"
+      number: 576
+      options {
+        66001: "TaskStateCompleted"
+      }
+    }
+    value {
+      name: "SHUTDOWN"
+      number: 640
+      options {
+        66001: "TaskStateShutdown"
+      }
+    }
+    value {
+      name: "FAILED"
+      number: 704
+      options {
+        66001: "TaskStateFailed"
+      }
+    }
+    value {
+      name: "REJECTED"
+      number: 768
+      options {
+        66001: "TaskStateRejected"
+      }
+    }
+    value {
+      name: "ORPHANED"
+      number: 832
+      options {
+        66001: "TaskStateOrphaned"
+      }
+    }
+    options {
+      62001: 0
+      62023: "TaskState"
+    }
+  }
+  enum_type {
+    name: "NodeRole"
+    value {
+      name: "WORKER"
+      number: 0
+      options {
+        66001: "NodeRoleWorker"
+      }
+    }
+    value {
+      name: "MANAGER"
+      number: 1
+      options {
+        66001: "NodeRoleManager"
+      }
+    }
+    options {
+      62023: "NodeRole"
+      62001: 0
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "google/protobuf/any.proto"
+  package: "google.protobuf"
+  message_type {
+    name: "Any"
+    field {
+      name: "type_url"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "typeUrl"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "value"
+    }
+  }
+  options {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "AnyProto"
+    java_multiple_files: true
+    go_package: "github.com/golang/protobuf/ptypes/any"
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/specs.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "google/protobuf/duration.proto"
+  dependency: "google/protobuf/any.proto"
+  message_type {
+    name: "NodeSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "desired_role"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeRole"
+      json_name: "desiredRole"
+    }
+    field {
+      name: "membership"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeSpec.Membership"
+      json_name: "membership"
+    }
+    field {
+      name: "availability"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeSpec.Availability"
+      json_name: "availability"
+    }
+    enum_type {
+      name: "Membership"
+      value {
+        name: "PENDING"
+        number: 0
+        options {
+          66001: "NodeMembershipPending"
+        }
+      }
+      value {
+        name: "ACCEPTED"
+        number: 1
+        options {
+          66001: "NodeMembershipAccepted"
+        }
+      }
+      options {
+        62001: 0
+      }
+    }
+    enum_type {
+      name: "Availability"
+      value {
+        name: "ACTIVE"
+        number: 0
+        options {
+          66001: "NodeAvailabilityActive"
+        }
+      }
+      value {
+        name: "PAUSE"
+        number: 1
+        options {
+          66001: "NodeAvailabilityPause"
+        }
+      }
+      value {
+        name: "DRAIN"
+        number: 2
+        options {
+          66001: "NodeAvailabilityDrain"
+        }
+      }
+      options {
+        62001: 0
+      }
+    }
+  }
+  message_type {
+    name: "ServiceSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "task"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.TaskSpec"
+      options {
+        65001: 0
+      }
+      json_name: "task"
+    }
+    field {
+      name: "replicated"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ReplicatedService"
+      oneof_index: 0
+      json_name: "replicated"
+    }
+    field {
+      name: "global"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.GlobalService"
+      oneof_index: 0
+      json_name: "global"
+    }
+    field {
+      name: "update"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.UpdateConfig"
+      json_name: "update"
+    }
+    field {
+      name: "rollback"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.UpdateConfig"
+      json_name: "rollback"
+    }
+    field {
+      name: "networks"
+      number: 7
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachmentConfig"
+      options {
+        deprecated: true
+      }
+      json_name: "networks"
+    }
+    field {
+      name: "endpoint"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EndpointSpec"
+      json_name: "endpoint"
+    }
+    oneof_decl {
+      name: "mode"
+    }
+  }
+  message_type {
+    name: "ReplicatedService"
+    field {
+      name: "replicas"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "replicas"
+    }
+  }
+  message_type {
+    name: "GlobalService"
+  }
+  message_type {
+    name: "TaskSpec"
+    field {
+      name: "attachment"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachmentSpec"
+      oneof_index: 0
+      json_name: "attachment"
+    }
+    field {
+      name: "container"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ContainerSpec"
+      oneof_index: 0
+      json_name: "container"
+    }
+    field {
+      name: "generic"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.GenericRuntimeSpec"
+      oneof_index: 0
+      json_name: "generic"
+    }
+    field {
+      name: "resources"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ResourceRequirements"
+      json_name: "resources"
+    }
+    field {
+      name: "restart"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RestartPolicy"
+      json_name: "restart"
+    }
+    field {
+      name: "placement"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Placement"
+      json_name: "placement"
+    }
+    field {
+      name: "log_driver"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "logDriver"
+    }
+    field {
+      name: "networks"
+      number: 7
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachmentConfig"
+      json_name: "networks"
+    }
+    field {
+      name: "force_update"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "forceUpdate"
+    }
+    field {
+      name: "resource_references"
+      number: 11
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ResourceReference"
+      options {
+        65001: 0
+      }
+      json_name: "resourceReferences"
+    }
+    oneof_decl {
+      name: "runtime"
+    }
+  }
+  message_type {
+    name: "ResourceReference"
+    field {
+      name: "resource_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "resourceId"
+    }
+    field {
+      name: "resource_type"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.ResourceType"
+      json_name: "resourceType"
+    }
+  }
+  message_type {
+    name: "GenericRuntimeSpec"
+    field {
+      name: "kind"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "kind"
+    }
+    field {
+      name: "payload"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Any"
+      json_name: "payload"
+    }
+  }
+  message_type {
+    name: "NetworkAttachmentSpec"
+    field {
+      name: "container_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "containerId"
+    }
+  }
+  message_type {
+    name: "ContainerSpec"
+    field {
+      name: "image"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "image"
+    }
+    field {
+      name: "labels"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ContainerSpec.LabelsEntry"
+      json_name: "labels"
+    }
+    field {
+      name: "command"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "command"
+    }
+    field {
+      name: "args"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "args"
+    }
+    field {
+      name: "hostname"
+      number: 14
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "hostname"
+    }
+    field {
+      name: "env"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "env"
+    }
+    field {
+      name: "dir"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "dir"
+    }
+    field {
+      name: "user"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "user"
+    }
+    field {
+      name: "groups"
+      number: 11
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "groups"
+    }
+    field {
+      name: "privileges"
+      number: 22
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Privileges"
+      json_name: "privileges"
+    }
+    field {
+      name: "tty"
+      number: 13
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      options {
+        65004: "TTY"
+      }
+      json_name: "tty"
+    }
+    field {
+      name: "open_stdin"
+      number: 18
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "openStdin"
+    }
+    field {
+      name: "read_only"
+      number: 19
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "readOnly"
+    }
+    field {
+      name: "stop_signal"
+      number: 20
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "stopSignal"
+    }
+    field {
+      name: "mounts"
+      number: 8
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Mount"
+      options {
+        65001: 0
+      }
+      json_name: "mounts"
+    }
+    field {
+      name: "stop_grace_period"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      json_name: "stopGracePeriod"
+    }
+    field {
+      name: "pull_options"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ContainerSpec.PullOptions"
+      json_name: "pullOptions"
+    }
+    field {
+      name: "secrets"
+      number: 12
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SecretReference"
+      json_name: "secrets"
+    }
+    field {
+      name: "configs"
+      number: 21
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ConfigReference"
+      json_name: "configs"
+    }
+    field {
+      name: "hosts"
+      number: 17
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "hosts"
+    }
+    field {
+      name: "dns_config"
+      number: 15
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ContainerSpec.DNSConfig"
+      options {
+        65004: "DNSConfig"
+      }
+      json_name: "dnsConfig"
+    }
+    field {
+      name: "healthcheck"
+      number: 16
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.HealthConfig"
+      json_name: "healthcheck"
+    }
+    nested_type {
+      name: "LabelsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+    nested_type {
+      name: "PullOptions"
+      field {
+        name: "registry_auth"
+        number: 64
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "registryAuth"
+      }
+    }
+    nested_type {
+      name: "DNSConfig"
+      field {
+        name: "nameservers"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "nameservers"
+      }
+      field {
+        name: "search"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "search"
+      }
+      field {
+        name: "options"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "options"
+      }
+    }
+  }
+  message_type {
+    name: "EndpointSpec"
+    field {
+      name: "mode"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.EndpointSpec.ResolutionMode"
+      json_name: "mode"
+    }
+    field {
+      name: "ports"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PortConfig"
+      json_name: "ports"
+    }
+    enum_type {
+      name: "ResolutionMode"
+      value {
+        name: "VIP"
+        number: 0
+        options {
+          66001: "ResolutionModeVirtualIP"
+        }
+      }
+      value {
+        name: "DNSRR"
+        number: 1
+        options {
+          66001: "ResolutionModeDNSRoundRobin"
+        }
+      }
+      options {
+        62001: 0
+      }
+    }
+  }
+  message_type {
+    name: "NetworkSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "driver_config"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "driverConfig"
+    }
+    field {
+      name: "ipv6_enabled"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "ipv6Enabled"
+    }
+    field {
+      name: "internal"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "internal"
+    }
+    field {
+      name: "ipam"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IPAMOptions"
+      options {
+        65004: "IPAM"
+      }
+      json_name: "ipam"
+    }
+    field {
+      name: "attachable"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "attachable"
+    }
+    field {
+      name: "ingress"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "ingress"
+    }
+    field {
+      name: "network"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "network"
+    }
+    oneof_decl {
+      name: "config_from"
+    }
+  }
+  message_type {
+    name: "ClusterSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "acceptance_policy"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.AcceptancePolicy"
+      options {
+        deprecated: true
+        65001: 0
+      }
+      json_name: "acceptancePolicy"
+    }
+    field {
+      name: "orchestration"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.OrchestrationConfig"
+      options {
+        65001: 0
+      }
+      json_name: "orchestration"
+    }
+    field {
+      name: "raft"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RaftConfig"
+      options {
+        65001: 0
+      }
+      json_name: "raft"
+    }
+    field {
+      name: "dispatcher"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.DispatcherConfig"
+      options {
+        65001: 0
+      }
+      json_name: "dispatcher"
+    }
+    field {
+      name: "ca_config"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.CAConfig"
+      options {
+        65001: 0
+        65004: "CAConfig"
+      }
+      json_name: "caConfig"
+    }
+    field {
+      name: "task_defaults"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.TaskDefaults"
+      options {
+        65001: 0
+      }
+      json_name: "taskDefaults"
+    }
+    field {
+      name: "encryption_config"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EncryptionConfig"
+      options {
+        65001: 0
+      }
+      json_name: "encryptionConfig"
+    }
+  }
+  message_type {
+    name: "SecretSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "data"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "data"
+    }
+    field {
+      name: "templating"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "templating"
+    }
+    field {
+      name: "driver"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "driver"
+    }
+  }
+  message_type {
+    name: "ConfigSpec"
+    field {
+      name: "annotations"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "data"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "data"
+    }
+    field {
+      name: "templating"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "templating"
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  package: "docker.protobuf.plugin"
+  dependency: "google/protobuf/descriptor.proto"
+  message_type {
+    name: "WatchSelectors"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "id"
+    }
+    field {
+      name: "id_prefix"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "idPrefix"
+    }
+    field {
+      name: "name"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "name"
+    }
+    field {
+      name: "name_prefix"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "namePrefix"
+    }
+    field {
+      name: "custom"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "custom"
+    }
+    field {
+      name: "custom_prefix"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "customPrefix"
+    }
+    field {
+      name: "service_id"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "serviceId"
+    }
+    field {
+      name: "node_id"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "nodeId"
+    }
+    field {
+      name: "slot"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "slot"
+    }
+    field {
+      name: "desired_state"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "desiredState"
+    }
+    field {
+      name: "role"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "role"
+    }
+    field {
+      name: "membership"
+      number: 12
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "membership"
+    }
+    field {
+      name: "kind"
+      number: 13
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "kind"
+    }
+  }
+  message_type {
+    name: "StoreObject"
+    field {
+      name: "watch_selectors"
+      number: 1
+      label: LABEL_REQUIRED
+      type: TYPE_MESSAGE
+      type_name: ".docker.protobuf.plugin.WatchSelectors"
+      json_name: "watchSelectors"
+    }
+  }
+  message_type {
+    name: "TLSAuthorization"
+    field {
+      name: "roles"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "roles"
+    }
+    field {
+      name: "insecure"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "insecure"
+    }
+  }
+  extension {
+    name: "deepcopy"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 70000
+    label: LABEL_OPTIONAL
+    type: TYPE_BOOL
+    default_value: "true"
+    json_name: "deepcopy"
+  }
+  extension {
+    name: "store_object"
+    extendee: ".google.protobuf.MessageOptions"
+    number: 70001
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".docker.protobuf.plugin.StoreObject"
+    json_name: "storeObject"
+  }
+  extension {
+    name: "tls_authorization"
+    extendee: ".google.protobuf.MethodOptions"
+    number: 73626345
+    label: LABEL_OPTIONAL
+    type: TYPE_MESSAGE
+    type_name: ".docker.protobuf.plugin.TLSAuthorization"
+    json_name: "tlsAuthorization"
+  }
+}
+file {
+  name: "github.com/docker/swarmkit/api/ca.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "github.com/docker/swarmkit/api/specs.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "NodeCertificateStatusRequest"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+  }
+  message_type {
+    name: "NodeCertificateStatusResponse"
+    field {
+      name: "status"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IssuanceStatus"
+      json_name: "status"
+    }
+    field {
+      name: "certificate"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Certificate"
+      json_name: "certificate"
+    }
+  }
+  message_type {
+    name: "IssueNodeCertificateRequest"
+    field {
+      name: "role"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeRole"
+      options {
+        deprecated: true
+      }
+      json_name: "role"
+    }
+    field {
+      name: "csr"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      options {
+        65004: "CSR"
+      }
+      json_name: "csr"
+    }
+    field {
+      name: "token"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "token"
+    }
+    field {
+      name: "availability"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeSpec.Availability"
+      json_name: "availability"
+    }
+  }
+  message_type {
+    name: "IssueNodeCertificateResponse"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "node_membership"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeSpec.Membership"
+      json_name: "nodeMembership"
+    }
+  }
+  message_type {
+    name: "GetRootCACertificateRequest"
+  }
+  message_type {
+    name: "GetRootCACertificateResponse"
+    field {
+      name: "certificate"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "certificate"
+    }
+  }
+  message_type {
+    name: "GetUnlockKeyRequest"
+  }
+  message_type {
+    name: "GetUnlockKeyResponse"
+    field {
+      name: "unlock_key"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "unlockKey"
+    }
+    field {
+      name: "version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      options {
+        65001: 0
+      }
+      json_name: "version"
+    }
+  }
+  service {
+    name: "CA"
+    method {
+      name: "GetRootCACertificate"
+      input_type: ".docker.swarmkit.v1.GetRootCACertificateRequest"
+      output_type: ".docker.swarmkit.v1.GetRootCACertificateResponse"
+      options {
+        73626345 {
+          2: 1
+        }
+      }
+    }
+    method {
+      name: "GetUnlockKey"
+      input_type: ".docker.swarmkit.v1.GetUnlockKeyRequest"
+      output_type: ".docker.swarmkit.v1.GetUnlockKeyResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  service {
+    name: "NodeCA"
+    method {
+      name: "IssueNodeCertificate"
+      input_type: ".docker.swarmkit.v1.IssueNodeCertificateRequest"
+      output_type: ".docker.swarmkit.v1.IssueNodeCertificateResponse"
+      options {
+        73626345 {
+          2: 1
+        }
+      }
+    }
+    method {
+      name: "NodeCertificateStatus"
+      input_type: ".docker.swarmkit.v1.NodeCertificateStatusRequest"
+      output_type: ".docker.swarmkit.v1.NodeCertificateStatusResponse"
+      options {
+        73626345 {
+          2: 1
+        }
+      }
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/objects.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "github.com/docker/swarmkit/api/specs.proto"
+  dependency: "google/protobuf/timestamp.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "google/protobuf/any.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "Meta"
+    field {
+      name: "version"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      options {
+        65001: 0
+      }
+      json_name: "version"
+    }
+    field {
+      name: "created_at"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "createdAt"
+    }
+    field {
+      name: "updated_at"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "updatedAt"
+    }
+  }
+  message_type {
+    name: "Node"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "description"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeDescription"
+      json_name: "description"
+    }
+    field {
+      name: "status"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeStatus"
+      options {
+        65001: 0
+      }
+      json_name: "status"
+    }
+    field {
+      name: "manager_status"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ManagerStatus"
+      json_name: "managerStatus"
+    }
+    field {
+      name: "attachment"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachment"
+      json_name: "attachment"
+    }
+    field {
+      name: "certificate"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Certificate"
+      options {
+        65001: 0
+      }
+      json_name: "certificate"
+    }
+    field {
+      name: "role"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeRole"
+      json_name: "role"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+          11: 1
+          12: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Service"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ServiceSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "spec_version"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "specVersion"
+    }
+    field {
+      name: "previous_spec"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ServiceSpec"
+      json_name: "previousSpec"
+    }
+    field {
+      name: "previous_spec_version"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "previousSpecVersion"
+    }
+    field {
+      name: "endpoint"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Endpoint"
+      json_name: "endpoint"
+    }
+    field {
+      name: "update_status"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.UpdateStatus"
+      json_name: "updateStatus"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Endpoint"
+    field {
+      name: "spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EndpointSpec"
+      json_name: "spec"
+    }
+    field {
+      name: "ports"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.PortConfig"
+      json_name: "ports"
+    }
+    field {
+      name: "virtual_ips"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Endpoint.VirtualIP"
+      options {
+        65004: "VirtualIPs"
+      }
+      json_name: "virtualIps"
+    }
+    nested_type {
+      name: "VirtualIP"
+      field {
+        name: "network_id"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "networkId"
+      }
+      field {
+        name: "addr"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "addr"
+      }
+    }
+  }
+  message_type {
+    name: "Task"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.TaskSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "spec_version"
+      number: 14
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "specVersion"
+    }
+    field {
+      name: "service_id"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "serviceId"
+    }
+    field {
+      name: "slot"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "slot"
+    }
+    field {
+      name: "node_id"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "annotations"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "service_annotations"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "serviceAnnotations"
+    }
+    field {
+      name: "status"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.TaskStatus"
+      options {
+        65001: 0
+      }
+      json_name: "status"
+    }
+    field {
+      name: "desired_state"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.TaskState"
+      json_name: "desiredState"
+    }
+    field {
+      name: "networks"
+      number: 11
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachment"
+      json_name: "networks"
+    }
+    field {
+      name: "endpoint"
+      number: 12
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Endpoint"
+      json_name: "endpoint"
+    }
+    field {
+      name: "log_driver"
+      number: 13
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "logDriver"
+    }
+    field {
+      name: "assigned_generic_resources"
+      number: 15
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.GenericResource"
+      json_name: "assignedGenericResources"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+          7: 1
+          8: 1
+          9: 1
+          10: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "NetworkAttachment"
+    field {
+      name: "network"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      json_name: "network"
+    }
+    field {
+      name: "addresses"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "addresses"
+    }
+    field {
+      name: "aliases"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "aliases"
+    }
+    field {
+      name: "driver_attachment_opts"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachment.DriverAttachmentOptsEntry"
+      json_name: "driverAttachmentOpts"
+    }
+    nested_type {
+      name: "DriverAttachmentOptsEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+  }
+  message_type {
+    name: "Network"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "driver_state"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Driver"
+      json_name: "driverState"
+    }
+    field {
+      name: "ipam"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.IPAMOptions"
+      options {
+        65004: "IPAM"
+      }
+      json_name: "ipam"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Cluster"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ClusterSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "root_ca"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RootCA"
+      options {
+        65001: 0
+        65004: "RootCA"
+      }
+      json_name: "rootCa"
+    }
+    field {
+      name: "network_bootstrap_keys"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EncryptionKey"
+      json_name: "networkBootstrapKeys"
+    }
+    field {
+      name: "encryption_key_lamport_clock"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "encryptionKeyLamportClock"
+    }
+    field {
+      name: "blacklisted_certificates"
+      number: 8
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster.BlacklistedCertificatesEntry"
+      json_name: "blacklistedCertificates"
+    }
+    field {
+      name: "unlock_keys"
+      number: 9
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EncryptionKey"
+      json_name: "unlockKeys"
+    }
+    nested_type {
+      name: "BlacklistedCertificatesEntry"
+      field {
+        name: "key"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "key"
+      }
+      field {
+        name: "value"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.BlacklistedCertificate"
+        json_name: "value"
+      }
+      options {
+        map_entry: true
+      }
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Secret"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SecretSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    field {
+      name: "internal"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "internal"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Config"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ConfigSpec"
+      options {
+        65001: 0
+      }
+      json_name: "spec"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Resource"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ID"
+      }
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "annotations"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "kind"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "kind"
+    }
+    field {
+      name: "payload"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Any"
+      json_name: "payload"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+          13: 1
+        }
+      }
+    }
+  }
+  message_type {
+    name: "Extension"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ID"
+      }
+      json_name: "id"
+    }
+    field {
+      name: "meta"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Meta"
+      options {
+        65001: 0
+      }
+      json_name: "meta"
+    }
+    field {
+      name: "annotations"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Annotations"
+      options {
+        65001: 0
+      }
+      json_name: "annotations"
+    }
+    field {
+      name: "description"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "description"
+    }
+    options {
+      70001 {
+        1 {
+          1: 1
+          2: 1
+          3: 1
+          4: 1
+          5: 1
+          6: 1
+        }
+      }
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/control.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/specs.proto"
+  dependency: "github.com/docker/swarmkit/api/objects.proto"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "GetNodeRequest"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+  }
+  message_type {
+    name: "GetNodeResponse"
+    field {
+      name: "node"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      json_name: "node"
+    }
+  }
+  message_type {
+    name: "ListNodesRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListNodesRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListNodesRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "memberships"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.NodeSpec.Membership"
+        options {
+          packed: false
+        }
+        json_name: "memberships"
+      }
+      field {
+        name: "roles"
+        number: 5
+        label: LABEL_REPEATED
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.NodeRole"
+        options {
+          packed: false
+        }
+        json_name: "roles"
+      }
+      field {
+        name: "name_prefixes"
+        number: 6
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListNodesResponse"
+    field {
+      name: "nodes"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      json_name: "nodes"
+    }
+  }
+  message_type {
+    name: "UpdateNodeRequest"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "node_version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "nodeVersion"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "UpdateNodeResponse"
+    field {
+      name: "node"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      json_name: "node"
+    }
+  }
+  message_type {
+    name: "RemoveNodeRequest"
+    field {
+      name: "node_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "force"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "force"
+    }
+  }
+  message_type {
+    name: "RemoveNodeResponse"
+  }
+  message_type {
+    name: "GetTaskRequest"
+    field {
+      name: "task_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "taskId"
+    }
+  }
+  message_type {
+    name: "GetTaskResponse"
+    field {
+      name: "task"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      json_name: "task"
+    }
+  }
+  message_type {
+    name: "RemoveTaskRequest"
+    field {
+      name: "task_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "taskId"
+    }
+  }
+  message_type {
+    name: "RemoveTaskResponse"
+  }
+  message_type {
+    name: "ListTasksRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListTasksRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListTasksRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "service_ids"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "serviceIds"
+      }
+      field {
+        name: "node_ids"
+        number: 5
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "nodeIds"
+      }
+      field {
+        name: "desired_states"
+        number: 6
+        label: LABEL_REPEATED
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.TaskState"
+        options {
+          packed: false
+        }
+        json_name: "desiredStates"
+      }
+      field {
+        name: "name_prefixes"
+        number: 7
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      field {
+        name: "runtimes"
+        number: 9
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "runtimes"
+      }
+      field {
+        name: "up_to_date"
+        number: 8
+        label: LABEL_OPTIONAL
+        type: TYPE_BOOL
+        json_name: "upToDate"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListTasksResponse"
+    field {
+      name: "tasks"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      json_name: "tasks"
+    }
+  }
+  message_type {
+    name: "CreateServiceRequest"
+    field {
+      name: "spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ServiceSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "CreateServiceResponse"
+    field {
+      name: "service"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      json_name: "service"
+    }
+  }
+  message_type {
+    name: "GetServiceRequest"
+    field {
+      name: "service_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "serviceId"
+    }
+    field {
+      name: "insert_defaults"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "insertDefaults"
+    }
+  }
+  message_type {
+    name: "GetServiceResponse"
+    field {
+      name: "service"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      json_name: "service"
+    }
+  }
+  message_type {
+    name: "UpdateServiceRequest"
+    field {
+      name: "service_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "serviceId"
+    }
+    field {
+      name: "service_version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "serviceVersion"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ServiceSpec"
+      json_name: "spec"
+    }
+    field {
+      name: "rollback"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.UpdateServiceRequest.Rollback"
+      json_name: "rollback"
+    }
+    enum_type {
+      name: "Rollback"
+      value {
+        name: "NONE"
+        number: 0
+      }
+      value {
+        name: "PREVIOUS"
+        number: 1
+      }
+    }
+  }
+  message_type {
+    name: "UpdateServiceResponse"
+    field {
+      name: "service"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      json_name: "service"
+    }
+  }
+  message_type {
+    name: "RemoveServiceRequest"
+    field {
+      name: "service_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "serviceId"
+    }
+  }
+  message_type {
+    name: "RemoveServiceResponse"
+  }
+  message_type {
+    name: "ListServicesRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListServicesRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListServicesRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "name_prefixes"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      field {
+        name: "runtimes"
+        number: 5
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "runtimes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListServicesResponse"
+    field {
+      name: "services"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      json_name: "services"
+    }
+  }
+  message_type {
+    name: "CreateNetworkRequest"
+    field {
+      name: "spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "CreateNetworkResponse"
+    field {
+      name: "network"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      json_name: "network"
+    }
+  }
+  message_type {
+    name: "GetNetworkRequest"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "network_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "networkId"
+    }
+  }
+  message_type {
+    name: "GetNetworkResponse"
+    field {
+      name: "network"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      json_name: "network"
+    }
+  }
+  message_type {
+    name: "RemoveNetworkRequest"
+    field {
+      name: "name"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "name"
+    }
+    field {
+      name: "network_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "networkId"
+    }
+  }
+  message_type {
+    name: "RemoveNetworkResponse"
+  }
+  message_type {
+    name: "ListNetworksRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListNetworksRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListNetworksRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "name_prefixes"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListNetworksResponse"
+    field {
+      name: "networks"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      json_name: "networks"
+    }
+  }
+  message_type {
+    name: "GetClusterRequest"
+    field {
+      name: "cluster_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "clusterId"
+    }
+  }
+  message_type {
+    name: "GetClusterResponse"
+    field {
+      name: "cluster"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      json_name: "cluster"
+    }
+  }
+  message_type {
+    name: "ListClustersRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListClustersRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListClustersRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "name_prefixes"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListClustersResponse"
+    field {
+      name: "clusters"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      json_name: "clusters"
+    }
+  }
+  message_type {
+    name: "KeyRotation"
+    field {
+      name: "worker_join_token"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "workerJoinToken"
+    }
+    field {
+      name: "manager_join_token"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "managerJoinToken"
+    }
+    field {
+      name: "manager_unlock_key"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "managerUnlockKey"
+    }
+  }
+  message_type {
+    name: "UpdateClusterRequest"
+    field {
+      name: "cluster_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "clusterId"
+    }
+    field {
+      name: "cluster_version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "clusterVersion"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ClusterSpec"
+      json_name: "spec"
+    }
+    field {
+      name: "rotation"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.KeyRotation"
+      options {
+        65001: 0
+      }
+      json_name: "rotation"
+    }
+  }
+  message_type {
+    name: "UpdateClusterResponse"
+    field {
+      name: "cluster"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      json_name: "cluster"
+    }
+  }
+  message_type {
+    name: "GetSecretRequest"
+    field {
+      name: "secret_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "secretId"
+    }
+  }
+  message_type {
+    name: "GetSecretResponse"
+    field {
+      name: "secret"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      json_name: "secret"
+    }
+  }
+  message_type {
+    name: "UpdateSecretRequest"
+    field {
+      name: "secret_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "secretId"
+    }
+    field {
+      name: "secret_version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "secretVersion"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SecretSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "UpdateSecretResponse"
+    field {
+      name: "secret"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      json_name: "secret"
+    }
+  }
+  message_type {
+    name: "ListSecretsRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListSecretsRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListSecretsRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "name_prefixes"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListSecretsResponse"
+    field {
+      name: "secrets"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      json_name: "secrets"
+    }
+  }
+  message_type {
+    name: "CreateSecretRequest"
+    field {
+      name: "spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SecretSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "CreateSecretResponse"
+    field {
+      name: "secret"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      json_name: "secret"
+    }
+  }
+  message_type {
+    name: "RemoveSecretRequest"
+    field {
+      name: "secret_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "secretId"
+    }
+  }
+  message_type {
+    name: "RemoveSecretResponse"
+  }
+  message_type {
+    name: "GetConfigRequest"
+    field {
+      name: "config_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "configId"
+    }
+  }
+  message_type {
+    name: "GetConfigResponse"
+    field {
+      name: "config"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      json_name: "config"
+    }
+  }
+  message_type {
+    name: "UpdateConfigRequest"
+    field {
+      name: "config_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "configId"
+    }
+    field {
+      name: "config_version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "configVersion"
+    }
+    field {
+      name: "spec"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ConfigSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "UpdateConfigResponse"
+    field {
+      name: "config"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      json_name: "config"
+    }
+  }
+  message_type {
+    name: "ListConfigsRequest"
+    field {
+      name: "filters"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ListConfigsRequest.Filters"
+      json_name: "filters"
+    }
+    nested_type {
+      name: "Filters"
+      field {
+        name: "names"
+        number: 1
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "names"
+      }
+      field {
+        name: "id_prefixes"
+        number: 2
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "idPrefixes"
+      }
+      field {
+        name: "labels"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.ListConfigsRequest.Filters.LabelsEntry"
+        json_name: "labels"
+      }
+      field {
+        name: "name_prefixes"
+        number: 4
+        label: LABEL_REPEATED
+        type: TYPE_STRING
+        json_name: "namePrefixes"
+      }
+      nested_type {
+        name: "LabelsEntry"
+        field {
+          name: "key"
+          number: 1
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "key"
+        }
+        field {
+          name: "value"
+          number: 2
+          label: LABEL_OPTIONAL
+          type: TYPE_STRING
+          json_name: "value"
+        }
+        options {
+          map_entry: true
+        }
+      }
+    }
+  }
+  message_type {
+    name: "ListConfigsResponse"
+    field {
+      name: "configs"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      json_name: "configs"
+    }
+  }
+  message_type {
+    name: "CreateConfigRequest"
+    field {
+      name: "spec"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ConfigSpec"
+      json_name: "spec"
+    }
+  }
+  message_type {
+    name: "CreateConfigResponse"
+    field {
+      name: "config"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      json_name: "config"
+    }
+  }
+  message_type {
+    name: "RemoveConfigRequest"
+    field {
+      name: "config_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "configId"
+    }
+  }
+  message_type {
+    name: "RemoveConfigResponse"
+  }
+  service {
+    name: "Control"
+    method {
+      name: "GetNode"
+      input_type: ".docker.swarmkit.v1.GetNodeRequest"
+      output_type: ".docker.swarmkit.v1.GetNodeResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListNodes"
+      input_type: ".docker.swarmkit.v1.ListNodesRequest"
+      output_type: ".docker.swarmkit.v1.ListNodesResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateNode"
+      input_type: ".docker.swarmkit.v1.UpdateNodeRequest"
+      output_type: ".docker.swarmkit.v1.UpdateNodeResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveNode"
+      input_type: ".docker.swarmkit.v1.RemoveNodeRequest"
+      output_type: ".docker.swarmkit.v1.RemoveNodeResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetTask"
+      input_type: ".docker.swarmkit.v1.GetTaskRequest"
+      output_type: ".docker.swarmkit.v1.GetTaskResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListTasks"
+      input_type: ".docker.swarmkit.v1.ListTasksRequest"
+      output_type: ".docker.swarmkit.v1.ListTasksResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveTask"
+      input_type: ".docker.swarmkit.v1.RemoveTaskRequest"
+      output_type: ".docker.swarmkit.v1.RemoveTaskResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetService"
+      input_type: ".docker.swarmkit.v1.GetServiceRequest"
+      output_type: ".docker.swarmkit.v1.GetServiceResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListServices"
+      input_type: ".docker.swarmkit.v1.ListServicesRequest"
+      output_type: ".docker.swarmkit.v1.ListServicesResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "CreateService"
+      input_type: ".docker.swarmkit.v1.CreateServiceRequest"
+      output_type: ".docker.swarmkit.v1.CreateServiceResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateService"
+      input_type: ".docker.swarmkit.v1.UpdateServiceRequest"
+      output_type: ".docker.swarmkit.v1.UpdateServiceResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveService"
+      input_type: ".docker.swarmkit.v1.RemoveServiceRequest"
+      output_type: ".docker.swarmkit.v1.RemoveServiceResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetNetwork"
+      input_type: ".docker.swarmkit.v1.GetNetworkRequest"
+      output_type: ".docker.swarmkit.v1.GetNetworkResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListNetworks"
+      input_type: ".docker.swarmkit.v1.ListNetworksRequest"
+      output_type: ".docker.swarmkit.v1.ListNetworksResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "CreateNetwork"
+      input_type: ".docker.swarmkit.v1.CreateNetworkRequest"
+      output_type: ".docker.swarmkit.v1.CreateNetworkResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveNetwork"
+      input_type: ".docker.swarmkit.v1.RemoveNetworkRequest"
+      output_type: ".docker.swarmkit.v1.RemoveNetworkResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetCluster"
+      input_type: ".docker.swarmkit.v1.GetClusterRequest"
+      output_type: ".docker.swarmkit.v1.GetClusterResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListClusters"
+      input_type: ".docker.swarmkit.v1.ListClustersRequest"
+      output_type: ".docker.swarmkit.v1.ListClustersResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateCluster"
+      input_type: ".docker.swarmkit.v1.UpdateClusterRequest"
+      output_type: ".docker.swarmkit.v1.UpdateClusterResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetSecret"
+      input_type: ".docker.swarmkit.v1.GetSecretRequest"
+      output_type: ".docker.swarmkit.v1.GetSecretResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateSecret"
+      input_type: ".docker.swarmkit.v1.UpdateSecretRequest"
+      output_type: ".docker.swarmkit.v1.UpdateSecretResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListSecrets"
+      input_type: ".docker.swarmkit.v1.ListSecretsRequest"
+      output_type: ".docker.swarmkit.v1.ListSecretsResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "CreateSecret"
+      input_type: ".docker.swarmkit.v1.CreateSecretRequest"
+      output_type: ".docker.swarmkit.v1.CreateSecretResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveSecret"
+      input_type: ".docker.swarmkit.v1.RemoveSecretRequest"
+      output_type: ".docker.swarmkit.v1.RemoveSecretResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "GetConfig"
+      input_type: ".docker.swarmkit.v1.GetConfigRequest"
+      output_type: ".docker.swarmkit.v1.GetConfigResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateConfig"
+      input_type: ".docker.swarmkit.v1.UpdateConfigRequest"
+      output_type: ".docker.swarmkit.v1.UpdateConfigResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ListConfigs"
+      input_type: ".docker.swarmkit.v1.ListConfigsRequest"
+      output_type: ".docker.swarmkit.v1.ListConfigsResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "CreateConfig"
+      input_type: ".docker.swarmkit.v1.CreateConfigRequest"
+      output_type: ".docker.swarmkit.v1.CreateConfigResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "RemoveConfig"
+      input_type: ".docker.swarmkit.v1.RemoveConfigRequest"
+      output_type: ".docker.swarmkit.v1.RemoveConfigResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/dispatcher.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "github.com/docker/swarmkit/api/objects.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  dependency: "google/protobuf/duration.proto"
+  message_type {
+    name: "SessionRequest"
+    field {
+      name: "description"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NodeDescription"
+      json_name: "description"
+    }
+    field {
+      name: "session_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+  }
+  message_type {
+    name: "SessionMessage"
+    field {
+      name: "session_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+    field {
+      name: "node"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      json_name: "node"
+    }
+    field {
+      name: "managers"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.WeightedPeer"
+      json_name: "managers"
+    }
+    field {
+      name: "network_bootstrap_keys"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.EncryptionKey"
+      json_name: "networkBootstrapKeys"
+    }
+    field {
+      name: "RootCA"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "RootCA"
+    }
+  }
+  message_type {
+    name: "HeartbeatRequest"
+    field {
+      name: "session_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+  }
+  message_type {
+    name: "HeartbeatResponse"
+    field {
+      name: "period"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Duration"
+      options {
+        65011: 1
+        65001: 0
+      }
+      json_name: "period"
+    }
+  }
+  message_type {
+    name: "UpdateTaskStatusRequest"
+    field {
+      name: "session_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+    field {
+      name: "updates"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.UpdateTaskStatusRequest.TaskStatusUpdate"
+      json_name: "updates"
+    }
+    nested_type {
+      name: "TaskStatusUpdate"
+      field {
+        name: "task_id"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "taskId"
+      }
+      field {
+        name: "status"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.TaskStatus"
+        json_name: "status"
+      }
+    }
+  }
+  message_type {
+    name: "UpdateTaskStatusResponse"
+  }
+  message_type {
+    name: "TasksRequest"
+    field {
+      name: "session_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+  }
+  message_type {
+    name: "TasksMessage"
+    field {
+      name: "tasks"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      json_name: "tasks"
+    }
+  }
+  message_type {
+    name: "AssignmentsRequest"
+    field {
+      name: "session_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "sessionId"
+    }
+  }
+  message_type {
+    name: "Assignment"
+    field {
+      name: "task"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      oneof_index: 0
+      json_name: "task"
+    }
+    field {
+      name: "secret"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      oneof_index: 0
+      json_name: "secret"
+    }
+    field {
+      name: "config"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      oneof_index: 0
+      json_name: "config"
+    }
+    oneof_decl {
+      name: "item"
+    }
+  }
+  message_type {
+    name: "AssignmentChange"
+    field {
+      name: "assignment"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Assignment"
+      json_name: "assignment"
+    }
+    field {
+      name: "action"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.AssignmentChange.AssignmentAction"
+      json_name: "action"
+    }
+    enum_type {
+      name: "AssignmentAction"
+      value {
+        name: "UPDATE"
+        number: 0
+        options {
+          66001: "AssignmentActionUpdate"
+        }
+      }
+      value {
+        name: "REMOVE"
+        number: 1
+        options {
+          66001: "AssignmentActionRemove"
+        }
+      }
+    }
+  }
+  message_type {
+    name: "AssignmentsMessage"
+    field {
+      name: "type"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.AssignmentsMessage.Type"
+      json_name: "type"
+    }
+    field {
+      name: "applies_to"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "appliesTo"
+    }
+    field {
+      name: "results_in"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "resultsIn"
+    }
+    field {
+      name: "changes"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.AssignmentChange"
+      json_name: "changes"
+    }
+    enum_type {
+      name: "Type"
+      value {
+        name: "COMPLETE"
+        number: 0
+      }
+      value {
+        name: "INCREMENTAL"
+        number: 1
+      }
+    }
+  }
+  service {
+    name: "Dispatcher"
+    method {
+      name: "Session"
+      input_type: ".docker.swarmkit.v1.SessionRequest"
+      output_type: ".docker.swarmkit.v1.SessionMessage"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+    method {
+      name: "Heartbeat"
+      input_type: ".docker.swarmkit.v1.HeartbeatRequest"
+      output_type: ".docker.swarmkit.v1.HeartbeatResponse"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "UpdateTaskStatus"
+      input_type: ".docker.swarmkit.v1.UpdateTaskStatusRequest"
+      output_type: ".docker.swarmkit.v1.UpdateTaskStatusResponse"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "Tasks"
+      input_type: ".docker.swarmkit.v1.TasksRequest"
+      output_type: ".docker.swarmkit.v1.TasksMessage"
+      options {
+        deprecated: true
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+    method {
+      name: "Assignments"
+      input_type: ".docker.swarmkit.v1.AssignmentsRequest"
+      output_type: ".docker.swarmkit.v1.AssignmentsMessage"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/health.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "HealthCheckRequest"
+    field {
+      name: "service"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "service"
+    }
+  }
+  message_type {
+    name: "HealthCheckResponse"
+    field {
+      name: "status"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.HealthCheckResponse.ServingStatus"
+      json_name: "status"
+    }
+    enum_type {
+      name: "ServingStatus"
+      value {
+        name: "UNKNOWN"
+        number: 0
+      }
+      value {
+        name: "SERVING"
+        number: 1
+      }
+      value {
+        name: "NOT_SERVING"
+        number: 2
+      }
+    }
+  }
+  service {
+    name: "Health"
+    method {
+      name: "Check"
+      input_type: ".docker.swarmkit.v1.HealthCheckRequest"
+      output_type: ".docker.swarmkit.v1.HealthCheckResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/logbroker.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "google/protobuf/timestamp.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "LogSubscriptionOptions"
+    field {
+      name: "streams"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.LogStream"
+      options {
+        packed: false
+      }
+      json_name: "streams"
+    }
+    field {
+      name: "follow"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "follow"
+    }
+    field {
+      name: "tail"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "tail"
+    }
+    field {
+      name: "since"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "since"
+    }
+  }
+  message_type {
+    name: "LogSelector"
+    field {
+      name: "service_ids"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "serviceIds"
+    }
+    field {
+      name: "node_ids"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "nodeIds"
+    }
+    field {
+      name: "task_ids"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "taskIds"
+    }
+  }
+  message_type {
+    name: "LogContext"
+    field {
+      name: "service_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "serviceId"
+    }
+    field {
+      name: "node_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "task_id"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "taskId"
+    }
+  }
+  message_type {
+    name: "LogAttr"
+    field {
+      name: "key"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "key"
+    }
+    field {
+      name: "value"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "value"
+    }
+  }
+  message_type {
+    name: "LogMessage"
+    field {
+      name: "context"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogContext"
+      options {
+        65001: 0
+      }
+      json_name: "context"
+    }
+    field {
+      name: "timestamp"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "timestamp"
+    }
+    field {
+      name: "stream"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.LogStream"
+      json_name: "stream"
+    }
+    field {
+      name: "data"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "data"
+    }
+    field {
+      name: "attrs"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogAttr"
+      options {
+        65001: 0
+      }
+      json_name: "attrs"
+    }
+  }
+  message_type {
+    name: "SubscribeLogsRequest"
+    field {
+      name: "selector"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogSelector"
+      json_name: "selector"
+    }
+    field {
+      name: "options"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogSubscriptionOptions"
+      json_name: "options"
+    }
+  }
+  message_type {
+    name: "SubscribeLogsMessage"
+    field {
+      name: "messages"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogMessage"
+      options {
+        65001: 0
+      }
+      json_name: "messages"
+    }
+  }
+  message_type {
+    name: "ListenSubscriptionsRequest"
+  }
+  message_type {
+    name: "SubscriptionMessage"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "id"
+    }
+    field {
+      name: "selector"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogSelector"
+      json_name: "selector"
+    }
+    field {
+      name: "options"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogSubscriptionOptions"
+      json_name: "options"
+    }
+    field {
+      name: "close"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "close"
+    }
+  }
+  message_type {
+    name: "PublishLogsMessage"
+    field {
+      name: "subscription_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "subscriptionId"
+    }
+    field {
+      name: "messages"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.LogMessage"
+      options {
+        65001: 0
+      }
+      json_name: "messages"
+    }
+    field {
+      name: "close"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "close"
+    }
+  }
+  message_type {
+    name: "PublishLogsResponse"
+  }
+  enum_type {
+    name: "LogStream"
+    value {
+      name: "LOG_STREAM_UNKNOWN"
+      number: 0
+      options {
+        66001: "LogStreamUnknown"
+      }
+    }
+    value {
+      name: "LOG_STREAM_STDOUT"
+      number: 1
+      options {
+        66001: "LogStreamStdout"
+      }
+    }
+    value {
+      name: "LOG_STREAM_STDERR"
+      number: 2
+      options {
+        66001: "LogStreamStderr"
+      }
+    }
+    options {
+      62001: 0
+      62023: "LogStream"
+    }
+  }
+  service {
+    name: "Logs"
+    method {
+      name: "SubscribeLogs"
+      input_type: ".docker.swarmkit.v1.SubscribeLogsRequest"
+      output_type: ".docker.swarmkit.v1.SubscribeLogsMessage"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+  }
+  service {
+    name: "LogBroker"
+    method {
+      name: "ListenSubscriptions"
+      input_type: ".docker.swarmkit.v1.ListenSubscriptionsRequest"
+      output_type: ".docker.swarmkit.v1.SubscriptionMessage"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+    method {
+      name: "PublishLogs"
+      input_type: ".docker.swarmkit.v1.PublishLogsMessage"
+      output_type: ".docker.swarmkit.v1.PublishLogsResponse"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+      client_streaming: true
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/coreos/etcd/raft/raftpb/raft.proto"
+  package: "raftpb"
+  dependency: "gogoproto/gogo.proto"
+  message_type {
+    name: "Entry"
+    field {
+      name: "Term"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "Term"
+    }
+    field {
+      name: "Index"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "Index"
+    }
+    field {
+      name: "Type"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".raftpb.EntryType"
+      options {
+        65001: 0
+      }
+      json_name: "Type"
+    }
+    field {
+      name: "Data"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "Data"
+    }
+  }
+  message_type {
+    name: "SnapshotMetadata"
+    field {
+      name: "conf_state"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".raftpb.ConfState"
+      options {
+        65001: 0
+      }
+      json_name: "confState"
+    }
+    field {
+      name: "index"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "index"
+    }
+    field {
+      name: "term"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "term"
+    }
+  }
+  message_type {
+    name: "Snapshot"
+    field {
+      name: "data"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "data"
+    }
+    field {
+      name: "metadata"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".raftpb.SnapshotMetadata"
+      options {
+        65001: 0
+      }
+      json_name: "metadata"
+    }
+  }
+  message_type {
+    name: "Message"
+    field {
+      name: "type"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".raftpb.MessageType"
+      options {
+        65001: 0
+      }
+      json_name: "type"
+    }
+    field {
+      name: "to"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "to"
+    }
+    field {
+      name: "from"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "from"
+    }
+    field {
+      name: "term"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "term"
+    }
+    field {
+      name: "logTerm"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "logTerm"
+    }
+    field {
+      name: "index"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "index"
+    }
+    field {
+      name: "entries"
+      number: 7
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".raftpb.Entry"
+      options {
+        65001: 0
+      }
+      json_name: "entries"
+    }
+    field {
+      name: "commit"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "commit"
+    }
+    field {
+      name: "snapshot"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".raftpb.Snapshot"
+      options {
+        65001: 0
+      }
+      json_name: "snapshot"
+    }
+    field {
+      name: "reject"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      options {
+        65001: 0
+      }
+      json_name: "reject"
+    }
+    field {
+      name: "rejectHint"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "rejectHint"
+    }
+    field {
+      name: "context"
+      number: 12
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "context"
+    }
+  }
+  message_type {
+    name: "HardState"
+    field {
+      name: "term"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "term"
+    }
+    field {
+      name: "vote"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "vote"
+    }
+    field {
+      name: "commit"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "commit"
+    }
+  }
+  message_type {
+    name: "ConfState"
+    field {
+      name: "nodes"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_UINT64
+      json_name: "nodes"
+    }
+  }
+  message_type {
+    name: "ConfChange"
+    field {
+      name: "ID"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "ID"
+    }
+    field {
+      name: "Type"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".raftpb.ConfChangeType"
+      options {
+        65001: 0
+      }
+      json_name: "Type"
+    }
+    field {
+      name: "NodeID"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      options {
+        65001: 0
+      }
+      json_name: "NodeID"
+    }
+    field {
+      name: "Context"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "Context"
+    }
+  }
+  enum_type {
+    name: "EntryType"
+    value {
+      name: "EntryNormal"
+      number: 0
+    }
+    value {
+      name: "EntryConfChange"
+      number: 1
+    }
+  }
+  enum_type {
+    name: "MessageType"
+    value {
+      name: "MsgHup"
+      number: 0
+    }
+    value {
+      name: "MsgBeat"
+      number: 1
+    }
+    value {
+      name: "MsgProp"
+      number: 2
+    }
+    value {
+      name: "MsgApp"
+      number: 3
+    }
+    value {
+      name: "MsgAppResp"
+      number: 4
+    }
+    value {
+      name: "MsgVote"
+      number: 5
+    }
+    value {
+      name: "MsgVoteResp"
+      number: 6
+    }
+    value {
+      name: "MsgSnap"
+      number: 7
+    }
+    value {
+      name: "MsgHeartbeat"
+      number: 8
+    }
+    value {
+      name: "MsgHeartbeatResp"
+      number: 9
+    }
+    value {
+      name: "MsgUnreachable"
+      number: 10
+    }
+    value {
+      name: "MsgSnapStatus"
+      number: 11
+    }
+    value {
+      name: "MsgCheckQuorum"
+      number: 12
+    }
+    value {
+      name: "MsgTransferLeader"
+      number: 13
+    }
+    value {
+      name: "MsgTimeoutNow"
+      number: 14
+    }
+    value {
+      name: "MsgReadIndex"
+      number: 15
+    }
+    value {
+      name: "MsgReadIndexResp"
+      number: 16
+    }
+    value {
+      name: "MsgPreVote"
+      number: 17
+    }
+    value {
+      name: "MsgPreVoteResp"
+      number: 18
+    }
+  }
+  enum_type {
+    name: "ConfChangeType"
+    value {
+      name: "ConfChangeAddNode"
+      number: 0
+    }
+    value {
+      name: "ConfChangeRemoveNode"
+      number: 1
+    }
+    value {
+      name: "ConfChangeUpdateNode"
+      number: 2
+    }
+  }
+  options {
+    63017: 1
+    63020: 1
+    63018: 1
+    63001: 0
+    63002: 0
+  }
+}
+file {
+  name: "github.com/docker/swarmkit/api/raft.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/objects.proto"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "github.com/coreos/etcd/raft/raftpb/raft.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "RaftMember"
+    field {
+      name: "raft_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "raftId"
+    }
+    field {
+      name: "node_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "nodeId"
+    }
+    field {
+      name: "addr"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+    field {
+      name: "status"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RaftMemberStatus"
+      options {
+        65001: 0
+      }
+      json_name: "status"
+    }
+  }
+  message_type {
+    name: "JoinRequest"
+    field {
+      name: "addr"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+  }
+  message_type {
+    name: "JoinResponse"
+    field {
+      name: "raft_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "raftId"
+    }
+    field {
+      name: "members"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RaftMember"
+      json_name: "members"
+    }
+    field {
+      name: "removed_members"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_UINT64
+      options {
+        packed: false
+      }
+      json_name: "removedMembers"
+    }
+  }
+  message_type {
+    name: "LeaveRequest"
+    field {
+      name: "node"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RaftMember"
+      json_name: "node"
+    }
+  }
+  message_type {
+    name: "LeaveResponse"
+  }
+  message_type {
+    name: "ProcessRaftMessageRequest"
+    field {
+      name: "message"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".raftpb.Message"
+      json_name: "message"
+    }
+    options {
+      70000: 0
+    }
+  }
+  message_type {
+    name: "ProcessRaftMessageResponse"
+  }
+  message_type {
+    name: "ResolveAddressRequest"
+    field {
+      name: "raft_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "raftId"
+    }
+  }
+  message_type {
+    name: "ResolveAddressResponse"
+    field {
+      name: "addr"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "addr"
+    }
+  }
+  message_type {
+    name: "InternalRaftRequest"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "id"
+    }
+    field {
+      name: "action"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.StoreAction"
+      options {
+        65001: 0
+      }
+      json_name: "action"
+    }
+  }
+  message_type {
+    name: "StoreAction"
+    field {
+      name: "action"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.StoreActionKind"
+      json_name: "action"
+    }
+    field {
+      name: "node"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      oneof_index: 0
+      json_name: "node"
+    }
+    field {
+      name: "service"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      oneof_index: 0
+      json_name: "service"
+    }
+    field {
+      name: "task"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      oneof_index: 0
+      json_name: "task"
+    }
+    field {
+      name: "network"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      oneof_index: 0
+      json_name: "network"
+    }
+    field {
+      name: "cluster"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      oneof_index: 0
+      json_name: "cluster"
+    }
+    field {
+      name: "secret"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      oneof_index: 0
+      json_name: "secret"
+    }
+    field {
+      name: "resource"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resource"
+      oneof_index: 0
+      json_name: "resource"
+    }
+    field {
+      name: "extension"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Extension"
+      oneof_index: 0
+      json_name: "extension"
+    }
+    field {
+      name: "config"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      oneof_index: 0
+      json_name: "config"
+    }
+    oneof_decl {
+      name: "target"
+    }
+  }
+  enum_type {
+    name: "StoreActionKind"
+    value {
+      name: "UNKNOWN"
+      number: 0
+      options {
+        66001: "StoreActionKindUnknown"
+      }
+    }
+    value {
+      name: "STORE_ACTION_CREATE"
+      number: 1
+      options {
+        66001: "StoreActionKindCreate"
+      }
+    }
+    value {
+      name: "STORE_ACTION_UPDATE"
+      number: 2
+      options {
+        66001: "StoreActionKindUpdate"
+      }
+    }
+    value {
+      name: "STORE_ACTION_REMOVE"
+      number: 3
+      options {
+        66001: "StoreActionKindRemove"
+      }
+    }
+    options {
+      62001: 0
+      62023: "StoreActionKind"
+    }
+  }
+  service {
+    name: "Raft"
+    method {
+      name: "ProcessRaftMessage"
+      input_type: ".docker.swarmkit.v1.ProcessRaftMessageRequest"
+      output_type: ".docker.swarmkit.v1.ProcessRaftMessageResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "ResolveAddress"
+      input_type: ".docker.swarmkit.v1.ResolveAddressRequest"
+      output_type: ".docker.swarmkit.v1.ResolveAddressResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  service {
+    name: "RaftMembership"
+    method {
+      name: "Join"
+      input_type: ".docker.swarmkit.v1.JoinRequest"
+      output_type: ".docker.swarmkit.v1.JoinResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "Leave"
+      input_type: ".docker.swarmkit.v1.LeaveRequest"
+      output_type: ".docker.swarmkit.v1.LeaveResponse"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  weak_dependency: 3
+  weak_dependency: 4
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/resource.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "AttachNetworkRequest"
+    field {
+      name: "config"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.NetworkAttachmentConfig"
+      json_name: "config"
+    }
+    field {
+      name: "container_id"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "containerId"
+    }
+  }
+  message_type {
+    name: "AttachNetworkResponse"
+    field {
+      name: "attachment_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "attachmentId"
+    }
+  }
+  message_type {
+    name: "DetachNetworkRequest"
+    field {
+      name: "attachment_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "attachmentId"
+    }
+  }
+  message_type {
+    name: "DetachNetworkResponse"
+  }
+  service {
+    name: "ResourceAllocator"
+    method {
+      name: "AttachNetwork"
+      input_type: ".docker.swarmkit.v1.AttachNetworkRequest"
+      output_type: ".docker.swarmkit.v1.AttachNetworkResponse"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+    }
+    method {
+      name: "DetachNetwork"
+      input_type: ".docker.swarmkit.v1.DetachNetworkRequest"
+      output_type: ".docker.swarmkit.v1.DetachNetworkResponse"
+      options {
+        73626345 {
+          1: "swarm-worker"
+          1: "swarm-manager"
+        }
+      }
+    }
+  }
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/snapshot.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/objects.proto"
+  dependency: "github.com/docker/swarmkit/api/raft.proto"
+  dependency: "gogoproto/gogo.proto"
+  message_type {
+    name: "StoreSnapshot"
+    field {
+      name: "nodes"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      json_name: "nodes"
+    }
+    field {
+      name: "services"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      json_name: "services"
+    }
+    field {
+      name: "networks"
+      number: 3
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      json_name: "networks"
+    }
+    field {
+      name: "tasks"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      json_name: "tasks"
+    }
+    field {
+      name: "clusters"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      json_name: "clusters"
+    }
+    field {
+      name: "secrets"
+      number: 6
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      json_name: "secrets"
+    }
+    field {
+      name: "resources"
+      number: 7
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resource"
+      json_name: "resources"
+    }
+    field {
+      name: "extensions"
+      number: 8
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Extension"
+      json_name: "extensions"
+    }
+    field {
+      name: "configs"
+      number: 9
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      json_name: "configs"
+    }
+  }
+  message_type {
+    name: "ClusterSnapshot"
+    field {
+      name: "members"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.RaftMember"
+      json_name: "members"
+    }
+    field {
+      name: "removed"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_UINT64
+      options {
+        packed: false
+      }
+      json_name: "removed"
+    }
+  }
+  message_type {
+    name: "Snapshot"
+    field {
+      name: "version"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.Snapshot.Version"
+      json_name: "version"
+    }
+    field {
+      name: "membership"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.ClusterSnapshot"
+      options {
+        65001: 0
+      }
+      json_name: "membership"
+    }
+    field {
+      name: "store"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.StoreSnapshot"
+      options {
+        65001: 0
+      }
+      json_name: "store"
+    }
+    enum_type {
+      name: "Version"
+      value {
+        name: "V0"
+        number: 0
+      }
+    }
+  }
+  weak_dependency: 2
+  syntax: "proto3"
+}
+file {
+  name: "github.com/docker/swarmkit/api/watch.proto"
+  package: "docker.swarmkit.v1"
+  dependency: "github.com/docker/swarmkit/api/specs.proto"
+  dependency: "github.com/docker/swarmkit/api/objects.proto"
+  dependency: "github.com/docker/swarmkit/api/types.proto"
+  dependency: "gogoproto/gogo.proto"
+  dependency: "github.com/docker/swarmkit/protobuf/plugin/plugin.proto"
+  message_type {
+    name: "Object"
+    field {
+      name: "node"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Node"
+      oneof_index: 0
+      json_name: "node"
+    }
+    field {
+      name: "service"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Service"
+      oneof_index: 0
+      json_name: "service"
+    }
+    field {
+      name: "network"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Network"
+      oneof_index: 0
+      json_name: "network"
+    }
+    field {
+      name: "task"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Task"
+      oneof_index: 0
+      json_name: "task"
+    }
+    field {
+      name: "cluster"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Cluster"
+      oneof_index: 0
+      json_name: "cluster"
+    }
+    field {
+      name: "secret"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Secret"
+      oneof_index: 0
+      json_name: "secret"
+    }
+    field {
+      name: "resource"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Resource"
+      oneof_index: 0
+      json_name: "resource"
+    }
+    field {
+      name: "extension"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Extension"
+      oneof_index: 0
+      json_name: "extension"
+    }
+    field {
+      name: "config"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Config"
+      oneof_index: 0
+      json_name: "config"
+    }
+    oneof_decl {
+      name: "Object"
+    }
+  }
+  message_type {
+    name: "SelectBySlot"
+    field {
+      name: "service_id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ServiceID"
+      }
+      json_name: "serviceId"
+    }
+    field {
+      name: "slot"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "slot"
+    }
+  }
+  message_type {
+    name: "SelectByCustom"
+    field {
+      name: "kind"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "kind"
+    }
+    field {
+      name: "index"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "index"
+    }
+    field {
+      name: "value"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "value"
+    }
+  }
+  message_type {
+    name: "SelectBy"
+    field {
+      name: "id"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ID"
+      }
+      oneof_index: 0
+      json_name: "id"
+    }
+    field {
+      name: "id_prefix"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "IDPrefix"
+      }
+      oneof_index: 0
+      json_name: "idPrefix"
+    }
+    field {
+      name: "name"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "name"
+    }
+    field {
+      name: "name_prefix"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "namePrefix"
+    }
+    field {
+      name: "custom"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SelectByCustom"
+      oneof_index: 0
+      json_name: "custom"
+    }
+    field {
+      name: "custom_prefix"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SelectByCustom"
+      oneof_index: 0
+      json_name: "customPrefix"
+    }
+    field {
+      name: "service_id"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ServiceID"
+      }
+      oneof_index: 0
+      json_name: "serviceId"
+    }
+    field {
+      name: "node_id"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "NodeID"
+      }
+      oneof_index: 0
+      json_name: "nodeId"
+    }
+    field {
+      name: "slot"
+      number: 9
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.SelectBySlot"
+      oneof_index: 0
+      json_name: "slot"
+    }
+    field {
+      name: "desired_state"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.TaskState"
+      oneof_index: 0
+      json_name: "desiredState"
+    }
+    field {
+      name: "role"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeRole"
+      oneof_index: 0
+      json_name: "role"
+    }
+    field {
+      name: "membership"
+      number: 12
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".docker.swarmkit.v1.NodeSpec.Membership"
+      oneof_index: 0
+      json_name: "membership"
+    }
+    field {
+      name: "referenced_network_id"
+      number: 13
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ReferencedNetworkID"
+      }
+      oneof_index: 0
+      json_name: "referencedNetworkId"
+    }
+    field {
+      name: "referenced_secret_id"
+      number: 14
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ReferencedSecretID"
+      }
+      oneof_index: 0
+      json_name: "referencedSecretId"
+    }
+    field {
+      name: "referenced_config_id"
+      number: 16
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      options {
+        65004: "ReferencedConfigID"
+      }
+      oneof_index: 0
+      json_name: "referencedConfigId"
+    }
+    field {
+      name: "kind"
+      number: 15
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "kind"
+    }
+    oneof_decl {
+      name: "By"
+    }
+  }
+  message_type {
+    name: "WatchRequest"
+    field {
+      name: "entries"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.WatchRequest.WatchEntry"
+      json_name: "entries"
+    }
+    field {
+      name: "resume_from"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "resumeFrom"
+    }
+    field {
+      name: "include_old_object"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "includeOldObject"
+    }
+    nested_type {
+      name: "WatchEntry"
+      field {
+        name: "kind"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_STRING
+        json_name: "kind"
+      }
+      field {
+        name: "action"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.WatchActionKind"
+        json_name: "action"
+      }
+      field {
+        name: "filters"
+        number: 3
+        label: LABEL_REPEATED
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.SelectBy"
+        json_name: "filters"
+      }
+    }
+  }
+  message_type {
+    name: "WatchMessage"
+    field {
+      name: "events"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.WatchMessage.Event"
+      json_name: "events"
+    }
+    field {
+      name: "version"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".docker.swarmkit.v1.Version"
+      json_name: "version"
+    }
+    nested_type {
+      name: "Event"
+      field {
+        name: "action"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_ENUM
+        type_name: ".docker.swarmkit.v1.WatchActionKind"
+        json_name: "action"
+      }
+      field {
+        name: "object"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.Object"
+        json_name: "object"
+      }
+      field {
+        name: "old_object"
+        number: 3
+        label: LABEL_OPTIONAL
+        type: TYPE_MESSAGE
+        type_name: ".docker.swarmkit.v1.Object"
+        json_name: "oldObject"
+      }
+    }
+  }
+  enum_type {
+    name: "WatchActionKind"
+    value {
+      name: "WATCH_ACTION_UNKNOWN"
+      number: 0
+      options {
+        66001: "WatchActionKindUnknown"
+      }
+    }
+    value {
+      name: "WATCH_ACTION_CREATE"
+      number: 1
+      options {
+        66001: "WatchActionKindCreate"
+      }
+    }
+    value {
+      name: "WATCH_ACTION_UPDATE"
+      number: 2
+      options {
+        66001: "WatchActionKindUpdate"
+      }
+    }
+    value {
+      name: "WATCH_ACTION_REMOVE"
+      number: 4
+      options {
+        66001: "WatchActionKindRemove"
+      }
+    }
+    options {
+      62001: 0
+      62023: "WatchActionKind"
+    }
+  }
+  service {
+    name: "Watch"
+    method {
+      name: "Watch"
+      input_type: ".docker.swarmkit.v1.WatchRequest"
+      output_type: ".docker.swarmkit.v1.WatchMessage"
+      options {
+        73626345 {
+          1: "swarm-manager"
+        }
+      }
+      server_streaming: true
+    }
+  }
+  syntax: "proto3"
+}

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,8 @@ dependencies:
         # Install protoc
         - wget "$PROTOC"
         - unzip -o "$(basename $PROTOC)" -d "$HOME"
+        - sudo cp -R "$HOME/include/google" /usr/local/include
+        - sudo chmod 777 -R /usr/local/include/google
 
         # Setup the GOPATH
         - mkdir -p "$(dirname $WORKDIR)"


### PR DESCRIPTION
Use the API stability tool of protobuild to stabilize the proto descriptors in swarmkit. It will generate:

- `api/api.pb.txt` for `api` package

Signed-off-by: He Xiaoxi <tossmilestone@gmail.com>