### PR TITLE
[17.06] Fix possible data race in manager/state/store/memory_test.go

### DIFF
--- a/manager/state/store/memory_test.go
+++ b/manager/state/store/memory_test.go
@@ -2035,7 +2035,7 @@ func BenchmarkNodeConcurrency(b *testing.B) {
 	var wg sync.WaitGroup
 	for c := 0; c != 5; c++ {
 		wg.Add(1)
-		go func() {
+		go func(c int) {
 			defer wg.Done()
 			for i := 0; i < b.N; i++ {
 				_ = s.Update(func(tx1 Tx) error {
@@ -2050,7 +2050,7 @@ func BenchmarkNodeConcurrency(b *testing.B) {
 					return nil
 				})
 			}
-		}()
+		}(c)
 	}
 
 	for c := 0; c != 5; c++ {


### PR DESCRIPTION
Backport of https://github.com/docker/swarmkit/pull/2537 for 17.06

```
git checkout -b 17.06-backport-2536-data-race upstream/bump_v17.06
git cherry-pick -s -S -x 06add13d57411618c18d4b9d181013e932462834
```

no conflicts, cherry-pick was clean



This PR is a fix for #2536, essentially using the first proposed way of fixing the original issue.

This fixes a possible data race in `manager/state/store/memory_test.go`

An alternative to this fix would be to define a new variable in the following way:

```Go
    for c := 0; c != 5; c++ {
        ...
        x := c
        go func() {
            ...
            Name: nodeIDs[i%benchmarkNumNodes] + "_" + strconv.Itoa(x) + "_" + strconv.Itoa(i),
            ...
        }
    }
 ```