### PR TITLE
[18.03] Fix racy batching on the dispatcher.

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -285,9 +285,16 @@ func (d *Dispatcher) Run(ctx context.Context) error {
 			publishManagers(ev.([]*api.Peer))
 		case <-d.processUpdatesTrigger:
 			d.processUpdates(ctx)
+			batchTimer.Stop()
+			// drain the timer, if it has already expired
+			select {
+			case <-batchTimer.C:
+			default:
+			}
 			batchTimer.Reset(maxBatchInterval)
 		case <-batchTimer.C:
 			d.processUpdates(ctx)
+			// batch timer has already expired, so no need to drain
 			batchTimer.Reset(maxBatchInterval)
 		case v := <-configWatcher:
 			cluster := v.(api.EventUpdateCluster)

--- a/node/node.go
+++ b/node/node.go
@@ -1000,6 +1000,11 @@ func (n *Node) superviseManager(ctx context.Context, securityConfig *ca.Security
 			// re-promoted. In this case, we must assume we were
 			// re-promoted, and restart the manager.
 			log.G(ctx).Warn("failed to get worker role after manager stop, forcing certificate renewal")
+
+			// We can safely reset this timer without stopping/draining the timer
+			// first because the only way the code has reached this point is if the timer
+			// has already expired - if the role changed or the context were canceled,
+			// then we would have returned already.
 			timer.Reset(roleChangeTimeout)
 
 			renewer.Renew()


### PR DESCRIPTION
cherry-pick of https://github.com/docker/swarmkit/pull/2676 for 18.03

```
git checkout -b 18.03-backport-dispatcher-batch-timer upstream/bump_v18.03
git cherry-pick -s -S -x 317ad86ad8fab82e8e3359d44407951c2e3cb4d2
```

cherry-pick was clean