### PR TITLE
Fix deprecation comment

### DIFF
--- a/api/objects.pb.go
+++ b/api/objects.pb.go
@@ -57,7 +57,7 @@ type Node struct {
 	// ManagerStatus provides the current status of the node's manager
 	// component, if the node is a manager.
 	ManagerStatus *ManagerStatus `protobuf:"bytes,6,opt,name=manager_status,json=managerStatus" json:"manager_status,omitempty"`
-	// DEPRECATED: Use lb_attachments to find the ingress network
+	// DEPRECATED: Use Attachments to find the ingress network
 	// The node attachment to the ingress network.
 	Attachment *NetworkAttachment `protobuf:"bytes,7,opt,name=attachment" json:"attachment,omitempty"`
 	// Certificate is the TLS certificate issued for the node, if any.

--- a/api/objects.proto
+++ b/api/objects.proto
@@ -59,7 +59,7 @@ message Node {
 	// component, if the node is a manager.
 	ManagerStatus manager_status = 6;
 
-	// DEPRECATED: Use lb_attachments to find the ingress network
+	// DEPRECATED: Use Attachments to find the ingress network
 	// The node attachment to the ingress network.
 	NetworkAttachment attachment = 7 [deprecated=true];
 


### PR DESCRIPTION
Commit https://github.com/docker/swarmkit/commit/a3eac7370f744e4273bef620a357c6363dae3b5f#diff-2d262053827f7ee9d77859975113953cR62 (https://github.com/docker/swarmkit/pull/2385) renamed `LbAttachments` to `Attachments`, but did not update this deprecation comment.


ping @stevvooe PTAL