### PR TITLE
[ca/manager] Stop encrypting the raft root CA key based on env vars

### DIFF
--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -642,21 +642,23 @@ func newLocalSigner(keyBytes, certBytes []byte, certExpiry time.Duration, rootPo
 		return nil, errors.Wrap(err, "error while validating signing CA certificate against roots and intermediates")
 	}
 
+	// We previously supported (1) encrypting the root CA key in raft using a passphrase provided by an environment variable,
+	// and (2) hitless passphrase rotation if the user wanted to provide us a previous passphrase as well as a current
+	// passphrase (we'd rotate the encryption).  We now no longer support encrypting the key in raft, since we will
+	// rely on TLS in transit and raft log encryption at rest, but we do still support reading the passphrase from both
+	// of the environment variables in order to decrypt the root CA key.
+	// If the root CA key is not encrypted, then we're good whether or not the KEKs are provided.  If the root CA key
+	// is encrypted in raft, and no KEKs are provided, we will fail to produce a valid signer.
 	var (
-		passphraseStr              string
 		passphrase, passphrasePrev []byte
 		priv                       crypto.Signer
 	)
-
-	// Attempt two distinct passphrases, so we can do a hitless passphrase rotation
-	if passphraseStr = os.Getenv(PassphraseENVVar); passphraseStr != "" {
-		passphrase = []byte(passphraseStr)
+	if p := os.Getenv(PassphraseENVVar); p != "" {
+		passphrase = []byte(p)
 	}
-
 	if p := os.Getenv(PassphraseENVVarPrev); p != "" {
 		passphrasePrev = []byte(p)
 	}
-
 	// Attempt to decrypt the current private-key with the passphrases provided
 	priv, err = keyutils.ParsePrivateKeyPEMWithPassword(keyBytes, passphrase)
 	if err != nil {
@@ -674,17 +676,6 @@ func newLocalSigner(keyBytes, certBytes []byte, certExpiry time.Duration, rootPo
 	signer, err := local.NewSigner(priv, parsedCerts[0], cfsigner.DefaultSigAlgo(priv), SigningPolicy(certExpiry))
 	if err != nil {
 		return nil, err
-	}
-
-	// If the key was loaded from disk unencrypted, but there is a passphrase set,
-	// ensure it is encrypted, so it doesn't hit raft in plain-text
-	// we don't have to check for nil, because if we couldn't pem-decode the bytes, then parsing above would have failed
-	keyBlock, _ := pem.Decode(keyBytes)
-	if passphraseStr != "" && !keyutils.IsEncryptedPEMBlock(keyBlock) {
-		keyBytes, err = EncryptECPrivateKey(keyBytes, passphraseStr)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to encrypt signing CA key material")
-		}
 	}
 
 	return &LocalSigner{Cert: certBytes, Key: keyBytes, Signer: signer, parsedCert: parsedCerts[0], cryptoSigner: priv}, nil
@@ -975,30 +966,6 @@ func GenerateNewCSR() ([]byte, []byte, error) {
 
 	key, err = pkcs8.ConvertECPrivateKeyPEM(key)
 	return csr, key, err
-}
-
-// EncryptECPrivateKey receives a PEM encoded private key and returns an encrypted
-// AES256 version using a passphrase
-// TODO: Make this method generic to handle RSA keys
-func EncryptECPrivateKey(key []byte, passphraseStr string) ([]byte, error) {
-	passphrase := []byte(passphraseStr)
-
-	keyBlock, _ := pem.Decode(key)
-	if keyBlock == nil {
-		// This RootCA does not have a valid signer.
-		return nil, errors.New("error while decoding PEM key")
-	}
-
-	encryptedPEMBlock, err := keyutils.EncryptPEMBlock(keyBlock.Bytes, passphrase)
-	if err != nil {
-		return nil, err
-	}
-
-	if encryptedPEMBlock.Headers == nil {
-		return nil, errors.New("unable to encrypt key - invalid PEM file produced")
-	}
-
-	return pem.EncodeToMemory(encryptedPEMBlock), nil
 }
 
 // NormalizePEMs takes a bundle of PEM-encoded certificates in a certificate bundle,

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/keyutils"
-	"github.com/docker/swarmkit/ca/pkcs8"
 	cautils "github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/fips"
@@ -45,8 +44,8 @@ import (
 )
 
 func init() {
-	os.Setenv(ca.PassphraseENVVar, "")
-	os.Setenv(ca.PassphraseENVVarPrev, "")
+	os.Unsetenv(ca.PassphraseENVVar)
+	os.Unsetenv(ca.PassphraseENVVarPrev)
 
 	ca.RenewTLSExponentialBackoff = events.ExponentialBackoffConfig{
 		Base:   250 * time.Millisecond,
@@ -230,21 +229,6 @@ some random garbage\n
 
 	_, err = ca.GetLocalRootCA(paths.RootCA)
 	require.Error(t, err)
-}
-
-func TestEncryptECPrivateKey(t *testing.T) {
-	tempBaseDir, err := ioutil.TempDir("", "swarm-ca-test-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tempBaseDir)
-
-	_, key, err := ca.GenerateNewCSR()
-	assert.NoError(t, err)
-	encryptedKey, err := ca.EncryptECPrivateKey(key, "passphrase")
-	assert.NoError(t, err)
-
-	keyBlock, _ := pem.Decode(encryptedKey)
-	assert.NotNil(t, keyBlock)
-	assert.True(t, pkcs8.IsEncryptedPEMBlock(keyBlock))
 }
 
 func TestParseValidateAndSignCSR(t *testing.T) {
@@ -955,6 +939,14 @@ func TestGetRemoteSignedCertificateConnectionErrors(t *testing.T) {
 }
 
 func TestNewRootCA(t *testing.T) {
+	// we expect nothing to happen with these environment variables - previously we supported encrypting
+	// the root CA key, and these passphrases would cause us to encrypt the CA key in raft using the
+	// provided encryption keys stored in these environment variables.
+	os.Setenv(ca.PassphraseENVVar, "password1")
+	defer os.Unsetenv(ca.PassphraseENVVar)
+	os.Setenv(ca.PassphraseENVVarPrev, "password2")
+	defer os.Unsetenv(ca.PassphraseENVVarPrev)
+
 	for _, pair := range []struct{ cert, key []byte }{
 		{cert: cautils.ECDSA256SHA256Cert, key: cautils.ECDSA256Key},
 		{cert: cautils.RSA2048SHA256Cert, key: cautils.RSA2048Key},
@@ -1330,65 +1322,6 @@ func TestRootCAWithCrossSignedIntermediates(t *testing.T) {
 	require.NoError(t, err)
 
 	checkValidateAgainstAllRoots(tlsCert)
-}
-
-func TestNewRootCAWithPassphrase(t *testing.T) {
-	defer os.Setenv(ca.PassphraseENVVar, "")
-	defer os.Setenv(ca.PassphraseENVVarPrev, "")
-
-	rootCA, err := ca.CreateRootCA("rootCN")
-	assert.NoError(t, err)
-	rcaSigner, err := rootCA.Signer()
-	assert.NoError(t, err)
-
-	// Ensure that we're encrypting the Key bytes out of NewRoot if there
-	// is a passphrase set as an env Var
-	os.Setenv(ca.PassphraseENVVar, "password1")
-	newRootCA, err := ca.NewRootCA(rootCA.Certs, rcaSigner.Cert, rcaSigner.Key, ca.DefaultNodeCertExpiration, nil)
-	assert.NoError(t, err)
-	nrcaSigner, err := newRootCA.Signer()
-	assert.NoError(t, err)
-	assert.NotEqual(t, rcaSigner.Key, nrcaSigner.Key)
-	assert.Equal(t, rootCA.Certs, newRootCA.Certs)
-	assert.NotContains(t, string(rcaSigner.Key), string(nrcaSigner.Key))
-	keyBlock, _ := pem.Decode(nrcaSigner.Key)
-	assert.NotNil(t, keyBlock)
-	assert.True(t, keyutils.IsEncryptedPEMBlock(keyBlock))
-
-	// Ensure that we're decrypting the Key bytes out of NewRoot if there
-	// is a passphrase set as an env Var
-	anotherNewRootCA, err := ca.NewRootCA(newRootCA.Certs, nrcaSigner.Cert, nrcaSigner.Key, ca.DefaultNodeCertExpiration, nil)
-	assert.NoError(t, err)
-	anrcaSigner, err := anotherNewRootCA.Signer()
-	assert.NoError(t, err)
-	assert.Equal(t, newRootCA, anotherNewRootCA)
-	assert.NotContains(t, string(rcaSigner.Key), string(anrcaSigner.Key))
-	keyBlock, _ = pem.Decode(anrcaSigner.Key)
-	assert.NotNil(t, keyBlock)
-	assert.True(t, keyutils.IsEncryptedPEMBlock(keyBlock))
-
-	// Ensure that we cant decrypt the Key bytes out of NewRoot if there
-	// is a wrong passphrase set as an env Var
-	os.Setenv(ca.PassphraseENVVar, "password2")
-	anotherNewRootCA, err = ca.NewRootCA(newRootCA.Certs, nrcaSigner.Cert, nrcaSigner.Key, ca.DefaultNodeCertExpiration, nil)
-	assert.Error(t, err)
-
-	// Ensure that we cant decrypt the Key bytes out of NewRoot if there
-	// is a wrong passphrase set as an env Var
-	os.Setenv(ca.PassphraseENVVarPrev, "password2")
-	anotherNewRootCA, err = ca.NewRootCA(newRootCA.Certs, nrcaSigner.Cert, nrcaSigner.Key, ca.DefaultNodeCertExpiration, nil)
-	assert.Error(t, err)
-
-	// Ensure that we can decrypt the Key bytes out of NewRoot if there
-	// is a wrong passphrase set as an env Var, but a valid as Prev
-	os.Setenv(ca.PassphraseENVVarPrev, "password1")
-	anotherNewRootCA, err = ca.NewRootCA(newRootCA.Certs, nrcaSigner.Cert, nrcaSigner.Key, ca.DefaultNodeCertExpiration, nil)
-	assert.NoError(t, err)
-	assert.Equal(t, newRootCA, anotherNewRootCA)
-	assert.NotContains(t, string(rcaSigner.Key), string(anrcaSigner.Key))
-	keyBlock, _ = pem.Decode(anrcaSigner.Key)
-	assert.NotNil(t, keyBlock)
-	assert.True(t, keyutils.IsEncryptedPEMBlock(keyBlock))
 }
 
 type certTestCase struct {


### PR DESCRIPTION
This feature was never documented nor advertised, and was deprecated almost a year ago.  So remove support for encrypting and rotating the root CA key KEK (key-encrypting-key), and only support decrypting the root CA key, if it's encrypted.

This removes some useless code and extra complexity from the manager and the ca package.