### PR TITLE
[18.03] address unassigned task leak when service is removed

### DIFF
--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -702,9 +702,20 @@ func (s *Scheduler) scheduleNTasksOnNodes(ctx context.Context, n int, taskGroup 
 	return tasksScheduled
 }
 
+// noSuitableNode checks unassigned tasks and make sure they have an existing service in the store before
+// updating the task status and adding it back to: schedulingDecisions, unassignedTasks and allTasks
 func (s *Scheduler) noSuitableNode(ctx context.Context, taskGroup map[string]*api.Task, schedulingDecisions map[string]schedulingDecision) {
 	explanation := s.pipeline.Explain()
 	for _, t := range taskGroup {
+		var service *api.Service
+		s.store.View(func(tx store.ReadTx) {
+			service = store.GetService(tx, t.ServiceID)
+		})
+		if service == nil {
+			log.G(ctx).WithField("task.id", t.ID).Debug("removing task from the scheduler")
+			continue
+		}
+
 		log.G(ctx).WithField("task.id", t.ID).Debug("no suitable node available for task")
 
 		newT := *t


### PR DESCRIPTION
cherry-pick of https://github.com/docker/swarmkit/pull/2706 for the bump_v18.03 branch;

```
git checkout -b 18.03-backport-task_leak upstream/bump_v18.03
git cherry-pick -s -S -x 9d977ce6fe0ecd674a17d596e76d141abb88293b
```

cherry-pick was clean; no conflicts