### PR TITLE
Cleanup store

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -580,7 +580,7 @@ func (w *worker) Subscribe(ctx context.Context, subscription *api.SubscriptionMe
 
 	// In follow mode, watch for new tasks. Don't close the subscription
 	// until it's cancelled.
-	ch, cancel := w.taskevents.Watch()
+	ch, cancel := w.taskevents.WatchAll()
 	defer cancel()
 	for {
 		select {

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -30,7 +30,6 @@ import (
 	cautils "github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/remotes"
 	"github.com/docker/swarmkit/testutils"
@@ -683,9 +682,7 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	csr, _, err := ca.GenerateNewCSR()
 	require.NoError(t, err)
 
-	updates, cancel := tc.MemoryStore.Queue().Watch(state.Matcher(
-		api.EventCreateNode{},
-	))
+	updates, cancel := tc.MemoryStore.Watch(api.EventCreateNode{})
 	defer cancel()
 
 	fakeCAServer := newNonSigningCAServer(t, tc)

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -683,7 +683,9 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	csr, _, err := ca.GenerateNewCSR()
 	require.NoError(t, err)
 
-	updates, cancel := state.Watch(tc.MemoryStore.WatchQueue(), api.EventCreateNode{})
+	updates, cancel := tc.MemoryStore.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateNode{},
+	))
 	defer cancel()
 
 	fakeCAServer := newNonSigningCAServer(t, tc)

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -683,7 +683,7 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	csr, _, err := ca.GenerateNewCSR()
 	require.NoError(t, err)
 
-	updates, cancel := tc.MemoryStore.WatchQueue().Watch(state.Matcher(
+	updates, cancel := tc.MemoryStore.Queue().Watch(state.Matcher(
 		api.EventCreateNode{},
 	))
 	defer cancel()

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -683,7 +683,7 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	csr, _, err := ca.GenerateNewCSR()
 	require.NoError(t, err)
 
-	updates, cancel := tc.MemoryStore.WatchQueue().CallbackWatch(state.Matcher(
+	updates, cancel := tc.MemoryStore.WatchQueue().Watch(state.Matcher(
 		api.EventCreateNode{},
 	))
 	defer cancel()

--- a/ca/config.go
+++ b/ca/config.go
@@ -260,7 +260,7 @@ func (s *SecurityConfig) UpdateRootCA(rootCA *RootCA) error {
 
 // Watch allows you to set a watch on the security config, in order to be notified of any changes
 func (s *SecurityConfig) Watch() (chan events.Event, func()) {
-	return s.queue.Watch()
+	return s.queue.WatchAll()
 }
 
 // IssuerInfo returns the issuer subject and issuer public key

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -741,7 +741,9 @@ func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
 
 	signErr := make(chan error)
 	go func() {
-		updates, cancel := state.Watch(tc.MemoryStore.WatchQueue(), api.EventCreateNode{})
+		updates, cancel := tc.MemoryStore.WatchQueue().CallbackWatch(state.Matcher(
+			api.EventCreateNode{},
+		))
 		defer cancel()
 		select {
 		case event := <-updates: // we want to skip the first node, which is the test CA

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/swarmkit/ca"
 	cautils "github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/log"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/testutils"
 	"github.com/pkg/errors"
@@ -741,9 +740,7 @@ func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
 
 	signErr := make(chan error)
 	go func() {
-		updates, cancel := tc.MemoryStore.Queue().Watch(state.Matcher(
-			api.EventCreateNode{},
-		))
+		updates, cancel := tc.MemoryStore.Watch(api.EventCreateNode{})
 		defer cancel()
 		select {
 		case event := <-updates: // we want to skip the first node, which is the test CA

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -741,7 +741,7 @@ func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
 
 	signErr := make(chan error)
 	go func() {
-		updates, cancel := tc.MemoryStore.WatchQueue().CallbackWatch(state.Matcher(
+		updates, cancel := tc.MemoryStore.WatchQueue().Watch(state.Matcher(
 			api.EventCreateNode{},
 		))
 		defer cancel()

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -741,7 +741,7 @@ func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
 
 	signErr := make(chan error)
 	go func() {
-		updates, cancel := tc.MemoryStore.WatchQueue().Watch(state.Matcher(
+		updates, cancel := tc.MemoryStore.Queue().Watch(state.Matcher(
 			api.EventCreateNode{},
 		))
 		defer cancel()

--- a/ca/server.go
+++ b/ca/server.go
@@ -165,8 +165,7 @@ func (s *Server) NodeCertificateStatus(ctx context.Context, request *api.NodeCer
 	}
 
 	// Retrieve the current value of the certificate with this token, and create a watcher
-	updates, cancel, err := store.ViewAndWatch(
-		s.store,
+	updates, cancel, err := s.store.ViewAndWatch(
 		func(tx store.ReadTx) error {
 			node = store.GetNode(tx, request.NodeID)
 			return nil
@@ -442,8 +441,7 @@ func (s *Server) Run(ctx context.Context) error {
 		cluster *api.Cluster
 		err     error
 	)
-	updates, cancel, err := store.ViewAndWatch(
-		s.store,
+	updates, cancel, err := s.store.ViewAndWatch(
 		func(readTx store.ReadTx) error {
 			cluster = store.GetCluster(readTx, s.clusterID)
 			if cluster == nil {

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -151,7 +151,7 @@ func (a *Allocator) Stop() {
 }
 
 func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
-	watch, watchCancel := a.store.WatchQueue().CallbackWatch(state.Matcher(
+	watch, watchCancel := a.store.WatchQueue().Watch(state.Matcher(
 		api.EventCreateNetwork{},
 		api.EventDeleteNetwork{},
 		api.EventCreateService{},

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -151,7 +151,7 @@ func (a *Allocator) Stop() {
 }
 
 func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
-	watch, watchCancel := state.Watch(a.store.WatchQueue(),
+	watch, watchCancel := a.store.WatchQueue().CallbackWatch(state.Matcher(
 		api.EventCreateNetwork{},
 		api.EventDeleteNetwork{},
 		api.EventCreateService{},
@@ -164,7 +164,7 @@ func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Eve
 		api.EventUpdateNode{},
 		api.EventDeleteNode{},
 		state.EventCommit{},
-	)
+	))
 
 	if err := aa.init(ctx); err != nil {
 		watchCancel()

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -151,7 +151,7 @@ func (a *Allocator) Stop() {
 }
 
 func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
-	watch, watchCancel := a.store.Queue().Watch(state.Matcher(
+	watch, watchCancel := a.store.Watch(
 		api.EventCreateNetwork{},
 		api.EventDeleteNetwork{},
 		api.EventCreateService{},
@@ -164,7 +164,7 @@ func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Eve
 		api.EventUpdateNode{},
 		api.EventDeleteNode{},
 		state.EventCommit{},
-	))
+	)
 
 	if err := aa.init(ctx); err != nil {
 		watchCancel()

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -151,7 +151,7 @@ func (a *Allocator) Stop() {
 }
 
 func (a *Allocator) init(ctx context.Context, aa *allocActor) (<-chan events.Event, func(), error) {
-	watch, watchCancel := a.store.WatchQueue().Watch(state.Matcher(
+	watch, watchCancel := a.store.Queue().Watch(state.Matcher(
 		api.EventCreateNetwork{},
 		api.EventDeleteNetwork{},
 		api.EventCreateService{},

--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -68,7 +68,7 @@ func TestIPAMNotNil(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))

--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -68,7 +68,7 @@ func TestIPAMNotNil(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	netWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))

--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 )
@@ -68,10 +67,10 @@ func TestIPAMNotNil(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.Queue().Watch(state.Matcher(
+	netWatch, cancel := s.Watch(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
-	))
+	)
 	defer cancel()
 
 	// Start allocator

--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -68,7 +68,10 @@ func TestIPAMNotNil(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateNetwork{}, api.EventDeleteNetwork{})
+	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateNetwork{},
+		api.EventDeleteNetwork{},
+	))
 	defer cancel()
 
 	// Start allocator

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -202,20 +201,20 @@ func TestAllocator(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.Queue().Watch(state.Matcher(
+	netWatch, cancel := s.Watch(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
-	))
+	)
 	defer cancel()
-	taskWatch, cancel := s.Queue().Watch(state.Matcher(
+	taskWatch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
-	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Watch(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
-	))
+	)
 	defer cancel()
 
 	// Start allocator
@@ -635,10 +634,10 @@ func TestNoDuplicateIPs(t *testing.T) {
 		return nil
 	}))
 
-	taskWatch, cancel := s.Queue().Watch(state.Matcher(
+	taskWatch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	assignedIPs := make(map[string]string)
@@ -821,16 +820,16 @@ func TestAllocatorRestoreForDuplicateIPs(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.Queue().Watch(state.Matcher(
+	taskWatch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
-	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Watch(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
-	))
+	)
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -977,16 +976,16 @@ func TestAllocatorRestartNoEndpointSpec(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.Queue().Watch(state.Matcher(
+	taskWatch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
-	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Watch(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
-	))
+	)
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -1187,16 +1186,16 @@ func TestAllocatorRestoreForUnallocatedNetwork(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.Queue().Watch(state.Matcher(
+	taskWatch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
-	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Watch(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
-	))
+	)
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -1248,15 +1247,15 @@ func TestNodeAllocator(t *testing.T) {
 		return nil
 	}))
 
-	nodeWatch, cancel := s.Queue().Watch(state.Matcher(
+	nodeWatch, cancel := s.Watch(
 		api.EventUpdateNode{},
 		api.EventDeleteNode{},
-	))
+	)
 	defer cancel()
-	netWatch, cancel := s.Queue().Watch(state.Matcher(
+	netWatch, cancel := s.Watch(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
-	))
+	)
 	defer cancel()
 
 	// Start allocator

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -202,11 +202,20 @@ func TestAllocator(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateNetwork{}, api.EventDeleteNetwork{})
+	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateNetwork{},
+		api.EventDeleteNetwork{},
+	))
 	defer cancel()
-	taskWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
-	serviceWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateService{}, api.EventDeleteService{})
+	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateService{},
+		api.EventDeleteService{},
+	))
 	defer cancel()
 
 	// Start allocator
@@ -626,7 +635,10 @@ func TestNoDuplicateIPs(t *testing.T) {
 		return nil
 	}))
 
-	taskWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	assignedIPs := make(map[string]string)
@@ -809,10 +821,16 @@ func TestAllocatorRestoreForDuplicateIPs(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
-	serviceWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateService{}, api.EventDeleteService{})
+	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateService{},
+		api.EventDeleteService{},
+	))
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -959,10 +977,16 @@ func TestAllocatorRestartNoEndpointSpec(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
-	serviceWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateService{}, api.EventDeleteService{})
+	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateService{},
+		api.EventDeleteService{},
+	))
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -1163,10 +1187,16 @@ func TestAllocatorRestoreForUnallocatedNetwork(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
-	serviceWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateService{}, api.EventDeleteService{})
+	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateService{},
+		api.EventDeleteService{},
+	))
 	defer cancel()
 
 	// Confirm tasks have no IPs that overlap with the services VIPs on restart
@@ -1218,9 +1248,15 @@ func TestNodeAllocator(t *testing.T) {
 		return nil
 	}))
 
-	nodeWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateNode{}, api.EventDeleteNode{})
+	nodeWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateNode{},
+		api.EventDeleteNode{},
+	))
 	defer cancel()
-	netWatch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateNetwork{}, api.EventDeleteNetwork{})
+	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateNetwork{},
+		api.EventDeleteNetwork{},
+	))
 	defer cancel()
 
 	// Start allocator

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -202,17 +202,17 @@ func TestAllocator(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	netWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))
 	defer cancel()
-	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	taskWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
-	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -635,7 +635,7 @@ func TestNoDuplicateIPs(t *testing.T) {
 		return nil
 	}))
 
-	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	taskWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
@@ -821,13 +821,13 @@ func TestAllocatorRestoreForDuplicateIPs(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	taskWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -977,13 +977,13 @@ func TestAllocatorRestartNoEndpointSpec(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	taskWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -1187,13 +1187,13 @@ func TestAllocatorRestoreForUnallocatedNetwork(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	taskWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	serviceWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -1248,12 +1248,12 @@ func TestNodeAllocator(t *testing.T) {
 		return nil
 	}))
 
-	nodeWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	nodeWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateNode{},
 		api.EventDeleteNode{},
 	))
 	defer cancel()
-	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
+	netWatch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -202,17 +202,17 @@ func TestAllocator(t *testing.T) {
 		return nil
 	}))
 
-	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))
 	defer cancel()
-	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
-	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -635,7 +635,7 @@ func TestNoDuplicateIPs(t *testing.T) {
 		return nil
 	}))
 
-	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
@@ -821,13 +821,13 @@ func TestAllocatorRestoreForDuplicateIPs(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -977,13 +977,13 @@ func TestAllocatorRestartNoEndpointSpec(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -1187,13 +1187,13 @@ func TestAllocatorRestoreForUnallocatedNetwork(t *testing.T) {
 	}()
 	defer a.Stop()
 
-	taskWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	taskWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
 	defer cancel()
 
-	serviceWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	serviceWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateService{},
 		api.EventDeleteService{},
 	))
@@ -1248,12 +1248,12 @@ func TestNodeAllocator(t *testing.T) {
 		return nil
 	}))
 
