### PR TITLE
Test if error is nil before to log it

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -962,7 +962,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 		// in order to allow running services on the predefined docker
 		// networks like `bridge` and `host`.
 		for _, p := range allocator.PredefinedNetworks() {
-			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != store.ErrNameConflict {
+			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil && err != store.ErrNameConflict {
 				log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 			}
 		}


### PR DESCRIPTION
Signed-off-by: nmengin <nicolas@containo.us>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

This PR adds a test on the error sent by the function `store.CreateNetwork()` when a manager becomes leader in the way to avoid the creation of an error message for a error which is `nil`.

**- How I did it**

The `if` statement test if the error is not nil before to log a message.

**- How to test it**

Start a swarmkit cluster with a log level >= `logLevel.Error`.
Thanks to the modification the errors described below sould not appear:

```
level=error msg="failed to create predefined network bridge" error="<nil>"
level=error msg="failed to create predefined network host" error="<nil>"
````

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Delete the error logs generated when prefefined networks are initiliazed successfully, Fixes #2719 .
