### PR TITLE
Default Address Pool Code Refactor

### DIFF
--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -16,7 +16,7 @@ func TestIPAMNotNil(t *testing.T) {
 	assert.NotNil(t, s)
 	defer s.Close()
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -27,7 +27,7 @@ func TestAllocator(t *testing.T) {
 	assert.NotNil(t, s)
 	defer s.Close()
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 
@@ -668,7 +668,7 @@ func TestNoDuplicateIPs(t *testing.T) {
 
 			return nil
 		}))
-		a, err := New(s, nil, nil, 0)
+		a, err := New(s, nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, a)
 
@@ -800,7 +800,7 @@ func TestAllocatorRestoreForDuplicateIPs(t *testing.T) {
 		return true
 	}
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 	// Start allocator
@@ -950,7 +950,7 @@ func TestAllocatorRestartNoEndpointSpec(t *testing.T) {
 		return true
 	}
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 	// Start allocator
@@ -1154,7 +1154,7 @@ func TestAllocatorRestoreForUnallocatedNetwork(t *testing.T) {
 		return true
 	}
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 	// Start allocator
@@ -1181,7 +1181,7 @@ func TestNodeAllocator(t *testing.T) {
 	assert.NotNil(t, s)
 	defer s.Close()
 
-	a, err := New(s, nil, nil, 0)
+	a, err := New(s, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, a)
 

--- a/manager/allocator/cnmallocator/drivers_ipam.go
+++ b/manager/allocator/cnmallocator/drivers_ipam.go
@@ -1,7 +1,6 @@
 package cnmallocator
 
 import (
-	"net"
 	"strconv"
 	"strings"
 
@@ -14,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func initIPAMDrivers(r *drvregistry.DrvRegistry, defaultAddrPool []*net.IPNet, subnetSize int) error {
+func initIPAMDrivers(r *drvregistry.DrvRegistry, netConfig *NetworkConfig) error {
 	var addressPool []*ipamutils.NetworkToSplit
 	var str strings.Builder
 	str.WriteString("Subnetlist - ")
@@ -22,16 +21,16 @@ func initIPAMDrivers(r *drvregistry.DrvRegistry, defaultAddrPool []*net.IPNet, s
 	// from the info. We will be using it to call Libnetwork API
 	// We also need to log new address pool info whenever swarm init
 	// happens with default address pool option
-	if defaultAddrPool != nil {
-		for _, p := range defaultAddrPool {
+	if netConfig != nil {
+		for _, p := range netConfig.DefaultAddrPool {
 			addressPool = append(addressPool, &ipamutils.NetworkToSplit{
-				Base: p.String(),
-				Size: subnetSize,
+				Base: p,
+				Size: int(netConfig.SubnetSize),
 			})
-			str.WriteString(p.String() + ",")
+			str.WriteString(p + ",")
 		}
 		str.WriteString(": Size ")
-		str.WriteString(strconv.Itoa(subnetSize))
+		str.WriteString(strconv.Itoa(int(netConfig.SubnetSize)))
 	}
 	if err := ipamutils.ConfigGlobalScopeDefaultNetworks(addressPool); err != nil {
 		return err

--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -86,8 +86,18 @@ type initializer struct {
 	ntype string
 }
 
+// NetworkConfig is used to store network related cluster config in the Manager.
+type NetworkConfig struct {
+	// DefaultAddrPool specifies default subnet pool for global scope networks
+	DefaultAddrPool []string
+
+	// SubnetSize specifies the subnet size of the networks created from
+	// the default subnet pool
+	SubnetSize uint32
+}
+
 // New returns a new NetworkAllocator handle
-func New(pg plugingetter.PluginGetter, defaultAddrPool []*net.IPNet, subnetSize int) (networkallocator.NetworkAllocator, error) {
+func New(pg plugingetter.PluginGetter, netConfig *NetworkConfig) (networkallocator.NetworkAllocator, error) {
 	na := &cnmNetworkAllocator{
 		networks: make(map[string]*network),
 		services: make(map[string]struct{}),
@@ -106,7 +116,7 @@ func New(pg plugingetter.PluginGetter, defaultAddrPool []*net.IPNet, subnetSize 
 		return nil, err
 	}
 
-	if err = initIPAMDrivers(reg, defaultAddrPool, subnetSize); err != nil {
+	if err = initIPAMDrivers(reg, netConfig); err != nil {
 		return nil, err
 	}
 

--- a/manager/allocator/cnmallocator/networkallocator_test.go
+++ b/manager/allocator/cnmallocator/networkallocator_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func newNetworkAllocator(t *testing.T) networkallocator.NetworkAllocator {
-	na, err := New(nil, nil, 0)
+	na, err := New(nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, na)
 	return na

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -68,7 +68,15 @@ type networkContext struct {
 }
 
 func (a *Allocator) doNetworkInit(ctx context.Context) (err error) {
-	na, err := cnmallocator.New(a.pluginGetter, a.defaultAddrPool, a.subnetSize)
+	var netConfig *cnmallocator.NetworkConfig
+	if a.networkConfig != nil && a.networkConfig.DefaultAddrPool != nil {
+		netConfig = &cnmallocator.NetworkConfig{
+			DefaultAddrPool: a.networkConfig.DefaultAddrPool,
+			SubnetSize:      a.networkConfig.SubnetSize,
+		}
+	}
+
+	na, err := cnmallocator.New(a.pluginGetter, netConfig)
 	if err != nil {
 		return err
 	}

--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -19,6 +19,13 @@ const (
 	// expiredCertGrace is the amount of time to keep a node in the
 	// blacklist beyond its certificate expiration timestamp.
 	expiredCertGrace = 24 * time.Hour * 7
+	// inbuilt default subnet size
+	inbuiltSubnetSize = 24
+)
+
+var (
+	// inbuilt default address pool
+	inbuiltDefaultAddressPool = []string{"10.0.0.0/8"}
 )
 
 func validateClusterSpec(spec *api.ClusterSpec) error {
@@ -267,6 +274,12 @@ func redactClusters(clusters []*api.Cluster) []*api.Cluster {
 			BlacklistedCertificates: cluster.BlacklistedCertificates,
 			DefaultAddressPool:      cluster.DefaultAddressPool,
 			SubnetSize:              cluster.SubnetSize,
+		}
+		if newCluster.DefaultAddressPool == nil {
+			// This is just for CLI display. Set the inbuilt default pool for
+			// user reference.
+			newCluster.DefaultAddressPool = inbuiltDefaultAddressPool
+			newCluster.SubnetSize = inbuiltSubnetSize
 		}
 		redactedClusters = append(redactedClusters, newCluster)
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager"
+	"github.com/docker/swarmkit/manager/allocator/cnmallocator"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/docker/swarmkit/remotes"
 	"github.com/docker/swarmkit/xnet"
@@ -105,12 +106,8 @@ type Config struct {
 	// for connections to the remote API (including the raft service).
 	AdvertiseRemoteAPI string
 
-	// DefaultAddrPool specifies default subnet pool for global scope networks
-	DefaultAddrPool []*net.IPNet
-
-	// SubnetSize specifies the subnet size of the networks created from
-	// the default subnet pool
-	SubnetSize int
+	// NetworkConfig stores network related config for the cluster
+	NetworkConfig *cnmallocator.NetworkConfig
 
 	// Executor specifies the executor to use for the agent.
 	Executor exec.Executor
@@ -1002,8 +999,7 @@ func (n *Node) runManager(ctx context.Context, securityConfig *ca.SecurityConfig
 		PluginGetter:     n.config.PluginGetter,
 		RootCAPaths:      rootPaths,
 		FIPS:             n.config.FIPS,
-		DefaultAddrPool:  n.config.DefaultAddrPool,
-		SubnetSize:       n.config.SubnetSize,
+		NetworkConfig:    n.config.NetworkConfig,
 	})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
 We have two params that have been passed around as part of swarm init
config. As part of refactoring the code, we created NetworkConfig struct
and added address pool and subnet mask length as part of the new struct
Older PR review comment has been addressed in this commit.
Signed-off-by: selansen <elango.siva@docker.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
