### PR TITLE
Ingress network should not be attachable

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -638,6 +638,10 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 		return nil, err
 	}
 
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
+		return nil, err
+	}
+
 	if err := s.checkPortConflicts(request.Spec, ""); err != nil {
 		return nil, err
 	}
@@ -713,7 +717,16 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 	if request.ServiceID == "" || request.ServiceVersion == nil {
 		return nil, grpc.Errorf(codes.InvalidArgument, errInvalidArgument.Error())
 	}
+
+	if err := s.validateNetworks(request.Spec.Networks); err != nil {
+		return nil, err
+	}
+
 	if err := validateServiceSpec(request.Spec); err != nil {
+		return nil, err
+	}
+
+	if err := s.validateNetworks(request.Spec.Task.Networks); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Ingress network is a special network used only to expose
ports. For this reason the network cannot be explicitly
attached during service create or service update

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>
(cherry picked from commit 610e2684f478eb63c7373fc28e60b50addd09684)