### PR TITLE
[manager/dispatcher] Remove redundant mutex from the dispatcher

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -171,8 +171,8 @@ func startDispatcher(c *Config) (*grpcDispatcher, error) {
 	}()
 	go d.Run(context.Background())
 	if err := testutils.PollFuncWithTimeout(nil, func() error {
-		d.mu.Lock()
-		defer d.mu.Unlock()
+		d.rpcRW.Lock()
+		defer d.rpcRW.Unlock()
 		if !d.isRunning() {
 			return fmt.Errorf("dispatcher is not running")
 		}


### PR DESCRIPTION
Removing the mutex from the dispatcher and use the rpc read-write lock. It was easier than I thought.