### PR TITLE
[v17.03] Fix linter errors.

### DIFF
--- a/ca/keyreadwriter.go
+++ b/ca/keyreadwriter.go
@@ -187,10 +187,7 @@ func (k *KeyReadWriter) ViewAndRotateKEK(cb func(KEKData, PEMKeyHeaders) (KEKDat
 		return err
 	}
 
-	if err := k.writeKey(keyBlock, updatedKEK, updatedHeaderObj); err != nil {
-		return err
-	}
-	return nil
+	return k.writeKey(keyBlock, updatedKEK, updatedHeaderObj)
 }
 
 // ViewAndUpdateHeaders updates the header manager, and updates any headers on the existing key

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -126,11 +126,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 	if len(networks) == 0 {
 		if err := a.store.Update(func(tx store.Tx) error {
 			nc.ingressNetwork.ID = identity.NewID()
-			if err := store.CreateNetwork(tx, nc.ingressNetwork); err != nil {
-				return err
-			}
-
-			return nil
+			return store.CreateNetwork(tx, nc.ingressNetwork)
 		}); err != nil {
 			return errors.Wrap(err, "failed to create ingress network")
 		}
@@ -215,11 +211,7 @@ func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
 	if err := a.allocateServices(ctx, false); err != nil {
 		return err
 	}
-	if err := a.allocateTasks(ctx, false); err != nil {
-		return err
-	}
-
-	return nil
+	return a.allocateTasks(ctx, false)
 }
 
 func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -83,11 +83,7 @@ func validateNetworkSpec(spec *api.NetworkSpec, pg plugingetter.PluginGetter) er
 		return err
 	}
 
-	if err := validateIPAM(spec.IPAM, pg); err != nil {
-		return err
-	}
-
-	return nil
+	return validateIPAM(spec.IPAM, pg)
 }
 
 // CreateNetwork creates and returns a Network based on the provided NetworkSpec.

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -46,10 +46,7 @@ func validateResourceRequirements(r *api.ResourceRequirements) error {
 	if err := validateResources(r.Limits); err != nil {
 		return err
 	}
-	if err := validateResources(r.Reservations); err != nil {
-		return err
-	}
-	return nil
+	return validateResources(r.Reservations)
 }
 
 func validateRestartPolicy(rp *api.RestartPolicy) error {
@@ -172,11 +169,7 @@ func validateTask(taskSpec api.TaskSpec) error {
 	if err != nil {
 		return grpc.Errorf(codes.InvalidArgument, err.Error())
 	}
-	if err := validateContainerSpec(preparedSpec); err != nil {
-		return err
-	}
-
-	return nil
+	return validateContainerSpec(preparedSpec)
 }
 
 func validateEndpointSpec(epSpec *api.EndpointSpec) error {
@@ -296,11 +289,7 @@ func validateServiceSpec(spec *api.ServiceSpec) error {
 		return err
 	}
 	// Check to see if the Secret Reference portion of the spec is valid
-	if err := validateSecretRefsSpec(spec); err != nil {
-		return err
-	}
-
-	return nil
+	return validateSecretRefsSpec(spec)
 }
 
 // checkPortConflicts does a best effort to find if the passed in spec has port

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -818,10 +818,7 @@ func (d *Dispatcher) Assignments(r *api.AssignmentsRequest, stream api.Dispatche
 		appliesTo = msg.ResultsIn
 		msg.Type = assignmentType
 
-		if err := stream.Send(&msg); err != nil {
-			return err
-		}
-		return nil
+		return stream.Send(&msg)
 	}
 
 	// returns a slice of new secrets to send down

--- a/manager/logbroker/broker_test.go
+++ b/manager/logbroker/broker_test.go
@@ -399,15 +399,11 @@ func TestLogBrokerNoFollow(t *testing.T) {
 			return err
 		}
 
-		if err := store.CreateTask(tx, &api.Task{
+		return store.CreateTask(tx, &api.Task{
 			ID:        "task2",
 			ServiceID: "service",
 			NodeID:    agent2Security.ServerTLSCreds.NodeID(),
-		}); err != nil {
-			return err
-		}
-
-		return nil
+		})
 	}))
 
 	// Subscribe to logs in no follow mode
@@ -503,15 +499,11 @@ func TestLogBrokerNoFollowMissingNode(t *testing.T) {
 			return err
 		}
 
-		if err := store.CreateTask(tx, &api.Task{
+		return store.CreateTask(tx, &api.Task{
 			ID:        "task2",
 			ServiceID: "service",
 			NodeID:    "node-2",
-		}); err != nil {
-			return err
-		}
-
-		return nil
+		})
 	}))
 
 	// Subscribe to logs in no follow mode
@@ -613,15 +605,11 @@ func TestLogBrokerNoFollowDisconnect(t *testing.T) {
 			return err
 		}
 
-		if err := store.CreateTask(tx, &api.Task{
+		return store.CreateTask(tx, &api.Task{
 			ID:        "task2",
 			ServiceID: "service",
 			NodeID:    agent2Security.ServerTLSCreds.NodeID(),
-		}); err != nil {
-			return err
-		}
-
-		return nil
+		})
 	}))
 
 	// Subscribe to logs in no follow mode

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -387,10 +387,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 				return errors.New("service was deleted")
 			}
 
-			if err := store.CreateTask(tx, updated); err != nil {
-				return err
-			}
-			return nil
+			return store.CreateTask(tx, updated)
 		})
 		if err != nil {
 			return err

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -86,11 +86,7 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 		tasksByNode[t.NodeID][t.ID] = t
 	}
 
-	if err := s.buildNodeSet(tx, tasksByNode); err != nil {
-		return err
-	}
-
-	return nil
+	return s.buildNodeSet(tx, tasksByNode)
 }
 
 // Run is the scheduler event loop.

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1663,10 +1663,7 @@ func (n *Node) applyAddNode(cc raftpb.ConfChange) error {
 		return nil
 	}
 
-	if err = n.registerNode(member); err != nil {
-		return err
-	}
-	return nil
+	return n.registerNode(member)
 }
 
 // applyUpdateNode is called when we receive a ConfChange from a member in the

--- a/manager/state/raft/storage/storage.go
+++ b/manager/state/raft/storage/storage.go
@@ -226,10 +226,7 @@ func (e *EncryptedRaftLogger) SaveSnapshot(snapshot raftpb.Snapshot) error {
 	if err := snapshotter.SaveSnap(snapshot); err != nil {
 		return err
 	}
-	if err := e.wal.ReleaseLockTo(snapshot.Metadata.Index); err != nil {
-		return err
-	}
-	return nil
+	return e.wal.ReleaseLockTo(snapshot.Metadata.Index)
 }
 
 // GC garbage collects snapshots and wals older than the provided index and term


### PR DESCRIPTION
Cherry picks #2377 to v17.03. Does not apply cleanly. Also involves making changes not in the original patch, but in the spirit of that patch.

(cherry picked from commit aa2c48b53cbae5203b8cf81262eaccf8be353ca6)
Signed-off-by: Drew Erny <drew.erny@docker.com>

/cc @anshulpundir 