### PR TITLE
Resend task statuses when reestablishing session

### DIFF
--- a/agent/reporter.go
+++ b/agent/reporter.go
@@ -13,12 +13,25 @@ import (
 // concurrently, so implementations should be goroutine-safe.
 type StatusReporter interface {
 	UpdateTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error
+	UpdateTaskStatuses(ctx context.Context, statuses map[string]*api.TaskStatus) error
 }
 
 type statusReporterFunc func(ctx context.Context, taskID string, status *api.TaskStatus) error
 
 func (fn statusReporterFunc) UpdateTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
 	return fn(ctx, taskID, status)
+}
+
+func (fn statusReporterFunc) UpdateTaskStatuses(ctx context.Context, statuses map[string]*api.TaskStatus) error {
+	for taskID, status := range statuses {
+		if err := fn(ctx, taskID, status); err != nil {
+			return err
+		}
+		// delete statuses from the map as we process them so the random failures
+		// can't sink every batch forever
+		delete(statuses, taskID)
+	}
+	return nil
 }
 
 // statusReporter creates a reliable StatusReporter that will always succeed.
@@ -45,24 +58,52 @@ func newStatusReporter(ctx context.Context, upstream StatusReporter) *statusRepo
 	return r
 }
 
+// UpdateTaskStatuses adds a single status update to the reporter
 func (sr *statusReporter) UpdateTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
 	sr.mu.Lock()
 	defer sr.mu.Unlock()
 
-	current, ok := sr.statuses[taskID]
-	if ok {
-		if reflect.DeepEqual(current, status) {
-			return nil
-		}
-
-		if current.State > status.State {
-			return nil // ignore old updates
-		}
-	}
-	sr.statuses[taskID] = status
+	sr.addStatus(taskID, status)
+	// signal the waiting loop in run, so that this update will fire quickly
 	sr.cond.Signal()
 
 	return nil
