### PR TITLE
Disallow deleting networks that are in use

### DIFF
--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -209,7 +209,10 @@ func (s *Server) removeNetwork(id string) error {
 		}
 
 		for _, t := range tasks {
-			if t.DesiredState <= api.TaskStateRunning && t.Status.State <= api.TaskStateRunning {
+			// we don't care about the desired state of the task, only its
+			// actual state. even if a task WILL be terminal, if it isn't yet,
+			// then it is still using resources.
+			if t.Status.State <= api.TaskStateRunning {
 				return status.Errorf(codes.FailedPrecondition, "network %s is in use by task %s", id, t.ID)
 			}
 		}


### PR DESCRIPTION

Signed-off-by: Drew Erny <drew.erny@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes a bug by which a network that was actually in use could be removed. By proxy, fixes a bug through which network resources (subnets etc.) could be reused even though tasks using them were still running.

**- How I did it**

Change the control API to disallow removing networks that are in use by tasks. Before, if a task had a terminal desired state, the network remove would be allowed to proceed. However, if the task is still running, its resources are still in use. This removes the check for desired state, so that only actual state is taken into consideration when checking if a network is in use.

**- How to test it**

Bluhhh I forgot to write a test.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
