### PR TITLE
[17.11] normalize "aarch64" architectures to "arm64"

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -294,6 +294,14 @@ func (f *PlatformFilter) platformEqual(imgPlatform, nodePlatform api.Platform) b
 		nodePlatform.Architecture = "amd64"
 	}
 
+	// normalize "aarch64" architectures to "arm64"
+	if imgPlatform.Architecture == "aarch64" {
+		imgPlatform.Architecture = "arm64"
+	}
+	if nodePlatform.Architecture == "aarch64" {
+		nodePlatform.Architecture = "arm64"
+	}
+
 	if (imgPlatform.Architecture == "" || imgPlatform.Architecture == nodePlatform.Architecture) && (imgPlatform.OS == "" || imgPlatform.OS == nodePlatform.OS) {
 		return true
 	}


### PR DESCRIPTION
Cherry-pick https://github.com/docker/swarmkit/pull/2411.

`git cherry-pick -s -x 9d702763118b132cbe9005a80625ba2160089c3d`

Cherry-pick was clean.