### PR TITLE
Just use the default GOPATH in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,12 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/go/src/github.com/docker/swarmkit
+    # CircleCI by default sets the gopath to be ~/.go_workspace and /usr/local/go_workspace
+    # apparently.  We cannot set the working directory or environment variables by using
+    # other environment variables (although the working directory can use the `~` character,
+    # but environment variables cannot), so to avoid having to override the GOPATH for every
+    # run command, just hard code in the directory to be CircleCI expects it to be.
+    working_directory: /home/circleci/.go_workspace/src/github.com/docker/swarmkit
     environment:
       # Needed to install go
       OS: linux
@@ -44,7 +49,6 @@ jobs:
         name: Install go
         command: |
             sudo rm -rf /usr/local/go
-            rm -rf "$GOPATH"
             curl -fsSL -o "$HOME/go.tar.gz" "https://storage.googleapis.com/golang/go$GOVERSION.$OS-$ARCH.tar.gz"
             sudo tar -C /usr/local -xzf "$HOME/go.tar.gz"
 
@@ -79,7 +83,7 @@ jobs:
     # The GOPATH setting would not be needed if we used the golang docker image
     - run:
         name: Compile/lint/vet/protobuf validation
-        command: GOPATH="$HOME/go" make check binaries checkprotos
+        command: make check binaries checkprotos
 
     - run:
         name: Run unit tests
@@ -87,13 +91,13 @@ jobs:
             sudo mkdir /tmpfs
             sudo mount -t tmpfs tmpfs /tmpfs
             sudo chown 1000:1000 /tmpfs
-            GOPATH="$HOME/go" TMPDIR=/tmpfs make coverage
+            TMPDIR=/tmpfs make coverage
 
     - run:
         name: Run integration tests
         command: |
             # TMPFS has already been set up previously in the unit test step
-            GOPATH="$HOME/go" TMPDIR=/tmpfs make coverage-integration
+            TMPDIR=/tmpfs make coverage-integration
 
     - run:
         name: Push coverage info to codecov.io


### PR DESCRIPTION
Apparently CircleCI sets a default GOPATH to `/home/circleci/.go_workspace` so go stuff won't fall back on the default of `~/go`.  So we have to set the environment variable for the whole job.  Apparently you can use `~` but not other environment variables when setting environment variables in CircleCI v2.

Anyway, I had set a GOPATH just in case for all our test commands, but I forgot it for the dependency validation, which was why #2688 and #2689 were failing.

Edit:  Nm, apparently `~` is not valid for environment variables, so I guess we go back to setting the GOPATH for every command, or just go with what CircleCI expects the go path to be I guess, which would hopefully make the circleci script more maintainable (no need to remember to set the GOPATH everywhere)