### PR TITLE
Avoid predefined error log

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1052,15 +1052,13 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			}
 		}
 		// Create now the static predefined if the store does not contain predefined
-		//networks like bridge/host node-local networks which
+		// networks like bridge/host node-local networks which
 		// are known to be present in each cluster node. This is needed
 		// in order to allow running services on the predefined docker
 		// networks like `bridge` and `host`.
 		for _, p := range allocator.PredefinedNetworks() {
-			if store.GetNetwork(tx, p.Name) == nil {
-				if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil {
-					log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
-				}
+			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != store.ErrNameConflict {
+				log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 			}
 		}
 		return nil


### PR DESCRIPTION
- fix the logic that was checking for predefined networks. Before the
GetNetwork was passing the network name, while instead the network ID is
the key that is supposed to be used. The CreateNetwork anyway is doing
the very same check and create the network if not existing.

Signed-off-by: Flavio Crisciani <flavio.crisciani@docker.com>