### PR TITLE
Fix racy batching on the dispatcher

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1136,6 +1136,11 @@ func (n *Node) superviseManager(ctx context.Context, securityConfig *ca.Security
 			// re-promoted. In this case, we must assume we were
 			// re-promoted, and restart the manager.
 			log.G(ctx).Warn("failed to get worker role after manager stop, forcing certificate renewal")
+
+			// We can safely reset this timer without stopping/draining the timer
+			// first because the only way the code has reached this point is if the timer
+			// has already expired - if the role changed or the context were canceled,
+			// then we would have returned already.
 			timer.Reset(roleChangeTimeout)
 
 			renewer.Renew()


### PR DESCRIPTION
TIL that go timers are racy from #2669.   I noticed the dispatcher also calls `Reset` without ensuring that it's stopped or expired first, so added a similar fix.  (See https://github.com/golang/go/issues/11513)

`dispatcher/heartbeat.go` also has a `Reset` without calling `Stop` first, but this seems ok?  If an extra heartbeat gets triggered, that seems inexpensive and fine?