### PR TITLE
[manager/orchestrator/reaper] Fix the condition used for skipping over running tasks

### DIFF
--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -168,6 +168,16 @@ func (tr *TaskReaper) Run(ctx context.Context) {
 	}
 }
 
+// taskInTerminalState returns true if task is in a terminal state.
+func taskInTerminalState(task *api.Task) bool {
+	return task.Status.State > api.TaskStateRunning
+}
+
+// taskWillNeverRun returns true if task will never reach running state.
+func taskWillNeverRun(task *api.Task) bool {
+	return task.Status.State < api.TaskStateAssigned && task.DesiredState > api.TaskStateRunning
+}
+
 // tick performs task history cleanup.
 func (tr *TaskReaper) tick() {
 	if len(tr.dirty) == 0 && len(tr.cleanup) == 0 {
@@ -267,22 +277,20 @@ func (tr *TaskReaper) tick() {
 
 			runningTasks := 0
 			for _, t := range historicTasks {
-				// Skip tasks which are desired to be running but the current state
-				// is less than or equal to running.
-				// This check is important to ignore tasks which are running or need to be running,
-				// but to delete tasks which are either past running,
-				// or have not reached running but need to be shutdown (because of a service update, for example).
-				if t.DesiredState == api.TaskStateRunning && t.Status.State <= api.TaskStateRunning {
-					// Don't delete running tasks
+				// Historical tasks can be considered for cleanup if:
+				// 1. The task has reached a terminal state i.e. actual state beyond TaskStateRunning.
+				// 2. The task has not yet become running and desired state is a terminal state i.e.
+				// actual state not yet TaskStateAssigned and desired state beyond TaskStateRunning.
+				if taskInTerminalState(t) || taskWillNeverRun(t) {
+					deleteTasks[t.ID] = struct{}{}
+
+					taskHistory++
+					if int64(len(historicTasks)) <= taskHistory {
+						break
+					}
+				} else {
+					// all other tasks are counted as running.
 					runningTasks++
-					continue
-				}
-
-				deleteTasks[t.ID] = struct{}{}
-
-				taskHistory++
-				if int64(len(historicTasks)) <= taskHistory {
-					break
 				}
 			}
 


### PR DESCRIPTION
Addresses the following from https://github.com/docker/swarmkit/issues/2672#issuecomment-399598738:

The previous logic for skipping over running tasks in tick() was:

if desired=running AND state <= running then don't delete else delete

For example, if a task is (desired=complete, state=running) then this code will delete it from SwarmKit, causing SwarmKit to believe that its resources are no longer in use, which is not correct.

This fixes the logic to ignore tasks which are running (including tasks which are desired to be shutdown), or which are desired to be running (desired state running). 