### PR TITLE
Remove Allocator task voting

### DIFF
--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -1,10 +1,9 @@
 package allocator
 
 import (
-	"sync"
+	"github.com/pkg/errors"
 
 	"github.com/docker/docker/pkg/plugingetter"
-	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
@@ -15,11 +14,6 @@ import (
 type Allocator struct {
 	// The manager store.
 	store *store.MemoryStore
-
-	// the ballot used to synchronize across all allocators to ensure
-	// all of them have completed their respective allocations so that the
-	// task can be moved to ALLOCATED state.
-	taskBallot *taskBallot
 
 	// context for the network allocator that will be needed by
 	// network allocator.
@@ -34,43 +28,11 @@ type Allocator struct {
 	pluginGetter plugingetter.PluginGetter
 }
 
-// taskBallot controls how the voting for task allocation is
-// coordinated b/w different allocators. This the only structure that
-// will be written by all allocator goroutines concurrently. Hence the
-// mutex.
-type taskBallot struct {
-	sync.Mutex
-
-	// List of registered voters who have to cast their vote to
-	// indicate their allocation complete
-	voters []string
-
-	// List of votes collected for every task so far from different voters.
-	votes map[string][]string
-}
-
-// allocActor controls the various phases in the lifecycle of one kind of allocator.
-type allocActor struct {
-	// Task voter identity of the allocator.
-	taskVoter string
-
-	// Action routine which is called for every event that the
-	// allocator received.
-	action func(context.Context, events.Event)
-
-	// Init routine which is called during the initialization of
-	// the allocator.
-	init func(ctx context.Context) error
-}
-
 // New returns a new instance of Allocator for use during allocation
 // stage of the manager.
 func New(store *store.MemoryStore, pg plugingetter.PluginGetter) (*Allocator, error) {
 	a := &Allocator{
-		store: store,
-		taskBallot: &taskBallot{
-			votes: make(map[string][]string),
-		},
+		store:        store,
 		stopChan:     make(chan struct{}),
 		doneChan:     make(chan struct{}),
 		pluginGetter: pg,
@@ -83,74 +45,11 @@ func New(store *store.MemoryStore, pg plugingetter.PluginGetter) (*Allocator, er
 func (a *Allocator) Run(ctx context.Context) error {
 	// Setup cancel context for all goroutines to use.
 	ctx, cancel := context.WithCancel(ctx)
-	var (
-		wg     sync.WaitGroup
-		actors []func() error
-	)
 
 	defer func() {
 		cancel()
-		wg.Wait()
 		close(a.doneChan)
 	}()
-
-	for _, aa := range []allocActor{
-		{
-			taskVoter: networkVoter,
-			init:      a.doNetworkInit,
-			action:    a.doNetworkAlloc,
-		},
-	} {
-		if aa.taskVoter != "" {
-			a.registerToVote(aa.taskVoter)
-		}
-
-		// Assign a pointer for variable capture
-		aaPtr := &aa
-		actor := func() error {
-			wg.Add(1)
-			defer wg.Done()
-
-			// init might return an allocator specific context
-			// which is a child of the passed in context to hold
-			// allocator specific state
-			watch, watchCancel, err := a.init(ctx, aaPtr)
-			if err != nil {
-				return err
-			}
-
-			wg.Add(1)
-			go func(watch <-chan events.Event, watchCancel func()) {
-				defer func() {
-					wg.Done()
-					watchCancel()
-				}()
-				a.run(ctx, *aaPtr, watch)
-			}(watch, watchCancel)
-			return nil
-		}
-
-		actors = append(actors, actor)
-	}
-
-	for _, actor := range actors {
-		if err := actor(); err != nil {
-			return err
-		}
-	}
-
-	<-a.stopChan
-	return nil
-}
-
-// Stop stops the allocator
-func (a *Allocator) Stop() {
-	close(a.stopChan)
-	// Wait for all allocator goroutines to truly exit
-	<-a.doneChan
-}
-
-func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
 	watch, watchCancel := state.Watch(a.store.WatchQueue(),
 		api.EventCreateNetwork{},
 		api.EventDeleteNetwork{},
@@ -165,67 +64,33 @@ func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Eve
 		api.EventDeleteNode{},
 		state.EventCommit{},
 	)
+	defer watchCancel()
 
-	if err := aa.init(ctx); err != nil {
-		watchCancel()
-		return nil, nil, err
+	if err := a.doNetworkInit(ctx); err != nil {
+		return err
 	}
 
-	return watch, watchCancel, nil
-}
-
-func (a *Allocator) run(ctx context.Context, aa allocActor, watch <-chan events.Event) {
 	for {
 		select {
 		case ev, ok := <-watch:
 			if !ok {
-				return
+				// the channel should not be closed unless we stop it, and if
+				// it does close that's an error
+				return errors.New("allocator event watch closed unexpectedly")
 			}
 
-			aa.action(ctx, ev)
+			a.doNetworkAlloc(ctx, ev)
 		case <-ctx.Done():
-			return
+			return ctx.Err()
+		case <-a.stopChan:
+			return nil
 		}
 	}
 }
 
-func (a *Allocator) registerToVote(name string) {
-	a.taskBallot.Lock()
-	defer a.taskBallot.Unlock()
-
-	a.taskBallot.voters = append(a.taskBallot.voters, name)
-}
-
-func (a *Allocator) taskAllocateVote(voter string, id string) bool {
-	a.taskBallot.Lock()
-	defer a.taskBallot.Unlock()
-
-	// If voter has already voted, return false
-	for _, v := range a.taskBallot.votes[id] {
-		// check if voter is in x
-		if v == voter {
-			return false
-		}
-	}
-
-	a.taskBallot.votes[id] = append(a.taskBallot.votes[id], voter)
-
-	// We haven't gotten enough votes yet
-	if len(a.taskBallot.voters) > len(a.taskBallot.votes[id]) {
-		return false
-	}
-
-nextVoter:
-	for _, voter := range a.taskBallot.voters {
-		for _, vote := range a.taskBallot.votes[id] {
-			if voter == vote {
-				continue nextVoter
-			}
-		}
-
-		// Not every registered voter has registered a vote.
-		return false
-	}
-
-	return true
+// Stop stops the allocator
+func (a *Allocator) Stop() {
+	close(a.stopChan)
+	// Wait for all allocator goroutines to truly exit
+	<-a.doneChan
 }

--- a/manager/allocator/doc.go
+++ b/manager/allocator/doc.go
@@ -1,18 +1,3 @@
-// Package allocator aims to manage allocation of different
-// cluster-wide resources on behalf of the manager. In particular, it
-// manages a set of independent allocator processes which can mostly
-// execute concurrently with only a minimal need for coordination.
-//
-// One of the instances where it needs coordination is when deciding to
-// move a task to the PENDING state. Since a task can move to the
-// PENDING state only when all the task allocators have completed,
-// they must cooperate. The way `allocator` achieves this is by creating
-// a `taskBallot` to which all task allocators register themselves as
-// mandatory voters. For each task that needs allocation, each allocator
-// independently votes to indicate the completion of their allocation.
-// Once all registered voters have voted then the task is moved to the
-// PENDING state.
-//
-// Other than the coordination needed for task PENDING state, all
-// the allocators function fairly independently.
+// Package allocator aims to manage allocation of network resources on behalf
+// of the manager.
 package allocator

--- a/manager/allocator/network_allocator_new.go
+++ b/manager/allocator/network_allocator_new.go
@@ -1,0 +1,303 @@
+package allocator
+
+import (
+	// standard libraries
+	"context"
+	"sync"
+
+	// external libraries
+	"github.com/pkg/errors"
+
+	// docker's libraries
+	"github.com/docker/docker/pkg/plugingetter"
+	"github.com/docker/go-events"
+
+	// libnetwork-specific imports
+	"github.com/docker/libnetwork/datastore"
+	"github.com/docker/libnetwork/driverapi"
+	"github.com/docker/libnetwork/drvregistry"
+	"github.com/docker/libnetwork/ipamapi"
+	builtinIpam "github.com/docker/libnetwork/ipams/builtin"
+	nullIpam "github.com/docker/libnetwork/ipams/null"
+	remoteIpam "github.com/docker/libnetwork/ipams/remote"
+	"github.com/docker/libnetwork/netlabel"
+
+	// internal libraries
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state"
+	"github.com/docker/swarmkit/manager/state/store"
+
+	// TODO(dperny): clean up networkallocator
+	"github.com/docker/swarmkit/manager/allocator/networkallocator"
+)
+
+const DefaultDriver = "overylay"
+
+type NetworkAllocator struct {
+	// store is the memory store of cluster
+	// store *store.MemoryStore
+	// actually, we don't need store. we shouldn't use store. initialization
+	// should be provided by the caller giving us a list of all of the object
+	// types we handle, and run-time should be accomplished through an event
+	// channel. we should return the objects we've allocated to the caller
+	// through a channel of our own
+
+	// we don't really need a PluginGetter in this object, but we have to have
+	// it because of the way wait on creating the nwallocator until Init()
+	pg plugingetter.PluginGetter
+
+	drvRegistry *drvregistry.DrvRegistry
+	// startChan blocks the execution of Run until Init is called
+	startChan chan struct{}
+	// stopChan signals the Run routine to end
+	stopChan chan struct{}
+	// doneChan signals that the allocator has stopped
+	doneChan chan struct{}
+}
+
+// NewNetworkAllocator returns the msot minimal NetworkAllocator object,
+// otherwise uninitialized. Because initialization might be a weighty action,
+// it's handled separately from the object creation
+func NewNetworkAllocator(pg plugingetter.PluginGetter) *NetworkAllocator {
+	return &NetworkAllocator{
+		pg:        pg,
+		startChan: make(chan struct{}),
+		stopChan:  make(chan struct{}),
+		doneChan:  make(chan struct{}),
+	}
+}
+
+// Init populates the local allocator state from the provided state, and
+// unblocks the run loop when it has completed successfully
+func (na *NetworkAllocator) Init(ctx context.Context, networks []*api.Network, nodes []*api.Node, services []*api.Service, tasks []*api.Task) (retErr error) {
+	ctx = log.WithField("method", "(*NetworkAllocator).Init")
+	log.G(ctx).Debug("initializing network allocator")
+
+	// defer a function that will close the start channel and allow Run to
+	// proceed, if the Init is returning successfully.
+	defer func() {
+		if retErr == nil {
+			close(startChan)
+		}
+	}()
+
+	// initialize the drivers state
+
+	log.G(ctx).Debug("initializing drivers")
+	// There are no driver configurations and notification
+	// functions as of now.
+	reg, err := drvregistry.New(nil, nil, nil, nil, pg)
+	if err != nil {
+		return errors.Wrap(err, "unable to initialize drvRegistry")
+	}
+	na.drvRegistry = reg
+
+	// initializers is a list of driver initializers specific to the particular
+	// platform we're on. the exact list can be found in the
+	// drivers_<platform>.go source files.
+	for _, i := range initializers {
+		if err := na.drvregistry.AddDriver(i.ntype, i.fn, nil); err != nil {
+			return errors.Wrapf(err, "unable to initialize driver %v", i.ntype)
+		}
+	}
+
+	// Initialize the ipam drivers. Not sure what the difference between these
+	// is
+	if err := builtinIpam.Init(na.drvRegistry, nil, nil); err != nil {
+		return errors.Wrap(err, "unable to initalize built in ipam driver")
+	}
+	if err := remoteIpam.Init(na.drvRegistry, nil, nil); err != nil {
+		return errors.Wrap(err, "unable to initalize remote ipam driver")
+	}
+	if err := nullIpam.Init(na.drvRegistry, nil, nil); err != nil {
+		return errors.Wrap(err, "unable to initalize null ipam driver")
+	}
+
+	log.G(ctx).Debug("initializing local state")
+	// TODO(dperny) optimize with concurrency
+	log.G(ctx).Debug("initializing state for networks")
+	for _, network := range networks {
+		name := getDriverName(n)
+		// No swarm-level allocation can be provided by the network driver for
+		// node-local networks. Only thing needed is populating the driver's
+		// name in the driver's state.
+		d, caps, err := na.resolveDriver(name)
+		if err != nil {
+			return errors.Wrapf(err, "error initializing network: %s", network.ID)
+		}
+		if caps.DataScope == datastore.LocalScope {
+			network.DriverState = &api.Driver{
+				Name: name,
+			}
+			network.IPAM = &api.IPAMOptions{Driver: &api.Driver{}}
+			continue
+		}
+
+		// now we need to initialize the pools... what is a pool?
+
+		// first, get the IPAM driver
+		ipamName, ipam, ipamOpts, err := na.resolveIPAM(network)
+		if err != nil {
+			return errors.Wrapf(err, "error initializing network: %v", network.ID)
+		}
+
+		// We don't support user defined address spaces yet so just
+		// retrieve default address space names for the driver.
+		_, asName, err := na.drvRegistry.IPAMDefaultAddressSpaces(ipamName)
+		if err != nil {
+			return errors.Wrapf(err, "error retrieving default IPAM address spaces for network %s with ipam driver %s", network.ID, ipamName)
+		}
+
+		pools := map[string]string
+		if n.IPAM != nil {
+
+		}
+	}
+	log.G(ctx).Debug("initializing state for nodes")
+	for _, node := range nodes {
+
+	}
+	log.G(ctx).Debug("initializing state for services")
+	for _, service := range services {
+	}
+	log.G(ctx).Debug("initializing state for tasks")
+	for _, task := range tasks {
+	}
+
+	return nil
+}
+
+func (na *NetworkAllocator) Run(ctx context.Context, eventq <-chan events.Event) error {
+	ctx = log.WithModule("networkallocator")
+	log.G(ctx).Debug("waiting on start channel to unblock")
+	select {
+	case <-na.startChan:
+		// when startChan unblocks, we can proceed
+	case <-na.stopChan:
+		// stopChan tells us we've been stopped, so don't do any work
+		return nil
+	case <-ctx.Done():
+		// if the context is done, unblock
+		return ctx.Err()
+	}
+
+	// main run loop, go forever, selecting on channels for behavior
+	for {
+		select {
+		case <-stopChan:
+			// Allocator has stopped, exit cleanly
+			return nil
+		case <-ctx.Done():
+			// Allocator has been aborted, return the reason why
+			return ctx.Err()
+		case ev := <-events.Event:
+			na.handle(ctx, ev)
+		}
+	}
+}
+
+func (na *NetworkAllocator) Stop(ctx context.Context) error {
+	ctx = log.WithField("method", "(*NetworkAllocator).Stop")
+	// close the stop channel to signal that the network allocator should stop
+	close(na.stopChan)
+
+	select {
+	case <-na.doneChan:
+		// wait for the network allocator to finish
+		return nil
+	case <-ctx.Done():
+		return errors.Wrap(err, "context canceled while waiting for clean exit")
+	}
+}
+
+// handle recieves events and switches them to the appropriate handler
+func handle(ctx context.Context, ev events.Event) {
+	switch ev.(type) {
+	case api.EventCreateNetwork:
+	case api.EventUpdateNetwork:
+	case api.EventDeleteNetwork:
+	case api.EventCreateNode:
+	case api.EventUpdateNode:
+	case api.EventDeleteNode:
+	case api.EventCreateService:
+	case api.EventUpdateService:
+	case api.EventDeleteService:
+	case api.EventCreateTask:
+	case api.EventUpdateTask:
+	case api.EventDeleteTask:
+	}
+}
+
+// resolveDriver returns the information for a driver for the provided name
+// it returns the driver and the driver capabailities, or an error if
+// resolution failed
+func (na *NetworkAllocator) resolveDriver(name string) (driverapi.Driver, *driverapi.Capability, error) {
+	d, drvcap := na.drvRegistry.Driver(dName)
+	// if the network driver is nil, it must be a plugin
+	if d == nil {
+		pg := na.drvRegistry.GetPluginGetter()
+		if pg == nil {
+			return nil, nil, errors.Errorf("error getting driver %v: plugin store is uninitialized", dName)
+		}
+
+		_, err := pg.Get(name, driverapi.NetworkPluginEndpointType, plugingetter.Lookup)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "error getting driver %v from plugin store", name)
+		}
+
+		// NOTE(dperny): I don't understand why calling Driver a second time
+		// is any different. what about the (PluginGetter).Get method is special?
+		// why does it have side effects? i figured initially that this method
+		// call was just to see if a plugin existed or whatever, but this must
+		// have side effects
+		d, drvcap = na.drvRegistry.Driver(name)
+		if d == nil {
+			return nil, errors.Errorf("could not resolve network driver %v", name)
+		}
+	}
+	return d, drvcap, nil
+}
+
+// resolveIPAM retrieves the IPAM driver and options for the network provided.
+// it returns the IPAM driver name, the IPAM driver, and the IPAM driver
+// options, or an error if resolving the IPAM driver fails, in that order.
+func (na *NetworkAllocator) resolveIPAM(n *api.Network) (string, ipamapi.IPAM, map[string]string, error) {
+	// set default name and driver options
+	dName := ipamapi.DefaultIPAM
+	dOptions := map[string]string{}
+
+	// check if the IPAM driver name and options are populated in the network
+	// spec. if so, use them instead of the defaults
+	if n.Spec.IPAM != nil && n.Spec.IPAM.Driver != nil {
+		if n.Spec.IPAM.Driver.Name != "" {
+			dName = n.Spec.IPAM.Driver.Name
+		}
+		if len(n.Spec.IPAM.Driver.Options) != 0 {
+			dOptions = n.Spec.IPAM.Driver.Options
+		}
+	}
+
+	// now get the IPAM driver from the driver registry. if it doesn't exist,
+	// return an error
+	ipam, _ := na.drvRegistry.IPAM(dName)
+	if ipam == nil {
+		return nil, "", nil, fmt.Errorf("could not resolve IPAM driver %s", dName)
+	}
+
+	return dName, ipam, dOptions, nil
+}
+
+// getDriverName returns the name of the driver for a given network, which is
+// either specified in its DriverConfig, or is assumed to be DefaultDriver
+//
+// NOTE(dperny) in a previous version of this code, getDriverName was performed
+// at the top of the resolveDriver method. however, this left the resolveDriver
+// method returning, essentially, 4 values simultaneously. to clean up that
+// function signature, i've moved getting the name to a different step
+func getDriverName(n *api.Network) string {
+	if n.Spec.DriverConfig != nil && n.Spec.DriverConfig.Name != "" {
+		return n.Spec.DriverConfig.Name
+	}
+	return DefaultDriver
+}


### PR DESCRIPTION
Removes the unused, dead Allocator task voting code.

The Allocator was originally designed to handle the allocation of many
different kinds of resources, and only move tasks to PENDING after all
allocators had been run. However, in time, no allocator other than for
networks has been written, and there is no forseeable future use case
for another allocator.

In addition, the task voting design was bad; it relied on the individual
allocator components to check if the voting for a particular task had
completed and move it to PENDING if so. This would have spread the
responibility for advancing task state to every single allocator, quite
nearly defeating the purpose of task voting altogether.

Therefore, with poorly designed task voting code serving no function
other than to confuse engineers, it has been removed. If we need it in
the future, we can do it better by rewriting it.

This is some set up leading up to #2516, by boiling out the useless
portions of the Allocator code before we start rebuilding it wholesale.