### PR TITLE
Don't use wrappers for grpc metadata

### DIFF
--- a/api/ca.pb.go
+++ b/api/ca.pb.go
@@ -990,7 +990,7 @@ func NewRaftProxyCAServer(local CAServer, connSelector raftselector.ConnProvider
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -998,7 +998,7 @@ func NewRaftProxyCAServer(local CAServer, connSelector raftselector.ConnProvider
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1132,7 +1132,7 @@ func NewRaftProxyNodeCAServer(local NodeCAServer, connSelector raftselector.Conn
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1140,7 +1140,7 @@ func NewRaftProxyNodeCAServer(local NodeCAServer, connSelector raftselector.Conn
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/control.pb.go
+++ b/api/control.pb.go
@@ -5863,7 +5863,7 @@ func NewRaftProxyControlServer(local ControlServer, connSelector raftselector.Co
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -5871,7 +5871,7 @@ func NewRaftProxyControlServer(local ControlServer, connSelector raftselector.Co
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -1606,7 +1606,7 @@ func NewRaftProxyDispatcherServer(local DispatcherServer, connSelector raftselec
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1614,7 +1614,7 @@ func NewRaftProxyDispatcherServer(local DispatcherServer, connSelector raftselec
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/health.pb.go
+++ b/api/health.pb.go
@@ -290,7 +290,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -298,7 +298,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -1277,7 +1277,7 @@ func NewRaftProxyLogsServer(local LogsServer, connSelector raftselector.ConnProv
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1285,7 +1285,7 @@ func NewRaftProxyLogsServer(local LogsServer, connSelector raftselector.ConnProv
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1400,7 +1400,7 @@ func NewRaftProxyLogBrokerServer(local LogBrokerServer, connSelector raftselecto
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1408,7 +1408,7 @@ func NewRaftProxyLogBrokerServer(local LogBrokerServer, connSelector raftselecto
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -1653,7 +1653,7 @@ func NewRaftProxyRaftServer(local RaftServer, connSelector raftselector.ConnProv
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1661,7 +1661,7 @@ func NewRaftProxyRaftServer(local RaftServer, connSelector raftselector.ConnProv
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1852,7 +1852,7 @@ func NewRaftProxyRaftMembershipServer(local RaftMembershipServer, connSelector r
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1860,7 +1860,7 @@ func NewRaftProxyRaftMembershipServer(local RaftMembershipServer, connSelector r
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/resource.pb.go
+++ b/api/resource.pb.go
@@ -407,7 +407,7 @@ func NewRaftProxyResourceAllocatorServer(local ResourceAllocatorServer, connSele
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -415,7 +415,7 @@ func NewRaftProxyResourceAllocatorServer(local ResourceAllocatorServer, connSele
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/api/watch.pb.go
+++ b/api/watch.pb.go
@@ -2047,7 +2047,7 @@ func NewRaftProxyWatchServer(local WatchServer, connSelector raftselector.ConnPr
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -2055,7 +2055,7 @@ func NewRaftProxyWatchServer(local WatchServer, connSelector raftselector.ConnPr
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/ca/forward.go
+++ b/ca/forward.go
@@ -17,7 +17,7 @@ const (
 // forwardedTLSInfoFromContext obtains forwarded TLS CN/OU from the grpc.MD
 // object in ctx.
 func forwardedTLSInfoFromContext(ctx context.Context) (remoteAddr string, cn string, org string, ous []string) {
-	md, _ := metadata.FromContext(ctx)
+	md, _ := metadata.FromIncomingContext(ctx)
 	if len(md[remoteAddrKey]) != 0 {
 		remoteAddr = md[remoteAddrKey][0]
 	}
@@ -32,7 +32,7 @@ func forwardedTLSInfoFromContext(ctx context.Context) (remoteAddr string, cn str
 }
 
 func isForwardedRequest(ctx context.Context) bool {
-	md, _ := metadata.FromContext(ctx)
+	md, _ := metadata.FromIncomingContext(ctx)
 	if len(md[certForwardedKey]) != 1 {
 		return false
 	}
@@ -42,7 +42,7 @@ func isForwardedRequest(ctx context.Context) bool {
 // WithMetadataForwardTLSInfo reads certificate from context and returns context where
 // ForwardCert is set based on original certificate.
 func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
 	}
@@ -73,5 +73,5 @@ func WithMetadataForwardTLSInfo(ctx context.Context) (context.Context, error) {
 		md[remoteAddrKey] = []string{peer.Addr.String()}
 	}
 
-	return metadata.NewContext(ctx, md), nil
+	return metadata.NewOutgoingContext(ctx, md), nil
 }

--- a/protobuf/plugin/raftproxy/raftproxy.go
+++ b/protobuf/plugin/raftproxy/raftproxy.go
@@ -39,7 +39,7 @@ func (g *raftProxyGen) genProxyConstructor(s *descriptor.ServiceDescriptorProto)
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -47,7 +47,7 @@ func (g *raftProxyGen) genProxyConstructor(s *descriptor.ServiceDescriptorProto)
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context)(context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)

--- a/protobuf/plugin/raftproxy/test/service.pb.go
+++ b/protobuf/plugin/raftproxy/test/service.pb.go
@@ -977,7 +977,7 @@ func NewRaftProxyRouteGuideServer(local RouteGuideServer, connSelector raftselec
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -985,7 +985,7 @@ func NewRaftProxyRouteGuideServer(local RouteGuideServer, connSelector raftselec
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)
@@ -1260,7 +1260,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			return ctx, status.Errorf(codes.InvalidArgument, "remote addr is not found in context")
 		}
 		addr := s.ServerTransport().RemoteAddr().String()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && len(md["redirect"]) != 0 {
 			return ctx, status.Errorf(codes.ResourceExhausted, "more than one redirect to leader from: %s", md["redirect"])
 		}
@@ -1268,7 +1268,7 @@ func NewRaftProxyHealthServer(local HealthServer, connSelector raftselector.Conn
 			md = metadata.New(map[string]string{})
 		}
 		md["redirect"] = append(md["redirect"], addr)
-		return metadata.NewContext(ctx, md), nil
+		return metadata.NewOutgoingContext(ctx, md), nil
 	}
 	remoteMods := []func(context.Context) (context.Context, error){redirectChecker}
 	remoteMods = append(remoteMods, remoteCtxMod)


### PR DESCRIPTION
This switches the current usage of NewContext and FromContext to use the
underlying methods in the metadata package.  The wrappers will be removed in
future versions of grpc.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>