### PR TITLE
use xnet.DialTimeoutLocal for swarmctl grpc Dialer

### DIFF
--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/xnet"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/context"
@@ -37,7 +38,7 @@ func DialConn(cmd *cobra.Command) (*grpc.ClientConn, error) {
 	opts = append(opts, grpc.WithTransportCredentials(insecureCreds))
 	opts = append(opts, grpc.WithDialer(
 		func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+			return xnet.DialTimeoutLocal(addr, timeout)
 		}))
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {


### PR DESCRIPTION
It will support swarmctl on windows(etc, swarmctl.exe -s //./pipe/swarm.sock cluster inspect default)