### PR TITLE
Provide custom gRPC dialer to override default proxy dialer

### DIFF
--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -3,6 +3,7 @@
 package transport
 
 import (
+	"net"
 	"sync"
 	"time"
 
@@ -347,6 +348,13 @@ func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
 	if t.config.SendTimeout > 0 {
 		grpcOptions = append(grpcOptions, grpc.WithTimeout(t.config.SendTimeout))
 	}
+
+	// gRPC dialer connects to proxy first. Provide a custom dialer here avoid that.
+	// TODO(anshul) Add an option to configure this.
+	grpcOptions = append(grpcOptions,
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("tcp", addr, timeout)
+		}))
 
 	cc, err := grpc.Dial(addr, grpcOptions...)
 	if err != nil {


### PR DESCRIPTION
gRPC connects to proxy by default (https://github.com/docker/swarmkit/commit/c23aa65fc646081600eb206c2f2dcff5a9e25143), breaking swarmkit. This change provides a basic custom dialer to override the proxy dialer for manager <-> manager and manager <-> worker connections.

Signed-off-by: Anshul Pundir <anshul.pundir@docker.com>