### PR TITLE
Error on cluster spec name change.

### DIFF
--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -58,6 +58,10 @@ func validateClusterSpec(spec *api.ClusterSpec) error {
 		}
 	}
 
+	if spec.Annotations.Name != store.DefaultClusterName {
+		return grpc.Errorf(codes.InvalidArgument, "modification of cluster name is not allowed")
+	}
+
 	return nil
 }
 

--- a/manager/controlapi/node.go
+++ b/manager/controlapi/node.go
@@ -299,7 +299,7 @@ func (s *Server) RemoveNode(ctx context.Context, request *api.RemoveNodeRequest)
 		}
 
 		// lookup the cluster
-		clusters, err := store.FindClusters(tx, store.ByName("default"))
+		clusters, err := store.FindClusters(tx, store.ByName(store.DefaultClusterName))
 		if err != nil {
 			return err
 		}

--- a/manager/keymanager/keymanager_test.go
+++ b/manager/keymanager/keymanager_test.go
@@ -36,7 +36,7 @@ func createCluster(t *testing.T, s *store.MemoryStore, id, name string) *api.Clu
 func TestKeyManagerDefaultSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
 	defer st.Close()
-	createCluster(t, st, "default", "default")
+	createCluster(t, st, "default", store.DefaultClusterName)
 
 	k := New(st, DefaultConfig())
 
@@ -72,7 +72,7 @@ func TestKeyManagerDefaultSubsystem(t *testing.T) {
 func TestKeyManagerCustomSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
 	defer st.Close()
-	createCluster(t, st, "default", "default")
+	createCluster(t, st, "default", store.DefaultClusterName)
 
 	config := &Config{
 		ClusterName:      store.DefaultClusterName,
@@ -118,7 +118,7 @@ func TestKeyManagerCustomSubsystem(t *testing.T) {
 func TestKeyManagerInvalidSubsystem(t *testing.T) {
 	st := store.NewMemoryStore(nil)
 	defer st.Close()
-	createCluster(t, st, "default", "default")
+	createCluster(t, st, "default", store.DefaultClusterName)
 
 	config := &Config{
 		ClusterName:      store.DefaultClusterName,

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -404,7 +404,7 @@ func (m *Manager) Run(parent context.Context) error {
 		)
 
 		m.raftNode.MemoryStore().View(func(readTx store.ReadTx) {
-			clusters, err = store.FindClusters(readTx, store.ByName("default"))
+			clusters, err = store.FindClusters(readTx, store.ByName(store.DefaultClusterName))
 
 		})
 

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -73,7 +73,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 	var err error
 	g.store.View(func(readTx store.ReadTx) {
 		var clusters []*api.Cluster
-		clusters, err = store.FindClusters(readTx, store.ByName("default"))
+		clusters, err = store.FindClusters(readTx, store.ByName(store.DefaultClusterName))
 
 		if len(clusters) != 1 {
 			return // just pick up the cluster when it is created.

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -17,7 +17,7 @@ import (
 // responds to changes in individual tasks (or nodes which run them).
 
 func (r *Orchestrator) initCluster(readTx store.ReadTx) error {
-	clusters, err := store.FindClusters(readTx, store.ByName("default"))
+	clusters, err := store.FindClusters(readTx, store.ByName(store.DefaultClusterName))
 	if err != nil {
 		return err
 	}

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -88,7 +88,7 @@ func TestUpdater(t *testing.T) {
 		// test cluster configuration propagation to task creation.
 		Spec: api.ClusterSpec{
 			Annotations: api.Annotations{
-				Name: "default",
+				Name: store.DefaultClusterName,
 			},
 		},
 	}
@@ -288,7 +288,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 	cluster := &api.Cluster{
 		Spec: api.ClusterSpec{
 			Annotations: api.Annotations{
-				Name: "default",
+				Name: store.DefaultClusterName,
 			},
 		},
 	}


### PR DESCRIPTION
Currently, the cluster name is hardcoded and is expected to not change for the swarmkit to function. Enforcing that by returning an error if cluster name change is attempted.

Signed-off-by: Anshul Pundir <anshul.pundir@docker.com>