### PR TITLE
Use gometalinter; switch from x/net/context -> context

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,6 +9,7 @@
 		"gofmt",
 		"goimports",
 		"golint",
+		"gosimple",
 		"ineffassign",
 		"deadcode",
 		"unconvert"

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -7,9 +7,11 @@
 		"vet",
 		"misspell",
 		"gofmt",
+		"goimports",
 		"golint",
 		"ineffassign",
-		"deadcode"
+		"deadcode",
+		"unconvert"
 	],
 	"Deadline": "2m"
 }

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -8,7 +8,8 @@
 		"misspell",
 		"gofmt",
 		"golint",
-		"ineffassign"
+		"ineffassign",
+		"deadcode"
 	],
 	"Deadline": "2m"
 }

--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,14 @@
+{
+	"Vendor": true,
+	"Exclude": [
+		".*\\.pb\\.go"
+	],
+	"Enable": [
+		"vet",
+		"misspell",
+		"gofmt",
+		"golint",
+		"ineffassign"
+	],
+	"Deadline": "2m"
+}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"bytes"
+	"context"
 	"math/rand"
 	"reflect"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"github.com/docker/swarmkit/xnet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 var localDispatcher = false
@@ -90,7 +90,8 @@ func TestAgentStartStop(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, agent)
 
-	ctx, _ := context.WithTimeout(tc.Context, 5000*time.Millisecond)
+	ctx, cancel := context.WithTimeout(tc.Context, 5000*time.Millisecond)
+	defer cancel()
 
 	assert.Equal(t, errAgentNotStarted, agent.Stop(ctx))
 	assert.NoError(t, agent.Start(ctx))

--- a/agent/errors.go
+++ b/agent/errors.go
@@ -13,10 +13,5 @@ var (
 	errAgentStarted    = errors.New("agent: already started")
 	errAgentNotStarted = errors.New("agent: not started")
 
-	errTaskNoController         = errors.New("agent: no task controller")
-	errTaskNotAssigned          = errors.New("agent: task not assigned")
-	errTaskStatusUpdateNoChange = errors.New("agent: no change in task status")
-	errTaskUnknown              = errors.New("agent: task unknown")
-
-	errTaskInvalid = errors.New("task: invalid")
+	errTaskUnknown = errors.New("agent: task unknown")
 )

--- a/agent/exec/controller.go
+++ b/agent/exec/controller.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Controller controls execution of a task.

--- a/agent/exec/controller_stub.go
+++ b/agent/exec/controller_stub.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
-	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
+	"context"
 	"runtime"
 	"strings"
+
+	"github.com/docker/swarmkit/api"
 )
 
 // StubController implements the Controller interface,

