### PR TITLE
Actually starting to use the deallocator to clean up services

### DIFF
--- a/cmd/swarmctl/network/inspect.go
+++ b/cmd/swarmctl/network/inspect.go
@@ -51,6 +51,10 @@ func printNetworkSummary(network *api.Network) {
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", network.ID)
 	common.FprintfIfNotEmpty(w, "Name\t: %s\n", spec.Annotations.Name)
 
+	if network.PendingDelete {
+		common.FprintfIfNotEmpty(w, "[Network %s marked for removal]\n", spec.Annotations.Name)
+	}
+
 	fmt.Fprintln(w, "Spec:\t")
 	if len(spec.Annotations.Labels) > 0 {
 		fmt.Fprintln(w, "  Labels:\t")

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -22,12 +22,17 @@ func printServiceSummary(service *api.Service, running int) {
 	w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
 	defer w.Flush()
 
-	task := service.Spec.Task
+	spec := service.Spec
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", service.ID)
-	common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Annotations.Name)
-	if len(service.Spec.Annotations.Labels) > 0 {
+	common.FprintfIfNotEmpty(w, "Name\t: %s\n", spec.Annotations.Name)
+
+	if service.PendingDelete {
+		common.FprintfIfNotEmpty(w, "[Service %s marked for removal]\n", spec.Annotations.Name)
+	}
+
+	if len(spec.Annotations.Labels) > 0 {
 		fmt.Fprintln(w, "Labels\t")
-		for k, v := range service.Spec.Annotations.Labels {
+		for k, v := range spec.Annotations.Labels {
 			fmt.Fprintf(w, "  %s\t: %s\n", k, v)
 		}
 	}
@@ -51,7 +56,8 @@ func printServiceSummary(service *api.Service, running int) {
 
 	fmt.Fprintln(w, "Template\t")
 	fmt.Fprintln(w, " Container\t")
-	ctr := service.Spec.Task.GetContainer()
+	task := spec.Task
+	ctr := task.GetContainer()
 	common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image)
 	common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
 	common.FprintfIfNotEmpty(w, "  Args\t: [%s]\n", strings.Join(ctr.Args, ", "))
@@ -90,7 +96,7 @@ func printServiceSummary(service *api.Service, running int) {
 			printResources(w, res.Limits)
 		}
 	}
-	if len(service.Spec.Task.Networks) > 0 {
+	if len(spec.Task.Networks) > 0 {
 		fmt.Fprint(w, "  Networks:")
 		for _, n := range service.Spec.Task.Networks {
 			fmt.Fprintf(w, " %s", n.Target)

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -191,9 +191,28 @@ func TestRemoveNetworkWithAttachedService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, nr.Network, nil)
 	assert.NotEqual(t, nr.Network.ID, "")
-	createServiceInNetwork(t, ts, "name", "image", nr.Network.ID, 1)
+	createServiceInNetwork(t, ts, "service1", "image", nr.Network.ID, 1)
 	_, err = ts.Client.RemoveNetwork(context.Background(), &api.RemoveNetworkRequest{NetworkID: nr.Network.ID})
 	assert.Error(t, err)
+}
+
+func TestRemoveNetworkWithAttachedServiceMarkedForRemoval(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+	nr, err := ts.Client.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
+		Spec: createNetworkSpec("testnet5"),
+	})
+	assert.NoError(t, err)
+	assert.NotEqual(t, nr.Network, nil)
+	assert.NotEqual(t, nr.Network.ID, "")
+	service := createServiceInNetwork(t, ts, "service2", "image", nr.Network.ID, 1)
+	// then let's delete the service
+	r, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{ServiceID: service.ID})
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+	// now we should be able to delete the network
+	_, err = ts.Client.RemoveNetwork(context.Background(), &api.RemoveNetworkRequest{NetworkID: nr.Network.ID})
+	assert.NoError(t, err)
 }
 
 func TestCreateNetworkInvalidDriver(t *testing.T) {

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -916,6 +916,19 @@ func TestUpdateService(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
+func TestUpdateServiceMarkedForRemoval(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Stop()
+
+	service := createService(t, ts, "name", "image", 1)
+	r, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{ServiceID: service.ID})
+	assert.NoError(t, err)
+	assert.NotNil(t, r)
+
+	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec, ServiceVersion: &service.Meta.Version})
+	assert.Equal(t, codes.FailedPrecondition, testutils.ErrorCode(err))
+}
+
 func TestServiceUpdateRejectNetworkChange(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Stop()

--- a/manager/deallocator/deallocator_test.go
+++ b/manager/deallocator/deallocator_test.go
@@ -225,11 +225,11 @@ func TestNetworkNotMarkedForDeletion(t *testing.T) {
 		false)
 }
 
