### PR TITLE
[manager/allocator] Logging for allocation workflows

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -632,7 +632,9 @@ func (a *Allocator) allocateServices(ctx context.Context, existingAddressesOnly 
 		}
 		return nil
 	}); err != nil {
-		log.G(ctx).WithError(err).Error("failed committing allocation of services during init")
+		for _, s := range allocatedServices {
+			log.G(ctx).WithError(err).Errorf("failed committing allocation of service %v during init", s.GetID())
+		}
 	}
 
 	return nil
@@ -653,8 +655,11 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 		return errors.Wrap(err, "error listing all tasks in store while trying to allocate during init")
 	}
 
+	logger := log.G(ctx).WithField("method", "(*Allocator).allocateTasks")
+
 	for _, t := range tasks {
 		if t.Status.State > api.TaskStateRunning {
+			logger.Debugf("task %v is in allocated state: %v", t.GetID(), t.Status.State)
 			continue
 		}
 
@@ -667,6 +672,7 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 				}
 			}
 			if !hasAddresses {
+				logger.Debugf("task %v has no attached addresses", t.GetID())
 				continue
 			}
 		}
@@ -684,6 +690,7 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 
 		if taskReadyForNetworkVote(t, s, nc) {
 			if t.Status.State >= api.TaskStatePending {
+				logger.Debugf("task %v is in allocated state: %v", t.GetID(), t.Status.State)
 				continue
 			}
 
@@ -694,6 +701,7 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 				// soon as possible.
 				updateTaskStatus(t, api.TaskStatePending, allocatedStatusMessage)
 				allocatedTasks = append(allocatedTasks, t)
+				logger.Debugf("allocated task %v, state update %v", t.GetID(), api.TaskStatePending)
 			}
 			continue
 		}
@@ -702,7 +710,7 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 		if err == nil {
 			allocatedTasks = append(allocatedTasks, t)
 		} else if err != errNoChanges {
-			log.G(ctx).WithError(err).Errorf("failed allocating task %s during init", t.ID)
+			logger.WithError(err).Errorf("failed allocating task %s during init", t.ID)
 			nc.unallocatedTasks[t.ID] = t
 		}
 	}
