### PR TITLE
[orchestrator/task reaper] Backport: Clean up tasks in dirty list for which the service has been deleted.

### DIFF
--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -177,6 +177,9 @@ func (tr *TaskReaper) tick() {
 		for dirty := range tr.dirty {
 			service := store.GetService(tx, dirty.serviceID)
 			if service == nil {
+				// If the service can't be found, assume that it was deleted
+				// and remove the slot from the dirty list.
+				delete(tr.dirty, dirty)
 				continue
 			}
 


### PR DESCRIPTION
cherry-pick 592e8eddfa43ec5fbd6e34da5ad6890dfa9313fb

Cherry-pick was clean.