### PR TITLE
Fix possible panic if NetworkConfig is nil

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1010,10 +1010,16 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 			cluster = store.GetCluster(tx, clusterID)
 		})
 		if cluster.DefaultAddressPool != nil {
+			if m.config.NetworkConfig == nil {
+				m.config.NetworkConfig = &cnmallocator.NetworkConfig{}
+			}
 			m.config.NetworkConfig.DefaultAddrPool = append(m.config.NetworkConfig.DefaultAddrPool, cluster.DefaultAddressPool...)
 			m.config.NetworkConfig.SubnetSize = cluster.SubnetSize
 		}
 		if cluster.VXLANUDPPort != 0 {
+			if m.config.NetworkConfig == nil {
+				m.config.NetworkConfig = &cnmallocator.NetworkConfig{}
+			}
 			m.config.NetworkConfig.VXLANUDPPort = cluster.VXLANUDPPort
 		}
 	}


### PR DESCRIPTION
This code can panic if `config.NetworkConfig` is nil; https://play.golang.org/p/FqfuJkpWUz9

```go
package main

type NetworkConfig struct {
	DefaultAddrPool []string
}

type Config struct {
	NetworkConfig *NetworkConfig
}

func main() {
	config := Config{}
	config.NetworkConfig.DefaultAddrPool = append(config.NetworkConfig.DefaultAddrPool, "foo")
}
```
