### PR TITLE
Allow users to customize Client Connection 

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	events "github.com/docker/go-events"
 	agentutils "github.com/docker/swarmkit/agent/testutils"
 	"github.com/docker/swarmkit/api"
@@ -26,6 +23,8 @@ import (
 	"github.com/docker/swarmkit/xnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 var localDispatcher = false
@@ -341,7 +340,7 @@ func TestSessionReconnectsIfDispatcherErrors(t *testing.T) {
 	}, 2*time.Second))
 	tester.stopDispatcher()
 	tester.remotes.setPeer(api.Peer{Addr: anotherDispatcher.Addr})
-	tester.agent.config.ConnBroker.SetLocalConn(nil)
+	tester.agent.config.ConnBroker.SetLocalConn("")
 
 	// It should have connected with the second dispatcher 3 times - first because the first dispatcher died,
 	// second because the dispatcher returned an error, third time because the session timed out.  So there should
@@ -512,10 +511,10 @@ func agentTestEnv(t *testing.T, nodeChangeCh chan *NodeChanges, tlsChangeCh chan
 	cleanup = append(cleanup, mockDispatcherStop)
 
 	fr := &fakeRemotes{}
-	broker := connectionbroker.New(fr)
+	broker := connectionbroker.New(fr, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(4200000)))
 	if localDispatcher {
 		insecureCreds := credentials.NewTLS(&tls.Config{InsecureSkipVerify: true})
-		conn, err := grpc.Dial(
+		err := broker.SetLocalConn(
 			mockDispatcher.Addr,
 			grpc.WithTransportCredentials(insecureCreds),
 			grpc.WithDialer(
@@ -524,9 +523,8 @@ func agentTestEnv(t *testing.T, nodeChangeCh chan *NodeChanges, tlsChangeCh chan
 				}),
 		)
 		require.NoError(t, err)
+		conn := broker.GetLocalConn()
 		cleanup = append(cleanup, func() { conn.Close() })
-
-		broker.SetLocalConn(conn)
 	} else {
 		fr.setPeer(api.Peer{Addr: mockDispatcher.Addr})
 	}

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -199,6 +199,9 @@ type NodeOptions struct {
 
 	// FIPS specifies whether the raft encryption should be FIPS compliant
 	FIPS bool
+
+	// TransportDefaultDialOptions is a slice of Dial Options set to the raft node
+	TransportDefaultDialOptions []grpc.DialOption
 }
 
 func init() {
@@ -363,10 +366,11 @@ func (n *Node) WithContext(ctx context.Context) (context.Context, context.Cancel
 
 func (n *Node) initTransport() {
 	transportConfig := &transport.Config{
-		HeartbeatInterval: time.Duration(n.Config.ElectionTick) * n.opts.TickInterval,
-		SendTimeout:       n.opts.SendTimeout,
-		Credentials:       n.opts.TLSCredentials,
-		Raft:              n,
+		HeartbeatInterval:  time.Duration(n.Config.ElectionTick) * n.opts.TickInterval,
+		SendTimeout:        n.opts.SendTimeout,
+		Credentials:        n.opts.TLSCredentials,
+		Raft:               n,
+		DefaultDialOptions: n.opts.TransportDefaultDialOptions,
 	}
 	n.transport = transport.New(transportConfig)
 }

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -38,6 +38,8 @@ type Config struct {
 	SendTimeout       time.Duration
 	Credentials       credentials.TransportCredentials
 	RaftID            string
+	// DefaultDialOptions is a slice of Dial Options set to the raft transport
+	DefaultDialOptions []grpc.DialOption
 
 	Raft
 }
@@ -338,6 +340,7 @@ func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
 		grpc.WithBackoffMaxDelay(8 * time.Second),
 	}
+	grpcOptions = append(grpcOptions, t.config.DefaultDialOptions...)
 	if t.config.Credentials != nil {
 		grpcOptions = append(grpcOptions, grpc.WithTransportCredentials(t.config.Credentials))
 	} else {


### PR DESCRIPTION
Signed-off-by: nmengin <nicolas@containo.us>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Adding an option to allow users to give `DialOptions` to the `ConnectionBroker` and `raft.Transport` gRPC client connection.

**- How I did it**

By creating an option into the `node.Node` Configuration.

**- How to test it**

I modified the test to add `DialOption`.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Adding an entry into the Node configuration to allow users to customize the `DialOptions` for the `ConnectionBroker` and `raft.Transport` gRPC client connection.

Fixes #2733 