### PR TITLE
Bump Go to 1.8.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 
         PROTOC: "https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip"
 
-        GOVERSION: "1.8.3"
+        GOVERSION: "1.8.4"
         GOPATH: "$HOME/.go_workspace"
 
         WORKDIR:  "$GOPATH/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"


### PR DESCRIPTION
Bumps the Go version used to 1.8.4, which contains security fixes; https://groups.google.com/forum/#!topic/golang-announce/1hZYiemnkdE
