### PR TITLE
[17.12] Fix IP overlap with empty EndpointSpec

### DIFF
--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -244,6 +245,7 @@ vipLoop:
 		}
 		for _, nAttach := range specNetworks {
 			if nAttach.Target == eAttach.NetworkID {
+				log.L.WithFields(logrus.Fields{"service_id": s.ID, "vip": eAttach.Addr}).Debug("allocate vip")
 				if err = na.allocateVIP(eAttach); err != nil {
 					return err
 				}


### PR DESCRIPTION
cherry-pick of https://github.com/docker/swarmkit/pull/2505 for 17.12

```
git checkout -b 17.12-backport-fixendpointspec upstream/bump_v17.12
git cherry-pick -s -S -x bd4e923c241ff1f9a493eab02125edbf6ec0b901
```

(no conflicts)


Passing and empty EndpointSpec in the service spec
was correctly triggering the VIP allocation but
the leader election was erroneusly handling the IPAM
state restore trying to release the VIP.
The fix focuses on proper handling of the restart case.

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>
(cherry picked from commit bd4e923c241ff1f9a493eab02125edbf6ec0b901)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>