### PR TITLE
Minor cleanup of raft encryption algorithms 

### DIFF
--- a/manager/encryption/encryption.go
+++ b/manager/encryption/encryption.go
@@ -79,19 +79,21 @@ type MultiDecrypter struct {
 }
 
 // Decrypt tries to decrypt using any decrypters that match the given algorithm.
-func (m MultiDecrypter) Decrypt(r api.MaybeEncryptedRecord) (result []byte, err error) {
+func (m MultiDecrypter) Decrypt(r api.MaybeEncryptedRecord) ([]byte, error) {
 	decrypters, ok := m.decrypters[r.Algorithm]
 	if !ok {
 		return nil, fmt.Errorf("cannot decrypt record encrypted using %s",
 			api.MaybeEncryptedRecord_Algorithm_name[int32(r.Algorithm)])
 	}
+	var rerr error
 	for _, d := range decrypters {
-		result, err = d.Decrypt(r)
+		result, err := d.Decrypt(r)
 		if err == nil {
-			return
+			return result, nil
 		}
+		rerr = err
 	}
-	return
+	return nil, rerr
 }
 
 // NewMultiDecrypter returns a new MultiDecrypter given multiple Decrypters.  If any of

--- a/manager/encryption/encryption_test.go
+++ b/manager/encryption/encryption_test.go
@@ -107,6 +107,15 @@ func TestMultiDecryptor(t *testing.T) {
 			require.IsType(t, ErrCannotDecrypt{}, err)
 		}
 	}
+
+	// Test multidecryptor where it does not have a decryptor with the right key
+	for _, d := range []MultiDecrypter{m, NewMultiDecrypter()} {
+		plaintext := []byte("message")
+		ciphertext, err := Encrypt(plaintext, NewNACLSecretbox([]byte("other")))
+		require.NoError(t, err)
+		_, err = Decrypt(ciphertext, d)
+		require.IsType(t, ErrCannotDecrypt{}, err)
+	}
 }
 
 // The default encrypter/decrypter, if FIPS is not enabled, is NACLSecretBox.

--- a/manager/encryption/fernet.go
+++ b/manager/encryption/fernet.go
@@ -48,7 +48,7 @@ func (f Fernet) Decrypt(record api.MaybeEncryptedRecord) ([]byte, error) {
 	out := fernet.VerifyAndDecrypt(record.Data, -1, []*fernet.Key{&f.key})
 	// VerifyandDecrypt returns a nil message if it can't be verified and decrypted
 	if out == nil {
-		return nil, fmt.Errorf("decryption error using Fernet")
+		return nil, fmt.Errorf("no decryption key for record encrypted with %s", f.Algorithm())
 	}
 	return out, nil
 }

--- a/manager/encryption/nacl.go
+++ b/manager/encryption/nacl.go
@@ -67,7 +67,7 @@ func (n NACLSecretbox) Decrypt(record api.MaybeEncryptedRecord) ([]byte, error) 
 	// appended to.  Since we don't want to append anything, we pass nil.
 	decrypted, ok := secretbox.Open(nil, record.Data, &decryptNonce, &n.key)
 	if !ok {
-		return nil, fmt.Errorf("decryption error using NACL secretbox")
+		return nil, fmt.Errorf("no decryption key for record encrypted with %s", n.Algorithm())
 	}
 	return decrypted, nil
 }


### PR DESCRIPTION
As @justincormack pointed out in https://github.com/docker/swarmkit/pull/2632, `MultiDecrypter`'s `Decrypt` function is somewhat hard to read, and there are no tests for the fallthrough case.  This PR adds those fallthrough tests and also uses explicit returns rather than named return variables in the `Decrypt` function.

Also changes the error message when we can't decrypt the record to be slightly more friendly.