### PR TITLE
Fix missing return before "success" message, and minor rephrasing of errors/logs

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -275,6 +275,7 @@ func (n *Node) currentRole() api.NodeRole {
 func configVXLANUDPPort(ctx context.Context, vxlanUDPPort uint32) {
 	if err := overlayutils.ConfigVXLANUDPPort(vxlanUDPPort); err != nil {
 		log.G(ctx).WithError(err).Error("Configuring VXLAN port failed")
+		return
 	}
 	logrus.Infof(" Swarm successfully initialized VXLAN UDP Port to %d ", vxlanUDPPort)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -274,10 +274,10 @@ func (n *Node) currentRole() api.NodeRole {
 // configVXLANUDPPort sets vxlan port in libnetwork
 func configVXLANUDPPort(ctx context.Context, vxlanUDPPort uint32) {
 	if err := overlayutils.ConfigVXLANUDPPort(vxlanUDPPort); err != nil {
-		log.G(ctx).WithError(err).Error("Configuring VXLAN port failed")
+		log.G(ctx).WithError(err).Error("failed to configure VXLAN UDP port")
 		return
 	}
-	logrus.Infof(" Swarm successfully initialized VXLAN UDP Port to %d ", vxlanUDPPort)
+	logrus.Infof("initialized VXLAN UDP port to %d ", vxlanUDPPort)
 }
 
 func (n *Node) run(ctx context.Context) (err error) {


### PR DESCRIPTION
There was a "return" missing, therefore the "success" message would always be logged, even in case of a failure.

Also rephrased the messages a bit;

- Use "failed to", as it's used in many other locations, so more consistent
- Removed "Swarm successfully ...", as it should be clear from the rest of the message