@@ -710,13 +718,15 @@ func (a *Allocator) allocateTasks(ctx context.Context, existingAddressesOnly boo
 	if err := a.store.Batch(func(batch *store.Batch) error {
 		for _, t := range allocatedTasks {
 			if err := a.commitAllocatedTask(ctx, batch, t); err != nil {
-				log.G(ctx).WithError(err).Errorf("failed committing allocation of task %s during init", t.ID)
+				logger.WithError(err).Errorf("failed committing allocation of task %s during init", t.ID)
 			}
 		}
 
 		return nil
 	}); err != nil {
-		log.G(ctx).WithError(err).Error("failed committing allocation of tasks during init")
+		for _, t := range allocatedTasks {
+			logger.WithError(err).Errorf("failed committing allocation of task %v during init", t.GetID())
+		}
 	}
 
 	return nil
@@ -795,6 +805,8 @@ func (a *Allocator) doTaskAlloc(ctx context.Context, ev events.Event) {
 		t        *api.Task
 	)
 
+	logger := log.G(ctx).WithField("method", "(*Allocator).doTaskAlloc")
+
 	// We may have already allocated this task. If a create or update
 	// event is older than the current version in the store, we run the
 	// risk of allocating the task a second time. Only operate on the
@@ -824,7 +836,7 @@ func (a *Allocator) doTaskAlloc(ctx context.Context, ev events.Event) {
 	if t.Status.State > api.TaskStateRunning || isDelete {
 		if nc.nwkAllocator.IsTaskAllocated(t) {
 			if err := nc.nwkAllocator.DeallocateTask(t); err != nil {
-				log.G(ctx).WithError(err).Errorf("Failed freeing network resources for task %s", t.ID)
+				logger.WithError(err).Errorf("Failed freeing network resources for task %s", t.ID)
 			} else {
 				nc.somethingWasDeallocated = true
 			}
@@ -840,6 +852,7 @@ func (a *Allocator) doTaskAlloc(ctx context.Context, ev events.Event) {
 	// If we are already in allocated state, there is
 	// absolutely nothing else to do.
 	if t.Status.State >= api.TaskStatePending {
+		logger.Debugf("Task %s is already in allocated state %v", t.ID, t.Status.State)
 		delete(nc.pendingTasks, t.ID)
 		delete(nc.unallocatedTasks, t.ID)
 		return
@@ -871,6 +884,7 @@ func (a *Allocator) doTaskAlloc(ctx context.Context, ev events.Event) {
 	a.taskCreateNetworkAttachments(t, s)
 
 	nc.pendingTasks[t.ID] = t
+	log.G(ctx).Debugf("task %v was marked pending allocation", t.ID)
 }
 
 func (a *Allocator) allocateNode(ctx context.Context, node *api.Node, existingAddressesOnly bool, networks []*api.Network) bool {
@@ -1093,6 +1107,8 @@ func (a *Allocator) allocateTask(ctx context.Context, t *api.Task) (err error) {
 	taskUpdated := false
 	nc := a.netCtx
 
+	logger := log.G(ctx).WithField("method", "(*Allocator).allocateTask")
+
 	// We might be here even if a task allocation has already
 	// happened but wasn't successfully committed to store. In such
 	// cases skip allocation and go straight ahead to updating the
@@ -1102,12 +1118,12 @@ func (a *Allocator) allocateTask(ctx context.Context, t *api.Task) (err error) {
 			if t.ServiceID != "" {
 				s := store.GetService(tx, t.ServiceID)
 				if s == nil {
-					err = fmt.Errorf("could not find service %s", t.ServiceID)
+					err = fmt.Errorf("could not find service %s for task %s", t.ServiceID, t.GetID())
 					return
 				}
 
 				if !nc.nwkAllocator.IsServiceAllocated(s) {
-					err = fmt.Errorf("service %s to which this task %s belongs has pending allocations", s.ID, t.ID)
+					err = fmt.Errorf("service %s to which task %s belongs has pending allocations", s.ID, t.ID)
 					return
 				}
 
@@ -1150,7 +1166,10 @@ func (a *Allocator) allocateTask(ctx context.Context, t *api.Task) (err error) {
 	if a.taskAllocateVote(networkVoter, t.ID) {
 		if t.Status.State < api.TaskStatePending {
 			updateTaskStatus(t, api.TaskStatePending, allocatedStatusMessage)
+			logger.Debugf("allocated task %v, state update %v", t.GetID(), api.TaskStatePending)
 			taskUpdated = true
+		} else {
+			logger.Debugf("task %v, already in allocated state %v", t.GetID(), t.Status.State)
 		}
 	}
 
@@ -1162,7 +1181,7 @@ func (a *Allocator) allocateTask(ctx context.Context, t *api.Task) (err error) {
 }
 
 func (a *Allocator) commitAllocatedTask(ctx context.Context, batch *store.Batch, t *api.Task) error {
-	return batch.Update(func(tx store.Tx) error {
+	retError := batch.Update(func(tx store.Tx) error {
 		err := store.UpdateTask(tx, t)
 
 		if err == store.ErrSequenceConflict {
@@ -1177,6 +1196,12 @@ func (a *Allocator) commitAllocatedTask(ctx context.Context, batch *store.Batch,
 
 		return errors.Wrapf(err, "failed updating state in store transaction for task %s", t.ID)
 	})
+
+	if retError == nil {
+		log.G(ctx).Debugf("committed allocated task %v, state update %v", t.GetID(), t.Status)
+	}
+
+	return retError
 }
 
 func (a *Allocator) procUnallocatedNetworks(ctx context.Context) {
@@ -1268,6 +1293,7 @@ func (a *Allocator) procTasksNetwork(ctx context.Context, onRetry bool) {
 	allocatedTasks := make([]*api.Task, 0, len(toAllocate))
 
 	for _, t := range toAllocate {
+
 		if err := a.allocateTask(ctx, t); err == nil {
 			allocatedTasks = append(allocatedTasks, t)
 		} else if err != errNoChanges {
@@ -1287,7 +1313,7 @@ func (a *Allocator) procTasksNetwork(ctx context.Context, onRetry bool) {
 		for _, t := range allocatedTasks {
 			err := a.commitAllocatedTask(ctx, batch, t)
 			if err != nil {
-				log.G(ctx).WithError(err).Error("task allocation commit failure")
+				log.G(ctx).WithField("method", "(*Allocator).procTasksNetwork").WithError(err).Errorf("allocation commit failure for task %s", t.GetID())
 				continue
 			}
 			delete(toAllocate, t.ID)

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -699,6 +699,7 @@ func (d *Dispatcher) processUpdates(ctx context.Context) {
 				task.Status = *status
 				task.Status.AppliedBy = d.securityConfig.ClientTLSCreds.NodeID()
 				task.Status.AppliedAt = ptypes.MustTimestampProto(time.Now())
+				logger.Debugf("state for task %v updated to %v", task.GetID(), task.Status.State)
 				if err := store.UpdateTask(tx, task); err != nil {
 					logger.WithError(err).Error("failed to update task status")
 					return nil


### PR DESCRIPTION
This is to help debug some of the recent issues around tasks stuck in state "new", desired state "running".