### PR TITLE
[manager/dispatcher] Initialize the dispatcher on becoming leader

### DIFF
--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -155,8 +155,8 @@ func startDispatcher(c *Config) (*grpcDispatcher, error) {
 	s := grpc.NewServer(serverOpts...)
 	tc := newTestCluster(l.Addr().String(), tca.MemoryStore)
 	driverGetter := &mockPluginGetter{}
-	d := New(tc, c, drivers.New(driverGetter), managerSecurityConfig)
-
+	d := New()
+	d.Init(tc, c, drivers.New(driverGetter), managerSecurityConfig)
 	authorize := func(ctx context.Context, roles []string) error {
 		_, err := ca.AuthorizeForwardedRoleAndOrg(ctx, roles, []string{ca.ManagerRole}, tca.Organization, nil)
 		return err


### PR DESCRIPTION
The motivation for this change is to have a clean slate dispatcher on leadership change. Also, it seems like we could have a stale config on the dispatcher since its not re-initialized when a node regains leadership.