### PR TITLE
Regenerate protobuf for 3.5 (again)

### DIFF
--- a/api/api.pb.txt
+++ b/api/api.pb.txt
@@ -514,6 +514,38 @@ file {
       type_name: ".google.protobuf.EnumOptions"
       json_name: "options"
     }
+    field {
+      name: "reserved_range"
+      number: 4
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.EnumDescriptorProto.EnumReservedRange"
+      json_name: "reservedRange"
+    }
+    field {
+      name: "reserved_name"
+      number: 5
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "reservedName"
+    }
+    nested_type {
+      name: "EnumReservedRange"
+      field {
+        name: "start"
+        number: 1
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "start"
+      }
+      field {
+        name: "end"
+        number: 2
+        label: LABEL_OPTIONAL
+        type: TYPE_INT32
+        json_name: "end"
+      }
+    }
   }
   message_type {
     name: "EnumValueDescriptorProto"
@@ -698,7 +730,7 @@ file {
     }
     field {
       name: "php_generic_services"
-      number: 19
+      number: 42
       label: LABEL_OPTIONAL
       type: TYPE_BOOL
       default_value: "false"
@@ -1256,6 +1288,7 @@ file {
     java_outer_classname: "DescriptorProtos"
     optimize_for: SPEED
     go_package: "github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor"
+    cc_enable_arenas: true
     objc_class_prefix: "GPB"
     csharp_namespace: "Google.Protobuf.Reflection"
   }


### PR DESCRIPTION
Protobuf was updated to version 3.5, in commit https://github.com/docker/swarmkit/pull/2448/commits/9b981e255e4b3172b54db76e3c96021f981f3e27 (https://github.com/docker/swarmkit/pull/2448)
and regenerated in https://github.com/docker/swarmkit/pull/2451/commits/93c3290f31990bf4fe0e01759deea7ac55c4d955 (https://github.com/docker/swarmkit/pull/2451), however in https://github.com/docker/swarmkit/pull/2458/commits/58e42ec9f7f3d241966b1d0f7bc34457888f6aa4 (https://github.com/docker/swarmkit/pull/2458)
those changes were reverted; possibly due to an older version of protobuf being used.

These are the changes after running `make generate` after installing protobuf 3.5.1
