### PR TITLE
Add option to redact sensitive cluster information from state dumps

### DIFF
--- a/cmd/swarm-rafttool/main.go
+++ b/cmd/swarm-rafttool/main.go
@@ -66,7 +66,12 @@ var (
 				return err
 			}
 
-			return dumpWAL(stateDir, unlockKey, start, end)
+			redact, err := cmd.Flags().GetBool("redact")
+			if err != nil {
+				return err
+			}
+
+			return dumpWAL(stateDir, unlockKey, start, end, redact)
 		},
 	}
 
@@ -84,7 +89,12 @@ var (
 				return err
 			}
 
-			return dumpSnapshot(stateDir, unlockKey)
+			redact, err := cmd.Flags().GetBool("redact")
+			if err != nil {
+				return err
+			}
+
+			return dumpSnapshot(stateDir, unlockKey, redact)
 		},
 	}
 
@@ -142,8 +152,11 @@ func init() {
 		dumpObjectCmd,
 	)
 
+	dumpSnapshotCmd.Flags().Bool("redact", false, "Redact the values of secrets, configs, and environment variables")
+
 	dumpWALCmd.Flags().Uint64("start", 0, "Start of index range to dump")
 	dumpWALCmd.Flags().Uint64("end", 0, "End of index range to dump")
+	dumpWALCmd.Flags().Bool("redact", false, "Redact the values of secrets, configs, and environment variables")
 
 	dumpObjectCmd.Flags().String("id", "", "Look up object by ID")
 	dumpObjectCmd.Flags().String("name", "", "Look up object by name")


### PR DESCRIPTION
The swarm raft logs and snapshots are useful, powerful debugging tools, but they contain very sensitive cluster information. This change adds a `--redact` flag to both dump-wal and dump-snapshot, which removes secret and config data, and removes container environment variables. The dumps will still contain sensitive information, but not rising to the level of passwords or encryption keys.

Signed-off-by: Drew Erny <drew.erny@docker.com>