-// this test that the deallocator also works with the "old" style of storing
+// this tests that the deallocator also works with the "old" style of storing
 // networks directly on the  service spec (instead of the task spec)
 // TODO: as said in the source file, we should really add a helper
 // on services objects itself, and test it there instead
-func TestDeallocatorWithOldStyleNetworks(t *testing.T) {
+func TestWithOldStyleNetworks(t *testing.T) {
 	s := store.NewMemoryStore(nil)
 	require.NotNil(t, s)
 	defer s.Close()
@@ -260,6 +260,81 @@ func TestDeallocatorWithOldStyleNetworks(t *testing.T) {
 		require.Nil(t, store.GetService(tx, service.ID))
 		require.Nil(t, store.GetNetwork(tx, network1.ID))
 		require.NotNil(t, store.GetNetwork(tx, network2.ID))
+	})
+}
+
+// this tests that when deciding whether a service has fully shut
+// down, the deallocator only cares about tasks whose actual status
+// is <= RUNNING
+func TestIgnoresTasksThatAreNotRunning(t *testing.T) {
+	s := store.NewMemoryStore(nil)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	service := newService("service", true)
+
+	task1 := newTaskWithState("task1", service, api.TaskStateCompleted)
+	task2 := newTaskWithState("task2", service, api.TaskStateFailed)
+
+	createDBObjects(t, s, service, task1, task2)
+
+	deallocator, ran := startNewDeallocator(t, s, true)
+	defer stopDeallocator(t, deallocator, ran)
+
+	s.View(func(tx store.ReadTx) {
+		assert.Nil(t, store.GetService(tx, service.ID))
+	})
+}
+
+// this tests that the deallocator also listens to task update events
+// and correctly processes them - i.e. that a service which still has
+// tasks but none that are still running is properly cleaned up
+func TestListensToTaskUpdates(t *testing.T) {
+	s := store.NewMemoryStore(nil)
+	require.NotNil(t, s)
+	defer s.Close()
+
+	service := newService("service", true)
+
+	task1 := newTaskWithState("task1", service, api.TaskStateRunning)
+	task2 := newTaskWithState("task2", service, api.TaskStateRunning)
+
+	createDBObjects(t, s, service, task1, task2)
+
+	deallocator, ran := startNewDeallocator(t, s, false)
+	defer stopDeallocator(t, deallocator, ran)
+
+	// the service should still be there
+	s.View(func(tx store.ReadTx) {
+		assert.NotNil(t, store.GetService(tx, service.ID))
+	})
+
+	// moving one task to state FAILED shouldn't do anything
+	updateStoreAndWaitForEvent(t, deallocator, func(tx store.Tx) {
+		task1.Status.State = api.TaskStateFailed
+		require.NoError(t, store.UpdateTask(tx, task1))
+	}, false)
+	s.View(func(tx store.ReadTx) {
+		assert.NotNil(t, store.GetService(tx, service.ID))
+	})
+
+	// nor should moving the same task to state REMOVE
+	updateStoreAndWaitForEvent(t, deallocator, func(tx store.Tx) {
+		task1.Status.State = api.TaskStateRemove
+		require.NoError(t, store.UpdateTask(tx, task1))
+	}, false)
+	s.View(func(tx store.ReadTx) {
+		assert.NotNil(t, store.GetService(tx, service.ID))
+	})
+
+	// but then moving the 2nd task to state COMPLETED should
+	// trigger the service clean up
+	updateStoreAndWaitForEvent(t, deallocator, func(tx store.Tx) {
+		task2.Status.State = api.TaskStateCompleted
+		require.NoError(t, store.UpdateTask(tx, task2))
+	}, true)
+	s.View(func(tx store.ReadTx) {
+		assert.Nil(t, store.GetService(tx, service.ID))
 	})
 }
 
@@ -339,6 +414,8 @@ func createDBObjects(t *testing.T, s *store.MemoryStore, objects ...interface{})
 				e = store.CreateTask(tx, typedObject)
 			case *api.Network:
 				e = store.CreateNetwork(tx, typedObject)
+			default:
+				t.Fatalf("Don't know how to create DB object %v", object)
 			}
 			require.NoError(t, e, "Unable to create DB object %v", object)
 		}
