### PR TITLE
Revert grpc max message size/large timeout workaround for snapshot shipping between raft nodes

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -38,6 +38,7 @@ import (
 	"github.com/docker/swarmkit/manager/resourceapi"
 	"github.com/docker/swarmkit/manager/scheduler"
 	"github.com/docker/swarmkit/manager/state/raft"
+	"github.com/docker/swarmkit/manager/state/raft/transport"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/manager/watchapi"
 	"github.com/docker/swarmkit/remotes"
@@ -54,9 +55,6 @@ import (
 const (
 	// defaultTaskHistoryRetentionLimit is the number of tasks to keep.
 	defaultTaskHistoryRetentionLimit = 5
-
-	// Default value for grpc max message size.
-	grpcMaxMessageSize = 128 << 20
 )
 
 // RemoteAddrs provides a listening address and an optional advertise address
@@ -234,7 +232,7 @@ func New(config *Config) (*Manager, error) {
 		grpc.Creds(config.SecurityConfig.ServerTLSCreds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
-		grpc.MaxMsgSize(grpcMaxMessageSize),
+		grpc.MaxMsgSize(transport.GRPCMaxMsgSize),
 	}
 
 	m := &Manager{

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -182,12 +182,9 @@ type NodeOptions struct {
 	ClockSource clock.Clock
 	// SendTimeout is the timeout on the sending messages to other raft
 	// nodes. Leave this as 0 to get the default value.
-	SendTimeout time.Duration
-	// LargeSendTimeout is the timeout on the sending snapshots to other raft
-	// nodes. Leave this as 0 to get the default value.
-	LargeSendTimeout time.Duration
-	TLSCredentials   credentials.TransportCredentials
-	KeyRotator       EncryptionKeyRotator
+	SendTimeout    time.Duration
+	TLSCredentials credentials.TransportCredentials
+	KeyRotator     EncryptionKeyRotator
 	// DisableStackDump prevents Run from dumping goroutine stacks when the
 	// store becomes stuck.
 	DisableStackDump bool
@@ -208,11 +205,6 @@ func NewNode(opts NodeOptions) *Node {
 	}
 	if opts.SendTimeout == 0 {
 		opts.SendTimeout = 2 * time.Second
-	}
-	if opts.LargeSendTimeout == 0 {
-		// a "slow" 100Mbps connection can send over 240MB data in 20 seconds
-		// which is well over the gRPC message limit of 128MB allowed by SwarmKit
-		opts.LargeSendTimeout = 20 * time.Second
 	}
 
 	raftStore := raft.NewMemoryStorage()
@@ -359,7 +351,6 @@ func (n *Node) initTransport() {
 	transportConfig := &transport.Config{
 		HeartbeatInterval: time.Duration(n.Config.ElectionTick) * n.opts.TickInterval,
 		SendTimeout:       n.opts.SendTimeout,
-		LargeSendTimeout:  n.opts.LargeSendTimeout,
 		Credentials:       n.opts.TLSCredentials,
 		Raft:              n,
 	}

--- a/manager/state/raft/transport/mock_raft_test.go
+++ b/manager/state/raft/transport/mock_raft_test.go
@@ -63,7 +63,6 @@ func newMockRaft() (*mockRaft, error) {
 	cfg := &Config{
 		HeartbeatInterval: 3 * time.Second,
 		SendTimeout:       2 * time.Second,
-		LargeSendTimeout:  20 * time.Second,
 		Raft:              mr,
 	}
 	tr := New(cfg)

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -196,15 +196,7 @@ func needsSplitting(m *raftpb.Message) bool {
 }
 
 func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
-	timeout := p.tr.config.SendTimeout
-	// if a snapshot is being sent, set timeout to LargeSendTimeout because
-	// sending snapshots can take more time than other messages sent between peers.
-	// The same applies to AppendEntries as well, where messages can get large.
-	// TODO(anshul) remove when streaming change ready to merge.
-	if m.Type == raftpb.MsgSnap || m.Type == raftpb.MsgApp {
-		timeout = p.tr.config.LargeSendTimeout
-	}
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	ctx, cancel := context.WithTimeout(ctx, p.tr.config.SendTimeout)
 	defer cancel()
 
 	var err error

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -211,10 +211,6 @@ func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 	var stream api.Raft_StreamRaftMessageClient
 	stream, err = api.NewRaftClient(p.conn()).StreamRaftMessage(ctx)
 
-	if err != nil {
-
-	}
-
 	if err == nil {
 		// Split the message if needed.
 		// Currently only supported for MsgSnap.

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -36,7 +36,6 @@ type Raft interface {
 type Config struct {
 	HeartbeatInterval time.Duration
 	SendTimeout       time.Duration
-	LargeSendTimeout  time.Duration
 	Credentials       credentials.TransportCredentials
 	RaftID            string
 


### PR DESCRIPTION
Since we can now stream snapshots between raft nodes, we can revert the grpc workarounds.