### PR TITLE
[18.03] Fix linting issues

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -117,27 +117,27 @@ func TestHandleSessionMessageNetworkManagerChanges(t *testing.T) {
 	var messages = []*api.SessionMessage{
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: ""}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: ""}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: nil,
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "", Addr: "10.0.0.1"}, 1.0}},
+				{Peer: &api.Peer{NodeID: "", Addr: "10.0.0.1"}, Weight: 1.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 		{
 			Managers: []*api.WeightedPeer{
-				{&api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, 0.0}},
+				{Peer: &api.Peer{NodeID: "node1", Addr: "10.0.0.1"}, Weight: 0.0}},
 			NetworkBootstrapKeys: []*api.EncryptionKey{{}},
 		},
 	}

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -414,7 +414,7 @@ func (d *Dispatcher) markNodesUnknown(ctx context.Context) error {
 
 				expireFunc := func() {
 					log := log.WithField("node", nodeID)
-					log.Info(`heartbeat expiration for node %s in state "unknown"`, nodeID)
+					log.Infof(`heartbeat expiration for node %s in state "unknown"`, nodeID)
 					if err := d.markNodeNotReady(nodeID, api.NodeStatus_DOWN, `heartbeat failure for node in "unknown" state`); err != nil {
 						log.WithError(err).Error(`failed deregistering node after heartbeat expiration for node in "unknown" state`)
 					}
@@ -535,7 +535,7 @@ func (d *Dispatcher) register(ctx context.Context, nodeID string, description *a
 	}
 
 	expireFunc := func() {
-		log.G(ctx).Debug("heartbeat expiration for worker %s, setting worker status to NodeStatus_DOWN ", nodeID)
+		log.G(ctx).Debugf("heartbeat expiration for worker %s, setting worker status to NodeStatus_DOWN ", nodeID)
 		if err := d.markNodeNotReady(nodeID, api.NodeStatus_DOWN, "heartbeat failure"); err != nil {
 			log.G(ctx).WithError(err).Errorf("failed deregistering node after heartbeat expiration")
 		}


### PR DESCRIPTION
cherry-pick of https://github.com/docker/swarmkit/pull/2693 for 18.03 branch

cherry-pick was clean; no conflicts


Go 1.11 is stricter, and compilation will fail, revealing these issues;

```
agent/agent_test.go:120: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:125: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:130: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:135: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
agent/agent_test.go:140: *github.com/docker/swarmkit/api.WeightedPeer composite literal uses unkeyed fields
manager/dispatcher/dispatcher.go:426: Entry.Info call has possible formatting directive %s
manager/dispatcher/dispatcher.go:547: Entry.Debug call has possible formatting directive %s
make: *** [vet] Error 1
```

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>
(cherry picked from commit 59064c30ef435525c33a4aa59391c68db561fa12)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
