### PR TITLE
Add support for templating engine labels

### DIFF
--- a/agent/exec/dockerapi/controller_test.go
+++ b/agent/exec/dockerapi/controller_test.go
@@ -417,6 +417,11 @@ func genTestControllerEnv(t *testing.T, task *api.Task) (context.Context, *StubA
 			OS:           "linux",
 			Architecture: "x86_64",
 		},
+		Engine: &api.EngineDescription{
+			Labels: map[string]string{
+				"EngineLabelKey": "engine-label-value",
+			},
+		},
 	}
 
 	client := NewStubAPIClient()

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -134,6 +134,11 @@ func validateContainerSpec(taskSpec api.TaskSpec) error {
 			OS:           "os",
 			Architecture: "architecture",
 		},
+		Engine: &api.EngineDescription{
+			Labels: map[string]string{
+				"EngineLabelKey": "engine-label-value",
+			},
+		},
 	}, &api.Task{
 		Spec:      taskSpec,
 		ServiceID: "serviceid",

--- a/template/context.go
+++ b/template/context.go
@@ -20,6 +20,11 @@ type Platform struct {
 	OS           string
 }
 
+// Engine holds information about the Docker Engine on the node.
+type Engine struct {
+	Labels map[string]string
+}
+
 // Context defines the strict set of values that can be injected into a
 // template expression in SwarmKit data structure.
 // NOTE: Be very careful adding any fields to this structure with types
@@ -36,6 +41,7 @@ type Context struct {
 		ID       string
 		Hostname string
 		Platform Platform
+		Engine   Engine
 	}
 
 	Task struct {
@@ -66,6 +72,9 @@ func NewContext(n *api.NodeDescription, t *api.Task) (ctx Context) {
 		ctx.Node.Platform = Platform{
 			Architecture: n.Platform.Architecture,
 			OS:           n.Platform.OS,
+		}
+		ctx.Node.Engine = Engine{
+			Labels: n.Engine.Labels,
 		}
 	}
 	ctx.Task.ID = t.ID

--- a/template/context_test.go
+++ b/template/context_test.go
@@ -68,6 +68,9 @@ func TestTemplateContext(t *testing.T) {
 								"TASK_NAME={{.Task.Name}}",
 								"NODE_ID={{.Node.ID}}",
 								"SERVICE_LABELS={{range $k, $v := .Service.Labels}}{{$k}}={{$v}},{{end}}",
+								"RACK_ID={{index .Node.Engine.Labels `RackID`}}",
+								"AVAILABILITY_ZONE_ID={{index .Node.Engine.Labels `AvailabilityZoneID`}}",
+								"DATACENTER_ID={{index .Node.Engine.Labels `com.example.DatacenterID`}}",
 							},
 						},
 					},
@@ -88,6 +91,9 @@ func TestTemplateContext(t *testing.T) {
 					"TASK_NAME=serviceName.10.taskID",
 					"NODE_ID=nodeID",
 					"SERVICE_LABELS=ServiceLabelOneKey=service-label-one-value,ServiceLabelTwoKey=service-label-two-value,com.example.ServiceLabelThreeKey=service-label-three-value,",
+					"RACK_ID=rack-ID",
+					"AVAILABILITY_ZONE_ID=availability-zone-ID",
+					"DATACENTER_ID=datacenter-ID",
 				},
 			},
 		},
@@ -249,6 +255,13 @@ func modifyNode(fn func(n *api.NodeDescription)) *api.NodeDescription {
 		Platform: &api.Platform{
 			Architecture: "x86_64",
 			OS:           "linux",
+		},
+		Engine: &api.EngineDescription{
+			Labels: map[string]string{
+				"RackID":                   "rack-ID",
+				"AvailabilityZoneID":       "availability-zone-ID",
+				"com.example.DatacenterID": "datacenter-ID",
+			},
 		},
 	}
 


### PR DESCRIPTION
In a swarm, engine labels can be used to indicate which rack, availability zone, or datacenter a docker node belongs to. This topology information would help stateful applications to improve their fault-tolerance by spreading data over a set of availability zones or datacenters to avoid losing data at the same time. This PR enables applications to access topology information of a swarm by making engine labels a template placeholder.

closes #2366 