### PR TITLE
update the task status state of agent to other nodes

### DIFF
--- a/agent/task.go
+++ b/agent/task.go
@@ -187,6 +187,13 @@ func (tm *taskManager) run(ctx context.Context) {
 			tm.task.Status = *status
 		case task := <-tm.updateq:
 			if equality.TasksEqualStable(task, tm.task) {
+				if tm.task.Status.State > task.Status.State {
+					select {
+					case run <- struct{}{}:
+					default:
+					}
+
+				}
 				continue // ignore the update
 			}
 


### PR DESCRIPTION
When the task status of the agent > the task status of the leader, update the task status state of agent to other nodes.

Signed-off-by: ZhiPeng Lu <lu.zhipeng@zte.com.cn>