### PR TITLE
RoleManager will remove deleted nodes from the cluster membership

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1078,7 +1078,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	m.taskReaper = taskreaper.New(s)
 	m.scheduler = scheduler.New(s)
 	m.keyManager = keymanager.New(s, keymanager.DefaultConfig())
-	m.roleManager = newRoleManager(s, m.raftNode, nil)
+	m.roleManager = newRoleManager(s, m.raftNode)
 
 	// TODO(stevvooe): Allocate a context that can be used to
 	// shutdown underlying manager processes when leadership is

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1078,7 +1078,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	m.taskReaper = taskreaper.New(s)
 	m.scheduler = scheduler.New(s)
 	m.keyManager = keymanager.New(s, keymanager.DefaultConfig())
-	m.roleManager = newRoleManager(s, m.raftNode)
+	m.roleManager = newRoleManager(s, m.raftNode, nil)
 
 	// TODO(stevvooe): Allocate a context that can be used to
 	// shutdown underlying manager processes when leadership is

--- a/manager/role_manager_test.go
+++ b/manager/role_manager_test.go
@@ -79,8 +79,14 @@ func TestRoleManagerRemovesDemotedNodesAndAddsPromotedNodes(t *testing.T) {
 		return store.UpdateNode(tx, n)
 	}))
 	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
-		if len(lead.GetMemberlist()) != 2 {
+		memberlist := lead.GetMemberlist()
+		if len(memberlist) != 2 {
 			return errors.New("raft node hasn't been removed yet")
+		}
+		for _, m := range memberlist {
+			if m.NodeID == nonLead.SecurityConfig.ClientTLSCreds.NodeID() {
+				return errors.New("wrong member was removed")
+			}
 		}
 		// use Update just because it returns an error
 		return lead.MemoryStore().Update(func(tx store.Tx) error {
@@ -154,8 +160,14 @@ func TestRoleManagerRemovesDemotedNodesOnStartup(t *testing.T) {
 	defer rm.Stop()
 
 	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
-		if len(lead.GetMemberlist()) != 2 {
+		memberlist := lead.GetMemberlist()
+		if len(memberlist) != 2 {
 			return errors.New("raft node hasn't been removed yet")
+		}
+		for _, m := range memberlist {
+			if m.NodeID == demoted.SecurityConfig.ClientTLSCreds.NodeID() {
+				return errors.New("wrong member was removed")
+			}
 		}
 		// use Update just because it returns an error
 		return lead.MemoryStore().Update(func(tx store.Tx) error {
@@ -165,6 +177,68 @@ func TestRoleManagerRemovesDemotedNodesOnStartup(t *testing.T) {
 			return nil
 		})
 	}, roleReconcileInterval/2))
+}
+
+// While roleManager is running, if a node is deleted, it is removed from the raft cluster.
+func TestRoleManagerRemovesDeletedNodes(t *testing.T) {
+	t.Parallel()
+
+	tc := cautils.NewTestCA(nil)
+	defer tc.Stop()
+
+	nodes, fc := raftutils.NewRaftCluster(t, tc)
+	defer raftutils.TeardownCluster(nodes)
+
+	// nodes is not a list, but a map.  The IDs are 1, 2, 3
+	require.Len(t, nodes[1].GetMemberlist(), 3)
+
+	// create node objects in the memory store
+	for _, node := range nodes {
+		s := raftutils.Leader(nodes).MemoryStore()
+		// Create a new node object
+		require.NoError(t, s.Update(func(tx store.Tx) error {
+			return store.CreateNode(tx, &api.Node{
+				Role: api.NodeRoleManager,
+				ID:   node.SecurityConfig.ClientTLSCreds.NodeID(),
+				Spec: api.NodeSpec{
+					DesiredRole:  api.NodeRoleManager,
+					Membership:   api.NodeMembershipAccepted,
+					Availability: api.NodeAvailabilityActive,
+				},
+			})
+		}))
+	}
+
+	lead := raftutils.Leader(nodes)
+	var nonLead *raftutils.TestNode
+	for _, n := range nodes {
+		if n != lead {
+			nonLead = n
+			break
+		}
+	}
+	rm := newRoleManager(lead.MemoryStore(), lead.Node)
+	rm.clocksource = fc
+	go rm.Run(tc.Context)
+	defer rm.Stop()
+
+	// delete the node
+	require.NoError(t, lead.MemoryStore().Update(func(tx store.Tx) error {
+		return store.DeleteNode(tx, nonLead.SecurityConfig.ClientTLSCreds.NodeID())
+	}))
+	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
+		memberlist := lead.GetMemberlist()
+		if len(memberlist) != 2 {
+			return errors.New("raft node hasn't been removed yet")
+		}
+		for _, m := range memberlist {
+			if m.NodeID == nonLead.SecurityConfig.ClientTLSCreds.NodeID() {
+				return errors.New("wrong member was removed")
+			}
+		}
+		return nil
+	}, roleReconcileInterval/2))
+
 }
 
 // If a node was removed before the roleManager starts up, roleManger will remove
