### PR TITLE
Fix manager/state/store.timedMutex

### DIFF
--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -129,10 +129,10 @@ func (m *timedMutex) Lock() {
 // for which it was locked in a metric.
 func (m *timedMutex) Unlock() {
 	unlockedTimestamp := m.lockedAt.Load()
+	m.lockedAt.Store(time.Time{})
 	m.Mutex.Unlock()
 	lockedFor := time.Since(unlockedTimestamp.(time.Time))
 	storeLockDurationTimer.Update(lockedFor)
-	m.lockedAt.Store(time.Time{})
 }
 
 func (m *timedMutex) LockedAt() time.Time {


### PR DESCRIPTION
**- What I did**
Fix for #2602

**- How I did it**
Move the conflicting operation inside the critical section (before the `Unlock()` call).

**- How to test it**


**- Description for the changelog**
Fix #2602: timedMutex critical operation outside of critical section