@@ -399,8 +476,15 @@ func newNetworkConfigs(networks ...*api.Network) []*api.NetworkAttachmentConfig 
 }
 
 func newTask(id string, service *api.Service) *api.Task {
+	return newTaskWithState(id, service, api.TaskStateNew)
+}
+
+func newTaskWithState(id string, service *api.Service, state api.TaskState) *api.Task {
 	return &api.Task{
 		ID:        id,
 		ServiceID: service.ID,
+		Status: api.TaskStatus{
+			State: state,
+		},
 	}
 }

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -328,7 +328,7 @@ func TestDeleteService(t *testing.T) {
 
 	testutils.WatchTaskCreate(t, watch)
 
-	deleteService(t, store, service1)
+	markServiceForDeletion(t, store, service1)
 	// task should be deleted
 	observedTask := testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name1")
@@ -468,9 +468,11 @@ func updateService(t *testing.T, s *store.MemoryStore, service *api.Service, for
 	})
 }
 
-func deleteService(t *testing.T, s *store.MemoryStore, service *api.Service) {
+func markServiceForDeletion(t *testing.T, s *store.MemoryStore, service *api.Service) {
 	s.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteService(tx, service.ID))
+		serviceCopy := service.Copy()
+		serviceCopy.PendingDelete = true
+		assert.NoError(t, store.UpdateService(tx, serviceCopy))
 		return nil
 	})
 }
@@ -540,7 +542,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	defer s.Close()
 
 	// create nodes, services and tasks in store directly
-	// where orchestrator runs, it should fix tasks to declarative state
+	// when orchestrator runs, it should fix tasks to declarative state
 	addNode(t, s, node1)
 	addService(t, s, service1)
 	tasks := []*api.Task{

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -61,7 +61,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 			return
 		}
 
-		if err = r.initServices(readTx); err != nil {
+		if err = r.initServices(ctx, readTx); err != nil {
 			return
 		}
 
@@ -78,7 +78,6 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 	for {
 		select {
 		case event := <-watcher:
-			// TODO(stevvooe): Use ctx to limit running time of operation.
 			r.handleTaskEvent(ctx, event)
 			r.handleServiceEvent(ctx, event)
 			switch v := event.(type) {
@@ -89,6 +88,8 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 			}
 		case <-r.stopChan:
 			return nil
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -557,9 +557,11 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	testutils.Expect(t, watch, api.EventUpdateTask{})
 	testutils.Expect(t, watch, state.EventCommit{})
 
-	// Delete the service. This should trigger both the task desired statuses to be set to REMOVE.
+	// Mark the service for deletion. This should trigger both the task desired
+	// statuses to be set to REMOVE.
 	err = s.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteService(tx, service1.ID))
+		service1.PendingDelete = true
+		assert.NoError(t, store.UpdateService(tx, service1))
 		return nil
 	})
 
@@ -720,13 +722,14 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	assert.Equal(t, api.TaskStateCompleted, observedTask4.Status.State)
 	assert.Equal(t, "original", observedTask4.ServiceAnnotations.Name)
 
-	// Delete the service.
+	// Mark the service for deletion.
 	err = s.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.DeleteService(tx, service1.ID))
+		service1.PendingDelete = true
+		assert.NoError(t, store.UpdateService(tx, service1))
 		return nil
 	})
 
-	// Service delete should trigger both the task desired statuses
+	// That should trigger both the task desired statuses
 	// to be set to REMOVE.
 	observedTask3 = testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, api.TaskStateRemove, observedTask3.DesiredState)


### PR DESCRIPTION
**- What I did**

This patch actually stars to use the deallocator to clean up services, as
well as service-level resources (as of now, only networks).

List of changes:
 * networks and services don't get deleted right away any more, that's
   now the deallocator's job
 * networks and services that are pending deletion are marked as such
   by swarmctl
 * updated all of the relevant code & tests around network & service
   deletion
 * added unit tests for new functionalities

**- How I did it**

A previous patch (https://github.com/docker/swarmkit/pull/2759) introduced a
new component, the deallocator, responsible for cleaning up services and
service-level resources. This patch is actually starting to make use of that
component.

Since the deallocator used to rely on the reaper deleting the tasks belonging
to services that had been marked for removal, a previous version of this patch
was modifying the task reaper quite heavily to also keep track of such services
(needed since otherwise the reaper would fail to clean up all of them, instead
keeping some for history tracking purposes). However, it soon appeared that
this was not the best approach:
 * this creates a hidden coupling between the reaper and the deallocator
 * it's also not the best user experience to suddenly remove all of a service's
   task history while shutting down, for not apparent reason to the user

For these reasons, this patch instead amends the deallocator to also look at tasks status when keeping track of how many alive tasks remain to a service.

**- How to test it**

Updated tests.

**- Description for the changelog**

Services & networks are no longer deleted immediately when a user requests their
deletion; instead, they are deleted when all their tasks are actually shut down.