### PR TITLE
Adding an (optional) `DOCKER_SWARMKIT_EXTRA_RUN_FLAGS` env var to `containerized.mk`

### DIFF
--- a/containerized.mk
+++ b/containerized.mk
@@ -52,6 +52,6 @@ run: ensure_image_exists
 			`# see https://github.com/derekparker/delve/issues/515#issuecomment-214911481'` ; \
 			DOCKER_RUN_COMMAND+=" --security-opt=seccomp:unconfined"; \
 		fi \
-		&& DOCKER_RUN_COMMAND+=" $$DOCKER_SWARMKIT_DOCKER_RUN_FLAGS ${IMAGE_NAME} $$DOCKER_SWARMKIT_DOCKER_RUN_CMD" \
+		&& DOCKER_RUN_COMMAND+=" $$DOCKER_SWARMKIT_DOCKER_RUN_FLAGS $$DOCKER_SWARMKIT_EXTRA_RUN_FLAGS ${IMAGE_NAME} $$DOCKER_SWARMKIT_DOCKER_RUN_CMD" \
 		&& echo $$DOCKER_RUN_COMMAND \
 		&& eval $$DOCKER_RUN_COMMAND


### PR DESCRIPTION
Comes in handy e.g. to mount a personalized volume on to /root, I like
having my usual bash and git shortcuts in my dev shell :)

Signed-off-by: Jean Rouge <jer329@cornell.edu>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
