### PR TITLE
Minor GRPC cleanups

### DIFF
--- a/ca/transport.go
+++ b/ca/transport.go
@@ -48,7 +48,7 @@ func (c *MutableTLSCreds) Info() credentials.ProtocolInfo {
 // It panics if validation of underlying config fails.
 func (c *MutableTLSCreds) Clone() credentials.TransportCredentials {
 	c.Lock()
-	newCfg, err := NewMutableTLS(c.config)
+	newCfg, err := NewMutableTLS(c.config.Clone())
 	if err != nil {
 		panic("validation error on Clone")
 	}

--- a/log/grpc.go
+++ b/log/grpc.go
@@ -1,13 +1,30 @@
 package log
 
 import (
+	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 )
+
+type logrusWrapper struct {
+	*logrus.Entry
+}
+
+// V provides the functionality that returns whether a particular log level is at
+// least l - this is needed to meet the LoggerV2 interface.  GRPC's logging levels
+// are: https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L71
+// 0=info, 1=warning, 2=error, 3=fatal
+// logrus's are: https://github.com/sirupsen/logrus/blob/master/logrus.go
+// 0=panic, 1=fatal, 2=error, 3=warn, 4=info, 5=debug
+func (lw logrusWrapper) V(l int) bool {
+	// translate to logrus level
+	logrusLevel := 4 - l
+	return int(lw.Logger.Level) <= logrusLevel
+}
 
 func init() {
 	ctx := WithModule(context.Background(), "grpc")
 
 	// completely replace the grpc logger with the logrus logger.
-	grpclog.SetLogger(G(ctx))
+	grpclog.SetLoggerV2(logrusWrapper{Entry: G(ctx)})
 }

--- a/log/grpc_test.go
+++ b/log/grpc_test.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGRPCLogrusLevelTranslation(t *testing.T) {
+	logger := logrus.New()
+	wrapped := logrusWrapper{Entry: logrus.NewEntry(logger)}
+	for _, tc := range []struct {
+		level     logrus.Level
+		grpcLevel int
+	}{
+		{
+			level:     logrus.InfoLevel,
+			grpcLevel: 0,
+		},
+		{
+			level:     logrus.WarnLevel,
+			grpcLevel: 1,
+		},
+		{
+			level:     logrus.ErrorLevel,
+			grpcLevel: 2,
+		},
+		{
+			level:     logrus.FatalLevel,
+			grpcLevel: 3,
+		},
+		// these don't translate to valid grpc log levels, but should still work
+		{
+			level:     logrus.DebugLevel,
+			grpcLevel: -1,
+		},
+		{
+			level:     logrus.PanicLevel,
+			grpcLevel: 4,
+		},
+	} {
+		logger.SetLevel(tc.level)
+		for i := -1; i < 5; i++ {
+			verbosityAtLeastI := wrapped.V(i)
+			require.Equal(t, i <= tc.grpcLevel, verbosityAtLeastI,
+				"Is verbosity at least %d? Logrus level at %v", i, tc.level)
+		}
+	}
+
+	// these values should also always work, even though they're not valid grpc log values
+	logrus.SetLevel(logrus.DebugLevel)
+	require.True(t, wrapped.V(-100))
+
+	logrus.SetLevel(logrus.PanicLevel)
+	require.False(t, wrapped.V(100))
+}

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -3,7 +3,6 @@ package controlapi
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"testing"
 
 	"github.com/docker/swarmkit/api"
@@ -241,7 +240,7 @@ func TestRemoveNodes(t *testing.T) {
 }
 
 func init() {
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	logrus.SetOutput(ioutil.Discard)
 }
 

--- a/manager/role_manager_test.go
+++ b/manager/role_manager_test.go
@@ -2,31 +2,15 @@ package manager
 
 import (
 	"errors"
-	"io/ioutil"
-	"log"
 	"testing"
-
-	"github.com/pivotal-golang/clock/fakeclock"
-
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/docker/swarmkit/api"
 	cautils "github.com/docker/swarmkit/ca/testutils"
 	raftutils "github.com/docker/swarmkit/manager/state/raft/testutils"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/testutils"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
-
-func getRaftCluster(t *testing.T, tc *cautils.TestCA) (map[uint64]*raftutils.TestNode, *fakeclock.FakeClock) {
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-	logrus.SetOutput(ioutil.Discard)
-
-	nodes, fc := raftutils.NewRaftCluster(t, tc)
-	raftutils.WaitForCluster(t, fc, nodes)
-	return nodes, fc
-}
 
 // While roleManager is running, if a node is demoted, it is removed from the raft cluster.  If a node is
 // promoted, it is not added to the cluster but its observed role will change to manager.

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 	"time"
@@ -26,12 +25,13 @@ import (
 
 var tc *cautils.TestCA
 
+func init() {
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	logrus.SetOutput(ioutil.Discard)
+}
+
 func TestMain(m *testing.M) {
 	tc = cautils.NewTestCA(nil)
-
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-	logrus.SetOutput(ioutil.Discard)
-
 	res := m.Run()
 	tc.Stop()
 	os.Exit(res)

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"net"
 	"os"
@@ -43,15 +42,14 @@ const (
 
 func init() {
 	store.WedgeTimeout = 3 * time.Second
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
+	logrus.SetOutput(ioutil.Discard)
 }
 
 var tc *cautils.TestCA
 
 func TestMain(m *testing.M) {
 	tc = cautils.NewTestCA(nil)
-
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
-	logrus.SetOutput(ioutil.Discard)
 
 	// Set a smaller segment size so we don't incur cost preallocating
 	// space on old filesystems like HFS+.

--- a/manager/watchapi/server_test.go
+++ b/manager/watchapi/server_test.go
@@ -2,7 +2,6 @@ package watchapi
 
 import (
 	"io/ioutil"
-	"log"
 	"net"
 	"os"
 	"testing"
@@ -102,6 +101,6 @@ func createNode(t *testing.T, ts *testServer, id string, role api.NodeRole, memb
 }
 
 func init() {
-	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	logrus.SetOutput(ioutil.Discard)
 }


### PR DESCRIPTION
This PR does 4 things:

1.  Our `MutableTLSCreds.Clone` function creates a new `MutableTLSCreds` object with the TLS config, which should not be re-used.  Previously, GRPC never called clone on the creds, but in 1.10.x, it does.  Our code should just call `tls.Config`'s `Clone` function anyway, because we should not be passing the same config object to multiple connections.  This should fix some issues with https://github.com/docker/swarmkit/pull/2631.

2. Our tests call `grpclog.SetLogger` in `TestMain` functions sometimes - the docs say that it should be set only in `init` functions.  Calling it in `TestMain` can cause races.  This should fix some issues with https://github.com/docker/swarmkit/pull/2631.

3.  Stops using `grpclog.SetLogger`, which is deprecated, and calls `grpc.SetLoggerV2` instead.  This required converting a `logrus.Entry` into something that satisfies the `grpclog.LoggerV2` interface.  I just did this since I was messing around with the logger anyway for the tests.

4.  Deletes some extra code in `role_manager_test.go` that didn't seem to be called from anywhere.

cc @thaJeztah 