### PR TITLE
Dockerfile, circleci: update protoc to 3.6.1, simplify install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       ARCH: amd64
       GOVERSION: 1.11
       # Needed to install protoc
-      PROTOC: https://github.com/google/protobuf/releases/download/v3.5.0/protoc-3.5.0-linux-x86_64.zip
+      PROTOC_VERSION: 3.6.1
 
     # Note(cyli): We create a tmpfs mount to be used for temporary files created by tests
     # to mitigate the excessive I/O latencies that sometimes cause the tests to fail.
@@ -61,12 +61,11 @@ jobs:
     - run:
         name: Install protoc
         command: |
-            curl -fsSL -o "$HOME/$(basename $PROTOC)" "$PROTOC"
-            unzip -o "$HOME/$(basename $PROTOC)" -d "$HOME"
-            sudo cp -R "$HOME/include/google" /usr/local/include
-            sudo chmod 777 -R /usr/local/include/google
-            sudo cp -R "$HOME/bin/protoc" /usr/local/bin
-            sudo chmod 777 /usr/local/bin/protoc
+            curl --silent --show-error --location --output protoc.zip \
+            https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \
+            && sudo unzip -d /usr/local protoc.zip include/\* bin\/* \
+            && sudo chmod -R a+r /usr/local/include/google/protobuf/
+            rm -f protoc.zip
 
     - run:
         name: Install test/lint dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,13 @@ FROM golang:1.11.0-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 
-# should stay consistent with the version we use in Circle builds
-ARG PROTOC_VERSION=3.5.0
-# make a directory to do these operations in
-RUN export PROTOC_TMP_DIR=protoc && mkdir -p $PROTOC_TMP_DIR && cd $PROTOC_TMP_DIR \
-  # download the pre-built protoc binary
-  && curl --silent --show-error --location --output protoc.zip \
-    https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \
-  # move the binary to /bin. move the well-known types ot /usr/local/include
-  && unzip protoc.zip && mv bin/protoc /bin/protoc && mv include/* /usr/local/include \
-  # remove all of the installation files
-  && cd .. && rm -rf $PROTOC_TMP_DIR
+# should stay consistent with the version in .circleci/config.yml
+ARG PROTOC_VERSION=3.6.1
+# download and install protoc binary and .proto files
+RUN curl --silent --show-error --location --output protoc.zip \
+  https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \
+  && unzip -d /usr/local protoc.zip include/\* bin/\* \
+  && rm -f protoc.zip
 
 WORKDIR /go/src/github.com/docker/swarmkit/
 


### PR DESCRIPTION
Use unzip options to unpack directly to /usr/local/{include,bin},
to avoid unnecessary I/O.

Unfortunately unzip does not support unpacking from a pipe (due
to a limitation of .zip format -- the index is at EOF) so we still
have to save the .zip to disk, read it back, and remove. If they
could only provide tarballs... *sigh*

// cc @wk8 @anshulpundir 