### PR TITLE
Ingress network should not be attachable

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -644,7 +644,7 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 		return nil, err
 	}
 
-	if err := s.validateNetworks(request.Spec.Networks); err != nil {
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
 		return nil, err
 	}
 
@@ -724,6 +724,10 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		return nil, status.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
 	if err := validateServiceSpec(request.Spec); err != nil {
+		return nil, err
+	}
+
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Ingress network is a special network used only to expose
ports. For this reason the network cannot be explicitly
attached during service create or service update

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>