### PR TITLE
Adding logging to keymanager and cluster store object create.

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -954,13 +954,18 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 		// store. Don't check the error because
 		// we expect this to fail unless this
 		// is a brand new cluster.
-		store.CreateCluster(tx, defaultClusterObject(
+		err := store.CreateCluster(tx, defaultClusterObject(
 			clusterID,
 			initialCAConfig,
 			raftCfg,
 			api.EncryptionConfig{AutoLockManagers: m.config.AutoLockManagers},
 			unlockKeys,
 			rootCA))
+
+		if err != nil && err != store.ErrExist {
+			log.G(ctx).WithError(err).Errorf("error creating cluster object")
+		}
+
 		// Add Node entry for ourself, if one
 		// doesn't exist already.
 		freshCluster := nil == store.CreateNode(tx, managerNode(nodeID, m.config.Availability))


### PR DESCRIPTION
We recently saw an issue where the cluster object was not found in the store during keymanager init. Adding some minor debug info. Probably not super helpful, but suggestions welcome.

cc @nishanttotla 

Signed-off-by: Anshul Pundir anshul.pundir@docker.com