### PR TITLE
Update google/certificate-transparency-go to v1.0.10

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -47,7 +47,7 @@ github.com/boltdb/bolt fff57c100f4dea1905678da7e90d92429dff2904
 github.com/cloudflare/cfssl 1.3.2
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/fernet/fernet-go 1b2437bc582b3cfbb341ee5a29f8ef5b42912ff2
-github.com/google/certificate-transparency-go 5ab67e519c93568ac3ee50fd6772a5bcf8aa460d
+github.com/google/certificate-transparency-go v1.0.10
 github.com/hashicorp/go-immutable-radix 8e8ed81f8f0bf1bdd829593fdd5c29922c1ea990
 github.com/hashicorp/go-memdb cb9a474f84cc5e41b273b20c6927680b2a8776ad
 github.com/hashicorp/golang-lru a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4

--- a/vendor/github.com/google/certificate-transparency-go/client/multilog.go
+++ b/vendor/github.com/google/certificate-transparency-go/client/multilog.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/client/configpb"


### PR DESCRIPTION
The current vendor was between v1.0.9 and v1.0.10; this
change switches the dependency to use golang/protobuf instead
of gogo/protobuf.

full diff: https://github.com/google/certificate-transparency-go/compare/5ab67e519c93568ac3ee50fd6772a5bcf8aa460d...v1.0.10