### PR TITLE
update the task status to failed if the task status is ready or stari…

### DIFF
--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -120,6 +120,9 @@ func Resolve(ctx context.Context, task *api.Task, executor Executor) (Controller
 		status.Message = "accepted"
 		status.State = api.TaskStateAccepted
 		status.Err = ""
+	} else if task.Status.State == api.TaskStateReady ||
+		task.Status.State == api.TaskStateStarting {
+		status.State = api.TaskStateFailed
 	}
 
 	return ctlr, status, err


### PR DESCRIPTION
…ng when creating new taskmanager of the task

When creating a new taskmanager, setting the task status to failed if the task status is ready or starting,so that the leader shutdown the task and recreate a task.

The container's NetworkSettings.Service is assigned by calling ctlr.Prepare when the task status.State is api.TaskStatePreparing, but don't  save it to tasks.db or related disk of the container. when the task state is api.TaskStateReady or api.TaskStateStarting, the host power down or restarts abnormally, and the container's NetworkSettings.Service is lost. When the agent init worker, the task state restores from the previous state, the container starts to run normally, but the NetworkSettings.Service information is lost,
there is no iptable rules and  the port of ingress network.

This problem is occasional,but we can add sleep when the task status is ready and power down the host of agent side.
(https://github.com/docker/swarmkit/blob/831df679a0b8a21b4dccd5791667d030642de7ff/agent/exec/controller.go#L343)

Signed-off-by: ZhiPeng Lu <lu.zhipeng@zte.com.cn>