### PR TITLE
Increased wait time on test utils WaitForCluster and WatchTaskCreate

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -355,7 +355,7 @@ func TestSessionReconnectsIfDispatcherErrors(t *testing.T) {
 			return fmt.Errorf("expecting 2 closed sessions, got %d", len(closedSessions))
 		}
 		return nil
-	}, 5*time.Second))
+	}, 10*time.Second))
 }
 
 type testSessionTracker struct {

--- a/manager/orchestrator/testutils/testutils.go
+++ b/manager/orchestrator/testutils/testutils.go
@@ -22,7 +22,7 @@ func WatchTaskCreate(t *testing.T, watch chan events.Event) *api.Task {
 			if _, ok := event.(api.EventUpdateTask); ok {
 				assert.FailNow(t, "got EventUpdateTask when expecting EventCreateTask", fmt.Sprint(event))
 			}
-		case <-time.After(time.Second):
+		case <-time.After(2 * time.Second):
 			assert.FailNow(t, "no task creation")
 		}
 	}

--- a/manager/state/raft/testutils/testutils.go
+++ b/manager/state/raft/testutils/testutils.go
@@ -60,13 +60,15 @@ func AdvanceTicks(clockSource *fakeclock.FakeClock, ticks int) {
 func WaitForCluster(t *testing.T, clockSource *fakeclock.FakeClock, nodes map[uint64]*TestNode) {
 	err := testutils.PollFunc(clockSource, func() error {
 		var prev *etcdraft.Status
+		var leadNode *TestNode
 	nodeLoop:
 		for _, n := range nodes {
 			if prev == nil {
 				prev = new(etcdraft.Status)
 				*prev = n.Status()
 				for _, n2 := range nodes {
-					if n2.Config.ID == prev.Lead && n2.ReadyForProposals() {
+					if n2.Config.ID == prev.Lead {
+						leadNode = n2
 						continue nodeLoop
 					}
 				}
@@ -84,7 +86,14 @@ func WaitForCluster(t *testing.T, clockSource *fakeclock.FakeClock, nodes map[ui
 			}
 			return errors.New("did not find leader in member list")
 		}
-		return nil
+		// Don't raise error just because test machine is running slowly
+		for i := 0; i < 5; i++ {
+			if leadNode.ReadyForProposals() {
+				return nil
+			}
+			time.Sleep(2 * time.Second)
+		}
+		return errors.New("leader is not ready")
 	})
 	require.NoError(t, err)
 }


### PR DESCRIPTION
I find out that most of the flaky tests looks to be caused by timeout during slowness on test machine.

This theory can be proven by running tests with CPU limit. I used these commands on my four core machine:
```
docker build . -t swarmkit-build
docker run --cpus="3" --rm --name test swarmkit-build make test
```

**- What I did**
* Added 5 x 2 second wait time to WaitForCluster function in case when ReadyForProposals() does not return true.
* Increased timeout from one second to two seconds on WatchTaskCreate() function, updated function TestSessionReconnectsIfDispatcherErrors() match with that one.

Fixes flaky tests on #2559 , #2600 and #2661