@@ -208,8 +282,14 @@ func TestRoleManagerRemovesDeletedNodesOnStartup(t *testing.T) {
 	defer rm.Stop()
 
 	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
-		if len(lead.GetMemberlist()) != 2 {
+		memberlist := lead.GetMemberlist()
+		if len(memberlist) != 2 {
 			return errors.New("raft node hasn't been removed yet")
+		}
+		for _, m := range memberlist {
+			if m.NodeID == nodes[3].SecurityConfig.ClientTLSCreds.NodeID() {
+				return errors.New("wrong member was removed")
+			}
 		}
 		return nil
 	}, roleReconcileInterval/2))

--- a/manager/role_manager_test.go
+++ b/manager/role_manager_test.go
@@ -67,7 +67,8 @@ func TestRoleManagerRemovesDemotedNodesAndAddsPromotedNodes(t *testing.T) {
 			break
 		}
 	}
-	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	rm := newRoleManager(lead.MemoryStore(), lead.Node)
+	rm.clocksource = fc
 	go rm.Run(tc.Context)
 	defer rm.Stop()
 
@@ -147,7 +148,8 @@ func TestRoleManagerRemovesDemotedNodesOnStartup(t *testing.T) {
 	demoted := nodes[3]
 
 	lead := raftutils.Leader(nodes)
-	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	rm := newRoleManager(lead.MemoryStore(), lead.Node)
+	rm.clocksource = fc
 	go rm.Run(tc.Context)
 	defer rm.Stop()
 
@@ -200,7 +202,8 @@ func TestRoleManagerRemovesDeletedNodesOnStartup(t *testing.T) {
 	}
 
 	lead := raftutils.Leader(nodes)
-	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	rm := newRoleManager(lead.MemoryStore(), lead.Node)
+	rm.clocksource = fc
 	go rm.Run(tc.Context)
 	defer rm.Stop()
 

--- a/manager/role_manager_test.go
+++ b/manager/role_manager_test.go
@@ -1,0 +1,213 @@
+package manager
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"testing"
+
+	"github.com/pivotal-golang/clock/fakeclock"
+
+	"google.golang.org/grpc/grpclog"
+
+	"github.com/docker/swarmkit/api"
+	cautils "github.com/docker/swarmkit/ca/testutils"
+	raftutils "github.com/docker/swarmkit/manager/state/raft/testutils"
+	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/testutils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func getRaftCluster(t *testing.T, tc *cautils.TestCA) (map[uint64]*raftutils.TestNode, *fakeclock.FakeClock) {
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+	logrus.SetOutput(ioutil.Discard)
+
+	nodes, fc := raftutils.NewRaftCluster(t, tc)
+	raftutils.WaitForCluster(t, fc, nodes)
+	return nodes, fc
+}
+
+// While roleManager is running, if a node is demoted, it is removed from the raft cluster.  If a node is
+// promoted, it is not added to the cluster but its observed role will change to manager.
+func TestRoleManagerRemovesDemotedNodesAndAddsPromotedNodes(t *testing.T) {
+	t.Parallel()
+
+	tc := cautils.NewTestCA(nil)
+	defer tc.Stop()
+
+	nodes, fc := raftutils.NewRaftCluster(t, tc)
+	defer raftutils.TeardownCluster(nodes)
+
+	// nodes is not a list, but a map.  The IDs are 1, 2, 3
+	require.Len(t, nodes[1].GetMemberlist(), 3)
+
+	// create node objects in the memory store
+	for _, node := range nodes {
+		s := raftutils.Leader(nodes).MemoryStore()
+		// Create a new node object
+		require.NoError(t, s.Update(func(tx store.Tx) error {
+			return store.CreateNode(tx, &api.Node{
+				Role: api.NodeRoleManager,
+				ID:   node.SecurityConfig.ClientTLSCreds.NodeID(),
+				Spec: api.NodeSpec{
+					DesiredRole:  api.NodeRoleManager,
+					Membership:   api.NodeMembershipAccepted,
+					Availability: api.NodeAvailabilityActive,
+				},
+			})
+		}))
+	}
+
+	lead := raftutils.Leader(nodes)
+	var nonLead *raftutils.TestNode
+	for _, n := range nodes {
+		if n != lead {
+			nonLead = n
+			break
+		}
+	}
+	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	go rm.Run(tc.Context)
+	defer rm.Stop()
+
+	// demote the node
+	require.NoError(t, lead.MemoryStore().Update(func(tx store.Tx) error {
+		n := store.GetNode(tx, nonLead.SecurityConfig.ClientTLSCreds.NodeID())
+		n.Spec.DesiredRole = api.NodeRoleWorker
+		return store.UpdateNode(tx, n)
+	}))
+	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
+		if len(lead.GetMemberlist()) != 2 {
+			return errors.New("raft node hasn't been removed yet")
+		}
+		// use Update just because it returns an error
+		return lead.MemoryStore().Update(func(tx store.Tx) error {
+			if n := store.GetNode(tx, nonLead.SecurityConfig.ClientTLSCreds.NodeID()); n.Role != api.NodeRoleWorker {
+				return errors.New("raft node hasn't been marked as a worker yet")
+			}
+			return nil
+		})
+	}, roleReconcileInterval/2))
+
+	// now promote the node
+	require.NoError(t, lead.MemoryStore().Update(func(tx store.Tx) error {
+		n := store.GetNode(tx, nonLead.SecurityConfig.ClientTLSCreds.NodeID())
+		n.Spec.DesiredRole = api.NodeRoleManager
+		return store.UpdateNode(tx, n)
+	}))
+	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
+		if len(lead.GetMemberlist()) != 2 {
+			return errors.New("raft nodes in membership should not have changed")
+		}
+		// use Update just because it returns an error
+		return lead.MemoryStore().Update(func(tx store.Tx) error {
+			if n := store.GetNode(tx, nonLead.SecurityConfig.ClientTLSCreds.NodeID()); n.Role != api.NodeRoleManager {
+				return errors.New("raft node hasn't been marked as a manager yet")
+			}
+			return nil
+		})
+	}, roleReconcileInterval/2))
+}
+
+// If a node was demoted before the roleManager starts up, roleManger will remove
+// the node from the cluster membership.
+func TestRoleManagerRemovesDemotedNodesOnStartup(t *testing.T) {
+	t.Parallel()
+
+	tc := cautils.NewTestCA(nil)
+	defer tc.Stop()
+
+	nodes, fc := raftutils.NewRaftCluster(t, tc)
+	defer raftutils.TeardownCluster(nodes)
+
+	// nodes is not a list, but a map.  The IDs are 1, 2, 3
+	require.Len(t, nodes[1].GetMemberlist(), 3)
+
+	// create node objects in the memory store
+	for i, node := range nodes {
+		s := raftutils.Leader(nodes).MemoryStore()
+		desired := api.NodeRoleManager
+		if i == 3 {
+			desired = api.NodeRoleWorker
+		}
+		// Create a new node object
+		require.NoError(t, s.Update(func(tx store.Tx) error {
+			return store.CreateNode(tx, &api.Node{
+				Role: api.NodeRoleManager,
+				ID:   node.SecurityConfig.ClientTLSCreds.NodeID(),
+				Spec: api.NodeSpec{
+					DesiredRole:  desired,
+					Membership:   api.NodeMembershipAccepted,
+					Availability: api.NodeAvailabilityActive,
+				},
+			})
+		}))
+	}
+	demoted := nodes[3]
+
+	lead := raftutils.Leader(nodes)
+	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	go rm.Run(tc.Context)
+	defer rm.Stop()
+
+	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
+		if len(lead.GetMemberlist()) != 2 {
+			return errors.New("raft node hasn't been removed yet")
+		}
+		// use Update just because it returns an error
+		return lead.MemoryStore().Update(func(tx store.Tx) error {
+			if n := store.GetNode(tx, demoted.SecurityConfig.ClientTLSCreds.NodeID()); n.Role != api.NodeRoleWorker {
+				return errors.New("raft node hasn't been marked as a worker yet")
+			}
+			return nil
+		})
+	}, roleReconcileInterval/2))
+}
+
+// If a node was removed before the roleManager starts up, roleManger will remove
+// the node from the cluster membership.
+func TestRoleManagerRemovesDeletedNodesOnStartup(t *testing.T) {
+	t.Parallel()
+
+	tc := cautils.NewTestCA(nil)
+	defer tc.Stop()
+
+	nodes, fc := raftutils.NewRaftCluster(t, tc)
+	defer raftutils.TeardownCluster(nodes)
+
+	// nodes is not a list, but a map.  The IDs are 1, 2, 3
+	require.Len(t, nodes[1].GetMemberlist(), 3)
+
+	// create node objects in the memory store
+	for i, node := range nodes {
+		s := raftutils.Leader(nodes).MemoryStore()
+		if i == 3 {
+			continue
+		}
+		// Create a new node object
+		require.NoError(t, s.Update(func(tx store.Tx) error {
+			return store.CreateNode(tx, &api.Node{
+				Role: api.NodeRoleManager,
+				ID:   node.SecurityConfig.ClientTLSCreds.NodeID(),
+				Spec: api.NodeSpec{
+					DesiredRole:  api.NodeRoleManager,
+					Membership:   api.NodeMembershipAccepted,
+					Availability: api.NodeAvailabilityActive,
+				},
+			})
+		}))
+	}
+
+	lead := raftutils.Leader(nodes)
+	rm := newRoleManager(lead.MemoryStore(), lead.Node, fc)
+	go rm.Run(tc.Context)
+	defer rm.Stop()
+
+	require.NoError(t, testutils.PollFuncWithTimeout(fc, func() error {
+		if len(lead.GetMemberlist()) != 2 {
+			return errors.New("raft node hasn't been removed yet")
+		}
+		return nil
+	}, roleReconcileInterval/2))
+}


### PR DESCRIPTION
Fixes https://github.com/docker/swarmkit/issues/2548 (please see description there), I think.

Wondering if we should also prevent node removal if the demotion process hasn't completed for a manager (e.g. if the node is still in the raft cluster, we disallow the remove node API call and require that the user try again later). 
