### PR TITLE
Replace deprecated grpc functions

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -195,7 +196,8 @@ func (s *session) heartbeat(ctx context.Context) error {
 			cancel()
 			if err != nil {
 				log.G(ctx).WithFields(fields).WithError(err).Errorf("heartbeat to manager %v failed", s.conn.Peer())
-				if grpc.Code(err) == codes.NotFound {
+				st, _ := status.FromError(err)
+				if st.Code() == codes.NotFound {
 					err = errNodeNotRegistered
 				}
 
@@ -252,7 +254,8 @@ func (s *session) logSubscriptions(ctx context.Context) error {
 
 	for {
 		resp, err := subscriptions.Recv()
-		if grpc.Code(err) == codes.Unimplemented {
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Unimplemented {
 			log.Warning("manager does not support log subscriptions")
 			// Don't return, because returning would bounce the session
 			select {
@@ -303,7 +306,8 @@ func (s *session) watch(ctx context.Context) error {
 			// If we get a code = 12 desc = unknown method Assignments, try to use tasks
 			resp, err = assignmentWatch.Recv()
 			if err != nil {
-				if grpc.Code(err) != codes.Unimplemented {
+				st, _ := status.FromError(err)
+				if st.Code() != codes.Unimplemented {
 					return err
 				}
 				tasksFallback = true
@@ -362,20 +366,21 @@ func (s *session) watch(ctx context.Context) error {
 }
 
 // sendTaskStatus uses the current session to send the status of a single task.
-func (s *session) sendTaskStatus(ctx context.Context, taskID string, status *api.TaskStatus) error {
+func (s *session) sendTaskStatus(ctx context.Context, taskID string, taskStatus *api.TaskStatus) error {
 	client := api.NewDispatcherClient(s.conn.ClientConn)
 	if _, err := client.UpdateTaskStatus(ctx, &api.UpdateTaskStatusRequest{
 		SessionID: s.sessionID,
 		Updates: []*api.UpdateTaskStatusRequest_TaskStatusUpdate{
 			{
 				TaskID: taskID,
-				Status: status,
+				Status: taskStatus,
 			},
 		},
 	}); err != nil {
 		// TODO(stevvooe): Dispatcher should not return this error. Status
 		// reports for unknown tasks should be ignored.
-		if grpc.Code(err) == codes.NotFound {
+		st, _ := status.FromError(err)
+		if st.Code() == codes.NotFound {
 			return errTaskUnknown
 		}
 

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/status"
 )
 
 func init() {
@@ -760,7 +761,8 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	// error - it should have returned after 1 second, but add some more for rudge time.
 	select {
 	case err = <-completed:
-		require.Equal(t, grpc.Code(err), codes.DeadlineExceeded)
+		s, _ := status.FromError(err)
+		require.Equal(t, s.Code(), codes.DeadlineExceeded)
 	case <-time.After(3 * time.Second):
 		require.FailNow(t, "GetRemoteSignedCertificate should have been canceled after 1 second, and it has been 3")
 	}

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
@@ -48,7 +47,7 @@ func TestRestartRootCA(t *testing.T) {
 
 	_, err := tc.NodeCAClients[0].NodeCertificateStatus(tc.Context, &api.NodeCertificateStatusRequest{NodeID: "foo"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	tc.CAServer.Stop()
 	go tc.CAServer.Run(tc.Context)
@@ -57,7 +56,7 @@ func TestRestartRootCA(t *testing.T) {
 
 	_, err = tc.NodeCAClients[0].NodeCertificateStatus(tc.Context, &api.NodeCertificateStatusRequest{NodeID: "foo"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 }
 
 func TestIssueNodeCertificate(t *testing.T) {

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -15,11 +15,13 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func main() {
 	if c, err := mainCmd.ExecuteC(); err != nil {
-		c.Println("Error:", grpc.ErrorDesc(err))
+		s, _ := status.FromError(err)
+		c.Println("Error:", s.Message())
 		// if it's not a grpc, we assume it's a user error and we display the usage.
 		if grpc.Code(err) == codes.Unknown {
 			c.Println(c.UsageString())

--- a/cmd/swarmctl/main.go
+++ b/cmd/swarmctl/main.go
@@ -13,8 +13,6 @@ import (
 	"github.com/docker/swarmkit/cmd/swarmd/defaults"
 	"github.com/docker/swarmkit/version"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -23,7 +21,7 @@ func main() {
 		s, _ := status.FromError(err)
 		c.Println("Error:", s.Message())
 		// if it's not a grpc, we assume it's a user error and we display the usage.
-		if grpc.Code(err) == codes.Unknown {
+		if _, ok := status.FromError(err); !ok {
 			c.Println(c.UsageString())
 		}
 

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -322,7 +322,7 @@ func (c *testCluster) SetNodeRole(id string, role api.NodeRole) error {
 		}); err != nil {
 			// there possible problems on calling update node because redirecting
 			// node or leader might want to shut down
-			if grpc.ErrorDesc(err) == "update out of sequence" {
+			if testutils.ErrorDesc(err) == "update out of sequence" {
 				continue
 			}
 			return err

--- a/manager/controlapi/ca_rotation_test.go
+++ b/manager/controlapi/ca_rotation_test.go
@@ -3,18 +3,18 @@ package controlapi
 import (
 	"context"
 	"crypto/x509"
+	"encoding/pem"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
-
-	"encoding/pem"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/cloudflare/cfssl/initca"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
+	grpcutils "github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -310,7 +310,7 @@ func TestValidateCAConfigInvalidValues(t *testing.T) {
 		_, err := validateCAConfig(context.Background(), secConfig, cluster)
 		require.Error(t, err, invalid.expectErrorString)
 		require.Equal(t, codes.InvalidArgument, grpc.Code(err), invalid.expectErrorString)
-		require.Contains(t, grpc.ErrorDesc(err), invalid.expectErrorString)
+		require.Contains(t, grpcutils.ErrorDesc(err), invalid.expectErrorString)
 	}
 }
 

--- a/manager/controlapi/ca_rotation_test.go
+++ b/manager/controlapi/ca_rotation_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/ca/testutils"
-	grpcutils "github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type rootCARotationTestCase struct {
@@ -309,8 +308,9 @@ func TestValidateCAConfigInvalidValues(t *testing.T) {
 		secConfig := getSecurityConfig(t, &localRootCA, cluster)
 		_, err := validateCAConfig(context.Background(), secConfig, cluster)
 		require.Error(t, err, invalid.expectErrorString)
-		require.Equal(t, codes.InvalidArgument, grpc.Code(err), invalid.expectErrorString)
-		require.Contains(t, grpcutils.ErrorDesc(err), invalid.expectErrorString)
+		s, _ := status.FromError(err)
+		require.Equal(t, codes.InvalidArgument, s.Code(), invalid.expectErrorString)
+		require.Contains(t, s.Message(), invalid.expectErrorString)
 	}
 }
 

--- a/manager/controlapi/cluster_test.go
+++ b/manager/controlapi/cluster_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/docker/swarmkit/ca/testutils"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
+	grpcutils "github.com/docker/swarmkit/testutils"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
@@ -113,7 +113,7 @@ func TestValidateClusterSpec(t *testing.T) {
 	} {
 		err := validateClusterSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err))
+		assert.Equal(t, bad.c, grpcutils.ErrorCode(err))
 	}
 
 	for _, good := range []*api.ClusterSpec{
@@ -130,11 +130,11 @@ func TestGetCluster(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.GetCluster(context.Background(), &api.GetClusterRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, grpcutils.ErrorCode(err))
 
 	_, err = ts.Client.GetCluster(context.Background(), &api.GetClusterRequest{ClusterID: "invalid"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, grpcutils.ErrorCode(err))
 
 	cluster := createCluster(t, ts, "name", "name", api.AcceptancePolicy{}, ts.Server.securityConfig.RootCA())
 	r, err := ts.Client.GetCluster(context.Background(), &api.GetClusterRequest{ClusterID: cluster.ID})
@@ -156,11 +156,11 @@ func TestGetClusterWithSecret(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.GetCluster(context.Background(), &api.GetClusterRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, grpcutils.ErrorCode(err))
 
 	_, err = ts.Client.GetCluster(context.Background(), &api.GetClusterRequest{ClusterID: "invalid"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, grpcutils.ErrorCode(err))
 
 	policy := api.AcceptancePolicy{Policies: []*api.AcceptancePolicy_RoleAdmissionPolicy{{Secret: &api.AcceptancePolicy_RoleAdmissionPolicy_Secret{Data: []byte("secret")}}}}
 	cluster := createCluster(t, ts, "name", "name", policy, ts.Server.securityConfig.RootCA())
@@ -180,16 +180,16 @@ func TestUpdateCluster(t *testing.T) {
 
 	_, err := ts.Client.UpdateCluster(context.Background(), &api.UpdateClusterRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, grpcutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateCluster(context.Background(), &api.UpdateClusterRequest{ClusterID: "invalid", Spec: &cluster.Spec, ClusterVersion: &api.Version{}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, grpcutils.ErrorCode(err))
 
 	// No update options.
 	_, err = ts.Client.UpdateCluster(context.Background(), &api.UpdateClusterRequest{ClusterID: cluster.ID, Spec: &cluster.Spec})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, grpcutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateCluster(context.Background(), &api.UpdateClusterRequest{ClusterID: cluster.ID, Spec: &cluster.Spec, ClusterVersion: &cluster.Meta.Version})
 	assert.NoError(t, err)

--- a/manager/controlapi/common_test.go
+++ b/manager/controlapi/common_test.go
@@ -4,15 +4,15 @@ import (
 	"testing"
 
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
 func TestValidateAnnotations(t *testing.T) {
 	err := validateAnnotations(api.Annotations{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	for _, good := range []api.Annotations{
 		{Name: "name"},

--- a/manager/controlapi/config_test.go
+++ b/manager/controlapi/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -54,7 +55,7 @@ func TestValidateConfigSpec(t *testing.T) {
 	} {
 		err := validateConfigSpec(createConfigSpec(badName, []byte("valid config"), nil))
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	for _, badSpec := range []*api.ConfigSpec{
@@ -63,7 +64,7 @@ func TestValidateConfigSpec(t *testing.T) {
 	} {
 		err := validateConfigSpec(badSpec)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	for _, goodName := range []string{
@@ -98,7 +99,7 @@ func TestCreateConfig(t *testing.T) {
 	// ---- creating a config with an invalid spec fails, thus checking that CreateConfig validates the spec ----
 	_, err := ts.Client.CreateConfig(context.Background(), &api.CreateConfigRequest{Spec: createConfigSpec("", nil, nil)})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- creating a config with a valid spec succeeds, and returns a config that reflects the config in the store
 	// exactly
@@ -123,7 +124,7 @@ func TestCreateConfig(t *testing.T) {
 	// ---- creating a config with the same name, even if it's the exact same spec, fails due to a name conflict ----
 	_, err = ts.Client.CreateConfig(context.Background(), &validSpecRequest)
 	assert.Error(t, err)
-	assert.Equal(t, codes.AlreadyExists, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.AlreadyExists, grpc.Code(err), testutils.ErrorDesc(err))
 }
 
 func TestGetConfig(t *testing.T) {
@@ -133,12 +134,12 @@ func TestGetConfig(t *testing.T) {
 	// ---- getting a config without providing an ID results in an InvalidArgument ----
 	_, err := ts.Client.GetConfig(context.Background(), &api.GetConfigRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- getting a non-existent config fails with NotFound ----
 	_, err = ts.Client.GetConfig(context.Background(), &api.GetConfigRequest{ConfigID: "12345"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- getting an existing config returns the config ----
 	config := configFromConfigSpec(createConfigSpec("name", []byte("data"), nil))
@@ -168,12 +169,12 @@ func TestUpdateConfig(t *testing.T) {
 	// updating a config without providing an ID results in an InvalidArgument
 	_, err = ts.Client.UpdateConfig(context.Background(), &api.UpdateConfigRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// getting a non-existent config fails with NotFound
 	_, err = ts.Client.UpdateConfig(context.Background(), &api.UpdateConfigRequest{ConfigID: "1234adsaa", ConfigVersion: &api.Version{Index: 1}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating an existing config's data returns an error
 	config.Spec.Data = []byte{1}
@@ -182,7 +183,7 @@ func TestUpdateConfig(t *testing.T) {
 		Spec:          &config.Spec,
 		ConfigVersion: &config.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating an existing config's Name returns an error
 	config.Spec.Data = nil
@@ -192,7 +193,7 @@ func TestUpdateConfig(t *testing.T) {
 		Spec:          &config.Spec,
 		ConfigVersion: &config.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating the config with the original spec succeeds
 	config.Spec.Data = []byte("data")
@@ -244,7 +245,7 @@ func TestRemoveUnusedConfig(t *testing.T) {
 	// removing a config without providing an ID results in an InvalidArgument
 	_, err := ts.Client.RemoveConfig(context.Background(), &api.RemoveConfigRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// removing a config that exists succeeds
 	config := configFromConfigSpec(createConfigSpec("name", []byte("data"), nil))
@@ -260,7 +261,7 @@ func TestRemoveUnusedConfig(t *testing.T) {
 	// ---- it was really removed because attempting to remove it again fails with a NotFound ----
 	_, err = ts.Client.RemoveConfig(context.Background(), &api.RemoveConfigRequest{ConfigID: config.ID})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 }
 
@@ -301,8 +302,8 @@ func TestRemoveUsedConfig(t *testing.T) {
 
 	// removing a config that exists but is in use fails
 	_, err = ts.Client.RemoveConfig(context.Background(), &api.RemoveConfigRequest{ConfigID: resp.Config.ID})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
-	assert.Regexp(t, "service[1-2], service[1-2]", grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
+	assert.Regexp(t, "service[1-2], service[1-2]", testutils.ErrorDesc(err))
 
 	// removing a config that exists but is not in use succeeds
 	_, err = ts.Client.RemoveConfig(context.Background(), &api.RemoveConfigRequest{ConfigID: resp2.Config.ID})
@@ -311,7 +312,7 @@ func TestRemoveUsedConfig(t *testing.T) {
 	// it was really removed because attempting to remove it again fails with a NotFound
 	_, err = ts.Client.RemoveConfig(context.Background(), &api.RemoveConfigRequest{ConfigID: resp2.Config.ID})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 }
 
 func TestListConfigs(t *testing.T) {

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -3,9 +3,9 @@ package controlapi
 import (
 	"testing"
 
+	"github.com/docker/swarmkit/testutils"
 	"golang.org/x/net/context"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/docker/swarmkit/api"
@@ -89,13 +89,13 @@ func TestValidateDriver(t *testing.T) {
 
 	err := validateDriver(&api.Driver{Name: ""}, nil, "")
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestValidateIPAMConfiguration(t *testing.T) {
 	err := validateIPAMConfiguration(nil)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf := &api.IPAMConfig{
 		Subnet: "",
@@ -103,12 +103,12 @@ func TestValidateIPAMConfiguration(t *testing.T) {
 
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Subnet = "bad"
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Subnet = "192.168.0.0/16"
 	err = validateIPAMConfiguration(IPAMConf)
@@ -117,12 +117,12 @@ func TestValidateIPAMConfiguration(t *testing.T) {
 	IPAMConf.Range = "bad"
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Range = "192.169.1.0/24"
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Range = "192.168.1.0/24"
 	err = validateIPAMConfiguration(IPAMConf)
@@ -131,12 +131,12 @@ func TestValidateIPAMConfiguration(t *testing.T) {
 	IPAMConf.Gateway = "bad"
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Gateway = "192.169.1.1"
 	err = validateIPAMConfiguration(IPAMConf)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	IPAMConf.Gateway = "192.168.1.1"
 	err = validateIPAMConfiguration(IPAMConf)

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 )
@@ -44,11 +43,11 @@ func TestGetNode(t *testing.T) {
 
 	_, err := ts.Client.GetNode(context.Background(), &api.GetNodeRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: "invalid"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	node := createNode(t, ts, "id", api.NodeRoleManager, api.NodeMembershipAccepted, api.NodeStatus_READY)
 	r, err := ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: node.ID})
@@ -465,7 +464,7 @@ func TestUpdateNode(t *testing.T) {
 		NodeVersion: &api.Version{},
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	// Create a node object for the manager
 	assert.NoError(t, nodes[1].MemoryStore().Update(func(tx store.Tx) error {
@@ -481,11 +480,11 @@ func TestUpdateNode(t *testing.T) {
 
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{NodeID: "invalid", Spec: &api.NodeSpec{}, NodeVersion: &api.Version{}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	r, err := ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: nodeID})
 	assert.NoError(t, err)
@@ -496,7 +495,7 @@ func TestUpdateNode(t *testing.T) {
 
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{NodeID: nodeID})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	spec := r.Node.Spec.Copy()
 	spec.Availability = api.NodeAvailabilityDrain
@@ -505,7 +504,7 @@ func TestUpdateNode(t *testing.T) {
 		Spec:   spec,
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateNode(context.Background(), &api.UpdateNodeRequest{
 		NodeID:      nodeID,
@@ -602,7 +601,7 @@ func testUpdateNodeDemote(t *testing.T) {
 		NodeVersion: version,
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, testutils.ErrorCode(err))
 
 	// Restart Node 3
 	nodes[3] = raftutils.RestartNode(t, clockSource, nodes[3], false)
@@ -705,7 +704,7 @@ func testUpdateNodeDemote(t *testing.T) {
 		NodeVersion: version,
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.FailedPrecondition, grpc.Code(err))
+	assert.Equal(t, codes.FailedPrecondition, testutils.ErrorCode(err))
 
 	// Propose a change in the spec and check if the remaining node can still process updates
 	r, err = ts.Client.GetNode(context.Background(), &api.GetNodeRequest{NodeID: lastNode.SecurityConfig.ClientTLSCreds.NodeID()})

--- a/manager/controlapi/secret_test.go
+++ b/manager/controlapi/secret_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -54,7 +55,7 @@ func TestValidateSecretSpec(t *testing.T) {
 	} {
 		err := validateSecretSpec(createSecretSpec(badName, []byte("valid secret"), nil))
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	for _, badSpec := range []*api.SecretSpec{
@@ -63,7 +64,7 @@ func TestValidateSecretSpec(t *testing.T) {
 	} {
 		err := validateSecretSpec(badSpec)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	for _, goodName := range []string{
@@ -95,7 +96,7 @@ func TestValidateSecretSpec(t *testing.T) {
 	spec.Driver = &api.Driver{}
 	err := validateSecretSpec(spec)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 	spec.Driver.Name = "secret-driver"
 	err = validateSecretSpec(spec)
 	assert.NoError(t, err)
@@ -108,7 +109,7 @@ func TestCreateSecret(t *testing.T) {
 	// ---- creating a secret with an invalid spec fails, thus checking that CreateSecret validates the spec ----
 	_, err := ts.Client.CreateSecret(context.Background(), &api.CreateSecretRequest{Spec: createSecretSpec("", nil, nil)})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- creating a secret with a valid spec succeeds, and returns a secret that reflects the secret in the store
 	// exactly, but without the private data ----
@@ -135,7 +136,7 @@ func TestCreateSecret(t *testing.T) {
 	// ---- creating a secret with the same name, even if it's the exact same spec, fails due to a name conflict ----
 	_, err = ts.Client.CreateSecret(context.Background(), &validSpecRequest)
 	assert.Error(t, err)
-	assert.Equal(t, codes.AlreadyExists, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.AlreadyExists, grpc.Code(err), testutils.ErrorDesc(err))
 }
 
 func TestGetSecret(t *testing.T) {
@@ -145,12 +146,12 @@ func TestGetSecret(t *testing.T) {
 	// ---- getting a secret without providing an ID results in an InvalidArgument ----
 	_, err := ts.Client.GetSecret(context.Background(), &api.GetSecretRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- getting a non-existent secret fails with NotFound ----
 	_, err = ts.Client.GetSecret(context.Background(), &api.GetSecretRequest{SecretID: "12345"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// ---- getting an existing secret returns the secret with all the private data cleaned ----
 	secret := secretFromSecretSpec(createSecretSpec("name", []byte("data"), nil))
@@ -184,12 +185,12 @@ func TestUpdateSecret(t *testing.T) {
 	// updating a secret without providing an ID results in an InvalidArgument
 	_, err = ts.Client.UpdateSecret(context.Background(), &api.UpdateSecretRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// getting a non-existent secret fails with NotFound
 	_, err = ts.Client.UpdateSecret(context.Background(), &api.UpdateSecretRequest{SecretID: "1234adsaa", SecretVersion: &api.Version{Index: 1}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating an existing secret's data returns an error
 	secret.Spec.Data = []byte{1}
@@ -198,7 +199,7 @@ func TestUpdateSecret(t *testing.T) {
 		Spec:          &secret.Spec,
 		SecretVersion: &secret.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating an existing secret's Name returns an error
 	secret.Spec.Data = nil
@@ -208,7 +209,7 @@ func TestUpdateSecret(t *testing.T) {
 		Spec:          &secret.Spec,
 		SecretVersion: &secret.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// updating the secret with the original spec succeeds
 	secret.Spec.Data = []byte("data")
@@ -260,7 +261,7 @@ func TestRemoveUnusedSecret(t *testing.T) {
 	// removing a secret without providing an ID results in an InvalidArgument
 	_, err := ts.Client.RemoveSecret(context.Background(), &api.RemoveSecretRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
 
 	// removing a secret that exists succeeds
 	secret := secretFromSecretSpec(createSecretSpec("name", []byte("data"), nil))
@@ -276,7 +277,7 @@ func TestRemoveUnusedSecret(t *testing.T) {
 	// ---- it was really removed because attempting to remove it again fails with a NotFound ----
 	_, err = ts.Client.RemoveSecret(context.Background(), &api.RemoveSecretRequest{SecretID: secret.ID})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 
 }
 
@@ -317,8 +318,8 @@ func TestRemoveUsedSecret(t *testing.T) {
 
 	// removing a secret that exists but is in use fails
 	_, err = ts.Client.RemoveSecret(context.Background(), &api.RemoveSecretRequest{SecretID: resp.Secret.ID})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), grpc.ErrorDesc(err))
-	assert.Regexp(t, "service[1-2], service[1-2]", grpc.ErrorDesc(err))
+	assert.Equal(t, codes.InvalidArgument, grpc.Code(err), testutils.ErrorDesc(err))
+	assert.Regexp(t, "service[1-2], service[1-2]", testutils.ErrorDesc(err))
 
 	// removing a secret that exists but is not in use succeeds
 	_, err = ts.Client.RemoveSecret(context.Background(), &api.RemoveSecretRequest{SecretID: resp2.Secret.ID})
@@ -327,7 +328,7 @@ func TestRemoveUsedSecret(t *testing.T) {
 	// it was really removed because attempting to remove it again fails with a NotFound
 	_, err = ts.Client.RemoveSecret(context.Background(), &api.RemoveSecretRequest{SecretID: resp2.Secret.ID})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err), grpc.ErrorDesc(err))
+	assert.Equal(t, codes.NotFound, grpc.Code(err), testutils.ErrorDesc(err))
 }
 
 func TestListSecrets(t *testing.T) {

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
+	"github.com/docker/swarmkit/testutils"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -361,7 +362,7 @@ func TestValidateContainerSpec(t *testing.T) {
 	} {
 		err := validateContainerSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, bad.c, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	good1 := api.TaskSpec{
@@ -431,7 +432,7 @@ func TestValidateServiceSpec(t *testing.T) {
 	} {
 		err := validateServiceSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err), grpc.ErrorDesc(err))
+		assert.Equal(t, bad.c, grpc.Code(err), testutils.ErrorDesc(err))
 	}
 
 	for _, good := range []*api.ServiceSpec{

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -12,7 +12,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
 
@@ -182,7 +181,7 @@ func TestValidateResources(t *testing.T) {
 	for _, b := range bad {
 		err := validateResources(b)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	}
 
 	for _, g := range good {
@@ -202,7 +201,7 @@ func TestValidateResourceRequirements(t *testing.T) {
 	for _, b := range bad {
 		err := validateResourceRequirements(b)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	}
 
 	for _, g := range good {
@@ -226,7 +225,7 @@ func TestValidateMode(t *testing.T) {
 	for _, b := range bad {
 		err := validateMode(b)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	}
 
 	for _, g := range good {
@@ -284,7 +283,7 @@ func TestValidateTaskSpec(t *testing.T) {
 	} {
 		err := validateTaskSpec(bad.s)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err))
+		assert.Equal(t, bad.c, testutils.ErrorCode(err))
 	}
 
 	for _, good := range []api.TaskSpec{
@@ -362,7 +361,7 @@ func TestValidateContainerSpec(t *testing.T) {
 	} {
 		err := validateContainerSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err), testutils.ErrorDesc(err))
+		assert.Equal(t, bad.c, testutils.ErrorCode(err), testutils.ErrorDesc(err))
 	}
 
 	good1 := api.TaskSpec{
@@ -432,7 +431,7 @@ func TestValidateServiceSpec(t *testing.T) {
 	} {
 		err := validateServiceSpec(bad.spec)
 		assert.Error(t, err)
-		assert.Equal(t, bad.c, grpc.Code(err), testutils.ErrorDesc(err))
+		assert.Equal(t, bad.c, testutils.ErrorCode(err), testutils.ErrorDesc(err))
 	}
 
 	for _, good := range []*api.ServiceSpec{
@@ -465,7 +464,7 @@ func TestValidateRestartPolicy(t *testing.T) {
 	for _, b := range bad {
 		err := validateRestartPolicy(b)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	}
 
 	for _, g := range good {
@@ -492,7 +491,7 @@ func TestValidateUpdate(t *testing.T) {
 	for _, b := range bad {
 		err := validateUpdate(b)
 		assert.Error(t, err)
-		assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+		assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	}
 
 	for _, g := range good {
@@ -505,7 +504,7 @@ func TestCreateService(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	spec := createSpec("name", "image", 1)
 	r, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
@@ -527,7 +526,7 @@ func TestCreateService(t *testing.T) {
 	}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test no port conflicts when no publish port is specified
 	spec3 := createSpec("name4", "image", 1)
@@ -591,7 +590,7 @@ func TestCreateService(t *testing.T) {
 	}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// ensure port conflict when host ports overlaps with ingress port (ingress port first)
 	spec = createSpec("name12", "image", 1)
@@ -608,14 +607,14 @@ func TestCreateService(t *testing.T) {
 	}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec2})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// ingress network cannot be attached explicitly
 	spec = createSpec("name14", "image", 1)
 	spec.Task.Networks = []*api.NetworkAttachmentConfig{{Target: getIngressTargetID(t, ts)}}
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestSecretValidation(t *testing.T) {
@@ -628,7 +627,7 @@ func TestSecretValidation(t *testing.T) {
 	secretRef.SecretName = "404"
 	serviceSpec := createServiceSpecWithSecrets("service", secretRef)
 	_, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test creating service with a secretRef that has an existing secret
 	// but mismatched SecretName fails.
@@ -636,21 +635,21 @@ func TestSecretValidation(t *testing.T) {
 	secretRef1.SecretName = "secret2"
 	serviceSpec = createServiceSpecWithSecrets("service1", secretRef1)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test secret target conflicts
 	secretRef2 := createSecret(t, ts, "secret2", "secret2.txt")
 	secretRef3 := createSecret(t, ts, "secret3", "secret2.txt")
 	serviceSpec = createServiceSpecWithSecrets("service2", secretRef2, secretRef3)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test secret target conflicts with same secret and two references
 	secretRef3.SecretID = secretRef2.SecretID
 	secretRef3.SecretName = secretRef2.SecretName
 	serviceSpec = createServiceSpecWithSecrets("service3", secretRef2, secretRef3)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test two different secretReferences with using the same secret
 	secretRef5 := secretRef2.Copy()
@@ -669,7 +668,7 @@ func TestSecretValidation(t *testing.T) {
 
 	serviceSpec = createServiceSpecWithSecrets("invalid-blank", secretRefBlank)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// Test secret References with valid filenames
 	// Note: "../secretfile.txt", "../../secretfile.txt" will be rejected
@@ -698,7 +697,7 @@ func TestSecretValidation(t *testing.T) {
 		Spec:           serviceSpec1,
 		ServiceVersion: &rs.Service.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestConfigValidation(t *testing.T) {
@@ -711,7 +710,7 @@ func TestConfigValidation(t *testing.T) {
 	configRef.ConfigName = "404"
 	serviceSpec := createServiceSpecWithConfigs("service", configRef)
 	_, err := ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test creating service with a configRef that has an existing config
 	// but mismatched ConfigName fails.
@@ -719,21 +718,21 @@ func TestConfigValidation(t *testing.T) {
 	configRef1.ConfigName = "config2"
 	serviceSpec = createServiceSpecWithConfigs("service1", configRef1)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test config target conflicts
 	configRef2 := createConfig(t, ts, "config2", "config2.txt")
 	configRef3 := createConfig(t, ts, "config3", "config2.txt")
 	serviceSpec = createServiceSpecWithConfigs("service2", configRef2, configRef3)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test config target conflicts with same config and two references
 	configRef3.ConfigID = configRef2.ConfigID
 	configRef3.ConfigName = configRef2.ConfigName
 	serviceSpec = createServiceSpecWithConfigs("service3", configRef2, configRef3)
 	_, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: serviceSpec})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	// test two different configReferences with using the same config
 	configRef5 := configRef2.Copy()
@@ -773,7 +772,7 @@ func TestConfigValidation(t *testing.T) {
 		Spec:           serviceSpec1,
 		ServiceVersion: &rs.Service.Meta.Version,
 	})
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestGetService(t *testing.T) {
@@ -781,11 +780,11 @@ func TestGetService(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.GetService(context.Background(), &api.GetServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.GetService(context.Background(), &api.GetServiceRequest{ServiceID: "invalid"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	service := createService(t, ts, "name", "image", 1)
 	r, err := ts.Client.GetService(context.Background(), &api.GetServiceRequest{ServiceID: service.ID})
@@ -801,16 +800,16 @@ func TestUpdateService(t *testing.T) {
 
 	_, err := ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: "invalid", Spec: &service.Spec, ServiceVersion: &api.Version{}})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	// No update options.
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec, ServiceVersion: &service.Meta.Version})
 	assert.NoError(t, err)
@@ -892,7 +891,7 @@ func TestUpdateService(t *testing.T) {
 		ServiceVersion: &rs.Service.Meta.Version,
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 	spec3.Endpoint = &api.EndpointSpec{Ports: []*api.PortConfig{
 		{PublishedPort: uint32(9001), TargetPort: uint32(9000), Protocol: api.PortConfig_Protocol(api.ProtocolTCP)},
 	}}
@@ -914,7 +913,7 @@ func TestUpdateService(t *testing.T) {
 		ServiceVersion: &rs.Service.Meta.Version,
 	})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestServiceUpdateRejectNetworkChange(t *testing.T) {
@@ -996,7 +995,7 @@ func TestRemoveService(t *testing.T) {
 	defer ts.Stop()
 	_, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	service := createService(t, ts, "name", "image", 1)
 	r, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{ServiceID: service.ID})
@@ -1091,14 +1090,14 @@ func TestValidateEndpointSpec(t *testing.T) {
 
 	err := validateEndpointSpec(endPointSpec1)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	err = validateEndpointSpec(endPointSpec2)
 	assert.NoError(t, err)
 
 	err = validateEndpointSpec(endPointSpec3)
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	err = validateEndpointSpec(endPointSpec4)
 	assert.NoError(t, err)
@@ -1149,7 +1148,7 @@ func TestServiceEndpointSpecUpdate(t *testing.T) {
 	_, err = ts.Client.UpdateService(context.Background(),
 		&api.UpdateServiceRequest{Spec: spec})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
 func TestListServices(t *testing.T) {

--- a/manager/controlapi/task_test.go
+++ b/manager/controlapi/task_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/swarmkit/testutils"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
 	"github.com/docker/swarmkit/api"
@@ -37,11 +37,11 @@ func TestGetTask(t *testing.T) {
 
 	_, err := ts.Client.GetTask(context.Background(), &api.GetTaskRequest{})
 	assert.Error(t, err)
-	assert.Equal(t, codes.InvalidArgument, grpc.Code(err))
+	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 
 	_, err = ts.Client.GetTask(context.Background(), &api.GetTaskRequest{TaskID: "invalid"})
 	assert.Error(t, err)
-	assert.Equal(t, codes.NotFound, grpc.Code(err))
+	assert.Equal(t, codes.NotFound, testutils.ErrorCode(err))
 
 	task := createTask(t, ts, api.TaskStateRunning)
 	r, err := ts.Client.GetTask(context.Background(), &api.GetTaskRequest{TaskID: task.ID})

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -384,7 +384,7 @@ func TestHeartbeatTimeout(t *testing.T) {
 	resp, err := gd.Clients[0].Heartbeat(context.Background(), &api.HeartbeatRequest{SessionID: expectedSessionID})
 	assert.Nil(t, resp)
 	assert.Error(t, err)
-	assert.Equal(t, grpc.ErrorDesc(err), ErrNodeNotRegistered.Error())
+	assert.Equal(t, testutils.ErrorDesc(err), ErrNodeNotRegistered.Error())
 }
 
 func TestHeartbeatUnregistered(t *testing.T) {
@@ -394,7 +394,7 @@ func TestHeartbeatUnregistered(t *testing.T) {
 	resp, err := gd.Clients[0].Heartbeat(context.Background(), &api.HeartbeatRequest{})
 	assert.Nil(t, resp)
 	assert.Error(t, err)
-	assert.Equal(t, ErrSessionInvalid.Error(), grpc.ErrorDesc(err))
+	assert.Equal(t, ErrSessionInvalid.Error(), testutils.ErrorDesc(err))
 }
 
 // If the session ID is not sent as part of the Assignments request, an error is returned to the stream

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -267,7 +267,7 @@ func TestRegisterExceedRateLimit(t *testing.T) {
 		assert.NoError(t, err)
 		_, err = stream.Recv()
 		assert.Error(t, err)
-		assert.Equal(t, codes.Unavailable, grpc.Code(err), err.Error())
+		assert.Equal(t, codes.Unavailable, testutils.ErrorCode(err), err.Error())
 	}
 }
 
@@ -311,7 +311,7 @@ func TestHeartbeat(t *testing.T) {
 		resp, err := gd.Clients[0].Heartbeat(context.Background(), &api.HeartbeatRequest{})
 		assert.Nil(t, resp)
 		assert.Error(t, err)
-		assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+		assert.Equal(t, testutils.ErrorCode(err), codes.InvalidArgument)
 	}
 
 	resp, err := gd.Clients[0].Heartbeat(context.Background(), &api.HeartbeatRequest{SessionID: expectedSessionID})
@@ -414,7 +414,7 @@ func TestAssignmentsErrorsIfNoSessionID(t *testing.T) {
 	resp, err := stream.Recv()
 	assert.Nil(t, resp)
 	assert.Error(t, err)
-	assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+	assert.Equal(t, testutils.ErrorCode(err), codes.InvalidArgument)
 }
 
 func TestAssignmentsSecretDriver(t *testing.T) {
@@ -1247,7 +1247,7 @@ func TestTaskUpdate(t *testing.T) {
 		resp, err := gd.Clients[0].UpdateTaskStatus(context.Background(), updReq)
 		assert.Nil(t, resp)
 		assert.Error(t, err)
-		assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+		assert.Equal(t, testutils.ErrorCode(err), codes.InvalidArgument)
 	}
 
 	updReq.SessionID = expectedSessionID
@@ -1266,7 +1266,7 @@ func TestTaskUpdate(t *testing.T) {
 		resp, err := gd.Clients[0].UpdateTaskStatus(context.Background(), updReq)
 		assert.Nil(t, resp)
 		assert.Error(t, err)
-		assert.Equal(t, grpc.Code(err), codes.PermissionDenied)
+		assert.Equal(t, testutils.ErrorCode(err), codes.PermissionDenied)
 	}
 
 	gd.dispatcherServer.processUpdates(context.Background())
@@ -1754,7 +1754,7 @@ func TestOldTasks(t *testing.T) {
 		resp, err := stream.Recv()
 		assert.Nil(t, resp)
 		assert.Error(t, err)
-		assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+		assert.Equal(t, testutils.ErrorCode(err), codes.InvalidArgument)
 	}
 
 	stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{SessionID: expectedSessionID})
@@ -1852,7 +1852,7 @@ func TestOldTasksStatusChange(t *testing.T) {
 		resp, err := stream.Recv()
 		assert.Nil(t, resp)
 		assert.Error(t, err)
-		assert.Equal(t, grpc.Code(err), codes.InvalidArgument)
+		assert.Equal(t, testutils.ErrorCode(err), codes.InvalidArgument)
 	}
 
 	stream, err := gd.Clients[0].Tasks(context.Background(), &api.TasksRequest{SessionID: expectedSessionID})

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -88,7 +88,7 @@ func TestManager(t *testing.T) {
 	client := api.NewDispatcherClient(conn)
 	require.NoError(t, testutils.PollFuncWithTimeout(nil, func() error {
 		_, err = client.Heartbeat(tc.Context, &api.HeartbeatRequest{})
-		if dispatcher.ErrNodeNotRegistered.Error() != grpc.ErrorDesc(err) {
+		if dispatcher.ErrNodeNotRegistered.Error() != testutils.ErrorDesc(err) {
 			return err
 		}
 		_, err = client.Session(tc.Context, &api.SessionRequest{})
@@ -109,7 +109,7 @@ func TestManager(t *testing.T) {
 
 	client = api.NewDispatcherClient(conn2)
 	_, err = client.Heartbeat(context.Background(), &api.HeartbeatRequest{})
-	require.Contains(t, grpc.ErrorDesc(err), "Permission denied: unauthorized peer role: rpc error: code = PermissionDenied desc = Permission denied: remote certificate not part of organization")
+	require.Contains(t, testutils.ErrorDesc(err), "Permission denied: unauthorized peer role: rpc error: code = PermissionDenied desc = Permission denied: remote certificate not part of organization")
 
 	// Verify that requests to the various GRPC services running on TCP
 	// are rejected if they don't have certs.
@@ -210,7 +210,7 @@ func TestManager(t *testing.T) {
 
 	client = api.NewDispatcherClient(conn)
 	_, err = client.Heartbeat(context.Background(), &api.HeartbeatRequest{})
-	require.Contains(t, grpc.ErrorDesc(err), "removed from swarm")
+	require.Contains(t, testutils.ErrorDesc(err), "removed from swarm")
 
 	m.Stop(tc.Context, false)
 
@@ -313,7 +313,7 @@ func TestManagerLockUnlock(t *testing.T) {
 			ClusterVersion: &cluster.Meta.Version,
 			Spec:           spec,
 		})
-		if grpc.ErrorDesc(err) == "update out of sequence" {
+		if testutils.ErrorDesc(err) == "update out of sequence" {
 			continue
 		}
 		// if there is any other type of error, this should fail
@@ -386,7 +386,7 @@ func TestManagerLockUnlock(t *testing.T) {
 			ClusterVersion: &cluster.Meta.Version,
 			Spec:           spec,
 		})
-		if grpc.ErrorDesc(err) == "update out of sequence" {
+		if testutils.ErrorDesc(err) == "update out of sequence" {
 			continue
 		}
 		require.NoError(t, err)

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -822,7 +822,7 @@ func TestRaftJoinWithIncorrectAddress(t *testing.T) {
 
 	err := n.JoinAndStart(context.Background())
 	assert.NotNil(t, err)
-	assert.Contains(t, grpc.ErrorDesc(err), "could not connect to prospective new cluster member using its advertised address")
+	assert.Contains(t, testutils.ErrorDesc(err), "could not connect to prospective new cluster member using its advertised address")
 
 	// Check if first node still has only itself registered in the memberlist
 	assert.Len(t, nodes[1].GetMemberlist(), 1)

--- a/manager/state/raft/transport/mock_raft_test.go
+++ b/manager/state/raft/transport/mock_raft_test.go
@@ -100,7 +100,7 @@ func (r *mockRaft) ProcessRaftMessage(ctx context.Context, req *api.ProcessRaftM
 // StreamRaftMessage is the mock server endpoint for streaming messages of type StreamRaftMessageRequest.
 func (r *mockRaft) StreamRaftMessage(stream api.Raft_StreamRaftMessageServer) error {
 	if r.forceErrorStream {
-		return grpc.Errorf(codes.Unimplemented, "streaming not supported")
+		return status.Errorf(codes.Unimplemented, "streaming not supported")
 	}
 	var recvdMsg, assembledMessage *api.StreamRaftMessageRequest
 	var err error

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
+	"github.com/docker/swarmkit/testutils"
 	"github.com/pkg/errors"
 )
 
@@ -244,7 +245,7 @@ func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 	}
 
 	// Handle errors.
-	if grpc.Code(err) == codes.NotFound && grpc.ErrorDesc(err) == membership.ErrMemberRemoved.Error() {
+	if grpc.Code(err) == codes.NotFound && testutils.ErrorDesc(err) == membership.ErrMemberRemoved.Error() {
 		p.tr.config.NodeRemoved()
 	}
 	if m.Type == raftpb.MsgSnap {

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -15,8 +15,8 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
-	"github.com/docker/swarmkit/testutils"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -239,13 +239,15 @@ func (p *peer) sendProcessMessage(ctx context.Context, m raftpb.Message) error {
 	}
 
 	// Try doing a regular rpc if the receiver doesn't support streaming.
-	if grpc.Code(err) == codes.Unimplemented {
+	s, _ := status.FromError(err)
+	if s.Code() == codes.Unimplemented {
 		log.G(ctx).Info("sending message to raft peer using ProcessRaftMessage()")
 		_, err = api.NewRaftClient(p.conn()).ProcessRaftMessage(ctx, &api.ProcessRaftMessageRequest{Message: &m})
 	}
 
 	// Handle errors.
-	if grpc.Code(err) == codes.NotFound && testutils.ErrorDesc(err) == membership.ErrMemberRemoved.Error() {
+	s, _ = status.FromError(err)
+	if s.Code() == codes.NotFound && s.Message() == membership.ErrMemberRemoved.Error() {
 		p.tr.config.NodeRemoved()
 	}
 	if m.Type == raftpb.MsgSnap {

--- a/protobuf/plugin/raftproxy/test/raftproxy_test.go
+++ b/protobuf/plugin/raftproxy/test/raftproxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -60,5 +61,5 @@ func TestSimpleRedirect(t *testing.T) {
 	client := NewRouteGuideClient(conn)
 	_, err = client.GetFeature(context.Background(), &Point{})
 	assert.NotNil(t, err)
-	assert.Equal(t, codes.ResourceExhausted, grpc.Code(err))
+	assert.Equal(t, codes.ResourceExhausted, testutils.ErrorCode(err))
 }

--- a/testutils/grpc.go
+++ b/testutils/grpc.go
@@ -1,6 +1,9 @@
 package testutils
 
-import "google.golang.org/grpc/status"
+import (
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 // ErrorDesc returns the error description of err if it was produced by the rpc system.
 // Otherwise, it returns err.Error() or empty string when err is nil.
@@ -9,4 +12,13 @@ func ErrorDesc(err error) string {
 		return s.Message()
 	}
 	return err.Error()
+}
+
+// ErrorCode returns the error code for err if it was produced by the rpc system.
+// Otherwise, it returns codes.Unknown.
+func ErrorCode(err error) codes.Code {
+	if s, ok := status.FromError(err); ok {
+		return s.Code()
+	}
+	return codes.Unknown
 }

--- a/testutils/grpc.go
+++ b/testutils/grpc.go
@@ -1,0 +1,12 @@
+package testutils
+
+import "google.golang.org/grpc/status"
+
+// ErrorDesc returns the error description of err if it was produced by the rpc system.
+// Otherwise, it returns err.Error() or empty string when err is nil.
+func ErrorDesc(err error) string {
+	if s, ok := status.FromError(err); ok {
+		return s.Message()
+	}
+	return err.Error()
+}


### PR DESCRIPTION
`grpc.ErrorDesc(err)` and `grpc.Code(err)` were deprecated in favor of the "status" package in https://github.com/grpc/grpc-go/commit/b5071124392bfd416c713e6595ac149b387f7186

Replacing these with their equivalent, in case the deprecated methods are removed in future