### PR TITLE
Add additional info for secret drivers

### DIFF
--- a/manager/drivers/secrets.go
+++ b/manager/drivers/secrets.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/api/naming"
 )
 
 const (
@@ -40,8 +41,14 @@ func (d *SecretDriver) Get(spec *api.SecretSpec, task *api.Task) ([]byte, bool, 
 	var secretResp SecretsProviderResponse
 	secretReq := &SecretsProviderRequest{
 		SecretName:    spec.Annotations.Name,
+		SecretLabels:  spec.Annotations.Labels,
+		ServiceID:     task.ServiceID,
 		ServiceName:   task.ServiceAnnotations.Name,
 		ServiceLabels: task.ServiceAnnotations.Labels,
+		TaskID:        task.ID,
+		TaskName:      naming.Task(task),
+		TaskImage:     task.Spec.GetContainer().Image,
+		NodeID:        task.NodeID,
 	}
 	container := task.Spec.GetContainer()
 	if container != nil {
@@ -82,9 +89,15 @@ func (d *SecretDriver) Get(spec *api.SecretSpec, task *api.Task) ([]byte, bool, 
 // SecretsProviderRequest is the secrets provider request.
 type SecretsProviderRequest struct {
 	SecretName          string            `json:",omitempty"` // SecretName is the name of the secret to request from the plugin
+	SecretLabels        map[string]string `json:",omitempty"` // SecretLabels capture environment names and other metadata pertaining to the secret
 	ServiceHostname     string            `json:",omitempty"` // ServiceHostname is the hostname of the service, can be used for x509 certificate
+	ServiceID           string            `json:",omitempty"` // ServiceID is the name of the service that requested the secret
 	ServiceName         string            `json:",omitempty"` // ServiceName is the name of the service that requested the secret
-	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata
+	ServiceLabels       map[string]string `json:",omitempty"` // ServiceLabels capture environment names and other metadata pertaining to the service
+	TaskID              string            `json:",omitempty"` // TaskID is the ID of the task that the secret will be assigned to
+	TaskName            string            `json:",omitempty"` // TaskName is the name of the task that the secret will be assigned to
+	TaskImage           string            `json:",omitempty"` // TaskName is the image of the task that the secret will be assigned to
+	NodeID              string            `json:",omitempty"` // NodeID is the ID of the node that the task will be executed on
 	ServiceEndpointSpec *EndpointSpec     `json:",omitempty"` // ServiceEndpointSpec holds the specification for endpoints
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I added the following fields to the type SecretsProviderRequest:
* SecretLabels
* ServiceID
* TaskID
* TaskName
* TaskImage
* NodeID

This provides more context for the secret driver when it is requested the value for the secret. It is useful both for audit purposes, e.g. an external system (such as HashiCorp Vault) logging which task requested what secret, as well as in a scenario where the plugin would return a different value (or error) based on e.g. labels on the secret.

**- How I did it**
I added the fields to the type and to the struct when it is built for the request to be made.

**- How to test it**
Write a plugin that makes use of the new fields. This would be made easier if https://github.com/docker/go-plugins-helpers/pull/111 were merged.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Provide additional secret, task and node context for secret driver plugins.