### PR TITLE
api/api.pb.txt: add missing init_value sections from #2350

### DIFF
--- a/api/api.pb.txt
+++ b/api/api.pb.txt
@@ -4587,6 +4587,14 @@ file {
       type_name: ".docker.swarmkit.v1.HealthConfig"
       json_name: "healthcheck"
     }
+    field {
+      name: "init_value"
+      number: 23
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      oneof_index: 0
+      json_name: "initValue"
+    }
     nested_type {
       name: "LabelsEntry"
       field {
@@ -4640,6 +4648,9 @@ file {
         type: TYPE_STRING
         json_name: "options"
       }
+    }
+    oneof_decl {
+      name: "init"
     }
   }
   message_type {


### PR DESCRIPTION
I ran `make generate` in a checkout of `master` and committed the changes. The changes to `api/api.pb.txt` were left out in #2350. This returns the invariant that `make generate` is a no-op on a fresh checkout. This issue was originally spotted by @stevvooe in #2365.