### PR TITLE
Fix agent logging race

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -435,7 +435,7 @@ func (w *worker) reportAllStatuses(ctx context.Context, reporter StatusReporter)
 			return reporter.UpdateTaskStatus(ctx, id, status)
 		})
 	}); err != nil {
-		log.G(ctx).WithError(err).Errorf("failed reporting initial statuses to registered listener %v", reporter)
+		log.G(ctx).WithError(err).Errorf("failed reporting initial statuses")
 	}
 }
 


### PR DESCRIPTION
Add an ID function to StatusReporter, so we can better log what reporter failed.

Granted, this is a lot of extra changes to fix this problematic line:  https://github.com/docker/swarmkit/compare/master...cyli:fix-agent-data-race?expand=1#diff-689e5cbc4a9f04fda8f8cd9749d87db7L438.

We could just take out the reporting on which reporter failed instead, and that would be shorter.  But since we've been having trouble debugging live logs, I thought more information would be more useful than less.

Fixes #2576 