### PR TITLE
[input needed] [18.03] [manager/dispatcher] Replace call to isRunning() to isRunningLocked() in dispatcher Heartbeat()

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1143,11 +1143,8 @@ func (d *Dispatcher) Heartbeat(ctx context.Context, r *api.HeartbeatRequest) (*a
 	d.rpcRW.RLock()
 	defer d.rpcRW.RUnlock()
 
-	// Its OK to call isRunning() here instead of isRunningLocked()
-	// because of the rpcRW readlock above.
-	// TODO(anshul) other uses of isRunningLocked() can probably
-	// also be removed.
-	if !d.isRunning() {
+	// TODO(anshul) Explore if its possible to check context here without locking.
+	if _, err := d.isRunningLocked(); err != nil {
 		return nil, status.Errorf(codes.Aborted, "dispatcher is stopped")
 	}
 


### PR DESCRIPTION
backport of https://github.com/docker/swarmkit/pull/2664 for 18.03

```
git checkout -b 18.03-backport-dispatcher upstream/bump_v18.03 
git cherry-pick -s -S -x caee4da2afedf487d98d4e66da3de5721ba415fa
```

cherry-pick was clean; no conflicts


We noticed repeated CI failures pointing to data races because of unlocked access to the dispatcher context in Heartbeat(). Golang also does not provide any guarantees around read-only operations on objects which are otherwise locked. 

This will likely have a performance impact, which we will evaluate and some of the dispatcher code might need to be re-written accordingly. But correctness is first.