### PR TITLE
Handle an edge case in CA rotation where we reclaim CA service from an external CA

### DIFF
--- a/manager/controlapi/ca_rotation_test.go
+++ b/manager/controlapi/ca_rotation_test.go
@@ -231,6 +231,11 @@ func TestValidateCAConfigInvalidValues(t *testing.T) {
 			expectErrorString: "there must be at least one valid, reachable external CA corresponding to the next CA certificate",
 		},
 		{
+			rootCA:            initialExternalRootCA,
+			caConfig:          api.CAConfig{}, // removing the current external CA is not supported
+			expectErrorString: "there must be at least one valid, reachable external CA corresponding to the current CA certificate",
+		},
+		{
 			rootCA: initialExternalRootCA,
 			caConfig: api.CAConfig{
 				SigningCACert: rotationCert,
@@ -417,7 +422,17 @@ func TestValidateCAConfigValidValues(t *testing.T) {
 		return init
 	}
 
-	// These require no rotation, because the cert is exactly the same.
+	// no change in the CAConfig spec means no rotation
+	runValidTestCases(t, []*rootCARotationTestCase{
+		{
+			description:  "no specified config changes results no root rotation",
+			rootCA:       initialLocalRootCA,
+			caConfig:     api.CAConfig{},
+			expectRootCA: initialLocalRootCA,
+		},
+	}, &localRootCA)
+
+	// These require no rotation, because the cert is exactly the same or there is no change specified.
 	testcases := []*rootCARotationTestCase{
 		{
 			description: "same desired cert and key as current Root CA results in no root rotation",
@@ -430,17 +445,12 @@ func TestValidateCAConfigValidValues(t *testing.T) {
 			expectRootCA: getExpectedRootCA(true),
 		},
 		{
-			description: "same desired cert as current Root CA but external->internal results in no root rotation and no key -> key",
+			description: "same desired cert as current Root CA but external->internal (remove external CA is ok) results in no root rotation and no key -> key",
 			rootCA:      initialExternalRootCA,
 			caConfig: api.CAConfig{
 				SigningCACert: uglifyOnePEM(initialLocalRootCA.CACert),
 				SigningCAKey:  initialLocalRootCA.CAKey,
 				ForceRotate:   5,
-				ExternalCAs: []*api.ExternalCA{
-					{
-						URL: initExtServer.URL,
-					},
-				},
 			},
 			expectRootCA: getExpectedRootCA(true),
 		},
@@ -459,18 +469,36 @@ func TestValidateCAConfigValidValues(t *testing.T) {
 			},
 			expectRootCA: getExpectedRootCA(false),
 		},
+		{
+			description: "same desired cert and key as current Root CA but adding an external CA results in no root rotation and no key change",
+			rootCA:      initialLocalRootCA,
+			caConfig: api.CAConfig{
+				SigningCACert: initialLocalRootCA.CACert,
+				SigningCAKey:  initialLocalRootCA.CAKey,
+				ExternalCAs: []*api.ExternalCA{
+					{
+						URL:    initExtServer.URL,
+						CACert: uglifyOnePEM(initialLocalRootCA.CACert),
+					},
+				},
+				ForceRotate: 5,
+			},
+			expectRootCA: getExpectedRootCA(true),
+		},
 	}
 	runValidTestCases(t, testcases, &localRootCA)
 
-	// These will abort root rotation because the desired cert is the same as the current RootCA cert
+	// These are the same test cases as above, but we are testing that it will abort root rotation because
+	// the desired cert is the same as the current RootCA cert
 	crossSigned, err := localRootCA.CrossSignCACertificate(rotationCert)
 	require.NoError(t, err)
 	for _, testcase := range testcases {
 		testcase.rootCA = getRootCAWithRotation(testcase.rootCA, rotationCert, rotationKey, crossSigned)
 	}
 	testcases[0].description = "same desired cert and key as current RootCA results in aborting root rotation"
-	testcases[1].description = "same desired cert, even if external->internal, as current RootCA results in aborting root rotation and no key -> key"
+	testcases[1].description = "same desired cert as current Root CA but external->internal (remove external CA is ok) results in aborting root rotation and no key -> key"
 	testcases[2].description = "same desired cert, even if internal->external, as current RootCA results in aborting root rotation and key -> no key"
+	testcases[3].description = "same desired cert and key as current Root CA but adding an external CA results in aborting root rotation and no key change"
 	runValidTestCases(t, testcases, &localRootCA)
 
 	// These will not change the root rotation because the desired cert is the same as the current to-be-rotated-to cert


### PR DESCRIPTION
Support the edge case for CA rotation where the current root CA has an external CA URL but not key, and the swarm update adds the same cert and key and removes
the external CA URL.  Previously this would error, because it first made sure that the external CA URLs needed by the old root CA were present. This now succeeds because no root rotation is needed, a key is just being provided where none was present before.

This also adds several additional CA root rotation test cases to validate the case where there was an external CA URL, but the root CA also has a key (the external URL is preferred), and the swarm update for removes the external URL without changing the certificate and key.

This should make it easier to reclaim CA functionality from an external CA if the swarm already has the CA cert and key.

cc @BillMills 