### PR TITLE
Remove unused "containerd-addr" and "containerd-namespace" flags

### DIFF
--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -257,8 +257,6 @@ func init() {
 	mainCmd.Flags().StringP("state-dir", "d", defaults.StateDir, "State directory")
 	mainCmd.Flags().StringP("join-token", "", "", "Specifies the secret token required to join the cluster")
 	mainCmd.Flags().String("engine-addr", "unix:///var/run/docker.sock", "Address of engine instance of agent.")
-	mainCmd.Flags().String("containerd-addr", "", "Address of containerd instance of agent.")
-	mainCmd.Flags().String("containerd-namespace", "swarmd", "Namespace to use when using containerd agent.")
 	mainCmd.Flags().String("hostname", "", "Override reported agent hostname")
 	mainCmd.Flags().String("advertise-remote-api", "", "Advertise address for remote API")
 	mainCmd.Flags().String("listen-remote-api", "0.0.0.0:4242", "Listen address for remote API")


### PR DESCRIPTION
commit https://github.com/docker/swarmkit/pull/2568/commits/fe9b06392aaa10d4aeb4a36bf4defffaa5556d96 (https://github.com/docker/swarmkit/pull/2568) removed the containerd executor, as it was not currently maintained, but these two flags were left behind and are no longer functional.

see https://github.com/docker/swarmkit/pull/2595#issue-179648668