### PR TITLE
Fix docs formatting typo

### DIFF
--- a/design/task_model.md
+++ b/design/task_model.md
@@ -127,7 +127,7 @@ that the requested node has the necessary resources, in the case of global
 services' tasks). It changes their state to `ASSIGNED`.
 
 From this point, control over the state passes to the agent. A task will
-progress through the `ACCEPTED`, `PREPARING`, `READY', and `STARTING` states on
+progress through the `ACCEPTED`, `PREPARING`, `READY`, and `STARTING` states on
 the way to `RUNNING`. If a task exits without an error code, it moves to the
 `COMPLETE` state. If it fails, it moves to the `FAILED` state instead.
 


### PR DESCRIPTION
backtick shoud be used instead of quote for pre-formatted block.

Signed-off-by: Shaan Malik <shaanmalik@gmail.com>