### PR TITLE
Resend all task statuses on new session

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -324,6 +324,8 @@ func (a *Agent) run(ctx context.Context) {
 			registered = nil // we only care about this once per session
 			backoff = 0      // reset backoff
 			sessionq = a.sessionq
+			// re-report all task statuses when re-establishing a session
+			go a.worker.Report(ctx, reporter)
 		case err := <-session.errs:
 			// TODO(stevvooe): This may actually block if a session is closed
 			// but no error was sent. This must be the only place

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -39,6 +39,9 @@ type Worker interface {
 	// The listener will be removed if the context is cancelled.
 	Listen(ctx context.Context, reporter StatusReporter)
 
+	// Report resends the status of all tasks controlled by this worker.
+	Report(ctx context.Context, reporter StatusReporter)
+
 	// Subscribe to log messages matching the subscription.
 	Subscribe(ctx context.Context, subscription *api.SubscriptionMessage) error
 
@@ -416,6 +419,17 @@ func (w *worker) Listen(ctx context.Context, reporter StatusReporter) {
 	}()
 
 	// report the current statuses to the new listener
+	w.reportAllStatuses(ctx, reporter)
+}
+
+func (w *worker) Report(ctx context.Context, reporter StatusReporter) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.reportAllStatuses(ctx, reporter)
+}
+
+func (w *worker) reportAllStatuses(ctx context.Context, reporter StatusReporter) {
 	if err := w.db.View(func(tx *bolt.Tx) error {
 		return WalkTaskStatus(tx, func(id string, status *api.TaskStatus) error {
 			return reporter.UpdateTaskStatus(ctx, id, status)


### PR DESCRIPTION
When the agent registers a new session, it should resend all task statuses, in case any were missed by the manager after the last session dropped.

Supercedes #2499, excludes code for batch-updating.

Signed-off-by: Drew Erny <drew.erny@docker.com>