### PR TITLE
[backport: 17.06] [manager/dispatcher] Replace call to isRunning() to isRunningLocked() in dispatcher Heartbeat()

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1095,11 +1095,8 @@ func (d *Dispatcher) Heartbeat(ctx context.Context, r *api.HeartbeatRequest) (*a
 	d.rpcRW.RLock()
 	defer d.rpcRW.RUnlock()
 
-	// Its OK to call isRunning() here instead of isRunningLocked()
-	// because of the rpcRW readlock above.
-	// TODO(anshul) other uses of isRunningLocked() can probably
-	// also be removed.
-	if !d.isRunning() {
+	// TODO(anshul) Explore if its possible to check context here without locking.
+	if _, err := d.isRunningLocked(); err != nil {
 		return nil, grpc.Errorf(codes.Aborted, "dispatcher is stopped")
 	}
 


### PR DESCRIPTION
backport of #2664 for 17.06

git cherry-pick -s -S -x caee4da2afedf487d98d4e66da3de5721ba415fa
cherry-pick was not clean.

We noticed repeated CI failures pointing to data races because of unlocked access to the dispatcher context in Heartbeat(). Golang also does not provide any guarantees around read-only operations on objects which are otherwise locked.

This will likely have a performance impact, which we will evaluate and some of the dispatcher code might need to be re-written accordingly. But correctness is first.