### PR TITLE
[17.11] Provide custom gRPC dialer to override default proxy dialer (#2419)

### DIFF
--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -3,6 +3,7 @@
 package transport
 
 import (
+	"net"
 	"sync"
 	"time"
 
@@ -346,6 +347,13 @@ func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
 	if t.config.SendTimeout > 0 {
 		grpcOptions = append(grpcOptions, grpc.WithTimeout(t.config.SendTimeout))
 	}
+
+	// gRPC dialer connects to proxy first. Provide a custom dialer here avoid that.
+	// TODO(anshul) Add an option to configure this.
+	grpcOptions = append(grpcOptions,
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("tcp", addr, timeout)
+		}))
 
 	cc, err := grpc.Dial(addr, grpcOptions...)
 	if err != nil {


### PR DESCRIPTION
Cherry-pick #2419.

`git cherry-pick -s -x 312be5983e2d2f01f0cbcc99d027b28433256705`

Cherry-pick was clean.