### PR TITLE
[18.03] backport [orchestrator/task reaper] Clean up tasks in dirty list for which the service has been deleted.

### DIFF
--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -188,6 +188,9 @@ func (tr *TaskReaper) tick() {
 		for dirty := range tr.dirty {
 			service := store.GetService(tx, dirty.ServiceID)
 			if service == nil {
+				// If the service can't be found, assume that it was deleted
+				// and remove the slot from the dirty list.
+				delete(tr.dirty, dirty)
 				continue
 			}
 


### PR DESCRIPTION
cherry-pick of https://github.com/docker/swarmkit/pull/2666 for the bump_v18.03 branch