### PR TITLE
Fix linting issues revealed by Go 1.11

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -117,27 +117,27 @@ func TestHandleSessionMessageNetworkManagerChanges(t *testing.T) {
 	var messages = []*api.SessionMessage{
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: ""}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: ""}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: nil,
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 0.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 0.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 	}

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -423,7 +423,7 @@ func (d *Dispatcher) markNodesUnknown(ctx context.Context) error {
 
 				expireFunc := func() {
 					log := log.WithField("node", nodeID)
-					log.Info(`heartbeat expiration for node %s in state "unknown"`, nodeID)
+					log.Infof(`heartbeat expiration for node %s in state "unknown"`, nodeID)
 					if err := d.markNodeNotReady(nodeID, api.NodeStatus_DOWN, `heartbeat failure for node in "unknown" state`); err != nil {
 						log.WithError(err).Error(`failed deregistering node after heartbeat expiration for node in "unknown" state`)
 					}
@@ -544,7 +544,7 @@ func (d *Dispatcher) register(ctx context.Context, nodeID string, description *a
 	}
 
 	expireFunc := func() {
-		log.G(ctx).Debug("heartbeat expiration for worker %s, setting worker status to NodeStatus_DOWN ", nodeID)
+		log.G(ctx).Debugf("heartbeat expiration for worker %s, setting worker status to NodeStatus_DOWN ", nodeID)
 		if err := d.markNodeNotReady(nodeID, api.NodeStatus_DOWN, "heartbeat failure"); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed deregistering node after heartbeat expiration")
 		}


### PR DESCRIPTION
Go 1.11 is stricter, and compilation will fail, revealing these issues;

```
agent/agent_test.go:120: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:125: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:130: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:135: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:140: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
manager/dispatcher/dispatcher.go:426: Entry.Info call has possible formatting directive %s
manager/dispatcher/dispatcher.go:547: Entry.Debug call has possible formatting directive %s
make: *** [vet] Error 1
```