-	nodeWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	nodeWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateNode{},
 		api.EventDeleteNode{},
 	))
 	defer cancel()
-	netWatch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	netWatch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateNetwork{},
 		api.EventDeleteNetwork{},
 	))

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -58,7 +58,7 @@ func TestIsStateDirty(t *testing.T) {
 	assert.False(t, isDirty)
 
 	// Wait for cluster and node to be created.
-	watch, cancel := m.raftNode.MemoryStore().WatchQueue().WatchAll()
+	watch, cancel := m.raftNode.MemoryStore().Queue().WatchAll()
 	defer cancel()
 	<-watch
 	<-watch

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,7 +58,7 @@ func TestIsStateDirty(t *testing.T) {
 	assert.False(t, isDirty)
 
 	// Wait for cluster and node to be created.
-	watch, cancel := state.Watch(m.raftNode.MemoryStore().WatchQueue())
+	watch, cancel := m.raftNode.MemoryStore().WatchQueue().Watch()
 	defer cancel()
 	<-watch
 	<-watch

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -58,7 +58,7 @@ func TestIsStateDirty(t *testing.T) {
 	assert.False(t, isDirty)
 
 	// Wait for cluster and node to be created.
-	watch, cancel := m.raftNode.MemoryStore().Queue().WatchAll()
+	watch, cancel := m.raftNode.MemoryStore().Watch()
 	defer cancel()
 	<-watch
 	<-watch

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -58,7 +58,7 @@ func TestIsStateDirty(t *testing.T) {
 	assert.False(t, isDirty)
 
 	// Wait for cluster and node to be created.
-	watch, cancel := m.raftNode.MemoryStore().WatchQueue().Watch()
+	watch, cancel := m.raftNode.MemoryStore().WatchQueue().WatchAll()
 	defer cancel()
 	<-watch
 	<-watch

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1253,7 +1253,7 @@ func (d *Dispatcher) Session(r *api.SessionRequest, stream api.Dispatcher_Sessio
 		return err
 	}
 
-	clusterUpdatesCh, clusterCancel := d.clusterUpdateQueue.Watch()
+	clusterUpdatesCh, clusterCancel := d.clusterUpdateQueue.WatchAll()
 	defer clusterCancel()
 
 	if err := stream.Send(&api.SessionMessage{

--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -172,7 +172,7 @@ func (lb *LogBroker) watchSubscriptions(nodeID string) ([]*subscription, chan ev
 	defer lb.mu.RUnlock()
 
 	// Watch for subscription changes for this node.
-	ch, cancel := lb.subscriptionQueue.CallbackWatch(events.MatcherFunc(func(event events.Event) bool {
+	ch, cancel := lb.subscriptionQueue.Watch(events.MatcherFunc(func(event events.Event) bool {
 		s := event.(*subscription)
 		return s.Contains(nodeID)
 	}))
@@ -192,7 +192,7 @@ func (lb *LogBroker) subscribe(id string) (chan events.Event, func()) {
 	lb.mu.RLock()
 	defer lb.mu.RUnlock()
 
-	return lb.logQueue.CallbackWatch(events.MatcherFunc(func(event events.Event) bool {
+	return lb.logQueue.Watch(events.MatcherFunc(func(event events.Event) bool {
 		publish := event.(*logMessage)
 		return publish.SubscriptionID == id
 	}))

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -67,8 +67,10 @@ func (s *subscription) Run(ctx context.Context) {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	if s.follow() {
-		wq := s.store.WatchQueue()
-		ch, cancel := wq.Watch(state.Matcher(api.EventCreateTask{}, api.EventUpdateTask{}))
+		ch, cancel := s.store.Queue().Watch(state.Matcher(
+			api.EventCreateTask{},
+			api.EventUpdateTask{},
+		))
 		go func() {
 			defer cancel()
 			s.watch(ch)

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -5,10 +5,9 @@ import (
 	"strings"
 	"sync"
 
-	events "github.com/docker/go-events"
+	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
 	"golang.org/x/net/context"
@@ -67,10 +66,10 @@ func (s *subscription) Run(ctx context.Context) {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
 	if s.follow() {
-		ch, cancel := s.store.Queue().Watch(state.Matcher(
+		ch, cancel := s.store.Watch(
 			api.EventCreateTask{},
 			api.EventUpdateTask{},
-		))
+		)
 		go func() {
 			defer cancel()
 			s.watch(ch)

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -68,7 +68,7 @@ func (s *subscription) Run(ctx context.Context) {
 
 	if s.follow() {
 		wq := s.store.WatchQueue()
-		ch, cancel := wq.CallbackWatch(state.Matcher(api.EventCreateTask{}, api.EventUpdateTask{}))
+		ch, cancel := wq.Watch(state.Matcher(api.EventCreateTask{}, api.EventUpdateTask{}))
 		go func() {
 			defer cancel()
 			s.watch(ch)

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -68,7 +68,7 @@ func (s *subscription) Run(ctx context.Context) {
 
 	if s.follow() {
 		wq := s.store.WatchQueue()
-		ch, cancel := state.Watch(wq, api.EventCreateTask{}, api.EventUpdateTask{})
+		ch, cancel := wq.CallbackWatch(state.Matcher(api.EventCreateTask{}, api.EventUpdateTask{}))
 		go func() {
 			defer cancel()
 			s.watch(ch)

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -775,7 +775,7 @@ func (m *Manager) updateKEK(ctx context.Context, cluster *api.Cluster) error {
 func (m *Manager) watchForClusterChanges(ctx context.Context) error {
 	clusterID := m.config.SecurityConfig.ClientTLSCreds.Organization()
 	var cluster *api.Cluster
-	clusterWatch, clusterWatchCancel, err := store.ViewAndWatch(m.raftNode.MemoryStore(),
+	clusterWatch, clusterWatchCancel, err := m.raftNode.MemoryStore().ViewAndWatch(
 		func(tx store.ReadTx) error {
 			cluster = store.GetCluster(tx, clusterID)
 			if cluster == nil {

--- a/manager/metrics/collector.go
+++ b/manager/metrics/collector.go
@@ -60,16 +60,18 @@ func (c *Collector) updateNodeState(prevNode, newNode *api.Node) {
 func (c *Collector) Run(ctx context.Context) error {
 	defer close(c.doneChan)
 
-	watcher, cancel, err := store.ViewAndWatch(c.store, func(readTx store.ReadTx) error {
-		nodes, err := store.FindNodes(readTx, store.All)
-		if err != nil {
-			return err
-		}
-		for _, node := range nodes {
-			c.updateNodeState(nil, node)
-		}
-		return nil
-	})
+	watcher, cancel, err := c.store.ViewAndWatch(
+		func(readTx store.ReadTx) error {
+			nodes, err := store.FindNodes(readTx, store.All)
+			if err != nil {
+				return err
+			}
+			for _, node := range nodes {
+				c.updateNodeState(nil, node)
+			}
+			return nil
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/swarmkit/api/genericresource"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/constraint"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 )
@@ -33,7 +32,7 @@ func New(store *store.MemoryStore) *ConstraintEnforcer {
 func (ce *ConstraintEnforcer) Run() {
 	defer close(ce.doneChan)
 
-	watcher, cancelWatch := ce.store.Queue().Watch(state.Matcher(api.EventUpdateNode{}))
+	watcher, cancelWatch := ce.store.Watch(api.EventUpdateNode{})
 	defer cancelWatch()
 
 	var (

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -33,7 +33,7 @@ func New(store *store.MemoryStore) *ConstraintEnforcer {
 func (ce *ConstraintEnforcer) Run() {
 	defer close(ce.doneChan)
 
-	watcher, cancelWatch := state.Watch(ce.store.WatchQueue(), api.EventUpdateNode{})
+	watcher, cancelWatch := ce.store.WatchQueue().CallbackWatch(state.Matcher(api.EventUpdateNode{}))
 	defer cancelWatch()
 
 	var (

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -33,7 +33,7 @@ func New(store *store.MemoryStore) *ConstraintEnforcer {
 func (ce *ConstraintEnforcer) Run() {
 	defer close(ce.doneChan)
 
-	watcher, cancelWatch := ce.store.WatchQueue().Watch(state.Matcher(api.EventUpdateNode{}))
+	watcher, cancelWatch := ce.store.Queue().Watch(state.Matcher(api.EventUpdateNode{}))
 	defer cancelWatch()
 
 	var (

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer.go
@@ -33,7 +33,7 @@ func New(store *store.MemoryStore) *ConstraintEnforcer {
 func (ce *ConstraintEnforcer) Run() {
 	defer close(ce.doneChan)
 
-	watcher, cancelWatch := ce.store.WatchQueue().CallbackWatch(state.Matcher(api.EventUpdateNode{}))
+	watcher, cancelWatch := ce.store.WatchQueue().Watch(state.Matcher(api.EventUpdateNode{}))
 	defer cancelWatch()
 
 	var (

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
@@ -123,7 +123,7 @@ func TestConstraintEnforcer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(api.EventUpdateTask{}))
 	defer cancel()
 
 	constraintEnforcer := New(s)

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
@@ -123,7 +123,7 @@ func TestConstraintEnforcer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(api.EventUpdateTask{}))
+	watch, cancel := s.Queue().Watch(state.Matcher(api.EventUpdateTask{}))
 	defer cancel()
 
 	constraintEnforcer := New(s)

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
@@ -123,7 +123,7 @@ func TestConstraintEnforcer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(api.EventUpdateTask{}))
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(api.EventUpdateTask{}))
 	defer cancel()
 
 	constraintEnforcer := New(s)

--- a/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
+++ b/manager/orchestrator/constraintenforcer/constraint_enforcer_test.go
@@ -123,7 +123,7 @@ func TestConstraintEnforcer(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(api.EventUpdateTask{}))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	constraintEnforcer := New(s)

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -65,7 +65,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 	defer close(g.doneChan)
 
 	// Watch changes to services and tasks
-	watcher, cancel := g.store.Queue().WatchAll()
+	watcher, cancel := g.store.Watch()
 	defer cancel()
 
 	// lookup the cluster

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -65,8 +65,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 	defer close(g.doneChan)
 
 	// Watch changes to services and tasks
-	queue := g.store.WatchQueue()
-	watcher, cancel := queue.WatchAll()
+	watcher, cancel := g.store.Queue().WatchAll()
 	defer cancel()
 
 	// lookup the cluster

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -66,7 +66,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 
 	// Watch changes to services and tasks
 	queue := g.store.WatchQueue()
-	watcher, cancel := queue.Watch()
+	watcher, cancel := queue.WatchAll()
 	defer cancel()
 
 	// lookup the cluster

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -135,7 +135,11 @@ func TestSetup(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue() /*state.EventCreateTask{}, state.EventUpdateTask{}*/)
+	watch, cancel := store.WatchQueue().Watch()
+	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -153,7 +157,7 @@ func TestAddNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -173,7 +177,7 @@ func TestDeleteNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -195,7 +199,7 @@ func TestNodeAvailability(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -259,7 +263,7 @@ func TestNodeState(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -300,7 +304,7 @@ func TestAddService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -320,7 +324,7 @@ func TestDeleteService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue())
+	watch, cancel := store.WatchQueue().Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -342,7 +346,11 @@ func TestRemoveTask(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := store.WatchQueue().Watch()
+	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -374,7 +382,11 @@ func TestTaskFailure(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := state.Watch(store.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := store.WatchQueue().Watch()
+	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// first, try a "restart on any" policy
@@ -573,7 +585,11 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -636,7 +652,11 @@ func TestInitializationFailedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -728,7 +748,11 @@ func TestInitializationExtraTask(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -808,7 +832,11 @@ func TestInitializationMultipleServices(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -949,7 +977,11 @@ func TestInitializationTaskWithoutService(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1007,7 +1039,11 @@ func TestInitializationTaskOnDrainedNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1079,7 +1115,11 @@ func TestInitializationTaskOnNonexistentNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1248,7 +1288,11 @@ func TestInitializationRestartHistory(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -135,8 +135,8 @@ func TestSetup(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
-	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
+	watch, cancel := store.Queue().WatchAll()
+	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -157,7 +157,7 @@ func TestAddNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -177,7 +177,7 @@ func TestDeleteNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -199,7 +199,7 @@ func TestNodeAvailability(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -263,7 +263,7 @@ func TestNodeState(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -304,7 +304,7 @@ func TestAddService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -324,7 +324,7 @@ func TestDeleteService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
+	watch, cancel := store.Queue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -346,8 +346,8 @@ func TestRemoveTask(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
-	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
+	watch, cancel := store.Queue().WatchAll()
+	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -382,8 +382,8 @@ func TestTaskFailure(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().WatchAll()
-	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
+	watch, cancel := store.Queue().WatchAll()
+	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -585,7 +585,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -652,7 +652,7 @@ func TestInitializationFailedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -748,7 +748,7 @@ func TestInitializationExtraTask(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -832,7 +832,7 @@ func TestInitializationMultipleServices(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -977,7 +977,7 @@ func TestInitializationTaskWithoutService(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1039,7 +1039,7 @@ func TestInitializationTaskOnDrainedNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1115,7 +1115,7 @@ func TestInitializationTaskOnNonexistentNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1288,7 +1288,7 @@ func TestInitializationRestartHistory(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -135,7 +135,7 @@ func TestSetup(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -157,7 +157,7 @@ func TestAddNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -177,7 +177,7 @@ func TestDeleteNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -199,7 +199,7 @@ func TestNodeAvailability(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -263,7 +263,7 @@ func TestNodeState(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -304,7 +304,7 @@ func TestAddService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -324,7 +324,7 @@ func TestDeleteService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -346,7 +346,7 @@ func TestRemoveTask(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -382,7 +382,7 @@ func TestTaskFailure(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.Queue().WatchAll()
+	watch, cancel := store.Watch()
 	/*watch, cancel := store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -585,11 +585,11 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -652,11 +652,11 @@ func TestInitializationFailedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -748,11 +748,11 @@ func TestInitializationExtraTask(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -832,11 +832,11 @@ func TestInitializationMultipleServices(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -977,11 +977,11 @@ func TestInitializationTaskWithoutService(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1039,11 +1039,11 @@ func TestInitializationTaskOnDrainedNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1115,11 +1115,11 @@ func TestInitializationTaskOnNonexistentNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)
@@ -1288,11 +1288,11 @@ func TestInitializationRestartHistory(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewGlobalOrchestrator(s)

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -136,10 +136,10 @@ func TestSetup(t *testing.T) {
 	defer store.Close()
 
 	watch, cancel := store.Watch()
-	/*watch, cancel := store.Queue().Watch(state.Matcher(
+	/*watch, cancel := store.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -347,10 +347,10 @@ func TestRemoveTask(t *testing.T) {
 	defer store.Close()
 
 	watch, cancel := store.Watch()
-	/*watch, cancel := store.Queue().Watch(state.Matcher(
+	/*watch, cancel := store.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -383,10 +383,10 @@ func TestTaskFailure(t *testing.T) {
 	defer store.Close()
 
 	watch, cancel := store.Watch()
-	/*watch, cancel := store.Queue().Watch(state.Matcher(
+	/*watch, cancel := store.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	// first, try a "restart on any" policy

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -135,8 +135,8 @@ func TestSetup(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
-	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := store.WatchQueue().WatchAll()
+	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -157,7 +157,7 @@ func TestAddNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -177,7 +177,7 @@ func TestDeleteNode(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -199,7 +199,7 @@ func TestNodeAvailability(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -263,7 +263,7 @@ func TestNodeState(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -304,7 +304,7 @@ func TestAddService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -324,7 +324,7 @@ func TestDeleteService(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
+	watch, cancel := store.WatchQueue().WatchAll()
 	defer cancel()
 
 	orchestrator := setup(t, store, watch)
@@ -346,8 +346,8 @@ func TestRemoveTask(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
-	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := store.WatchQueue().WatchAll()
+	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -382,8 +382,8 @@ func TestTaskFailure(t *testing.T) {
 	assert.NotNil(t, store)
 	defer store.Close()
 
-	watch, cancel := store.WatchQueue().Watch()
-	/*watch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := store.WatchQueue().WatchAll()
+	/*watch, cancel := store.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -585,7 +585,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -652,7 +652,7 @@ func TestInitializationFailedTasks(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -748,7 +748,7 @@ func TestInitializationExtraTask(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -832,7 +832,7 @@ func TestInitializationMultipleServices(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -977,7 +977,7 @@ func TestInitializationTaskWithoutService(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1039,7 +1039,7 @@ func TestInitializationTaskOnDrainedNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1115,7 +1115,7 @@ func TestInitializationTaskOnNonexistentNode(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -1288,7 +1288,7 @@ func TestInitializationRestartHistory(t *testing.T) {
 	}
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/testutils"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -206,9 +205,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -206,7 +206,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -206,7 +206,7 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -206,7 +206,9 @@ func TestDrain(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -48,8 +48,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 	defer close(r.doneChan)
 
 	// Watch changes to services and tasks
-	queue := r.store.WatchQueue()
-	watcher, cancel := queue.WatchAll()
+	watcher, cancel := r.store.Queue().WatchAll()
 	defer cancel()
 
 	// Balance existing services and drain initial tasks attached to invalid

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -48,7 +48,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 	defer close(r.doneChan)
 
 	// Watch changes to services and tasks
-	watcher, cancel := r.store.Queue().WatchAll()
+	watcher, cancel := r.store.Watch()
 	defer cancel()
 
 	// Balance existing services and drain initial tasks attached to invalid

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -49,7 +49,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 
 	// Watch changes to services and tasks
 	queue := r.store.WatchQueue()
-	watcher, cancel := queue.Watch()
+	watcher, cancel := queue.WatchAll()
 	defer cancel()
 
 	// Balance existing services and drain initial tasks attached to invalid

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -24,8 +24,8 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -213,7 +213,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
@@ -554,7 +554,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -694,7 +694,7 @@ func TestInitializationFailedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -814,7 +814,7 @@ func TestInitializationNodeDown(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -927,7 +927,7 @@ func TestInitializationDelayStart(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -24,8 +24,8 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -213,7 +213,7 @@ func TestReplicatedScaleDown(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 	))
@@ -554,7 +554,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -694,7 +694,7 @@ func TestInitializationFailedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -814,7 +814,7 @@ func TestInitializationNodeDown(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
@@ -927,7 +927,7 @@ func TestInitializationDelayStart(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/testutils"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -24,7 +23,7 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -213,10 +212,10 @@ func TestReplicatedScaleDown(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	s1 := &api.Service{
@@ -554,11 +553,11 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -694,11 +693,11 @@ func TestInitializationFailedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -814,11 +813,11 @@ func TestInitializationNodeDown(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -927,11 +926,11 @@ func TestInitializationDelayStart(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventDeleteTask{},
-	))
+	)
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -24,7 +24,11 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -209,7 +213,10 @@ func TestReplicatedScaleDown(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	s1 := &api.Service{
@@ -547,7 +554,11 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -683,7 +694,11 @@ func TestInitializationFailedTasks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -799,7 +814,11 @@ func TestInitializationNodeDown(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)
@@ -908,7 +927,11 @@ func TestInitializationDelayStart(t *testing.T) {
 	assert.NoError(t, err)
 
 	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventDeleteTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventDeleteTask{},
+	))
 	defer cancel()
 
 	orchestrator := NewReplicatedOrchestrator(s)

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -24,8 +24,8 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -133,7 +133,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -260,7 +260,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -396,8 +396,8 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -492,7 +492,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -663,8 +663,8 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -24,7 +24,7 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -133,10 +133,10 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))
+	)
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -260,10 +260,10 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))
+	)
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -396,7 +396,7 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -492,10 +492,10 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
+	watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))
+	)
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -663,7 +663,7 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -25,10 +25,10 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -397,10 +397,10 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -664,10 +664,10 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -24,7 +24,11 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -129,7 +133,10 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -253,7 +260,10 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -386,7 +396,11 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -478,7 +492,10 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -646,7 +663,11 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -24,8 +24,8 @@ func TestOrchestratorRestartOnAny(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -133,7 +133,7 @@ func TestOrchestratorRestartOnFailure(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -260,7 +260,7 @@ func TestOrchestratorRestartOnNone(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -396,8 +396,8 @@ func TestOrchestratorRestartDelay(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -492,7 +492,7 @@ func TestOrchestratorRestartMaxAttempts(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))
@@ -663,8 +663,8 @@ func TestOrchestratorRestartWindow(t *testing.T) {
 	orchestrator := NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -39,18 +39,18 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 		failImage2 uint32
 	)
 
-	watchCreate, cancelCreate := s.WatchQueue().CallbackWatch(state.Matcher(
+	watchCreate, cancelCreate := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 	))
 	defer cancelCreate()
 
-	watchServiceUpdate, cancelServiceUpdate := s.WatchQueue().CallbackWatch(state.Matcher(
+	watchServiceUpdate, cancelServiceUpdate := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateService{},
 	))
 	defer cancelServiceUpdate()
 
 	// Fail new tasks the updater tries to run
-	watchUpdate, cancelUpdate := s.WatchQueue().CallbackWatch(state.Matcher(
+	watchUpdate, cancelUpdate := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancelUpdate()

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -39,14 +39,20 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 		failImage2 uint32
 	)
 
-	watchCreate, cancelCreate := state.Watch(s.WatchQueue(), api.EventCreateTask{})
+	watchCreate, cancelCreate := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+	))
 	defer cancelCreate()
 
-	watchServiceUpdate, cancelServiceUpdate := state.Watch(s.WatchQueue(), api.EventUpdateService{})
+	watchServiceUpdate, cancelServiceUpdate := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateService{},
+	))
 	defer cancelServiceUpdate()
 
 	// Fail new tasks the updater tries to run
-	watchUpdate, cancelUpdate := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watchUpdate, cancelUpdate := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancelUpdate()
 	go func() {
 		failedLast := false

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/testutils"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
@@ -39,20 +38,14 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 		failImage2 uint32
 	)
 
-	watchCreate, cancelCreate := s.Queue().Watch(state.Matcher(
-		api.EventCreateTask{},
-	))
+	watchCreate, cancelCreate := s.Watch(api.EventCreateTask{})
 	defer cancelCreate()
 
-	watchServiceUpdate, cancelServiceUpdate := s.Queue().Watch(state.Matcher(
-		api.EventUpdateService{},
-	))
+	watchServiceUpdate, cancelServiceUpdate := s.Watch(api.EventUpdateService{})
 	defer cancelServiceUpdate()
 
 	// Fail new tasks the updater tries to run
-	watchUpdate, cancelUpdate := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watchUpdate, cancelUpdate := s.Watch(api.EventUpdateTask{})
 	defer cancelUpdate()
 	go func() {
 		failedLast := false

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -39,18 +39,18 @@ func testUpdaterRollback(t *testing.T, rollbackFailureAction api.UpdateConfig_Fa
 		failImage2 uint32
 	)
 
-	watchCreate, cancelCreate := s.WatchQueue().Watch(state.Matcher(
+	watchCreate, cancelCreate := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 	))
 	defer cancelCreate()
 
-	watchServiceUpdate, cancelServiceUpdate := s.WatchQueue().Watch(state.Matcher(
+	watchServiceUpdate, cancelServiceUpdate := s.Queue().Watch(state.Matcher(
 		api.EventUpdateService{},
 	))
 	defer cancelServiceUpdate()
 
 	// Fail new tasks the updater tries to run
-	watchUpdate, cancelUpdate := s.WatchQueue().Watch(state.Matcher(
+	watchUpdate, cancelUpdate := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancelUpdate()

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -421,7 +421,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 	if waitForTask {
 		// Wait for either the old task to complete, or the old task's
 		// node to become unavailable.
-		watch, cancelWatch = r.store.WatchQueue().CallbackWatch(state.Matcher(
+		watch, cancelWatch = r.store.WatchQueue().Watch(state.Matcher(
 			api.EventUpdateTask{
 				Task:   &api.Task{ID: oldTask.ID, Status: api.TaskStatus{State: api.TaskStateRunning}},
 				Checks: []api.TaskCheckFunc{api.TaskCheckID, state.TaskCheckStateGreaterThan},

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -421,7 +421,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 	if waitForTask {
 		// Wait for either the old task to complete, or the old task's
 		// node to become unavailable.
-		watch, cancelWatch = r.store.Queue().Watch(state.Matcher(
+		watch, cancelWatch = r.store.Watch(
 			api.EventUpdateTask{
 				Task:   &api.Task{ID: oldTask.ID, Status: api.TaskStatus{State: api.TaskStateRunning}},
 				Checks: []api.TaskCheckFunc{api.TaskCheckID, state.TaskCheckStateGreaterThan},
@@ -434,7 +434,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 				Node:   &api.Node{ID: oldTask.NodeID},
 				Checks: []api.NodeCheckFunc{api.NodeCheckID},
 			},
-		))
+		)
 	}
 
 	go func() {

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -421,7 +421,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 	if waitForTask {
 		// Wait for either the old task to complete, or the old task's
 		// node to become unavailable.
-		watch, cancelWatch = r.store.WatchQueue().Watch(state.Matcher(
+		watch, cancelWatch = r.store.Queue().Watch(state.Matcher(
 			api.EventUpdateTask{
 				Task:   &api.Task{ID: oldTask.ID, Status: api.TaskStatus{State: api.TaskStateRunning}},
 				Checks: []api.TaskCheckFunc{api.TaskCheckID, state.TaskCheckStateGreaterThan},

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -421,8 +421,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 	if waitForTask {
 		// Wait for either the old task to complete, or the old task's
 		// node to become unavailable.
-		watch, cancelWatch = state.Watch(
-			r.store.WatchQueue(),
+		watch, cancelWatch = r.store.WatchQueue().CallbackWatch(state.Matcher(
 			api.EventUpdateTask{
 				Task:   &api.Task{ID: oldTask.ID, Status: api.TaskStatus{State: api.TaskStateRunning}},
 				Checks: []api.TaskCheckFunc{api.TaskCheckID, state.TaskCheckStateGreaterThan},
@@ -435,7 +434,7 @@ func (r *Supervisor) DelayStart(ctx context.Context, _ store.Tx, oldTask *api.Ta
 				Node:   &api.Node{ID: oldTask.NodeID},
 				Checks: []api.NodeCheckFunc{api.NodeCheckID},
 			},
-		)
+		))
 	}
 
 	go func() {

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -63,7 +63,7 @@ func (tr *TaskReaper) Run(ctx context.Context) {
 
 	var (
 		orphanedTasks []*api.Task
-		removeTasks []*api.Task
+		removeTasks   []*api.Task
 	)
 	watcher, watchCancel := tr.store.ViewAndWatch(
 		func(readTx store.ReadTx) {
@@ -90,7 +90,7 @@ func (tr *TaskReaper) Run(ctx context.Context) {
 	)
 	defer watchCancel()
 
-	if len(orphanedTasks) + len(removeTasks) > 0 {
+	if len(orphanedTasks)+len(removeTasks) > 0 {
 		for _, t := range orphanedTasks {
 			// Do not reap service tasks immediately.
 			// Let them go through the regular history cleanup process

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -60,7 +60,7 @@ func New(store *store.MemoryStore) *TaskReaper {
 // responsible for cleaning up tasks associated with slots that were removed as part of
 // service scale down or service removal.
 func (tr *TaskReaper) Run(ctx context.Context) {
-	watcher, watchCancel := tr.store.WatchQueue().Watch(state.Matcher(
+	watcher, watchCancel := tr.store.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventUpdateCluster{},

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -60,7 +60,11 @@ func New(store *store.MemoryStore) *TaskReaper {
 // responsible for cleaning up tasks associated with slots that were removed as part of
 // service scale down or service removal.
 func (tr *TaskReaper) Run(ctx context.Context) {
-	watcher, watchCancel := state.Watch(tr.store.WatchQueue(), api.EventCreateTask{}, api.EventUpdateTask{}, api.EventUpdateCluster{})
+	watcher, watchCancel := tr.store.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+		api.EventUpdateCluster{},
+	))
 
 	defer func() {
 		close(tr.doneChan)

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"golang.org/x/net/context"
 )
@@ -60,11 +59,11 @@ func New(store *store.MemoryStore) *TaskReaper {
 // responsible for cleaning up tasks associated with slots that were removed as part of
 // service scale down or service removal.
 func (tr *TaskReaper) Run(ctx context.Context) {
-	watcher, watchCancel := tr.store.Queue().Watch(state.Matcher(
+	watcher, watchCancel := tr.store.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventUpdateCluster{},
-	))
+	)
 
 	defer func() {
 		close(tr.doneChan)

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -60,7 +60,7 @@ func New(store *store.MemoryStore) *TaskReaper {
 // responsible for cleaning up tasks associated with slots that were removed as part of
 // service scale down or service removal.
 func (tr *TaskReaper) Run(ctx context.Context) {
-	watcher, watchCancel := tr.store.WatchQueue().CallbackWatch(state.Matcher(
+	watcher, watchCancel := tr.store.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 		api.EventUpdateCluster{},

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -223,7 +223,11 @@ func TestTaskHistory(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -357,7 +361,7 @@ func TestTaskStateRemoveOnScaledown(t *testing.T) {
 	defer orchestrator.Stop()
 
 	// watch all incoming events
-	watch, cancel := state.Watch(s.WatchQueue())
+	watch, cancel := s.WatchQueue().Watch()
 	defer cancel()
 
 	service1 := &api.Service{
@@ -489,7 +493,11 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	service1 := &api.Service{
@@ -626,7 +634,11 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	service1 := &api.Service{
@@ -780,7 +792,11 @@ func TestServiceRemoveUnassignedTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := state.Watch(s.WatchQueue() /*api.EventCreateTask{}, api.EventUpdateTask{}*/)
+	watch, cancel := s.WatchQueue().Watch()
+	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventCreateTask{},
+		api.EventUpdateTask{},
+	))*/
 	defer cancel()
 
 	service1 := &api.Service{

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -223,8 +223,8 @@ func TestTaskHistory(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -361,7 +361,7 @@ func TestTaskStateRemoveOnScaledown(t *testing.T) {
 	defer orchestrator.Stop()
 
 	// watch all incoming events
-	watch, cancel := s.WatchQueue().Watch()
+	watch, cancel := s.WatchQueue().WatchAll()
 	defer cancel()
 
 	service1 := &api.Service{
@@ -493,8 +493,8 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -634,8 +634,8 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -792,8 +792,8 @@ func TestServiceRemoveUnassignedTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().Watch()
-	/*watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().WatchAll()
+	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -224,10 +224,10 @@ func TestTaskHistory(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	// Create a service with two instances specified before the orchestrator is
@@ -494,10 +494,10 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	service1 := &api.Service{
@@ -635,10 +635,10 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	service1 := &api.Service{
@@ -793,10 +793,10 @@ func TestServiceRemoveUnassignedTasks(t *testing.T) {
 	defer orchestrator.Stop()
 
 	watch, cancel := s.Watch()
-	/*watch, cancel := s.Queue().Watch(state.Matcher(
+	/*watch, cancel := s.Watch(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
-	))*/
+	)*/
 	defer cancel()
 
 	service1 := &api.Service{

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -223,7 +223,7 @@ func TestTaskHistory(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -361,7 +361,7 @@ func TestTaskStateRemoveOnScaledown(t *testing.T) {
 	defer orchestrator.Stop()
 
 	// watch all incoming events
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	defer cancel()
 
 	service1 := &api.Service{
@@ -493,7 +493,7 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -634,7 +634,7 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
@@ -792,7 +792,7 @@ func TestServiceRemoveUnassignedTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -223,8 +223,8 @@ func TestTaskHistory(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -361,7 +361,7 @@ func TestTaskStateRemoveOnScaledown(t *testing.T) {
 	defer orchestrator.Stop()
 
 	// watch all incoming events
-	watch, cancel := s.WatchQueue().WatchAll()
+	watch, cancel := s.Queue().WatchAll()
 	defer cancel()
 
 	service1 := &api.Service{
@@ -493,8 +493,8 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -634,8 +634,8 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/
@@ -792,8 +792,8 @@ func TestServiceRemoveUnassignedTasks(t *testing.T) {
 	orchestrator := replicated.NewReplicatedOrchestrator(s)
 	defer orchestrator.Stop()
 
-	watch, cancel := s.WatchQueue().WatchAll()
-	/*watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().WatchAll()
+	/*watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventCreateTask{},
 		api.EventUpdateTask{},
 	))*/

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -203,7 +203,7 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 
 	if updateConfig.FailureAction != api.UpdateConfig_CONTINUE {
 		var cancelWatch func()
-		failedTaskWatch, cancelWatch = u.store.WatchQueue().CallbackWatch(state.Matcher(
+		failedTaskWatch, cancelWatch = u.store.WatchQueue().Watch(state.Matcher(
 			api.EventUpdateTask{
 				Task:   &api.Task{ServiceID: service.ID, Status: api.TaskStatus{State: api.TaskStateRunning}},
 				Checks: []api.TaskCheckFunc{api.TaskCheckServiceID, state.TaskCheckStateGreaterThan},
@@ -361,7 +361,7 @@ func (u *Updater) worker(ctx context.Context, queue <-chan orchestrator.Slot, up
 
 func (u *Updater) updateTask(ctx context.Context, slot orchestrator.Slot, updated *api.Task, order api.UpdateConfig_UpdateOrder) error {
 	// Kick off the watch before even creating the updated task. This is in order to avoid missing any event.
-	taskUpdates, cancel := u.watchQueue.CallbackWatch(state.Matcher(
+	taskUpdates, cancel := u.watchQueue.Watch(state.Matcher(
 		api.EventUpdateTask{
 			Task:   &api.Task{ID: updated.ID},
 			Checks: []api.TaskCheckFunc{api.TaskCheckID},

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
@@ -66,9 +65,7 @@ func TestUpdater(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -261,9 +258,7 @@ func TestUpdaterPlacement(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -375,9 +370,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 	defer s.Close()
 
 	// Fail new tasks the updater tries to run
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -531,9 +524,7 @@ func TestUpdaterTaskTimeout(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -625,9 +616,7 @@ func TestUpdaterOrder(t *testing.T) {
 	assert.NotNil(t, s)
 
 	// Move tasks to their desired state.
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 	go func() {
 		for e := range watch {

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -66,7 +66,9 @@ func TestUpdater(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -259,7 +261,9 @@ func TestUpdaterPlacement(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -371,7 +375,9 @@ func TestUpdaterFailureAction(t *testing.T) {
 	defer s.Close()
 
 	// Fail new tasks the updater tries to run
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -525,7 +531,9 @@ func TestUpdaterTaskTimeout(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 	go func() {
 		for e := range watch {
@@ -617,7 +625,9 @@ func TestUpdaterOrder(t *testing.T) {
 	assert.NotNil(t, s)
 
 	// Move tasks to their desired state.
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 	go func() {
 		for e := range watch {

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -66,7 +66,7 @@ func TestUpdater(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -261,7 +261,7 @@ func TestUpdaterPlacement(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -375,7 +375,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 	defer s.Close()
 
 	// Fail new tasks the updater tries to run
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -531,7 +531,7 @@ func TestUpdaterTaskTimeout(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -625,7 +625,7 @@ func TestUpdaterOrder(t *testing.T) {
 	assert.NotNil(t, s)
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -66,7 +66,7 @@ func TestUpdater(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -261,7 +261,7 @@ func TestUpdaterPlacement(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -375,7 +375,7 @@ func TestUpdaterFailureAction(t *testing.T) {
 	defer s.Close()
 
 	// Fail new tasks the updater tries to run
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -531,7 +531,7 @@ func TestUpdaterTaskTimeout(t *testing.T) {
 	defer s.Close()
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -625,7 +625,7 @@ func TestUpdaterOrder(t *testing.T) {
 	assert.NotNil(t, s)
 
 	// Move tasks to their desired state.
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/role_manager.go
+++ b/manager/role_manager.go
@@ -95,7 +95,7 @@ func (rm *roleManager) Run(ctx context.Context) {
 		tickerCh <-chan time.Time
 	)
 
-	watcher, cancelWatch, err := store.ViewAndWatch(rm.store,
+	watcher, cancelWatch, err := rm.store.ViewAndWatch(
 		func(readTx store.ReadTx) error {
 			var err error
 			nodes, err = store.FindNodes(readTx, store.All)

--- a/manager/role_manager.go
+++ b/manager/role_manager.go
@@ -87,7 +87,7 @@ func (rm *roleManager) Run(ctx context.Context) {
 
 	var (
 		nodes []*api.Node
-
+		err   error
 		// ticker and tickerCh are used to time the reconciliation interval, which will
 		// periodically attempt to re-reconcile nodes that failed to reconcile the first
 		// time through
@@ -95,11 +95,9 @@ func (rm *roleManager) Run(ctx context.Context) {
 		tickerCh <-chan time.Time
 	)
 
-	watcher, cancelWatch, err := rm.store.ViewAndWatch(
-		func(readTx store.ReadTx) error {
-			var err error
+	watcher, cancelWatch := rm.store.ViewAndWatch(
+		func(readTx store.ReadTx) {
 			nodes, err = store.FindNodes(readTx, store.All)
-			return err
 		},
 		api.EventUpdateNode{},
 		api.EventDeleteNode{})

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -105,12 +105,15 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 func (s *Scheduler) Run(ctx context.Context) error {
 	defer close(s.doneChan)
 
-	updates, cancel, err := s.store.ViewAndWatch(s.setupTasksList)
+	var err error
+	updates, cancel := s.store.ViewAndWatch(func(tx store.ReadTx) {
+		err = s.setupTasksList(tx)
+	})
+	defer cancel()
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("snapshot store update failed")
 		return err
 	}
-	defer cancel()
 
 	// Validate resource for tasks from preassigned tasks
 	// do this before other tasks because preassigned tasks like

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -105,7 +105,7 @@ func (s *Scheduler) setupTasksList(tx store.ReadTx) error {
 func (s *Scheduler) Run(ctx context.Context) error {
 	defer close(s.doneChan)
 
-	updates, cancel, err := store.ViewAndWatch(s.store, s.setupTasksList)
+	updates, cancel, err := s.store.ViewAndWatch(s.setupTasksList)
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("snapshot store update failed")
 		return err

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -112,7 +112,7 @@ func TestScheduler(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -463,7 +463,7 @@ func testHA(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -779,7 +779,7 @@ func testPreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1045,7 +1045,7 @@ func testMultiplePreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1144,7 +1144,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1256,7 +1256,7 @@ func TestSchedulerFaultyNode(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1404,7 +1404,7 @@ func TestSchedulerFaultyNodeSpecVersion(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1589,7 +1589,7 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1751,7 +1751,7 @@ func TestSchedulerResourceConstraintHA(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1841,7 +1841,7 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1945,7 +1945,7 @@ func TestSchedulerPreexistingDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2141,7 +2141,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2275,7 +2275,7 @@ func TestPreassignedTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2376,7 +2376,7 @@ func TestIgnoreTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2760,7 +2760,7 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2933,7 +2933,7 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints bool) {
 		s := store.NewMemoryStore(nil)
 		scheduler := New(s)
 
-		watch, cancel := s.WatchQueue().Watch(state.Matcher(
+		watch, cancel := s.Queue().Watch(state.Matcher(
 			api.EventUpdateTask{},
 		))
 
@@ -3136,7 +3136,7 @@ func TestSchedulerHostPort(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().Watch(state.Matcher(
+	watch, cancel := s.Queue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -112,7 +112,7 @@ func TestScheduler(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -463,7 +463,7 @@ func testHA(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -779,7 +779,7 @@ func testPreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1045,7 +1045,7 @@ func testMultiplePreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1144,7 +1144,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1256,7 +1256,7 @@ func TestSchedulerFaultyNode(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1404,7 +1404,7 @@ func TestSchedulerFaultyNodeSpecVersion(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1589,7 +1589,7 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1751,7 +1751,7 @@ func TestSchedulerResourceConstraintHA(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1841,7 +1841,7 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -1945,7 +1945,7 @@ func TestSchedulerPreexistingDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2141,7 +2141,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2275,7 +2275,7 @@ func TestPreassignedTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2376,7 +2376,7 @@ func TestIgnoreTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2760,7 +2760,7 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()
@@ -2933,7 +2933,7 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints bool) {
 		s := store.NewMemoryStore(nil)
 		scheduler := New(s)
 
-		watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		watch, cancel := s.WatchQueue().Watch(state.Matcher(
 			api.EventUpdateTask{},
 		))
 
@@ -3136,7 +3136,7 @@ func TestSchedulerHostPort(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+	watch, cancel := s.WatchQueue().Watch(state.Matcher(
 		api.EventUpdateTask{},
 	))
 	defer cancel()

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/genericresource"
 	"github.com/docker/swarmkit/identity"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,9 +111,7 @@ func TestScheduler(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -463,9 +460,7 @@ func testHA(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -779,9 +774,7 @@ func testPreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1045,9 +1038,7 @@ func testMultiplePreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1144,9 +1135,7 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1256,9 +1245,7 @@ func TestSchedulerFaultyNode(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1404,9 +1391,7 @@ func TestSchedulerFaultyNodeSpecVersion(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1589,9 +1574,7 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1751,9 +1734,7 @@ func TestSchedulerResourceConstraintHA(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1841,9 +1822,7 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -1945,9 +1924,7 @@ func TestSchedulerPreexistingDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -2141,9 +2118,7 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -2275,9 +2250,7 @@ func TestPreassignedTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -2376,9 +2349,7 @@ func TestIgnoreTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -2760,9 +2731,7 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {
@@ -2933,9 +2902,7 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints bool) {
 		s := store.NewMemoryStore(nil)
 		scheduler := New(s)
 
-		watch, cancel := s.Queue().Watch(state.Matcher(
-			api.EventUpdateTask{},
-		))
+		watch, cancel := s.Watch(api.EventUpdateTask{})
 
 		go func() {
 			_ = scheduler.Run(ctx)
@@ -3136,9 +3103,7 @@ func TestSchedulerHostPort(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := s.Queue().Watch(state.Matcher(
-		api.EventUpdateTask{},
-	))
+	watch, cancel := s.Watch(api.EventUpdateTask{})
 	defer cancel()
 
 	go func() {

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -112,7 +112,9 @@ func TestScheduler(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -461,7 +463,9 @@ func testHA(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -775,7 +779,9 @@ func testPreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1039,7 +1045,9 @@ func testMultiplePreferences(t *testing.T, useSpecVersion bool) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1136,7 +1144,9 @@ func TestSchedulerNoReadyNodes(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1246,7 +1256,9 @@ func TestSchedulerFaultyNode(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1392,7 +1404,9 @@ func TestSchedulerFaultyNodeSpecVersion(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1575,7 +1589,9 @@ func TestSchedulerResourceConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1735,7 +1751,9 @@ func TestSchedulerResourceConstraintHA(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1823,7 +1841,9 @@ func TestSchedulerResourceConstraintDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -1925,7 +1945,9 @@ func TestSchedulerPreexistingDeadTask(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -2119,7 +2141,9 @@ func TestSchedulerCompatiblePlatform(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -2251,7 +2275,9 @@ func TestPreassignedTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -2350,7 +2376,9 @@ func TestIgnoreTasks(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -2732,7 +2760,9 @@ func TestSchedulerPluginConstraint(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {
@@ -2903,7 +2933,9 @@ func benchScheduler(b *testing.B, nodes, tasks int, networkConstraints bool) {
 		s := store.NewMemoryStore(nil)
 		scheduler := New(s)
 
-		watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+		watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+			api.EventUpdateTask{},
+		))
 
 		go func() {
 			_ = scheduler.Run(ctx)
@@ -3104,7 +3136,9 @@ func TestSchedulerHostPort(t *testing.T) {
 
 	scheduler := New(s)
 
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
+	watch, cancel := s.WatchQueue().CallbackWatch(state.Matcher(
+		api.EventUpdateTask{},
+	))
 	defer cancel()
 
 	go func() {

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1655,7 +1655,7 @@ func (n *Node) ChangesBetween(from, to api.Version) ([]state.Change, error) {
 // SubscribePeers subscribes to peer updates in cluster. It sends always full
 // list of peers.
 func (n *Node) SubscribePeers() (q chan events.Event, cancel func()) {
-	return n.cluster.PeersBroadcast.Watch()
+	return n.cluster.PeersBroadcast.WatchAll()
 }
 
 // GetMemberlist returns the current list of raft members in the cluster.
@@ -2029,7 +2029,7 @@ func (n *Node) applyRemoveNode(ctx context.Context, cc raftpb.ConfChange) (err e
 // will be sent in form of raft.LeadershipState. Also cancel func is returned -
 // it should be called when listener is no longer interested in events.
 func (n *Node) SubscribeLeadership() (q chan events.Event, cancel func()) {
-	return n.leadershipBroadcast.Watch()
+	return n.leadershipBroadcast.WatchAll()
 }
 
 // createConfigChangeEnts creates a series of Raft entries (i.e.

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -59,7 +59,7 @@ func WaitForLeader(ctx context.Context, n *Node) error {
 // committed to raft. This ensures that we can see and serve informations
 // related to the cluster.
 func WaitForCluster(ctx context.Context, n *Node) (cluster *api.Cluster, err error) {
-	watch, cancel := n.MemoryStore().WatchQueue().CallbackWatch(state.Matcher(api.EventCreateCluster{}))
+	watch, cancel := n.MemoryStore().WatchQueue().Watch(state.Matcher(api.EventCreateCluster{}))
 	defer cancel()
 
 	var clusters []*api.Cluster

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -59,7 +59,7 @@ func WaitForLeader(ctx context.Context, n *Node) error {
 // committed to raft. This ensures that we can see and serve informations
 // related to the cluster.
 func WaitForCluster(ctx context.Context, n *Node) (cluster *api.Cluster, err error) {
-	watch, cancel := state.Watch(n.MemoryStore().WatchQueue(), api.EventCreateCluster{})
+	watch, cancel := n.MemoryStore().WatchQueue().CallbackWatch(state.Matcher(api.EventCreateCluster{}))
 	defer cancel()
 
 	var clusters []*api.Cluster

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -59,7 +59,7 @@ func WaitForLeader(ctx context.Context, n *Node) error {
 // committed to raft. This ensures that we can see and serve informations
 // related to the cluster.
 func WaitForCluster(ctx context.Context, n *Node) (cluster *api.Cluster, err error) {
-	watch, cancel := n.MemoryStore().WatchQueue().Watch(state.Matcher(api.EventCreateCluster{}))
+	watch, cancel := n.MemoryStore().Queue().Watch(state.Matcher(api.EventCreateCluster{}))
 	defer cancel()
 
 	var clusters []*api.Cluster

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -6,9 +6,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -56,10 +55,10 @@ func WaitForLeader(ctx context.Context, n *Node) error {
 }
 
 // WaitForCluster waits until node observes that the cluster wide config is
-// committed to raft. This ensures that we can see and serve informations
+// committed to raft. This ensures that we can see and serve information
 // related to the cluster.
 func WaitForCluster(ctx context.Context, n *Node) (cluster *api.Cluster, err error) {
-	watch, cancel := n.MemoryStore().Queue().Watch(state.Matcher(api.EventCreateCluster{}))
+	watch, cancel := n.MemoryStore().Watch(api.EventCreateCluster{})
 	defer cancel()
 
 	var clusters []*api.Cluster

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -826,8 +826,8 @@ func (s *MemoryStore) Restore(snapshot *pb.StoreSnapshot) error {
 	})
 }
 
-// WatchQueue returns the publish/subscribe queue.
-func (s *MemoryStore) WatchQueue() *watch.Queue {
+// Queue returns the publish/subscribe queue.
+func (s *MemoryStore) Queue() *watch.Queue {
 	return s.queue
 }
 
@@ -845,7 +845,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 		if err := cb(tx); err != nil {
 			return err
 		}
-		watch, cancel = store.WatchQueue().Watch(state.Matcher(specifiers...))
+		watch, cancel = store.Queue().Watch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {
@@ -860,7 +860,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // from "version", and new events until the channel is closed. If "version"
 // is nil, this function is equivalent to
 //
-//     store.WatchQueue().Watch(state.Matcher(specifiers...))
+//     store.Queue().Watch(state.Matcher(specifiers...))
 //
 // If the log has been compacted and it's not possible to produce the exact
 // set of events leading from "version" to the current state, this function
@@ -870,7 +870,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // longer needed.
 func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event) (chan events.Event, func(), error) {
 	if version == nil {
-		ch, cancel := store.WatchQueue().Watch(state.Matcher(specifiers...))
+		ch, cancel := store.Queue().Watch(state.Matcher(specifiers...))
 		return ch, cancel, nil
 	}
 
@@ -889,7 +889,7 @@ func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event
 		curVersion = store.proposer.GetVersion()
 		// Start the watch with the store locked so events cannot be
 		// missed
-		watch, cancelWatch = store.WatchQueue().Watch(state.Matcher(specifiers...))
+		watch, cancelWatch = store.Queue().Watch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -845,7 +845,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 		if err := cb(tx); err != nil {
 			return err
 		}
-		watch, cancel = store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
+		watch, cancel = store.WatchQueue().Watch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {
@@ -860,7 +860,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // from "version", and new events until the channel is closed. If "version"
 // is nil, this function is equivalent to
 //
-//     store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
+//     store.WatchQueue().Watch(state.Matcher(specifiers...))
 //
 // If the log has been compacted and it's not possible to produce the exact
 // set of events leading from "version" to the current state, this function
@@ -870,7 +870,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // longer needed.
 func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event) (chan events.Event, func(), error) {
 	if version == nil {
-		ch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
+		ch, cancel := store.WatchQueue().Watch(state.Matcher(specifiers...))
 		return ch, cancel, nil
 	}
 
@@ -889,7 +889,7 @@ func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event
 		curVersion = store.proposer.GetVersion()
 		// Start the watch with the store locked so events cannot be
 		// missed
-		watch, cancelWatch = store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
+		watch, cancelWatch = store.WatchQueue().Watch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -113,6 +113,17 @@ func register(os ObjectStoreConfig) {
 	schema.Tables[os.Table.Name] = os.Table
 }
 
+func applyStoreAction(tx Tx, sa api.StoreAction) error {
+	for _, os := range objectStorers {
+		err := os.ApplyStoreAction(tx, sa)
+		if err != errUnknownStoreAction {
+			return err
+		}
+	}
+
+	return errors.New("unrecognized action type")
+}
+
 // timedMutex wraps a sync.Mutex, and keeps track of when it was locked.
 type timedMutex struct {
 	sync.Mutex
@@ -302,17 +313,6 @@ func (s *MemoryStore) ApplyStoreActions(actions []api.StoreAction) error {
 	}
 	s.updateLock.Unlock()
 	return nil
-}
-
-func applyStoreAction(tx Tx, sa api.StoreAction) error {
-	for _, os := range objectStorers {
-		err := os.ApplyStoreAction(tx, sa)
-		if err != errUnknownStoreAction {
-			return err
-		}
-	}
-
-	return errors.New("unrecognized action type")
 }
 
 func (s *MemoryStore) update(proposer state.Proposer, cb func(Tx) error) error {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -13,11 +13,10 @@ import (
 	"github.com/docker/go-events"
 	"github.com/docker/go-metrics"
 	"github.com/docker/swarmkit/api"
-	pb "github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/watch"
 	gogotypes "github.com/gogo/protobuf/types"
-	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-memdb"
 	"golang.org/x/net/context"
 )
 
@@ -802,8 +801,8 @@ func (tx readTx) find(table string, by By, checkType func(By) error, appendResul
 }
 
 // Save serializes the data in the store.
-func (s *MemoryStore) Save(tx ReadTx) (*pb.StoreSnapshot, error) {
-	var snapshot pb.StoreSnapshot
+func (s *MemoryStore) Save(tx ReadTx) (*api.StoreSnapshot, error) {
+	var snapshot api.StoreSnapshot
 	for _, os := range objectStorers {
 		if err := os.Save(tx, &snapshot); err != nil {
 			return nil, err
@@ -815,7 +814,7 @@ func (s *MemoryStore) Save(tx ReadTx) (*pb.StoreSnapshot, error) {
 
 // Restore sets the contents of the store to the serialized data in the
 // argument.
-func (s *MemoryStore) Restore(snapshot *pb.StoreSnapshot) error {
+func (s *MemoryStore) Restore(snapshot *api.StoreSnapshot) error {
 	return s.updateLocal(func(tx Tx) error {
 		for _, os := range objectStorers {
 			if err := os.Restore(tx, snapshot); err != nil {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -597,10 +597,6 @@ func (s *MemoryStore) update(proposer state.Proposer, cb func(Tx) error) error {
 	return err
 }
 
-func (s *MemoryStore) updateLocal(cb func(Tx) error) error {
-	return s.update(nil, cb)
-}
-
 // Update executes a read/write transaction.
 func (s *MemoryStore) Update(cb func(Tx) error) error {
 	return s.update(s.proposer, cb)
@@ -757,7 +753,7 @@ func (s *MemoryStore) Save(tx ReadTx) (*api.StoreSnapshot, error) {
 // Restore sets the contents of the store to the serialized data in the
 // argument.
 func (s *MemoryStore) Restore(snapshot *api.StoreSnapshot) error {
-	return s.updateLocal(func(tx Tx) error {
+	return s.update(nil, func(tx Tx) error {
 		for _, os := range objectStorers {
 			if err := os.Restore(tx, snapshot); err != nil {
 				return err

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -544,7 +544,7 @@ func (s *MemoryStore) WatchFrom(version *api.Version, specifiers ...api.Event) (
 	}
 
 	// Get current version and watch for changes for the future
-	var curVersion  *api.Version
+	var curVersion *api.Version
 	futureWatch, futureCancel := s.ViewAndWatch(
 		func(tx ReadTx) {
 			curVersion = s.proposer.GetVersion()

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -845,7 +845,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 		if err := cb(tx); err != nil {
 			return err
 		}
-		watch, cancel = state.Watch(store.WatchQueue(), specifiers...)
+		watch, cancel = store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {
@@ -870,7 +870,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // longer needed.
 func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event) (chan events.Event, func(), error) {
 	if version == nil {
-		ch, cancel := state.Watch(store.WatchQueue(), specifiers...)
+		ch, cancel := store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
 		return ch, cancel, nil
 	}
 
@@ -889,7 +889,7 @@ func WatchFrom(store *MemoryStore, version *api.Version, specifiers ...api.Event
 		curVersion = store.proposer.GetVersion()
 		// Start the watch with the store locked so events cannot be
 		// missed
-		watch, cancelWatch = state.Watch(store.WatchQueue(), specifiers...)
+		watch, cancelWatch = store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
 		return nil
 	})
 	if watch != nil && err != nil {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -469,7 +469,7 @@ func (s *MemoryStore) View(cb func(ReadTx)) {
 // ViewAndWatch calls a callback which can observe the state of this
 // MemoryStore. It also returns a channel that will return further events from
 // this point so the snapshot can be kept up to date. The watch channel must be
-// released with cancel function provided when it is no longer needed.
+// released with the cancel function provided when it is no longer needed.
 // The channel is guaranteed to get all events after the moment of the snapshot,
 // and only those events.
 func (s *MemoryStore) ViewAndWatch(cb func(ReadTx), specifiers ...api.Event) (watch chan events.Event, cancel func()) {
@@ -485,6 +485,8 @@ func (s *MemoryStore) ViewAndWatch(cb func(ReadTx), specifiers ...api.Event) (wa
 	return
 }
 
+// Watch returns a channel that will return events. The watch channel must be
+// released with the cancel function provided when it is no longer needed.
 func (s *MemoryStore) Watch(specifiers ...api.Event) (watch chan events.Event, cancel func()) {
 	if len(specifiers) == 0 {
 		return s.queue.WatchAll()

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -860,7 +860,7 @@ func ViewAndWatch(store *MemoryStore, cb func(ReadTx) error, specifiers ...api.E
 // from "version", and new events until the channel is closed. If "version"
 // is nil, this function is equivalent to
 //
-//     state.Watch(store.WatchQueue(), specifiers...).
+//     store.WatchQueue().CallbackWatch(state.Matcher(specifiers...))
 //
 // If the log has been compacted and it's not possible to produce the exact
 // set of events leading from "version" to the current state, this function

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -865,7 +865,7 @@ func TestStoreSnapshot(t *testing.T) {
 	}
 
 	// Fork
-	watcher, cancel, err := ViewAndWatch(s1, copyToS2)
+	watcher, cancel, err := s1.ViewAndWatch(copyToS2)
 	defer cancel()
 	assert.NoError(t, err)
 
@@ -1427,9 +1427,11 @@ func TestStoreSaveRestore(t *testing.T) {
 		append(altResourceSet, r),
 	)
 
-	watcher, cancel, err := ViewAndWatch(s2, func(ReadTx) error {
-		return nil
-	})
+	watcher, cancel, err := s2.ViewAndWatch(
+		func(ReadTx) error {
+			return nil
+		},
+	)
 	assert.NoError(t, err)
 	defer cancel()
 
@@ -1752,10 +1754,11 @@ func TestWatchFrom(t *testing.T) {
 	}
 
 	// Try to watch from an invalid index
-	_, _, err := WatchFrom(s, &api.Version{Index: 5000})
+	_, _, err := s.WatchFrom(&api.Version{Index: 5000})
 	assert.Error(t, err)
 
-	watch1, cancel1, err := WatchFrom(s, &api.Version{Index: 10}, api.EventCreateNode{}, state.EventCommit{})
+	watch1, cancel1, err := s.WatchFrom(&api.Version{Index: 10},
+	api.EventCreateNode{}, state.EventCommit{})
 	require.NoError(t, err)
 	defer cancel1()
 
@@ -1785,7 +1788,8 @@ func TestWatchFrom(t *testing.T) {
 		}
 	}
 
-	watch2, cancel2, err := WatchFrom(s, &api.Version{Index: 13}, api.EventCreateService{}, state.EventCommit{})
+	watch2, cancel2, err := s.WatchFrom(&api.Version{Index: 13},
+	api.EventCreateService{}, state.EventCommit{})
 	require.NoError(t, err)
 	defer cancel2()
 

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1760,7 +1760,9 @@ func TestWatchFrom(t *testing.T) {
 	assert.Error(t, err)
 
 	watch1, cancel1, err := s.WatchFrom(&api.Version{Index: 10},
-	api.EventCreateNode{}, state.EventCommit{})
+		api.EventCreateNode{},
+		state.EventCommit{},
+	)
 	require.NoError(t, err)
 	defer cancel1()
 
@@ -1791,7 +1793,9 @@ func TestWatchFrom(t *testing.T) {
 	}
 
 	watch2, cancel2, err := s.WatchFrom(&api.Version{Index: 13},
-	api.EventCreateService{}, state.EventCommit{})
+		api.EventCreateService{},
+		state.EventCommit{},
+	)
 	require.NoError(t, err)
 	defer cancel2()
 

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1271,7 +1271,7 @@ func TestBatch(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.WatchQueue().WatchAll()
+	watch, cancel := s.Queue().WatchAll()
 	defer cancel()
 
 	// Create 405 nodes. Should get split across 3 transactions.
@@ -1332,7 +1332,7 @@ func TestBatchFailure(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.WatchQueue().WatchAll()
+	watch, cancel := s.Queue().WatchAll()
 	defer cancel()
 
 	// Return an error partway through a transaction.

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1271,7 +1271,7 @@ func TestBatch(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.WatchQueue().Watch()
+	watch, cancel := s.WatchQueue().WatchAll()
 	defer cancel()
 
 	// Create 405 nodes. Should get split across 3 transactions.
@@ -1332,7 +1332,7 @@ func TestBatchFailure(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.WatchQueue().Watch()
+	watch, cancel := s.WatchQueue().WatchAll()
 	defer cancel()
 
 	// Return an error partway through a transaction.

--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -1274,7 +1274,7 @@ func TestBatch(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	defer cancel()
 
 	// Create 405 nodes. Should get split across 3 transactions.
@@ -1335,7 +1335,7 @@ func TestBatchFailure(t *testing.T) {
 	s := NewMemoryStore(&testutils.MockProposer{})
 	assert.NotNil(t, s)
 
-	watch, cancel := s.Queue().WatchAll()
+	watch, cancel := s.Watch()
 	defer cancel()
 
 	// Return an error partway through a transaction.

--- a/manager/state/watch.go
+++ b/manager/state/watch.go
@@ -3,7 +3,6 @@ package state
 import (
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
-	"github.com/docker/swarmkit/watch"
 )
 
 // EventCommit delineates a transaction boundary.
@@ -27,42 +26,53 @@ func NodeCheckState(n1, n2 *api.Node) bool {
 	return n1.Status.State == n2.Status.State
 }
 
-// Watch takes a variable number of events to match against. The subscriber
-// will receive events that match any of the arguments passed to Watch.
+// Matcher returns an events.Matcher that Matches the specifiers with OR logic.
+// The subscriber will receive events that match any of the arguments passed to Matcher.
 //
 // Examples:
 //
 // // subscribe to all events
-// Watch(q)
+// q.Watch()
+// // or
+// q.CallbackWatch(Matcher())
 //
 // // subscribe to all UpdateTask events
-// Watch(q, EventUpdateTask{})
+// q.CallbackWatch(Matcher(EventUpdateTask{}))
 //
 // // subscribe to all task-related events
-// Watch(q, EventUpdateTask{}, EventCreateTask{}, EventDeleteTask{})
+// q.CallbackWatch(Matcher(
+// 	api.EventUpdateTask{},
+// 	api.EventCreateTask{},
+// 	api.EventDeleteTask{},
+// ))
 //
 // // subscribe to UpdateTask for node 123
-// Watch(q, EventUpdateTask{Task: &api.Task{NodeID: 123},
-//                         Checks: []TaskCheckFunc{TaskCheckNodeID}})
+// q.CallbackWatch(Matcher(
+// 	api.EventUpdateTask{
+// 		Task: &api.Task{NodeID: 123},
+// 		Checks: []TaskCheckFunc{TaskCheckNodeID},
+// 	},
+// ))
 //
 // // subscribe to UpdateTask for node 123, as well as CreateTask
 // // for node 123 that also has ServiceID set to "abc"
-// Watch(q, EventUpdateTask{Task: &api.Task{NodeID: 123},
-//                         Checks: []TaskCheckFunc{TaskCheckNodeID}},
-//         EventCreateTask{Task: &api.Task{NodeID: 123, ServiceID: "abc"},
-//                         Checks: []TaskCheckFunc{TaskCheckNodeID,
-//                                                 func(t1, t2 *api.Task) bool {
-//                                                         return t1.ServiceID == t2.ServiceID
-//                                                 }}})
-func Watch(queue *watch.Queue, specifiers ...api.Event) (eventq chan events.Event, cancel func()) {
-	if len(specifiers) == 0 {
-		return queue.Watch()
-	}
-	return queue.CallbackWatch(Matcher(specifiers...))
-}
-
-// Matcher returns an events.Matcher that Matches the specifiers with OR logic.
+// q.CallbackWatch(Matcher(
+// 	api.EventUpdateTask{
+// 		Task: &api.Task{NodeID: 123},
+// 		Checks: []TaskCheckFunc{TaskCheckNodeID},
+// 	},
+// 	api.EventCreateTask{
+// 		Task: &api.Task{NodeID: 123, ServiceID: "abc"},
+// 		Checks: []TaskCheckFunc{
+// 			TaskCheckNodeID,
+// 			func(t1, t2 *api.Task) bool {return t1.ServiceID == t2.ServiceID},
+// 		},
+// 	},
+// ))
 func Matcher(specifiers ...api.Event) events.MatcherFunc {
+	if len(specifiers) == 0 {
+		return nil
+	}
 	return events.MatcherFunc(func(event events.Event) bool {
 		for _, s := range specifiers {
 			if s.Matches(event) {

--- a/manager/state/watch.go
+++ b/manager/state/watch.go
@@ -70,9 +70,6 @@ func NodeCheckState(n1, n2 *api.Node) bool {
 // 	},
 // ))
 func Matcher(specifiers ...api.Event) events.MatcherFunc {
-	if len(specifiers) == 0 {
-		return nil
-	}
 	return events.MatcherFunc(func(event events.Event) bool {
 		for _, s := range specifiers {
 			if s.Matches(event) {

--- a/manager/state/watch.go
+++ b/manager/state/watch.go
@@ -32,22 +32,22 @@ func NodeCheckState(n1, n2 *api.Node) bool {
 // Examples:
 //
 // // subscribe to all events
-// q.Watch()
+// q.WatchAll()
 // // or
-// q.CallbackWatch(Matcher())
+// q.Watch(Matcher())
 //
 // // subscribe to all UpdateTask events
-// q.CallbackWatch(Matcher(EventUpdateTask{}))
+// q.Watch(Matcher(EventUpdateTask{}))
 //
 // // subscribe to all task-related events
-// q.CallbackWatch(Matcher(
+// q.Watch(Matcher(
 // 	api.EventUpdateTask{},
 // 	api.EventCreateTask{},
 // 	api.EventDeleteTask{},
 // ))
 //
 // // subscribe to UpdateTask for node 123
-// q.CallbackWatch(Matcher(
+// q.Watch(Matcher(
 // 	api.EventUpdateTask{
 // 		Task: &api.Task{NodeID: 123},
 // 		Checks: []TaskCheckFunc{TaskCheckNodeID},
@@ -56,7 +56,7 @@ func NodeCheckState(n1, n2 *api.Node) bool {
 //
 // // subscribe to UpdateTask for node 123, as well as CreateTask
 // // for node 123 that also has ServiceID set to "abc"
-// q.CallbackWatch(Matcher(
+// q.Watch(Matcher(
 // 	api.EventUpdateTask{
 // 		Task: &api.Task{NodeID: 123},
 // 		Checks: []TaskCheckFunc{TaskCheckNodeID},

--- a/manager/watchapi/watch.go
+++ b/manager/watchapi/watch.go
@@ -3,7 +3,6 @@ package watchapi
 import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
-	"github.com/docker/swarmkit/manager/state/store"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -29,7 +28,7 @@ func (s *Server) Watch(request *api.WatchRequest, stream api.Watch_WatchServer) 
 	}
 
 	watchArgs = append(watchArgs, state.EventCommit{})
-	watch, cancel, err := store.WatchFrom(s.store, request.ResumeFrom, watchArgs...)
+	watch, cancel, err := s.store.WatchFrom(request.ResumeFrom, watchArgs...)
 	if err != nil {
 		return err
 	}

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -85,13 +84,6 @@ func (q *Queue) Watch() (eventq chan events.Event, cancel func()) {
 	return q.CallbackWatch(nil)
 }
 
-// WatchContext returns a channel where all items published to the queue will
-// be received. The channel will be closed when the provided context is
-// cancelled.
-func (q *Queue) WatchContext(ctx context.Context) (eventq chan events.Event) {
-	return q.CallbackWatchContext(ctx, nil)
-}
-
 // CallbackWatch returns a channel which will receive all events published to
 // the queue from this point that pass the check in the provided callback
 // function. The returned cancel function will stop the flow of events and
@@ -163,18 +155,6 @@ func (q *Queue) CallbackWatch(matcher events.Matcher) (eventq chan events.Event,
 	}()
 
 	return outChan, externalCancelFunc
-}
-
-// CallbackWatchContext returns a channel where all items published to the queue will
-// be received. The channel will be closed when the provided context is
-// cancelled.
-func (q *Queue) CallbackWatchContext(ctx context.Context, matcher events.Matcher) (eventq chan events.Event) {
-	c, cancel := q.CallbackWatch(matcher)
-	go func() {
-		<-ctx.Done()
-		cancel()
-	}()
-	return c
 }
 
 // Publish adds an item to the queue.

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -78,17 +78,17 @@ func WithLimit(limit uint64) func(*Queue) error {
 	}
 }
 
-// Watch returns a channel which will receive all items published to the
+// WatchAll returns a channel which will receive all items published to the
 // queue from this point, until cancel is called.
-func (q *Queue) Watch() (eventq chan events.Event, cancel func()) {
-	return q.CallbackWatch(nil)
+func (q *Queue) WatchAll() (eventq chan events.Event, cancel func()) {
+	return q.Watch(nil)
 }
 
-// CallbackWatch returns a channel which will receive all events published to
+// Watch returns a channel which will receive all events published to
 // the queue from this point that pass the check in the provided callback
 // function. The returned cancel function will stop the flow of events and
 // close the channel.
-func (q *Queue) CallbackWatch(matcher events.Matcher) (eventq chan events.Event, cancel func()) {
+func (q *Queue) Watch(matcher events.Matcher) (eventq chan events.Event, cancel func()) {
 	chanSink, ch := q.sinkGen.NewChannelSink()
 	lq := queue.NewLimitQueue(chanSink, q.limit)
 	sink := events.Sink(lq)

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -18,7 +18,8 @@ func TestTimeoutLimitWatch(t *testing.T) {
 	watch, cancel := q.WatchAll()
 	doneChan := make(chan struct{})
 	go func() {
-		for range watch {}
+		for range watch {
+		}
 		close(doneChan)
 	}()
 	cancel()

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,7 +1,6 @@
 package watch
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -14,15 +13,12 @@ func TestTimeoutLimitWatch(t *testing.T) {
 	require := require.New(t)
 	q := NewQueue(WithTimeout(time.Second), WithLimit(5), WithCloseOutChan())
 	defer q.Close()
-	ctx, cancel := context.WithCancel(context.Background())
 
-	// Cancelling a watcher's context should remove the watcher from the queue and
-	// close its channel.
+	// Cancelling a watcher should remove the watcher from the queue and close its channel.
+	watch, cancel := q.Watch()
 	doneChan := make(chan struct{})
 	go func() {
-		events := q.WatchContext(ctx)
-		for range events {
-		}
+		for range watch {}
 		close(doneChan)
 	}()
 	cancel()

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -15,7 +15,7 @@ func TestTimeoutLimitWatch(t *testing.T) {
 	defer q.Close()
 
 	// Cancelling a watcher should remove the watcher from the queue and close its channel.
-	watch, cancel := q.Watch()
+	watch, cancel := q.WatchAll()
 	doneChan := make(chan struct{})
 	go func() {
 		for range watch {}
@@ -29,7 +29,7 @@ func TestTimeoutLimitWatch(t *testing.T) {
 	readerSleepDuration := 100 * time.Millisecond
 	writerSleepDuration := 10 * time.Millisecond
 
-	events, cancel := q.Watch()
+	events, cancel := q.WatchAll()
 	defer cancel()
 
 	receivedChan := make(chan struct{})
@@ -91,9 +91,9 @@ func TestWatch(t *testing.T) {
 	}
 
 	// Create filtered watchers
-	c1, c1cancel := q.CallbackWatch(tagFilter("t1"))
+	c1, c1cancel := q.Watch(tagFilter("t1"))
 	defer c1cancel()
-	c2, c2cancel := q.CallbackWatch(tagFilter("t2"))
+	c2, c2cancel := q.Watch(tagFilter("t2"))
 	defer c2cancel()
 
 	// Publish items on the queue
@@ -227,7 +227,7 @@ func benchmarkWatchForQueue(q *Queue, b *testing.B, nlisteners, npublishers int,
 		watchersAttached.Add(1)
 		watchersRunning.Add(1)
 		go func(n int) {
-			w, cancel := q.Watch()
+			w, cancel := q.WatchAll()
 			defer cancel()
 			watchersAttached.Done()
 


### PR DESCRIPTION
**- What I did**
Clean up `Watch` related functions and methods of the `manager/state` package.

**- How I did it**
As proposed in #2629
`manager/state/store/memory.go` was also reordered. The ordering decissions can be checked from the different commits.

**- How to test it**

**- Description for the changelog**
Clean up `store.MemoryStore` watch API.