### PR TITLE
[17.11] Avoid running plugin filter when Log Driver does not have a Name

### DIFF
--- a/manager/scheduler/filter.go
+++ b/manager/scheduler/filter.go
@@ -169,7 +169,10 @@ func (f *PluginFilter) Check(n *NodeInfo) bool {
 		}
 	}
 
-	if f.t.Spec.LogDriver != nil && f.t.Spec.LogDriver.Name != "none" {
+	// It's possible that the LogDriver object does not carry a name, just some
+	// configuration options. In that case, the plugin filter shouldn't fail to
+	// schedule the task
+	if f.t.Spec.LogDriver != nil && f.t.Spec.LogDriver.Name != "none" && f.t.Spec.LogDriver.Name != "" {
 		// If there are no log driver types in the list at all, most likely this is
 		// an older daemon that did not report this information. In this case don't filter
 		if typeFound, exists := f.pluginExistsOnNode("Log", f.t.Spec.LogDriver.Name, nodePlugins); !exists && typeFound {

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -2583,6 +2583,28 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 		},
 	}
 
+	// log driver with no name
+	t7 := &api.Task{
+		ID:           "task7_ID",
+		DesiredState: api.TaskStateRunning,
+		Spec: api.TaskSpec{
+			Runtime: &api.TaskSpec_Container{
+				Container: &api.ContainerSpec{},
+			},
+			LogDriver: &api.Driver{
+				Options: map[string]string{
+					"max-size": "50k",
+				},
+			},
+		},
+		ServiceAnnotations: api.Annotations{
+			Name: "task7",
+		},
+		Status: api.TaskStatus{
+			State: api.TaskStatePending,
+		},
+	}
+
 	s := store.NewMemoryStore(nil)
 	assert.NotNil(t, s)
 	defer s.Close()
@@ -2687,6 +2709,7 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 	assert.Equal(t, assignment4.ID, "task5_ID")
 	assert.Equal(t, assignment4.NodeID, "node4_ID")
 
+	// check that t6 gets assigned to some node
 	err = s.Update(func(tx store.Tx) error {
 		assert.NoError(t, store.CreateTask(tx, t6))
 		return nil
@@ -2695,6 +2718,16 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 	assignment5 := watchAssignment(t, watch)
 	assert.Equal(t, assignment5.ID, "task6_ID")
 	assert.NotEqual(t, assignment5.NodeID, "")
+
+	// check that t7 gets assigned to some node
+	err = s.Update(func(tx store.Tx) error {
+		assert.NoError(t, store.CreateTask(tx, t7))
+		return nil
+	})
+	assert.NoError(t, err)
+	assignment6 := watchAssignment(t, watch)
+	assert.Equal(t, assignment6.ID, "task7_ID")
+	assert.NotEqual(t, assignment6.NodeID, "")
 }
 
 func BenchmarkScheduler1kNodes1kTasks(b *testing.B) {


### PR DESCRIPTION
Cherry-pick #2438.

`git cherry-pick -s -x 05c8675eeeece04daffec34c5f99769b560d2d0d`

Cherry-pick was clean.
