### PR TITLE
Replace deprecated grpc.Errorf() with status.Errorf()

### DIFF
--- a/api/ca.pb.go
+++ b/api/ca.pb.go
@@ -235,6 +235,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -984,12 +985,12 @@ func NewRaftProxyCAServer(local CAServer, connSelector raftselector.ConnProvider
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})
@@ -1126,12 +1127,12 @@ func NewRaftProxyNodeCAServer(local NodeCAServer, connSelector raftselector.Conn
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -19,6 +19,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -5859,12 +5860,12 @@ func NewRaftProxyControlServer(local ControlServer, connSelector raftselector.Co
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -24,6 +24,7 @@ import github_com_gogo_protobuf_types "github.com/gogo/protobuf/types"
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -1602,12 +1603,12 @@ func NewRaftProxyDispatcherServer(local DispatcherServer, connSelector raftselec
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/health.pb.go
+++ b/api/health.pb.go
@@ -17,6 +17,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -286,12 +287,12 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -20,6 +20,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -1273,12 +1274,12 @@ func NewRaftProxyLogsServer(local LogsServer, connSelector raftselector.ConnProv
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})
@@ -1396,12 +1397,12 @@ func NewRaftProxyLogBrokerServer(local LogBrokerServer, connSelector raftselecto
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -21,6 +21,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -1488,12 +1489,12 @@ func NewRaftProxyRaftServer(local RaftServer, connSelector raftselector.ConnProv
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})
@@ -1630,12 +1631,12 @@ func NewRaftProxyRaftMembershipServer(local RaftMembershipServer, connSelector r
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -19,6 +19,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -403,12 +404,12 @@ func NewRaftProxyResourceAllocatorServer(local ResourceAllocatorServer, connSele
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/api/watch.pb.go
+++ b/api/watch.pb.go
@@ -19,6 +19,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -2043,12 +2044,12 @@ func NewRaftProxyWatchServer(local WatchServer, connSelector raftselector.ConnPr
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -11,8 +11,8 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -23,17 +23,17 @@ const (
 
 func validateClusterSpec(spec *api.ClusterSpec) error {
 	if spec == nil {
-		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	// Validate that expiry time being provided is valid, and over our minimum
 	if spec.CAConfig.NodeCertExpiry != nil {
 		expiry, err := gogotypes.DurationFromProto(spec.CAConfig.NodeCertExpiry)
 		if err != nil {
-			return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+			return status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 		}
 		if expiry < ca.MinNodeCertExpiration {
-			return grpc.Errorf(codes.InvalidArgument, "minimum certificate expiry time is: %s", ca.MinNodeCertExpiration)
+			return status.Errorf(codes.InvalidArgument, "minimum certificate expiry time is: %s", ca.MinNodeCertExpiration)
 		}
 	}
 
@@ -42,7 +42,7 @@ func validateClusterSpec(spec *api.ClusterSpec) error {
 	if len(spec.AcceptancePolicy.Policies) > 0 {
 		for _, policy := range spec.AcceptancePolicy.Policies {
 			if policy.Secret != nil && strings.ToLower(policy.Secret.Alg) != "bcrypt" {
-				return grpc.Errorf(codes.InvalidArgument, "hashing algorithm is not supported: %s", policy.Secret.Alg)
+				return status.Errorf(codes.InvalidArgument, "hashing algorithm is not supported: %s", policy.Secret.Alg)
 			}
 		}
 	}
@@ -51,15 +51,15 @@ func validateClusterSpec(spec *api.ClusterSpec) error {
 	if spec.Dispatcher.HeartbeatPeriod != nil {
 		heartbeatPeriod, err := gogotypes.DurationFromProto(spec.Dispatcher.HeartbeatPeriod)
 		if err != nil {
-			return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+			return status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 		}
 		if heartbeatPeriod < 0 {
-			return grpc.Errorf(codes.InvalidArgument, "heartbeat time period cannot be a negative duration")
+			return status.Errorf(codes.InvalidArgument, "heartbeat time period cannot be a negative duration")
 		}
 	}
 
 	if spec.Annotations.Name != store.DefaultClusterName {
-		return grpc.Errorf(codes.InvalidArgument, "modification of cluster name is not allowed")
+		return status.Errorf(codes.InvalidArgument, "modification of cluster name is not allowed")
 	}
 
 	return nil
@@ -70,7 +70,7 @@ func validateClusterSpec(spec *api.ClusterSpec) error {
 // - Returns `NotFound` if the Cluster is not found.
 func (s *Server) GetCluster(ctx context.Context, request *api.GetClusterRequest) (*api.GetClusterResponse, error) {
 	if request.ClusterID == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	var cluster *api.Cluster
@@ -78,7 +78,7 @@ func (s *Server) GetCluster(ctx context.Context, request *api.GetClusterRequest)
 		cluster = store.GetCluster(tx, request.ClusterID)
 	})
 	if cluster == nil {
-		return nil, grpc.Errorf(codes.NotFound, "cluster %s not found", request.ClusterID)
+		return nil, status.Errorf(codes.NotFound, "cluster %s not found", request.ClusterID)
 	}
 
 	redactedClusters := redactClusters([]*api.Cluster{cluster})
@@ -96,7 +96,7 @@ func (s *Server) GetCluster(ctx context.Context, request *api.GetClusterRequest)
 // - Returns an error if the update fails.
 func (s *Server) UpdateCluster(ctx context.Context, request *api.UpdateClusterRequest) (*api.UpdateClusterResponse, error) {
 	if request.ClusterID == "" || request.ClusterVersion == nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 	if err := validateClusterSpec(request.Spec); err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (s *Server) UpdateCluster(ctx context.Context, request *api.UpdateClusterRe
 	err := s.store.Update(func(tx store.Tx) error {
 		cluster = store.GetCluster(tx, request.ClusterID)
 		if cluster == nil {
-			return grpc.Errorf(codes.NotFound, "cluster %s not found", request.ClusterID)
+			return status.Errorf(codes.NotFound, "cluster %s not found", request.ClusterID)
 		}
 		// This ensures that we have the current rootCA with which to generate tokens (expiration doesn't matter
 		// for generating the tokens)
@@ -114,7 +114,7 @@ func (s *Server) UpdateCluster(ctx context.Context, request *api.UpdateClusterRe
 		if err != nil {
 			log.G(ctx).WithField(
 				"method", "(*controlapi.Server).UpdateCluster").WithError(err).Error("invalid cluster root CA")
-			return grpc.Errorf(codes.Internal, "error loading cluster rootCA for update")
+			return status.Errorf(codes.Internal, "error loading cluster rootCA for update")
 		}
 
 		cluster.Meta.Version = *request.ClusterVersion

--- a/manager/controlapi/node.go
+++ b/manager/controlapi/node.go
@@ -9,13 +9,13 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func validateNodeSpec(spec *api.NodeSpec) error {
 	if spec == nil {
-		return grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 	return nil
 }
@@ -25,7 +25,7 @@ func validateNodeSpec(spec *api.NodeSpec) error {
 // - Returns `NotFound` if the Node is not found.
 func (s *Server) GetNode(ctx context.Context, request *api.GetNodeRequest) (*api.GetNodeResponse, error) {
 	if request.NodeID == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	var node *api.Node
@@ -33,7 +33,7 @@ func (s *Server) GetNode(ctx context.Context, request *api.GetNodeRequest) (*api
 		node = store.GetNode(tx, request.NodeID)
 	})
 	if node == nil {
-		return nil, grpc.Errorf(codes.NotFound, "node %s not found", request.NodeID)
+		return nil, status.Errorf(codes.NotFound, "node %s not found", request.NodeID)
 	}
 
 	if s.raft != nil {
@@ -196,7 +196,7 @@ func (s *Server) ListNodes(ctx context.Context, request *api.ListNodesRequest) (
 // - Returns an error if the update fails.
 func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest) (*api.UpdateNodeResponse, error) {
 	if request.NodeID == "" || request.NodeVersion == nil {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 	if err := validateNodeSpec(request.Spec); err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 	err := s.store.Update(func(tx store.Tx) error {
 		node = store.GetNode(tx, request.NodeID)
 		if node == nil {
-			return grpc.Errorf(codes.NotFound, "node %s not found", request.NodeID)
+			return status.Errorf(codes.NotFound, "node %s not found", request.NodeID)
 		}
 
 		// Demotion sanity checks.
@@ -218,20 +218,20 @@ func (s *Server) UpdateNode(ctx context.Context, request *api.UpdateNodeRequest)
 			// Check for manager entries in Store.
 			managers, err := store.FindNodes(tx, store.ByRole(api.NodeRoleManager))
 			if err != nil {
-				return grpc.Errorf(codes.Internal, "internal store error: %v", err)
+				return status.Errorf(codes.Internal, "internal store error: %v", err)
 			}
 			if len(managers) == 1 && managers[0].ID == node.ID {
-				return grpc.Errorf(codes.FailedPrecondition, "attempting to demote the last manager of the swarm")
+				return status.Errorf(codes.FailedPrecondition, "attempting to demote the last manager of the swarm")
 			}
 
 			// Check for node in memberlist
 			if member = s.raft.GetMemberByNodeID(request.NodeID); member == nil {
-				return grpc.Errorf(codes.NotFound, "can't find manager in raft memberlist")
+				return status.Errorf(codes.NotFound, "can't find manager in raft memberlist")
 			}
 
 			// Quorum safeguard
 			if !s.raft.CanRemoveMember(member.RaftID) {
-				return grpc.Errorf(codes.FailedPrecondition, "can't remove member from the raft: this would result in a loss of quorum")
+				return status.Errorf(codes.FailedPrecondition, "can't remove member from the raft: this would result in a loss of quorum")
 			}
 		}
 
@@ -278,24 +278,24 @@ func removeNodeAttachments(tx store.Tx, nodeID string) error {
 // - Returns an error if the delete fails.
 func (s *Server) RemoveNode(ctx context.Context, request *api.RemoveNodeRequest) (*api.RemoveNodeResponse, error) {
 	if request.NodeID == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	err := s.store.Update(func(tx store.Tx) error {
 		node := store.GetNode(tx, request.NodeID)
 		if node == nil {
-			return grpc.Errorf(codes.NotFound, "node %s not found", request.NodeID)
+			return status.Errorf(codes.NotFound, "node %s not found", request.NodeID)
 		}
 		if node.Spec.DesiredRole == api.NodeRoleManager {
 			if s.raft == nil {
-				return grpc.Errorf(codes.FailedPrecondition, "node %s is a manager but cannot access node information from the raft memberlist", request.NodeID)
+				return status.Errorf(codes.FailedPrecondition, "node %s is a manager but cannot access node information from the raft memberlist", request.NodeID)
 			}
 			if member := s.raft.GetMemberByNodeID(request.NodeID); member != nil {
-				return grpc.Errorf(codes.FailedPrecondition, "node %s is a cluster manager and is a member of the raft cluster. It must be demoted to worker before removal", request.NodeID)
+				return status.Errorf(codes.FailedPrecondition, "node %s is a cluster manager and is a member of the raft cluster. It must be demoted to worker before removal", request.NodeID)
 			}
 		}
 		if !request.Force && node.Status.State == api.NodeStatus_READY {
-			return grpc.Errorf(codes.FailedPrecondition, "node %s is not down and can't be removed", request.NodeID)
+			return status.Errorf(codes.FailedPrecondition, "node %s is not down and can't be removed", request.NodeID)
 		}
 
 		// lookup the cluster
@@ -304,7 +304,7 @@ func (s *Server) RemoveNode(ctx context.Context, request *api.RemoveNodeRequest)
 			return err
 		}
 		if len(clusters) != 1 {
-			return grpc.Errorf(codes.Internal, "could not fetch cluster object")
+			return status.Errorf(codes.Internal, "could not fetch cluster object")
 		}
 		cluster := clusters[0]
 

--- a/manager/controlapi/task.go
+++ b/manager/controlapi/task.go
@@ -6,8 +6,8 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // GetTask returns a Task given a TaskID.
@@ -15,7 +15,7 @@ import (
 // - Returns `NotFound` if the Task is not found.
 func (s *Server) GetTask(ctx context.Context, request *api.GetTaskRequest) (*api.GetTaskResponse, error) {
 	if request.TaskID == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	var task *api.Task
@@ -23,7 +23,7 @@ func (s *Server) GetTask(ctx context.Context, request *api.GetTaskRequest) (*api
 		task = store.GetTask(tx, request.TaskID)
 	})
 	if task == nil {
-		return nil, grpc.Errorf(codes.NotFound, "task %s not found", request.TaskID)
+		return nil, status.Errorf(codes.NotFound, "task %s not found", request.TaskID)
 	}
 	return &api.GetTaskResponse{
 		Task: task,
@@ -36,7 +36,7 @@ func (s *Server) GetTask(ctx context.Context, request *api.GetTaskRequest) (*api
 // - Returns an error if the deletion fails.
 func (s *Server) RemoveTask(ctx context.Context, request *api.RemoveTaskRequest) (*api.RemoveTaskResponse, error) {
 	if request.TaskID == "" {
-		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
+		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 
 	err := s.store.Update(func(tx store.Tx) error {
@@ -44,7 +44,7 @@ func (s *Server) RemoveTask(ctx context.Context, request *api.RemoveTaskRequest)
 	})
 	if err != nil {
 		if err == store.ErrNotExist {
-			return nil, grpc.Errorf(codes.NotFound, "task %s not found", request.TaskID)
+			return nil, status.Errorf(codes.NotFound, "task %s not found", request.TaskID)
 		}
 		return nil, err
 	}

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -7,10 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/transport"
-
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/equality"
@@ -25,6 +21,9 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/transport"
 )
 
 const (
@@ -322,7 +321,7 @@ func (d *Dispatcher) isRunningLocked() (context.Context, error) {
 	d.mu.Lock()
 	if !d.isRunning() {
 		d.mu.Unlock()
-		return nil, grpc.Errorf(codes.Aborted, "dispatcher is stopped")
+		return nil, status.Errorf(codes.Aborted, "dispatcher is stopped")
 	}
 	ctx := d.ctx
 	d.mu.Unlock()
@@ -556,7 +555,7 @@ func (d *Dispatcher) UpdateTaskStatus(ctx context.Context, r *api.UpdateTaskStat
 		}
 
 		if t.NodeID != nodeID {
-			err := grpc.Errorf(codes.PermissionDenied, "cannot update a task not assigned this node")
+			err := status.Errorf(codes.PermissionDenied, "cannot update a task not assigned this node")
 			log.WithField("task.id", u.TaskID).Error(err)
 			return nil, err
 		}
@@ -1189,7 +1188,7 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 			log.WithError(err).Error("failed to remove node")
 		}
 		// still return an abort if the transport closure was ineffective.
-		return grpc.Errorf(codes.Aborted, "node must disconnect")
+		return status.Errorf(codes.Aborted, "node must disconnect")
 	}
 
 	for {

--- a/manager/health/health.go
+++ b/manager/health/health.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Server represents a Health Check server to check
@@ -46,7 +46,7 @@ func (s *Server) Check(ctx context.Context, in *api.HealthCheckRequest) (*api.He
 			Status: status,
 		}, nil
 	}
-	return nil, grpc.Errorf(codes.NotFound, "unknown service")
+	return nil, status.Errorf(codes.NotFound, "unknown service")
 }
 
 // SetServingStatus is called when need to reset the serving status of a service

--- a/manager/state/raft/transport/mock_raft_test.go
+++ b/manager/state/raft/transport/mock_raft_test.go
@@ -4,16 +4,15 @@ import (
 	"net"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/health"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
-
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type snapshotReport struct {
@@ -89,7 +88,7 @@ func (r *mockRaft) RemovePeer(id uint64) error {
 
 func (r *mockRaft) ProcessRaftMessage(ctx context.Context, req *api.ProcessRaftMessageRequest) (*api.ProcessRaftMessageResponse, error) {
 	if r.removed[req.Message.From] {
-		return nil, grpc.Errorf(codes.NotFound, "%s", membership.ErrMemberRemoved.Error())
+		return nil, status.Errorf(codes.NotFound, "%s", membership.ErrMemberRemoved.Error())
 	}
 	r.processedMessages <- req.Message
 	return &api.ProcessRaftMessageResponse{}, nil

--- a/manager/watchapi/watch.go
+++ b/manager/watchapi/watch.go
@@ -1,12 +1,11 @@
 package watchapi
 
 import (
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Watch starts a stream that returns any changes to objects that match
@@ -26,7 +25,7 @@ func (s *Server) Watch(request *api.WatchRequest, stream api.Watch_WatchServer) 
 
 	watchArgs, err := api.ConvertWatchArgs(request.Entries)
 	if err != nil {
-		return grpc.Errorf(codes.InvalidArgument, "%s", err.Error())
+		return status.Errorf(codes.InvalidArgument, "%s", err.Error())
 	}
 
 	watchArgs = append(watchArgs, state.EventCommit{})

--- a/protobuf/plugin/raftproxy/raftproxy.go
+++ b/protobuf/plugin/raftproxy/raftproxy.go
@@ -36,12 +36,12 @@ func (g *raftProxyGen) genProxyConstructor(s *descriptor.ServiceDescriptorProto)
 	g.gen.P(`redirectChecker := func(ctx context.Context)(context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})
@@ -376,6 +376,7 @@ func (g *raftProxyGen) GenerateImports(file *generator.FileDescriptor) {
 	}
 	g.gen.P("import raftselector \"github.com/docker/swarmkit/manager/raftselector\"")
 	g.gen.P("import codes \"google.golang.org/grpc/codes\"")
+	g.gen.P("import status \"google.golang.org/grpc/status\"")
 	g.gen.P("import metadata \"google.golang.org/grpc/metadata\"")
 	g.gen.P("import transport \"google.golang.org/grpc/transport\"")
 	// don't conflict with import added by ptypes

--- a/protobuf/plugin/raftproxy/test/service.pb.go
+++ b/protobuf/plugin/raftproxy/test/service.pb.go
@@ -32,6 +32,7 @@ import (
 
 import raftselector "github.com/docker/swarmkit/manager/raftselector"
 import codes "google.golang.org/grpc/codes"
+import status "google.golang.org/grpc/status"
 import metadata "google.golang.org/grpc/metadata"
 import transport "google.golang.org/grpc/transport"
 import rafttime "time"
@@ -973,12 +974,12 @@ func NewRaftProxyRouteGuideServer(local RouteGuideServer, connSelector raftselec
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})
@@ -1256,12 +1257,12 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 	redirectChecker := func(ctx context.Context) (context.Context, error) {
 		s, ok := transport.StreamFromContext(ctx)
 		if !ok {
-			return ctx, grpc.Errorf(codes.InvalidArgument, "remote addr is not found in context")
+			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
 		md, ok := metadata.FromContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
-			return ctx, grpc.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
+			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
 		if !ok {
 			md = metadata.New(map[string]string{})

--- a/protobuf/plugin/storeobject/storeobject.go
+++ b/protobuf/plugin/storeobject/storeobject.go
@@ -552,7 +552,7 @@ func (d *storeObjectGen) genMsgStoreObject(m *generator.Descriptor, storeObject 
 
 	/*                switch v := filter.By.(type) {
 	default:
-	        return nil, grpc.Errorf(codes.InvalidArgument, "selector type %T is unsupported for tasks", filter.By)
+	        return nil, status.Errorf(codes.InvalidArgument, "selector type %T is unsupported for tasks", filter.By)
 	}
 	*/
 


### PR DESCRIPTION

from the function's description; https://github.com/docker/swarmkit/blob/c23aa65fc646081600eb206c2f2dcff5a9e25143/vendor/google.golang.org/grpc/rpc_util.go#L393-L399

```go
// Errorf returns an error containing an error code and a description;
// Errorf returns nil if c is OK.
//
// Deprecated; use status.Errorf instead.
func Errorf(c codes.Code, format string, a ...interface{}) error {
	return status.Errorf(c, format, a...)
}
```