### PR TITLE
Fix possible data race in manager/state/store/memory_test.go

### DIFF
--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -2035,7 +2035,7 @@ func BenchmarkNodeConcurrency(b *testing.B) {
 	var wg sync.WaitGroup
 	for c := 0; c != 5; c++ {
 		wg.Add(1)
-		go func() {
+		go func(c int) {
 			defer wg.Done()
 			for i := 0; i < b.N; i++ {
 				_ = s.Update(func(tx1 Tx) error {
@@ -2050,7 +2050,7 @@ func BenchmarkNodeConcurrency(b *testing.B) {
 					return nil
 				})
 			}
-		}()
+		}(c)
 	}
 
 	for c := 0; c != 5; c++ {


### PR DESCRIPTION
This PR is a fix for #2536, essentially using the first proposed way of fixing the original issue.

This fixes a possible data race in `manager/state/store/memory_test.go`

An alternative to this fix would be to define a new variable in the following way:

```Go
    for c := 0; c != 5; c++ {
        ...
        x := c
        go func() {
            ...
            Name: nodeIDs[i%benchmarkNumNodes] + "_" + strconv.Itoa(x) + "_" + strconv.Itoa(i),
            ...
        }
    }
 ```