### PR TITLE
Fix `deepcopy.Copy` panicing with BoolValue

### DIFF
--- a/api/deepcopy/copy.go
+++ b/api/deepcopy/copy.go
@@ -44,6 +44,9 @@ func Copy(dst, src interface{}) {
 	case *types.Timestamp:
 		src := src.(*types.Timestamp)
 		*dst = *src
+	case *types.BoolValue:
+		src := src.(*types.BoolValue)
+		*dst = *src
 	case CopierFrom:
 		dst.CopyFrom(src)
 	default:


### PR DESCRIPTION
Previously, trying to create a service with `Init` (which is a
BoolValue) would panic. It is now fixed.

Before, `swarmctl service create --init --name=foo --image nginx:alpine` would make the daemon panic, after, it creates the container with the correct spec.

Required for https://github.com/moby/moby/pull/37183 and carrying https://github.com/docker/cli/pull/479

Signed-off-by: Vincent Demeester <vincent@sbr.pm>