+}
+
+// UpdateTaskStatuses updates all of the task statuses at once. The key
+// difference between this and calling UpdateTaskStatus repeatedly is that this
+// hold the lock until all updates are queued, meaning no update will happen
+// until all updates are ready
+func (sr *statusReporter) UpdateTaskStatuses(ctx context.Context, statuses map[string]*api.TaskStatus) error {
+	ctx = log.WithField(ctx, "method", "(*statusReporter).UpdateTaskStatuses")
+	log.G(ctx).Debugf("Updating %v task statuses", len(statuses))
+	sr.mu.Lock()
+	defer sr.mu.Unlock()
+	for taskID, status := range statuses {
+		sr.addStatus(taskID, status)
+	}
+
+	// the useful thing about this function is this: it doesn't wake the
+	// waiting loop in run until everything has been added.
+	sr.cond.Signal()
+
+	return nil
+}
+
+// addStatus adds the passed status to the statuses map if it's the newest
+// update
+func (sr *statusReporter) addStatus(taskID string, status *api.TaskStatus) {
+	current, ok := sr.statuses[taskID]
+	if ok {
+		if reflect.DeepEqual(current, status) {
+			return
+		}
+
+		if current.State > status.State {
+			return // ignore old updates
+		}
+	}
+	sr.statuses[taskID] = status
 }
 
 func (sr *statusReporter) Close() error {
@@ -76,6 +117,7 @@ func (sr *statusReporter) Close() error {
 }
 
 func (sr *statusReporter) run(ctx context.Context) {
+	ctx = log.WithModule(ctx, "statusReporter")
 	done := make(chan struct{})
 	defer close(done)
 
@@ -102,27 +144,30 @@ func (sr *statusReporter) run(ctx context.Context) {
 			return
 		}
 
-		for taskID, status := range sr.statuses {
-			delete(sr.statuses, taskID) // delete the entry, while trying to send.
-
-			sr.mu.Unlock()
-			err := sr.reporter.UpdateTaskStatus(ctx, taskID, status)
-			sr.mu.Lock()
-
-			// reporter might be closed during UpdateTaskStatus call
-			if sr.closed {
-				return
-			}
-
-			if err != nil {
-				log.G(ctx).WithError(err).Error("status reporter failed to report status to agent")
-
-				// place it back in the map, if not there, allowing us to pick
-				// the value if a new one came in when we were sending the last
-				// update.
-				if _, ok := sr.statuses[taskID]; !ok {
-					sr.statuses[taskID] = status
-				}
+		// swap out the statuses map, so we can release the lock while we
+		// do the batch
+		statuses := sr.statuses
+		sr.statuses = map[string]*api.TaskStatus{}
+		// unlock the map so new statuses can be added while we process the
+		// current ones
+		sr.mu.Unlock()
+		err := sr.reporter.UpdateTaskStatuses(ctx, statuses)
+		// re-lock the map so we can add statuses back if we need to.
+		sr.mu.Lock()
+		// it's possible that the status reporter may have closed while the
+		// lock was released, but as the code is structured now, that's
+		// unimportant. we might add some statuses back to the map, which would
+		// be useless, but when we back get around to the sr.closed check
+		// above, we'll exit anyway.
+		if err != nil {
+			// this is probably just a hiccup in the dispatcher, not an
+			// unrecoverable error
+			log.G(ctx).WithError(err).Warn("status reporter failed to batch-update tasks")
+			// if the batch failed, we don't know what statuses worked or
+			// not. stick them all back into the statuses map and process them
+			// one by one
+			for id, status := range statuses {
+				sr.addStatus(id, status)
 			}
 		}
 	}

--- a/agent/reporter_test.go
+++ b/agent/reporter_test.go
@@ -91,7 +91,7 @@ func TestReporter(t *testing.T) {
 
 			// simulate pounding this with a bunch of goroutines
 			go func() {
-				if err := reporter.UpdateTaskStatus(ctx, taskID, status); err != nil {
+				if err := reporter.UpdateTaskStatus(ctx, map[string]*api.TaskStatus{taskID: status}); err != nil {
 					assert.NoError(t, err, "sending should not fail")
 				}
 			}()

--- a/agent/reporter_test.go
+++ b/agent/reporter_test.go
@@ -1,11 +1,11 @@
 package agent
 
 import (
-	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/stretchr/testify/assert"
@@ -21,17 +21,27 @@ func TestReporter(t *testing.T) {
 	const ntasks = 100
 
 	var (
-		ctx      = context.Background()
-		statuses = make(map[string]*api.TaskStatus) // destination map
-		unique   = make(map[uniqueStatus]struct{})  // ensure we don't receive any status twice
-		mu       sync.Mutex
-		expected = make(map[string]*api.TaskStatus)
-		wg       sync.WaitGroup
+		// NOTE(dperny): don't increase this timeout! this test should never
+		// take anything close to a minute. If it does, you have a bug
+		// someplace else. Probably a deadlock.
+		ctx, cancel = context.WithTimeout(context.Background(), 60*time.Second)
+		statuses    = make(map[string]*api.TaskStatus) // destination map
+		unique      = make(map[uniqueStatus]struct{})  // ensure we don't receive any status twice
+		mu          sync.Mutex
+		expected    = make(map[string]*api.TaskStatus)
+		// in the past, this test used a waitgroup to determine when all
+		// statuses had been reported. the problem is that if the test fails
+		// and some statuses don't get reported, the test would deadlock.
+		// instead, we use a channel here, so we can select on that channel and
+		// ctx.Done(), allowing us to gracefully exit the test on timeout.
+		remaining = ntasks
+		done      = make(chan struct{})
 	)
+	defer cancel()
 
 	reporter := newStatusReporter(ctx, statusReporterFunc(func(ctx context.Context, taskID string, status *api.TaskStatus) error {
 		if rand.Float64() > 0.9 {
-			return errors.New("status send failed")
+			return fmt.Errorf("status send failed for %v to %v", taskID, status.State)
 		}
 
 		mu.Lock()
@@ -40,11 +50,21 @@ func TestReporter(t *testing.T) {
 		key := uniqueStatus{taskID, status}
 		// make sure we get the status only once.
 		if _, ok := unique[key]; ok {
-			t.Fatal("encountered status twice")
+			// do not Fatal here. This runs in a goroutine and Fatal won't
+			// cause the test to exit.
+			t.Errorf("got update for %v to %v twice", taskID, status.State)
+			// return here, don't release a wg. also don't return error, which
+			// will cause the batch to be redone indefinitely.
+			// TODO(dperny): duplicate updates isn't an error condition
+			return nil
 		}
 
 		if status.State == api.TaskStateCompleted {
-			wg.Done()
+			remaining = remaining - 1
+			if remaining <= 0 {
+				// defer the close so it runs after we finish this run
+				defer close(done)
+			}
 		}
 
 		unique[key] = struct{}{}
@@ -58,8 +78,6 @@ func TestReporter(t *testing.T) {
 
 		return nil
 	}))
-
-	wg.Add(ntasks) // statuses will be reported!
 
 	for _, state := range []api.TaskState{
 		api.TaskStateAccepted,
@@ -81,7 +99,12 @@ func TestReporter(t *testing.T) {
 		}
 	}
 
-	wg.Wait() // wait for the propagation
+	select {
+	case <-ctx.Done():
+		t.Error("context done. you probably have a deadlock somewhere")
+	case <-done:
+		// we're done, finish out the test.
+	}
 	assert.NoError(t, reporter.Close())
 	mu.Lock()
 	defer mu.Unlock()

--- a/agent/session.go
+++ b/agent/session.go
@@ -355,6 +355,8 @@ func (s *session) watch(ctx context.Context) error {
 }
 
 // sendTaskStatus uses the current session to send the status of a single task.
+// NOTE(dperny): this code is unused, because we use the below, batching case
+// (sendTaskStatuses) but has been left in for future reference
 func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
 	ctx = log.WithField(ctx, "method", "(*session).sendTaskStatus")
 	client := api.NewDispatcherClient(s.conn.ClientConn)
@@ -379,6 +381,8 @@ func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api
 	return nil
 }
 
+// sendTaskStatuses uses the current session to send all of the provided
+// updates in one batch
 func (s *session) sendTaskStatuses(ctx context.Context, updates ...*api.UpdateTaskStatusRequest_TaskStatusUpdate) ([]*api.UpdateTaskStatusRequest_TaskStatusUpdate, error) {
 	ctx = log.WithField(ctx, "method", "(*session).sendTaskStatuses)")
 	log.G(ctx).Debugf("sending batch of %v task statuses", len(updates))

--- a/agent/session.go
+++ b/agent/session.go
@@ -271,7 +271,7 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 
 func (s *session) watch(ctx context.Context) error {
 	log := log.G(ctx).WithFields(logrus.Fields{"method": "(*session).watch"})
-	log.Debugf("")
+	log.Debug("started session watch")
 	var (
 		resp            *api.AssignmentsMessage
 		assignmentWatch api.Dispatcher_AssignmentsClient
@@ -356,6 +356,7 @@ func (s *session) watch(ctx context.Context) error {
 
 // sendTaskStatus uses the current session to send the status of a single task.
 func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
+	ctx = log.WithField(ctx, "method", "(*session).sendTaskStatus")
 	client := api.NewDispatcherClient(s.conn.ClientConn)
 	if _, err := client.UpdateTaskStatus(ctx, &api.UpdateTaskStatusRequest{
 		SessionID: s.sessionID,
@@ -379,6 +380,8 @@ func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api
 }
 
 func (s *session) sendTaskStatuses(ctx context.Context, updates ...*api.UpdateTaskStatusRequest_TaskStatusUpdate) ([]*api.UpdateTaskStatusRequest_TaskStatusUpdate, error) {
+	ctx = log.WithField(ctx, "method", "(*session).sendTaskStatuses)")
+	log.G(ctx).Debugf("sending batch of %v task statuses", len(updates))
 	if len(updates) < 1 {
 		return nil, nil
 	}

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -39,6 +39,9 @@ type Worker interface {
 	// The listener will be removed if the context is cancelled.
 	Listen(ctx context.Context, reporter StatusReporter)
 
+	// Report send the status of all tasks to the provided reporter.
+	Report(ctx context.Context, reporter StatusReporter) error
+
 	// Subscribe to log messages matching the subscription.
 	Subscribe(ctx context.Context, subscription *api.SubscriptionMessage) error
 
@@ -402,12 +405,13 @@ func reconcileConfigs(ctx context.Context, w *worker, assignments []*api.Assignm
 }
 
 func (w *worker) Listen(ctx context.Context, reporter StatusReporter) {
+	ctx = log.WithField(ctx, "method", "(*worker).Listen")
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	log.G(ctx).Debug("listening with new reporter")
 
 	key := &statusReporterKey{reporter}
 	w.listeners[key] = struct{}{}
-
 	go func() {
 		<-ctx.Done()
 		w.mu.Lock()
@@ -416,13 +420,39 @@ func (w *worker) Listen(ctx context.Context, reporter StatusReporter) {
 	}()
 
 	// report the current statuses to the new listener
-	if err := w.db.View(func(tx *bolt.Tx) error {
-		return WalkTaskStatus(tx, func(id string, status *api.TaskStatus) error {
-			return reporter.UpdateTaskStatus(ctx, id, status)
-		})
-	}); err != nil {
+	if err := w.updateAllTasks(ctx, reporter); err != nil {
 		log.G(ctx).WithError(err).Errorf("failed reporting initial statuses to registered listener %v", reporter)
 	}
+}
+
+// Report walks all task statuses and reports them with the provided
+// StatusReporter
+func (w *worker) Report(ctx context.Context, reporter StatusReporter) error {
+	ctx = log.WithField(ctx, "method", "(*worker).Report")
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.updateAllTasks(ctx, reporter)
+}
+
+// updateAllTasks is the common functionality of Report and Listen. The
+// behavior of Listen is a superset of the behavior of report, but we can't
+// call into Report from Listen because both methods acquire the lock and that
+// case would obviously deadlock. Instead, the common functionality is in this
+// method, sans lock, to avoid that case while still not duplicating code.
+func (w *worker) updateAllTasks(ctx context.Context, reporter StatusReporter) error {
+	return w.db.View(func(tx *bolt.Tx) error {
+		statuses := map[string]*api.TaskStatus{}
+		log.G(ctx).Debug("Walking task statuses")
+		if err := WalkTaskStatus(tx, func(id string, status *api.TaskStatus) error {
+			// build a map of the statuses to send in a batch update
+			statuses[id] = status
+			return nil
+		}); err != nil {
+			return err
+		}
+		// and then send all of the statuses to the reporter.
+		return reporter.UpdateTaskStatuses(ctx, statuses)
+	})
 }
 
 func (w *worker) startTask(ctx context.Context, tx *bolt.Tx, task *api.Task) error {

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -451,7 +451,7 @@ func (w *worker) updateAllTasks(ctx context.Context, reporter StatusReporter) er
 			return err
 		}
 		// and then send all of the statuses to the reporter.
-		return reporter.UpdateTaskStatuses(ctx, statuses)
+		return reporter.UpdateTaskStatus(ctx, statuses)
 	})
 }
 
@@ -522,7 +522,7 @@ func (w *worker) updateTaskStatus(ctx context.Context, tx *bolt.Tx, taskID strin
 
 	// broadcast the task status out.
 	for key := range w.listeners {
-		if err := key.StatusReporter.UpdateTaskStatus(ctx, taskID, status); err != nil {
+		if err := key.StatusReporter.UpdateTaskStatus(ctx, map[string]*api.TaskStatus{taskID: status}); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed updating status for reporter %v", key.StatusReporter)
 		}
 	}


### PR DESCRIPTION
Oh boy this one is a doozy

1. Makes the status reporter support batch updates
2. Makes the agent support batch updates as a status reporter
3. Makes the places that use a status report use batch updates when
available
4. Makes the worker's `Listen` method callable multiple times with the
same status reporter, reporting all of the statuses to that reporter
every time it is called.
5. Makes the agent call the worker's `Listen` method every time it
reestablishes a session.

This fixes a race condition that results from the Dispatcher in the
manager batching updates, and telling the agent that task updates have
succeeded when they haven't actually been committed to the raft log.
This has the effect of making the managers drop status updates if there
is a leadership change while a batch of status updates is in the
pipeline. The fix here is that when agent's reestablish a session, they
re-send all of their task statuses, so the manager will DEFINITELY be
up to date.

This commit is marked "WIP" because I'm not totally confident on the
architecture and I want some review before I write unit tests for all
this new junk.

/cc @stevvooe for review, and also @aluzzardi, because this is... 
quite an impactful change, and i'm not totally confident about this 
approach.