### PR TITLE
[17.06] orchestrator/update: Only shut down old tasks on success

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -427,7 +427,7 @@ func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, update
 				u.updatedTasks[updated.ID] = time.Now()
 				u.updatedTasksMu.Unlock()
 
-				if startThenStop {
+				if startThenStop && updated.Status.State == api.TaskStateRunning {
 					err := u.store.Batch(func(batch *store.Batch) error {
 						_, err := u.removeOldTasks(ctx, batch, slot)
 						if err != nil {


### PR DESCRIPTION
Cherry-pick #2308.

`git cherry-pick -s -x 6728c52055ba639312a293306cf58ce4be5d2aa6`

Cherry-pick was clean.