--- a/agent/exec/controller_test.go
+++ b/agent/exec/controller_test.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestResolve(t *testing.T) {

--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -1,6 +1,7 @@
 package dockerapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +17,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/agent/exec/dockerapi/adapter.go
+++ b/agent/exec/dockerapi/adapter.go
@@ -144,15 +144,13 @@ func (c *containerAdapter) removeNetworks(ctx context.Context) error {
 }
 
 func (c *containerAdapter) create(ctx context.Context) error {
-	if _, err := c.client.ContainerCreate(ctx,
+	_, err := c.client.ContainerCreate(ctx,
 		c.container.config(),
 		c.container.hostConfig(),
 		c.container.networkingConfig(),
-		c.container.name()); err != nil {
-		return err
-	}
+		c.container.name())
 
-	return nil
+	return err
 }
 
 func (c *containerAdapter) start(ctx context.Context) error {

--- a/agent/exec/dockerapi/controller.go
+++ b/agent/exec/dockerapi/controller.go
@@ -3,6 +3,7 @@ package dockerapi
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -19,7 +20,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 )
 

--- a/agent/exec/dockerapi/controller_integration_test.go
+++ b/agent/exec/dockerapi/controller_integration_test.go
@@ -1,6 +1,7 @@
 package dockerapi
 
 import (
+	"context"
 	"flag"
 	"testing"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/genericresource"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/agent/exec/dockerapi/controller_test.go
+++ b/agent/exec/dockerapi/controller_test.go
@@ -2,6 +2,7 @@ package dockerapi
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,7 +21,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 var tenSecond = 10 * time.Second

--- a/agent/exec/dockerapi/docker_client_stub.go
+++ b/agent/exec/dockerapi/docker_client_stub.go
@@ -1,16 +1,17 @@
 package dockerapi
 
 import (
+	"context"
+	"io"
+	"runtime"
+	"strings"
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/events"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
-	"golang.org/x/net/context"
-	"io"
-	"runtime"
-	"strings"
-	"time"
 )
 
 // StubAPIClient implements the client.APIClient interface, but allows

--- a/agent/exec/dockerapi/executor.go
+++ b/agent/exec/dockerapi/executor.go
@@ -1,8 +1,10 @@
 package dockerapi
 
 import (
+	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/docker/docker/api/types/filters"
 	engineapi "github.com/docker/docker/client"
@@ -10,8 +12,6 @@ import (
 	"github.com/docker/swarmkit/agent/secrets"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
-	"sync"
 )
 
 type executor struct {

--- a/agent/exec/executor.go
+++ b/agent/exec/executor.go
@@ -1,8 +1,9 @@
 package exec
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // Executor provides controllers for tasks.

--- a/agent/helpers.go
+++ b/agent/helpers.go
@@ -1,6 +1,6 @@
 package agent
 
-import "golang.org/x/net/context"
+import "context"
 
 // runctx blocks until the function exits, closed is closed, or the context is
 // cancelled. Call as part of go statement.

--- a/agent/reporter.go
+++ b/agent/reporter.go
@@ -1,12 +1,12 @@
 package agent
 
 import (
+	"context"
 	"reflect"
 	"sync"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // StatusReporter receives updates to task status. Method may be called

--- a/agent/reporter_test.go
+++ b/agent/reporter_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 type uniqueStatus struct {

--- a/agent/resource.go
+++ b/agent/resource.go
@@ -1,8 +1,9 @@
 package agent
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 type resourceAllocator struct {

--- a/agent/session.go
+++ b/agent/session.go
@@ -17,7 +17,6 @@ import (
 
 var (
 	dispatcherRPCTimeout = 5 * time.Second
-	errSessionDisconnect = errors.New("agent: session disconnect") // instructed to disconnect
 	errSessionClosed     = errors.New("agent: session closed")
 )
 

--- a/agent/session.go
+++ b/agent/session.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/connectionbroker"
 	"github.com/docker/swarmkit/log"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -137,7 +137,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	// `ctx` is done and hence fail to propagate the timeout error to the agent.
 	// If the error is not propogated to the agent, the agent will not close
 	// the session or rebuild a new session.
-	sessionCtx, cancelSession := context.WithCancel(ctx)
+	sessionCtx, cancelSession := context.WithCancel(ctx) // nolint: vet
 
 	// Need to run Session in a goroutine since there's no way to set a
 	// timeout for an individual Recv call in a stream.
@@ -160,7 +160,7 @@ func (s *session) start(ctx context.Context, description *api.NodeDescription) e
 	select {
 	case err := <-errChan:
 		if err != nil {
-			return err
+			return err // nolint: vet
 		}
 	case <-time.After(dispatcherRPCTimeout):
 		cancelSession()

--- a/agent/task.go
+++ b/agent/task.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/equality"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // taskManager manages all aspects of task execution and reporting for an agent

--- a/agent/task_test.go
+++ b/agent/task_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func init() {

--- a/agent/testutils/fakes.go
+++ b/agent/testutils/fakes.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/log"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 // TestExecutor is executor for integration tests

--- a/agent/testutils/fakes.go
+++ b/agent/testutils/fakes.go
@@ -140,17 +140,13 @@ func (m *MockDispatcher) UpdateTaskStatus(context.Context, *api.UpdateTaskStatus
 
 // Tasks keeps an open stream until canceled
 func (m *MockDispatcher) Tasks(_ *api.TasksRequest, stream api.Dispatcher_TasksServer) error {
-	select {
-	case <-stream.Context().Done():
-	}
+	<-stream.Context().Done()
 	return nil
 }
 
 // Assignments keeps an open stream until canceled
 func (m *MockDispatcher) Assignments(_ *api.AssignmentsRequest, stream api.Dispatcher_AssignmentsServer) error {
-	select {
-	case <-stream.Context().Done():
-	}
+	<-stream.Context().Done()
 	return nil
 }
 

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/swarmkit/agent/exec"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/watch"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/net/context"
 )
 
 // Worker implements the core task management logic and persistence. It

--- a/agent/worker_test.go
+++ b/agent/worker_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/swarmkit/agent/exec"
@@ -9,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/net/context"
 )
 
 type testPublisherProvider struct {

--- a/api/genericresource/resource_management.go
+++ b/api/genericresource/resource_management.go
@@ -2,6 +2,7 @@ package genericresource
 
 import (
 	"fmt"
+
 	"github.com/docker/swarmkit/api"
 )
 

--- a/api/genericresource/validate.go
+++ b/api/genericresource/validate.go
@@ -2,6 +2,7 @@ package genericresource
 
 import (
 	"fmt"
+
 	"github.com/docker/swarmkit/api"
 )
 

--- a/ca/auth.go
+++ b/ca/auth.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509/pkix"
 	"strings"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/peer"

--- a/ca/certificates.go
+++ b/ca/certificates.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -31,7 +32,6 @@ import (
 	"github.com/docker/swarmkit/ioutils"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -1,6 +1,7 @@
 package ca_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	cryptorand "crypto/rand"
@@ -38,7 +39,6 @@ import (
 	"github.com/phayes/permbits"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/status"
 )
 
@@ -748,7 +748,8 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	// make sure if we time out the GetRemoteSignedCertificate call, it cancels immediately and doesn't keep
 	// polling the status
 	go func() {
-		ctx, _ := context.WithTimeout(tc.Context, 1*time.Second)
+		ctx, cancel := context.WithTimeout(tc.Context, 1*time.Second)
+		defer cancel()
 		_, err := ca.GetRemoteSignedCertificate(ctx, csr, tc.RootCA.Pool,
 			ca.CertificateRequestConfig{
 				Token:      tc.WorkerToken,

--- a/ca/certificates_test.go
+++ b/ca/certificates_test.go
@@ -706,12 +706,10 @@ func TestGetRemoteSignedCertificateWithPending(t *testing.T) {
 	var node *api.Node
 	// wait for a new node to show up
 	for node == nil {
-		select {
-		case event := <-updates: // we want to skip the first node, which is the test CA
-			n := event.(api.EventCreateNode).Node.Copy()
-			if n.Certificate.Status.State == api.IssuanceStatePending {
-				node = n
-			}
+		event := <-updates // we want to skip the first node, which is the test CA
+		n := event.(api.EventCreateNode).Node.Copy()
+		if n.Certificate.Status.State == api.IssuanceStatePending {
+			node = n
 		}
 	}
 

--- a/ca/config.go
+++ b/ca/config.go
@@ -31,7 +31,6 @@ const (
 	rootCAKeyFilename   = "swarm-root-ca.key"
 	nodeTLSCertFilename = "swarm-node.crt"
 	nodeTLSKeyFilename  = "swarm-node.key"
-	nodeCSRFilename     = "swarm-node.csr"
 
 	// DefaultRootCN represents the root CN that we should create roots CAs with by default
 	DefaultRootCN = "swarm-ca"

--- a/ca/config.go
+++ b/ca/config.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -23,8 +24,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/credentials"
-
-	"golang.org/x/net/context"
 )
 
 const (

--- a/ca/config.go
+++ b/ca/config.go
@@ -624,7 +624,7 @@ func calculateRandomExpiry(validFrom, validUntil time.Time) time.Duration {
 	if maxValidity-minValidity < 1 {
 		randomExpiry = minValidity
 	} else {
-		randomExpiry = rand.Intn(maxValidity-minValidity) + int(minValidity)
+		randomExpiry = rand.Intn(maxValidity-minValidity) + minValidity
 	}
 
 	expiry := validFrom.Add(time.Duration(randomExpiry) * time.Minute).Sub(time.Now())

--- a/ca/config.go
+++ b/ca/config.go
@@ -627,7 +627,7 @@ func calculateRandomExpiry(validFrom, validUntil time.Time) time.Duration {
 		randomExpiry = rand.Intn(maxValidity-minValidity) + minValidity
 	}
 
-	expiry := validFrom.Add(time.Duration(randomExpiry) * time.Minute).Sub(time.Now())
+	expiry := time.Until(validFrom.Add(time.Duration(randomExpiry) * time.Minute))
 	if expiry < 0 {
 		return 0
 	}

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -2,6 +2,7 @@ package ca_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -15,8 +16,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-
-	"golang.org/x/net/context"
 
 	cfconfig "github.com/cloudflare/cfssl/config"
 	"github.com/cloudflare/cfssl/helpers"

--- a/ca/config_test.go
+++ b/ca/config_test.go
@@ -787,24 +787,22 @@ func TestRenewTLSConfigUpdatesRootNonUnknownAuthError(t *testing.T) {
 	go func() {
 		updates, cancel := state.Watch(tc.MemoryStore.WatchQueue(), api.EventCreateNode{})
 		defer cancel()
-		select {
-		case event := <-updates: // we want to skip the first node, which is the test CA
-			n := event.(api.EventCreateNode).Node
-			if n.Certificate.Status.State == api.IssuanceStatePending {
-				signErr <- tc.MemoryStore.Update(func(tx store.Tx) error {
-					node := store.GetNode(tx, n.ID)
-					certChain, err := rootCA.ParseValidateAndSignCSR(node.Certificate.CSR, node.Certificate.CN, ca.WorkerRole, tc.Organization)
-					if err != nil {
-						return err
-					}
-					node.Certificate.Certificate = cautils.ReDateCert(t, certChain, cert, key, time.Now().Add(-5*time.Hour), time.Now().Add(-4*time.Hour))
-					node.Certificate.Status = api.IssuanceStatus{
-						State: api.IssuanceStateIssued,
-					}
-					return store.UpdateNode(tx, node)
-				})
-				return
-			}
+		event := <-updates // we want to skip the first node, which is the test CA
+		n := event.(api.EventCreateNode).Node
+		if n.Certificate.Status.State == api.IssuanceStatePending {
+			signErr <- tc.MemoryStore.Update(func(tx store.Tx) error {
+				node := store.GetNode(tx, n.ID)
+				certChain, err := rootCA.ParseValidateAndSignCSR(node.Certificate.CSR, node.Certificate.CN, ca.WorkerRole, tc.Organization)
+				if err != nil {
+					return err
+				}
+				node.Certificate.Certificate = cautils.ReDateCert(t, certChain, cert, key, time.Now().Add(-5*time.Hour), time.Now().Add(-4*time.Hour))
+				node.Certificate.Status = api.IssuanceStatus{
+					State: api.IssuanceStateIssued,
+				}
+				return store.UpdateNode(tx, node)
+			})
+			return
 		}
 	}()
 

--- a/ca/external.go
+++ b/ca/external.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	cryptorand "crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
@@ -21,7 +22,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/ca/external_test.go
+++ b/ca/external_test.go
@@ -113,9 +113,7 @@ func TestExternalCASignRequestTimesOut(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(http.ResponseWriter, *http.Request) {
 		// hang forever
-		select {
-		case <-allDone:
-		}
+		<-allDone
 	})
 
 	server := httptest.NewServer(mux)

--- a/ca/forward.go
+++ b/ca/forward.go
@@ -1,7 +1,8 @@
 package ca
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )

--- a/ca/renewer.go
+++ b/ca/renewer.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // RenewTLSExponentialBackoff sets the exponential backoff when trying to renew TLS certificates that have expired

--- a/ca/renewer_test.go
+++ b/ca/renewer_test.go
@@ -1,6 +1,7 @@
 package ca_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestForceRenewTLSConfig(t *testing.T) {

--- a/ca/server.go
+++ b/ca/server.go
@@ -2,6 +2,7 @@ package ca
 
 import (
 	"bytes"
+	"context"
 	"crypto/subtle"
 	"crypto/x509"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/ca/server_test.go
+++ b/ca/server_test.go
@@ -2,6 +2,7 @@ package ca_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 

--- a/ca/testutils/cautils.go
+++ b/ca/testutils/cautils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"crypto"
 	cryptorand "crypto/rand"
 	"crypto/tls"
@@ -29,7 +30,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -18,12 +18,6 @@ var (
 	alpnProtoStr = []string{"h2"}
 )
 
-type timeoutError struct{}
-
-func (timeoutError) Error() string   { return "mutablecredentials: Dial timed out" }
-func (timeoutError) Timeout() bool   { return true }
-func (timeoutError) Temporary() bool { return true }
-
 // MutableTLSCreds is the credentials required for authenticating a connection using TLS.
 type MutableTLSCreds struct {
 	// Mutex for the tls config

--- a/ca/transport.go
+++ b/ca/transport.go
@@ -1,6 +1,7 @@
 package ca
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -9,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
 )
 

--- a/cmd/swarm-bench/benchmark.go
+++ b/cmd/swarm-bench/benchmark.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"time"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/cmd/swarm-bench/collector.go
+++ b/cmd/swarm-bench/collector.go
@@ -23,10 +23,7 @@ type Collector struct {
 func (c *Collector) Listen(port int) error {
 	var err error
 	c.ln, err = net.Listen("tcp", ":"+strconv.Itoa(port))
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Collect blocks until `count` tasks phoned home.

--- a/cmd/swarm-bench/collector.go
+++ b/cmd/swarm-bench/collector.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/docker/swarmkit/log"
 	"github.com/rcrowley/go-metrics"
-	"golang.org/x/net/context"
 )
 
 // Collector waits for tasks to phone home while collecting statistics.

--- a/cmd/swarm-bench/main.go
+++ b/cmd/swarm-bench/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/cmd/swarm-rafttool/common.go
+++ b/cmd/swarm-rafttool/common.go
@@ -1,12 +1,11 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/wal/walpb"

--- a/cmd/swarmctl/cluster/common.go
+++ b/cmd/swarmctl/cluster/common.go
@@ -1,9 +1,8 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 )

--- a/cmd/swarmctl/common/common.go
+++ b/cmd/swarmctl/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 	"strings"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/xnet"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/cmd/swarmctl/common/resolver.go
+++ b/cmd/swarmctl/common/resolver.go
@@ -1,11 +1,11 @@
 package common
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 // Resolver provides ID to Name resolution.

--- a/cmd/swarmctl/config/common.go
+++ b/cmd/swarmctl/config/common.go
@@ -1,10 +1,10 @@
 package config
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 func getConfig(ctx context.Context, c api.ControlClient, input string) (*api.Config, error) {

--- a/cmd/swarmctl/network/common.go
+++ b/cmd/swarmctl/network/common.go
@@ -1,10 +1,10 @@
 package network
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // GetNetwork tries to query for a network as an ID and if it can't be

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -48,11 +48,7 @@ func changeNodeAvailability(cmd *cobra.Command, args []string, availability api.
 		Spec:        spec,
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func changeNodeRole(cmd *cobra.Command, args []string, role api.NodeRole) error {
@@ -86,11 +82,7 @@ func changeNodeRole(cmd *cobra.Command, args []string, role api.NodeRole) error 
 		Spec:        spec,
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func getNode(ctx context.Context, c api.ControlClient, input string) (*api.Node, error) {
@@ -169,9 +161,5 @@ func updateNode(cmd *cobra.Command, args []string) error {
 		Spec:        spec,
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -1,12 +1,11 @@
 package node
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/cmd/swarmctl/common"

--- a/cmd/swarmctl/node/common.go
+++ b/cmd/swarmctl/node/common.go
@@ -55,44 +55,6 @@ func changeNodeAvailability(cmd *cobra.Command, args []string, availability api.
 	return nil
 }
 
-func changeNodeMembership(cmd *cobra.Command, args []string, membership api.NodeSpec_Membership) error {
-	if len(args) == 0 {
-		return errors.New("missing node ID")
-	}
-
-	if len(args) > 1 {
-		return errors.New("command takes exactly 1 argument")
-	}
-
-	c, err := common.Dial(cmd)
-	if err != nil {
-		return err
-	}
-	node, err := getNode(common.Context(cmd), c, args[0])
-	if err != nil {
-		return err
-	}
-	spec := &node.Spec
-
-	if spec.Membership == membership {
-		return errNoChange
-	}
-
-	spec.Membership = membership
-
-	_, err = c.UpdateNode(common.Context(cmd), &api.UpdateNodeRequest{
-		NodeID:      node.ID,
-		NodeVersion: &node.Meta.Version,
-		Spec:        spec,
-	})
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func changeNodeRole(cmd *cobra.Command, args []string, role api.NodeRole) error {
 	if len(args) == 0 {
 		return errors.New("missing node ID")

--- a/cmd/swarmctl/secret/common.go
+++ b/cmd/swarmctl/secret/common.go
@@ -1,10 +1,10 @@
 package secret
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 func getSecret(ctx context.Context, c api.ControlClient, input string) (*api.Secret, error) {

--- a/cmd/swarmctl/service/common.go
+++ b/cmd/swarmctl/service/common.go
@@ -1,9 +1,8 @@
 package service
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 )

--- a/cmd/swarmctl/service/logs.go
+++ b/cmd/swarmctl/service/logs.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/cmd/swarmctl/common"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/cmd/swarmd/main.go
+++ b/cmd/swarmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	_ "expvar"
 	"fmt"
 	"net"
@@ -23,7 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/net/context"
 )
 
 var externalCAOpt cli.ExternalCAOpt

--- a/direct.mk
+++ b/direct.mk
@@ -1,9 +1,6 @@
 .DEFAULT_GOAL = all
 .PHONY: all
-all: check binaries test integration-tests ## run fmt, vet, lint, build the binaries and run the tests
-
-.PHONY: check
-check: fmt vet lint ineffassign misspell
+all: check binaries test integration-tests ## run check, build the binaries and run the tests
 
 .PHONY: ci
 ci: check binaries checkprotos coverage coverage-integration ## to be used by the CI
@@ -20,10 +17,8 @@ version/version.go:
 setup: ## install dependencies
 	@echo "🐳 $@"
 	# TODO(stevvooe): Install these from the vendor directory
-	@go get -u github.com/golang/lint/golint
-	#@go get -u github.com/kisielk/errcheck
-	@go get -u github.com/gordonklaus/ineffassign
-	@go get -u github.com/client9/misspell/cmd/misspell
+	@go get -u github.com/alecthomas/gometalinter
+	@gometalinter --install
 	@go get -u github.com/lk4d4/vndr
 	@go get -u github.com/stevvooe/protobuild
 
@@ -44,41 +39,18 @@ checkprotos: generate ## check if protobufs needs to be generated again
 		((git diff | cat) && \
 		(echo "👹 please run 'make generate' when making changes to proto files" && false))
 
-# Depends on binaries because vet will silently fail if it can't load compiled
-# imports
-.PHONY: vet
-vet: binaries ## run go vet
+.PHONY: check
+check: fmt-proto
+check: ## Run various source code validation tools
 	@echo "🐳 $@"
-	@test -z "$$(go vet ${PACKAGES} 2>&1 | grep -v 'constant [0-9]* not a string in call to Errorf' | egrep -v '(timestamp_test.go|duration_test.go|exit status 1)' | tee /dev/stderr)"
+	@gometalinter ./...
 
-.PHONY: misspell
-misspell:
-	@echo "🐳 $@"
-	@test -z "$$(find . -type f | grep -v vendor/ | grep -v bin/ | grep -v .git/ | grep -v MAINTAINERS | xargs misspell | tee /dev/stderr)"
-
-.PHONY: fmt
-fmt: ## run go fmt
-	@echo "🐳 $@"
-	@test -z "$$(gofmt -s -l . | grep -v vendor/ | grep -v ".pb.go$$" | tee /dev/stderr)" || \
-		(echo "👹 please format Go code with 'gofmt -s -w'" && false)
+.PHONY: fmt-proto
+fmt-proto:
 	@test -z "$$(find . -path ./vendor -prune -o ! -name timestamp.proto ! -name duration.proto -name '*.proto' -type f -exec grep -Hn -e "^ " {} \; | tee /dev/stderr)" || \
 		(echo "👹 please indent proto files with tabs only" && false)
 	@test -z "$$(find . -path ./vendor -prune -o -name '*.proto' -type f -exec grep -Hn "Meta meta = " {} \; | grep -v '(gogoproto.nullable) = false' | tee /dev/stderr)" || \
 		(echo "👹 meta fields in proto files must have option (gogoproto.nullable) = false" && false)
-
-.PHONY: lint
-lint: ## run go lint
-	@echo "🐳 $@"
-	@test -z "$$(golint ./... | grep -v vendor/ | grep -v ".pb.go:" | tee /dev/stderr)"
-
-.PHONY: ineffassign
-ineffassign: ## run ineffassign
-	@echo "🐳 $@"
-	@test -z "$$(ineffassign . | grep -v vendor/ | grep -v ".pb.go:" | tee /dev/stderr)"
-
-#errcheck: ## run go errcheck
-#	@echo "🐳 $@"
-#	@test -z "$$(errcheck ./... | grep -v vendor/ | grep -v ".pb.go:" | tee /dev/stderr)"
 
 .PHONY: build
 build: ## build the go packages

--- a/integration/api.go
+++ b/integration/api.go
@@ -1,8 +1,9 @@
 package integration
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 type dummyAPI struct {

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math/rand"
@@ -19,7 +20,6 @@ import (
 	"github.com/docker/swarmkit/node"
 	"github.com/docker/swarmkit/testutils"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const opsTimeout = 64 * time.Second

--- a/integration/cluster.go
+++ b/integration/cluster.go
@@ -39,23 +39,6 @@ type testCluster struct {
 
 var testnameKey struct{}
 
-// NewCluster creates new cluster to which nodes can be added.
-// AcceptancePolicy is set to most permissive mode on first manager node added.
-func newTestCluster(testname string, fips bool) *testCluster {
-	ctx, cancel := context.WithCancel(context.Background())
-	ctx = context.WithValue(ctx, testnameKey, testname)
-	c := &testCluster{
-		ctx:        ctx,
-		cancel:     cancel,
-		nodes:      make(map[string]*testNode),
-		nodesOrder: make(map[string]int),
-		errs:       make(chan error, 1024),
-		fips:       fips,
-	}
-	c.api = &dummyAPI{c: c}
-	return c
-}
-
 // Stop makes best effort to stop all nodes and close connections to them.
 func (c *testCluster) Stop() error {
 	c.cancel()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -13,8 +14,6 @@ import (
 	"time"
 
 	"github.com/docker/swarmkit/node"
-
-	"golang.org/x/net/context"
 
 	"reflect"
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -62,6 +62,23 @@ func TestMain(m *testing.M) {
 	os.Exit(res)
 }
 
+// newTestCluster creates new cluster to which nodes can be added.
+// AcceptancePolicy is set to most permissive mode on first manager node added.
+func newTestCluster(testname string, fips bool) *testCluster {
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, testnameKey, testname)
+	c := &testCluster{
+		ctx:        ctx,
+		cancel:     cancel,
+		nodes:      make(map[string]*testNode),
+		nodesOrder: make(map[string]int),
+		errs:       make(chan error, 1024),
+		fips:       fips,
+	}
+	c.api = &dummyAPI{c: c}
+	return c
+}
+
 // pollClusterReady calls control api until all conditions are true:
 // * all nodes are ready
 // * all managers has membership == accepted

--- a/integration/node.go
+++ b/integration/node.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/swarmkit/ca"
 	"github.com/docker/swarmkit/node"
 	"github.com/docker/swarmkit/testutils"
-	"golang.org/x/net/context"
 )
 
 // TestNode is representation of *agent.Node. It stores listeners, connections,

--- a/ioutils/ioutils_test.go
+++ b/ioutils/ioutils_test.go
@@ -25,7 +25,7 @@ func TestAtomicWriteToFile(t *testing.T) {
 		t.Fatalf("Error reading from file: %v", err)
 	}
 
-	if bytes.Compare(actual, expected) != 0 {
+	if !bytes.Equal(actual, expected) {
 		t.Fatalf("Data mismatch, expected %q, got %q", expected, actual)
 	}
 }

--- a/log/context.go
+++ b/log/context.go
@@ -1,10 +1,10 @@
 package log
 
 import (
+	"context"
 	"path"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -1,10 +1,10 @@
 package log
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestLoggerContext(t *testing.T) {

--- a/log/grpc.go
+++ b/log/grpc.go
@@ -1,8 +1,9 @@
 package log
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/grpclog"
 )
 

--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/docker/pkg/plugingetter"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator/cnmallocator"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // Allocator controls how the allocation stage in the manager is handled.

--- a/manager/allocator/allocator_linux_test.go
+++ b/manager/allocator/allocator_linux_test.go
@@ -1,9 +1,8 @@
 package allocator
 
 import (
+	"context"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"

--- a/manager/allocator/allocator_test.go
+++ b/manager/allocator/allocator_test.go
@@ -1,13 +1,12 @@
 package allocator
 
 import (
+	"context"
 	"net"
 	"runtime/debug"
 	"strconv"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"

--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -1,6 +1,7 @@
 package cnmallocator
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -815,8 +815,7 @@ func (na *cnmNetworkAllocator) resolveDriver(n *api.Network) (*networkDriver, er
 
 	d, drvcap := na.drvRegistry.Driver(dName)
 	if d == nil {
-		var err error
-		err = na.loadDriver(dName)
+		err := na.loadDriver(dName)
 		if err != nil {
 			return nil, err
 		}

--- a/manager/allocator/cnmallocator/portallocator.go
+++ b/manager/allocator/cnmallocator/portallocator.go
@@ -407,12 +407,12 @@ func (ps *portSpace) allocate(p *api.PortConfig) (err error) {
 	}
 	defer func() {
 		if err != nil {
-			ps.dynamicPortSpace.Release(uint64(swarmPort))
+			ps.dynamicPortSpace.Release(swarmPort)
 		}
 	}()
 
 	// Make sure we allocate the same port from the master space.
-	if err = ps.masterPortSpace.GetSpecificID(uint64(swarmPort)); err != nil {
+	if err = ps.masterPortSpace.GetSpecificID(swarmPort); err != nil {
 		return
 	}
 

--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -1,6 +1,7 @@
 package allocator
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/constraint/constraint.go
+++ b/manager/constraint/constraint.go
@@ -56,7 +56,7 @@ func Parse(env []string) ([]Constraint, error) {
 			part0 := strings.TrimSpace(parts[0])
 			// validate key
 			matched := alphaNumeric.MatchString(part0)
-			if matched == false {
+			if !matched {
 				return nil, fmt.Errorf("key '%s' is invalid", part0)
 			}
 
@@ -64,7 +64,7 @@ func Parse(env []string) ([]Constraint, error) {
 
 			// validate Value
 			matched = valuePattern.MatchString(part1)
-			if matched == false {
+			if !matched {
 				return nil, fmt.Errorf("value '%s' is invalid", part1)
 			}
 			// TODO(dongluochen): revisit requirements to see if globing or regex are useful

--- a/manager/controlapi/cluster.go
+++ b/manager/controlapi/cluster.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/cluster_test.go
+++ b/manager/controlapi/cluster_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 

--- a/manager/controlapi/config.go
+++ b/manager/controlapi/config.go
@@ -2,6 +2,7 @@ package controlapi
 
 import (
 	"bytes"
+	"context"
 	"strings"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/config_test.go
+++ b/manager/controlapi/config_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"net"
 
 	"github.com/docker/docker/pkg/plugingetter"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator"
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -1,10 +1,10 @@
 package controlapi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/swarmkit/testutils"
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc/codes"
 

--- a/manager/controlapi/node.go
+++ b/manager/controlapi/node.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/node_test.go
+++ b/manager/controlapi/node_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"testing"
@@ -14,7 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 )

--- a/manager/controlapi/secret.go
+++ b/manager/controlapi/secret.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"crypto/subtle"
 	"strings"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/secret_test.go
+++ b/manager/controlapi/secret_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	stateutils "github.com/docker/swarmkit/manager/state/testutils"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 type testServer struct {

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/swarmkit/protobuf/ptypes"
 	"github.com/docker/swarmkit/template"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -197,7 +197,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if interval != 0 && interval < time.Duration(minimumDuration) {
+		if interval != 0 && interval < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: Interval in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}
@@ -207,7 +207,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if timeout != 0 && timeout < time.Duration(minimumDuration) {
+		if timeout != 0 && timeout < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: Timeout in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}
@@ -217,7 +217,7 @@ func validateHealthCheck(hc *api.HealthConfig) error {
 		if err != nil {
 			return err
 		}
-		if sp != 0 && sp < time.Duration(minimumDuration) {
+		if sp != 0 && sp < minimumDuration {
 			return status.Errorf(codes.InvalidArgument, "ContainerSpec: StartPeriod in HealthConfig cannot be less than %s", minimumDuration)
 		}
 	}

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -1,6 +1,7 @@
 package controlapi
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/testutils"
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 )
 

--- a/manager/controlapi/task.go
+++ b/manager/controlapi/task.go
@@ -1,11 +1,12 @@
 package controlapi
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/naming"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/controlapi/task_test.go
+++ b/manager/controlapi/task_test.go
@@ -1,11 +1,11 @@
 package controlapi
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/docker/swarmkit/testutils"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	"github.com/docker/swarmkit/api"

--- a/manager/dirty_test.go
+++ b/manager/dirty_test.go
@@ -1,11 +1,10 @@
 package manager
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/ca"

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1090,14 +1090,10 @@ func (d *Dispatcher) moveTasksToOrphaned(nodeID string) error {
 				task.Status.State = api.TaskStateOrphaned
 			}
 
-			if err := batch.Update(func(tx store.Tx) error {
-				err := store.UpdateTask(tx, task)
-				if err != nil {
-					return err
-				}
-
-				return nil
-			}); err != nil {
+			err := batch.Update(func(tx store.Tx) error {
+				return store.UpdateTask(tx, task)
+			})
+			if err != nil {
 				return err
 			}
 

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -2087,7 +2087,6 @@ func (m *mockPluginGetter) GetAllManagedPluginsByCap(capability string) []plugin
 	return nil
 }
 func (m *mockPluginGetter) Handle(capability string, callback func(string, *plugins.Client)) {
-	return
 }
 
 // MockPlugin mocks a v2 docker plugin

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -1,6 +1,7 @@
 package dispatcher
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -12,8 +13,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/manager/dispatcher/nodes.go
+++ b/manager/dispatcher/nodes.go
@@ -156,7 +156,7 @@ func (s *nodeStore) Heartbeat(id, sid string) (time.Duration, error) {
 		return 0, err
 	}
 	period := s.periodChooser.Choose() // base period for node
-	grace := period * time.Duration(s.gracePeriodMultiplierNormal)
+	grace := period * s.gracePeriodMultiplierNormal
 	rn.mu.Lock()
 	rn.Heartbeat.Update(grace)
 	rn.Heartbeat.Beat()

--- a/manager/health/health.go
+++ b/manager/health/health.go
@@ -8,10 +8,10 @@
 package health
 
 import (
+	"context"
 	"sync"
 
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/keymanager/keymanager.go
+++ b/manager/keymanager/keymanager.go
@@ -6,6 +6,7 @@ package keymanager
 // which is used to exchange service discovery and overlay network control
 // plane information. It can also be used to encrypt overlay data traffic.
 import (
+	"context"
 	cryptorand "crypto/rand"
 	"encoding/binary"
 	"sync"
@@ -15,7 +16,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/keymanager/keymanager_test.go
+++ b/manager/keymanager/keymanager_test.go
@@ -2,13 +2,13 @@ package keymanager
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func createClusterSpec(name string) *api.ClusterSpec {

--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/logbroker/broker_test.go
+++ b/manager/logbroker/broker_test.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -8,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/docker/swarmkit/api"

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -1,6 +1,7 @@
 package logbroker
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/watch"
-	"golang.org/x/net/context"
 )
 
 type subscription struct {

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -45,7 +46,6 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1002,9 +1002,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			cluster = store.GetCluster(tx, clusterID)
 		})
 		if cluster.DefaultAddressPool != nil {
-			for _, address := range cluster.DefaultAddressPool {
-				m.config.NetworkConfig.DefaultAddrPool = append(m.config.NetworkConfig.DefaultAddrPool, address)
-			}
+			m.config.NetworkConfig.DefaultAddrPool = append(m.config.NetworkConfig.DefaultAddrPool, cluster.DefaultAddressPool...)
 			m.config.NetworkConfig.SubnetSize = cluster.SubnetSize
 		}
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/pem"
 	"errors"
@@ -11,8 +12,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/manager/metrics/collector.go
+++ b/manager/metrics/collector.go
@@ -188,7 +188,6 @@ func (c *Collector) handleNodeEvent(event events.Event) {
 	if newNode != nil {
 		nodesMetric.WithValues(strings.ToLower(newNode.Status.State.String())).Inc(1)
 	}
-	return
 }
 
 func (c *Collector) handleTaskEvent(event events.Event) {
@@ -218,8 +217,6 @@ func (c *Collector) handleTaskEvent(event events.Event) {
 			strings.ToLower(newTask.Status.State.String()),
 		).Inc(1)
 	}
-
-	return
 }
 
 func (c *Collector) handleServiceEvent(event events.Event) {

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -1,6 +1,8 @@
 package global
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/constraint"
@@ -9,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator/taskinit"
 	"github.com/docker/swarmkit/manager/orchestrator/update"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 type globalService struct {

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -586,11 +586,3 @@ func (g *Orchestrator) SlotTuple(t *api.Task) orchestrator.SlotTuple {
 		NodeID:    t.NodeID,
 	}
 }
-
-func isTaskCompleted(t *api.Task, restartPolicy api.RestartPolicy_RestartCondition) bool {
-	if t == nil || t.DesiredState <= api.TaskStateRunning {
-		return false
-	}
-	return restartPolicy == api.RestartOnNone ||
-		(restartPolicy == api.RestartOnFailure && t.Status.State == api.TaskStateCompleted)
-}

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -1,6 +1,7 @@
 package global
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,7 +14,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/manager/orchestrator/replicated/drain_test.go
+++ b/manager/orchestrator/replicated/drain_test.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/swarmkit/api"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 func TestDrain(t *testing.T) {

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -1,12 +1,13 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
 	"github.com/docker/swarmkit/manager/orchestrator/update"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // An Orchestrator runs a reconciliation loop to create and destroy

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestReplicatedOrchestrator(t *testing.T) {

--- a/manager/orchestrator/replicated/restart_test.go
+++ b/manager/orchestrator/replicated/restart_test.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestOrchestratorRestartOnAny(t *testing.T) {

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"sort"
 
 	"github.com/docker/go-events"
@@ -8,7 +9,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // This file provices service-level orchestration. It observes changes to

--- a/manager/orchestrator/replicated/slot.go
+++ b/manager/orchestrator/replicated/slot.go
@@ -1,10 +1,11 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 type slotsByRunningState []orchestrator.Slot

--- a/manager/orchestrator/replicated/tasks.go
+++ b/manager/orchestrator/replicated/tasks.go
@@ -1,13 +1,14 @@
 package replicated
 
 import (
+	"context"
+
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/orchestrator/taskinit"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // This file provides task-level orchestration. It observes changes to task

--- a/manager/orchestrator/replicated/update_test.go
+++ b/manager/orchestrator/replicated/update_test.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -12,7 +13,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestUpdaterRollback(t *testing.T) {

--- a/manager/orchestrator/restart/restart.go
+++ b/manager/orchestrator/restart/restart.go
@@ -2,6 +2,7 @@ package restart
 
 import (
 	"container/list"
+	"context"
 	"errors"
 	"sync"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 )
 
 const defaultOldTaskTimeout = time.Minute

--- a/manager/orchestrator/service.go
+++ b/manager/orchestrator/service.go
@@ -1,10 +1,11 @@
 package orchestrator
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 // IsReplicatedService checks if a service is a replicated service.

--- a/manager/orchestrator/task_test.go
+++ b/manager/orchestrator/task_test.go
@@ -1,11 +1,12 @@
 package orchestrator
 
 import (
-	google_protobuf "github.com/gogo/protobuf/types"
-	"github.com/stretchr/testify/assert"
 	"sort"
 	"strconv"
 	"testing"
+
+	google_protobuf "github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/docker/swarmkit/api"
 )

--- a/manager/orchestrator/taskinit/init.go
+++ b/manager/orchestrator/taskinit/init.go
@@ -1,6 +1,7 @@
 package taskinit
 
 import (
+	"context"
 	"sort"
 	"time"
 
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator/restart"
 	"github.com/docker/swarmkit/manager/state/store"
 	gogotypes "github.com/gogo/protobuf/types"
-	"golang.org/x/net/context"
 )
 
 // InitHandler defines orchestrator's action to fix tasks at start.

--- a/manager/orchestrator/taskinit/init.go
+++ b/manager/orchestrator/taskinit/init.go
@@ -80,7 +80,7 @@ func CheckTasks(ctx context.Context, s *store.MemoryStore, readTx store.ReadTx, 
 				}
 				if err == nil {
 					restartTime := timestamp.Add(restartDelay)
-					calculatedRestartDelay := restartTime.Sub(time.Now())
+					calculatedRestartDelay := time.Until(restartTime)
 					if calculatedRestartDelay < restartDelay {
 						restartDelay = calculatedRestartDelay
 					}

--- a/manager/orchestrator/taskreaper/task_reaper.go
+++ b/manager/orchestrator/taskreaper/task_reaper.go
@@ -1,6 +1,7 @@
 package taskreaper
 
 import (
+	"context"
 	"sort"
 	"sync"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -1,13 +1,12 @@
 package update
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"

--- a/manager/orchestrator/update/updater_test.go
+++ b/manager/orchestrator/update/updater_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,7 +13,6 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func getRunnableSlotSlice(t *testing.T, s *store.MemoryStore, service *api.Service) []orchestrator.Slot {

--- a/manager/raftselector/raftselector.go
+++ b/manager/raftselector/raftselector.go
@@ -1,9 +1,8 @@
 package raftselector
 
 import (
+	"context"
 	"errors"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 )

--- a/manager/resourceapi/allocator.go
+++ b/manager/resourceapi/allocator.go
@@ -1,6 +1,7 @@
 package resourceapi
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/identity"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/manager/role_manager.go
+++ b/manager/role_manager.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/membership"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pivotal-golang/clock"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -1,12 +1,12 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/api/genericresource"
 	"github.com/docker/swarmkit/log"
-	"golang.org/x/net/context"
 )
 
 // hostPortSpec specifies a used host port.

--- a/manager/scheduler/scheduler.go
+++ b/manager/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"time"
 
 	"github.com/docker/swarmkit/api"
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/swarmkit/manager/state"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/docker/swarmkit/protobuf/ptypes"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/scheduler/scheduler_test.go
+++ b/manager/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"strconv"
@@ -16,7 +17,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestScheduler(t *testing.T) {

--- a/manager/state/proposer.go
+++ b/manager/state/proposer.go
@@ -1,8 +1,9 @@
 package state
 
 import (
+	"context"
+
 	"github.com/docker/swarmkit/api"
-	"golang.org/x/net/context"
 )
 
 // A Change includes a version number and a set of store actions from a

--- a/manager/state/raft/membership/cluster_test.go
+++ b/manager/state/raft/membership/cluster_test.go
@@ -1,14 +1,13 @@
 package membership_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc/grpclog"
 
@@ -279,7 +278,8 @@ func TestCanRemoveMember(t *testing.T) {
 
 	// Removing nodes at this point fails because we lost quorum
 	for i := 1; i <= 3; i++ {
-		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		err := nodes[1].RemoveMember(ctx, uint64(i))
 		assert.Error(t, err)
 		members := nodes[1].GetMemberlist()
@@ -341,15 +341,17 @@ func TestCanRemoveMember(t *testing.T) {
 	}))
 
 	// Removing node 2 should fail (this would break the quorum)
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	err := nodes[leader].RemoveMember(ctx, nodes[2].Config.ID)
+	cancel()
 	assert.EqualError(t, err, raft.ErrCannotRemoveMember.Error())
 	members := nodes[leader].GetMemberlist()
 	assert.Equal(t, len(members), 3)
 
 	// Removing node 3 works fine because it is already unreachable
-	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	err = nodes[leader].RemoveMember(ctx, nodes[3].Config.ID)
+	cancel()
 	assert.NoError(t, err)
 	members = nodes[leader].GetMemberlist()
 	assert.Nil(t, members[nodes[3].Config.ID])
@@ -380,16 +382,18 @@ func TestCanRemoveMember(t *testing.T) {
 	}))
 
 	// Removing node 3 should succeed
-	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	err = nodes[leader].RemoveMember(ctx, nodes[3].Config.ID)
+	cancel()
 	assert.NoError(t, err)
 	members = nodes[leader].GetMemberlist()
 	assert.Nil(t, members[nodes[3].Config.ID])
 	assert.Equal(t, len(members), 2)
 
 	// Removing node 2 should succeed
-	ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
 	err = nodes[leader].RemoveMember(ctx, nodes[2].Config.ID)
+	cancel()
 	assert.NoError(t, err)
 	members = nodes[leader].GetMemberlist()
 	assert.Nil(t, members[nodes[2].Config.ID])

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -30,7 +31,6 @@ import (
 	"github.com/pivotal-golang/clock"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/manager/state/raft/raft.go
+++ b/manager/state/raft/raft.go
@@ -1182,11 +1182,8 @@ func (n *Node) CanRemoveMember(id uint64) bool {
 	}
 
 	nquorum := (len(members)-1)/2 + 1
-	if nreachable < nquorum {
-		return false
-	}
 
-	return true
+	return nreachable >= nquorum
 }
 
 func (n *Node) removeMember(ctx context.Context, id uint64) error {
@@ -1591,10 +1588,7 @@ func (n *Node) ProposeValue(ctx context.Context, storeAction []api.StoreAction, 
 	defer cancel()
 	_, err := n.processInternalRaftRequest(ctx, &api.InternalRaftRequest{Action: storeAction}, cb)
 
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // GetVersion returns the sequence information for the current raft round.

--- a/manager/state/raft/raft_test.go
+++ b/manager/state/raft/raft_test.go
@@ -1,6 +1,7 @@
 package raft_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -16,8 +17,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/status"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/coreos/etcd/wal"
@@ -110,8 +109,9 @@ func TestRaftJoinTwice(t *testing.T) {
 	assert.NoError(t, err)
 	raftClient := api.NewRaftMembershipClient(cc)
 	defer cc.Close()
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	_, err = raftClient.Join(ctx, &api.JoinRequest{Addr: l.Addr().String()})
+	cancel()
 	assert.NoError(t, err)
 
 	// Propose a value and wait for it to propagate
@@ -367,8 +367,9 @@ func TestRaftFollowerLeave(t *testing.T) {
 	assert.NoError(t, err)
 	raftClient := api.NewRaftMembershipClient(cc)
 	defer cc.Close()
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	resp, err := raftClient.Leave(ctx, &api.LeaveRequest{Node: &api.RaftMember{RaftID: nodes[5].Config.ID}})
+	cancel()
 	assert.NoError(t, err, "error sending message to leave the raft")
 	assert.NotNil(t, resp, "leave response message is nil")
 
@@ -412,8 +413,8 @@ func TestRaftLeaderLeave(t *testing.T) {
 	raftClient := api.NewRaftMembershipClient(cc)
 	defer cc.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	resp, err := raftClient.Leave(ctx, &api.LeaveRequest{Node: &api.RaftMember{RaftID: nodes[1].Config.ID}})
+	cancel()
 	assert.NoError(t, err, "error sending message to leave the raft")
 	assert.NotNil(t, resp, "leave response message is nil")
 

--- a/manager/state/raft/storage.go
+++ b/manager/state/raft/storage.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/coreos/etcd/raft"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/manager/state/raft/storage"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/manager/state/raft/storage/storage.go
+++ b/manager/state/raft/storage/storage.go
@@ -1,12 +1,11 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/pkg/fileutil"
 	"github.com/coreos/etcd/raft/raftpb"

--- a/manager/state/raft/storage/storage_test.go
+++ b/manager/state/raft/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestBootstrapFromDisk(t *testing.T) {

--- a/manager/state/raft/storage/walwrap.go
+++ b/manager/state/raft/storage/walwrap.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // This package wraps the github.com/coreos/etcd/wal package, and encrypts

--- a/manager/state/raft/storage/walwrap_test.go
+++ b/manager/state/raft/storage/walwrap_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,6 @@ import (
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/encryption"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 var _ WALFactory = walCryptor{}

--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -8,8 +9,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 
@@ -520,12 +519,13 @@ func ProposeValue(t *testing.T, raftNode *TestNode, time time.Duration, nodeID .
 		},
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time)
+	ctx, cancel := context.WithTimeout(context.Background(), time)
 
 	err := raftNode.ProposeValue(ctx, storeActions, func() {
 		err := raftNode.MemoryStore().ApplyStoreActions(storeActions)
 		assert.NoError(t, err, "error applying actions")
 	})
+	cancel()
 	if err != nil {
 		return nil, err
 	}

--- a/manager/state/raft/transport/mock_raft_test.go
+++ b/manager/state/raft/transport/mock_raft_test.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"context"
 	"io"
 	"net"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/docker/swarmkit/log"
 	"github.com/docker/swarmkit/manager/health"
 	"github.com/docker/swarmkit/manager/state/raft/membership"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/manager/state/raft/transport/peer.go
+++ b/manager/state/raft/transport/peer.go
@@ -1,11 +1,10 @@
 package transport
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/manager/state/raft/transport/peer_test.go
+++ b/manager/state/raft/transport/peer_test.go
@@ -1,10 +1,9 @@
 package transport
 
 import (
+	"context"
 	"math"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/stretchr/testify/assert"

--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -3,11 +3,10 @@
 package transport
 
 import (
+	"context"
 	"net"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"google.golang.org/grpc"

--- a/manager/state/raft/transport/transport_test.go
+++ b/manager/state/raft/transport/transport_test.go
@@ -1,10 +1,9 @@
 package transport
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"

--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -1,9 +1,8 @@
 package raft
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/swarmkit/watch"
 	gogotypes "github.com/gogo/protobuf/types"
 	memdb "github.com/hashicorp/go-memdb"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -689,7 +689,7 @@ func (tx readTx) findIterators(table string, by By, checkType func(By) error) ([
 		}
 		return []memdb.ResultIterator{it}, nil
 	case bySlot:
-		it, err := tx.memDBTx.Get(table, indexSlot, v.serviceID+"\x00"+strconv.FormatUint(uint64(v.slot), 10))
+		it, err := tx.memDBTx.Get(table, indexSlot, v.serviceID+"\x00"+strconv.FormatUint(v.slot, 10))
 		if err != nil {
 			return nil, err
 		}

--- a/manager/state/testutils/mock_proposer.go
+++ b/manager/state/testutils/mock_proposer.go
@@ -1,11 +1,11 @@
 package testutils
 
 import (
+	"context"
 	"errors"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state"
-	"golang.org/x/net/context"
 )
 
 // MockProposer is a simple proposer implementation for use in tests.

--- a/manager/watchapi/server.go
+++ b/manager/watchapi/server.go
@@ -1,11 +1,11 @@
 package watchapi
 
 import (
+	"context"
 	"errors"
 	"sync"
 
 	"github.com/docker/swarmkit/manager/state/store"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/manager/watchapi/server_test.go
+++ b/manager/watchapi/server_test.go
@@ -1,6 +1,7 @@
 package watchapi
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )

--- a/manager/watchapi/watch_test.go
+++ b/manager/watchapi/watch_test.go
@@ -1,13 +1,13 @@
 package watchapi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/docker/swarmkit/api"
 	"github.com/docker/swarmkit/manager/state/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestWatch(t *testing.T) {

--- a/node/node.go
+++ b/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io/ioutil"
@@ -35,7 +36,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/status"

--- a/node/node.go
+++ b/node/node.go
@@ -1204,19 +1204,16 @@ func (s *persistentRemotes) Observe(peer api.Peer, weight int) {
 	s.c.Broadcast()
 	if err := s.save(); err != nil {
 		logrus.Errorf("error writing cluster state file: %v", err)
-		return
 	}
-	return
 }
+
 func (s *persistentRemotes) Remove(peers ...api.Peer) {
 	s.Lock()
 	defer s.Unlock()
 	s.Remotes.Remove(peers...)
 	if err := s.save(); err != nil {
 		logrus.Errorf("error writing cluster state file: %v", err)
-		return
 	}
-	return
 }
 
 func (s *persistentRemotes) save() error {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"bytes"
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -25,7 +26,6 @@ import (
 	"github.com/docker/swarmkit/testutils"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func getLoggingContext(t *testing.T) context.Context {

--- a/protobuf/plugin/raftproxy/test/raftproxy_test.go
+++ b/protobuf/plugin/raftproxy/test/raftproxy_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -8,8 +9,6 @@ import (
 	"github.com/docker/swarmkit/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"golang.org/x/net/context"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/watch/sinks_test.go
+++ b/watch/sinks_test.go
@@ -39,8 +39,7 @@ func TestTimeoutDropErrSinkGen(t *testing.T) {
 	<-ch2.Done()
 
 	// Make sure that closing a sink closes the channel
-	var errClose error
-	errClose = sink.Close()
+	errClose := sink.Close()
 	<-ch.Done()
 	require.NoError(errClose)
 


### PR DESCRIPTION
This PR contains a few related changes. The following is a copy-paste from commit messages. Hope it makes sense.

## I. Makefile: use gometalinter

Instead of running many small source code checkers and linters one by
one, let's use gometalinter that runs them all in parallel.

While at it, remove the individual make targets (fmt, vet, lint,
ineffassign, and misspell) and replace with a single check target.

One thing it provides is faster source validation.

BEFORE:

    real    0m24.025s
    user    1m2.646s
    sys     0m3.860s

(note these timings are without building binaries, which
for some reason was a dependency of the vet target)

AFTER:

    real    0m6.330s
    user    0m20.255s
    sys     0m1.019s

In addition to this, it is now way easier to add/remove the checks,
as well as to filter out some errors from linters that we consider
false positives.

## II. Switch from x/net/context -> context

1. Since Go 1.7, context is a standard package. Since Go 1.9, everything
that is provided by "x/net/context" is a couple of type aliases to
types in "context".

2. While at it, fix the order of imports (done by goimports and some shell
trickery, see below).

3. Also, when the standard context package is used, the errors of
not calling cancel() are detected/reported by go vet:

> the cancel function returned by context.WithTimeout should be called,
> not discarded, to avoid a context leak (vet)

This essentially asks to call cancel() as otherwise a stray timer
is leaked. Fix a few such issues, mostly in _test.go files.

4. Since in func (*session).start (see agent/session.go) we deliberately
do not want to cancel the context, govet gives us a couple of errors:

> agent/session.go:140: the cancelSession function is not used
>  on all paths (possible context leak)
> agent/session.go:163: this return statement may be reached
>  without using the cancelSession var defined on line 140

To silence these, use `// nolint: vet` mark in a couple of places
(this is a feature of gometalinter).

Oh, the conversion (items 1 and 2 above) was performed by this
shell script:

```sh
FILES=$*
test -z "$FILES" && FILES=$(git ls-files \*.go | grep -v ^vendor/ | grep -v .pb.go$)

for f in $FILES; do
        sed -i 's|"golang.org/x/net/context"|"context"|' $f
        goimports -w $f
        for i in 1 2; do
                awk '/^$/ {e=1; next;}
                        /\t"context"$/ {e=0;}
                        {if (e) {print ""; e=0}; print;}' < $f > $f.new && mv $f.new $f
                goimports -w $f
        done
        echo -n .
done
echo
```

Multiple `goimports` calls and some awk trickery is needed to iron out
incorrect formatting (excessive empty lines) from the import statements.

## III. Add some more linters and fix warnings reported by those

Those are:
* deadcode
* goimports
* unconvert
* gosimple

For the warnings reported and fixed, please see individual commit messages.