### PR TITLE
address unassigned task leak when service is removed (v17.06 backport)

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -674,9 +674,20 @@ func (s *Scheduler) scheduleNTasksOnNodes(ctx context.Context, n int, taskGroup 
 	return tasksScheduled
 }
 
+// noSuitableNode checks unassigned tasks and make sure they have an existing service in the store before
+// updating the task status and adding it back to: schedulingDecisions, unassignedTasks and allTasks
 func (s *Scheduler) noSuitableNode(ctx context.Context, taskGroup map[string]*api.Task, schedulingDecisions map[string]schedulingDecision) {
 	explanation := s.pipeline.Explain()
 	for _, t := range taskGroup {
+		var service *api.Service
+		s.store.View(func(tx store.ReadTx) {
+			service = store.GetService(tx, t.ServiceID)
+		})
+		if service == nil {
+			log.G(ctx).WithField("task.id", t.ID).Debug("removing task from the scheduler")
+			continue
+		}
+
 		log.G(ctx).WithField("task.id", t.ID).Debug("no suitable node available for task")
 
 		newT := *t


### PR DESCRIPTION
Signed-off-by: Dani Louca <dani.louca@docker.com>

**- What I did**
BACKPORT v17.06
If a task is not yet assigned (for ex:  `noSuitableNode` ) and its service has been removed, the task stays in the `unassignedTasks` map until a new leader election.
 
**- How I did it**

Before re-adding the task to `unassignedTasks` map, the fix checks if the task has a valid service in the store.

**- How to test it**

steps to repro:
- set daemon.log to debug
- create a service with a node constraint that does not exist:
ex: `docker service create -d --constraint 'node.labels.type == queue' alpine sleep 10000`
- watch the logs, you should see an error 
`no suitable node available for task`
- delete the service and invoke the tick() by creating another service; watch the log and notice the same warning taskID in pops up after service is deleted

**- Description for the changelog**

Avoid a leak when a service with unassigned tasks is deleted