### PR TITLE
Increase grpc max recv message size

### DIFF
--- a/manager/state/raft/transport/transport.go
+++ b/manager/state/raft/transport/transport.go
@@ -4,6 +4,7 @@ package transport
 
 import (
 	"context"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -353,6 +354,15 @@ func (t *Transport) dial(addr string) (*grpc.ClientConn, error) {
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("tcp", addr, timeout)
 		}))
+
+	// TODO(dperny): this changes the max received message size for outgoing
+	// client connections. this means if the server sends a message larger than
+	// this, we will still accept and unmarshal it. i'm unsure what the
+	// potential consequences are of setting this to be effectively unbounded,
+	// so after docker/swarmkit#2774 is fixed, we should remove this option
+	grpcOptions = append(grpcOptions, grpc.WithDefaultCallOptions(
+		grpc.MaxCallRecvMsgSize(math.MaxInt32),
+	))
 
 	cc, err := grpc.Dial(addr, grpcOptions...)
 	if err != nil {


### PR DESCRIPTION
Skipping the usual boilerplate, because this is a kludge, everyone involved knows its a kludge, and we'll revert it in the next release.

Increases the maximum recieved message size for gRPC client connections to math.MaxInt32. This means that large controlapi `List` requests will be proxied correctly.