### PR TITLE
[17.11] Don't filter nodes if logdriver==none

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -169,7 +169,7 @@ func (f *PluginFilter) Check(n *NodeInfo) bool {
 		}
 	}
 
-	if f.t.Spec.LogDriver != nil {
+	if f.t.Spec.LogDriver != nil && f.t.Spec.LogDriver.Name != "none" {
 		// If there are no log driver types in the list at all, most likely this is
 		// an older daemon that did not report this information. In this case don't filter
 		if typeFound, exists := f.pluginExistsOnNode("Log", f.t.Spec.LogDriver.Name, nodePlugins); !exists && typeFound {


### PR DESCRIPTION
Cherry-pick https://github.com/docker/swarmkit/pull/2396.

`git cherry-pick -s -x 9608c63711181bff3a33c71f763aedde2d3596ec`

Cherry-pick was clean.

Signed-off-by: Brian Goff <cpuguy83@gmail.com>
(cherry picked from commit 9608c63711181bff3a33c71f763aedde2d3596ec)
Signed-off-by: Nishant Totla <nishanttotla@gmail.com>