### PR TITLE
[18.03 backport] Avoid predefined error log, and Test if error is nil before to log it

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -882,15 +882,13 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			}
 		}
 		// Create now the static predefined if the store does not contain predefined
-		//networks like bridge/host node-local networks which
+		// networks like bridge/host node-local networks which
 		// are known to be present in each cluster node. This is needed
 		// in order to allow running services on the predefined docker
 		// networks like `bridge` and `host`.
 		for _, p := range allocator.PredefinedNetworks() {
-			if store.GetNetwork(tx, p.Name) == nil {
-				if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil {
-					log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
-				}
+			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != store.ErrNameConflict {
+				log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 			}
 		}
 		return nil

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -887,7 +887,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 		// in order to allow running services on the predefined docker
 		// networks like `bridge` and `host`.
 		for _, p := range allocator.PredefinedNetworks() {
-			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != store.ErrNameConflict {
+			if err := store.CreateNetwork(tx, newPredefinedNetwork(p.Name, p.Driver)); err != nil && err != store.ErrNameConflict {
 				log.G(ctx).WithError(err).Error("failed to create predefined network " + p.Name)
 			}
 		}


### PR DESCRIPTION
Backport of https://github.com/docker/swarmkit/pull/2561 and https://github.com/docker/swarmkit/pull/2720 for the bump_v18.03 branch

```
git checkout -b 18.03-backport-2719-fix-error-message-logging upstream/bump_v18.03
git cherry-pick -s -S -x f6e6e694ed86f6ca470bf67112722eb5ade17bf5
git cherry-pick -s -S -x 99a0f5842bdd05e50de0a5fd386202a8b34220f4
git push -u origin
```

cherry-pick was clean; no conflicts
