### PR TITLE
Add make option to not bindmount local dir

### DIFF
--- a/containerized.mk
+++ b/containerized.mk
@@ -4,6 +4,26 @@ DOCKER_IMAGE_DIR=${GOPATH}/src/${PROJECT_ROOT}
 
 DOCKER_SWARMKIT_DELVE_PORT ?= 2345
 
+# HOW TO USE CONTAINERIZED BUILDS:
+#
+# There are lots of flags that we've added to containerized builds of swarmkit,
+# mostly to support the various swarmkit dev's workflows. These can be kind of
+# confusing, and might feel like they require reading the makefile to fully
+# understand. For clarity, these are the various flags and what they do:
+#
+# DOCKER_SWARMKIT_USE_CONTAINER: Build swarmkit inside of a docker container.
+# DOCKER_SWARMKIT_NOMOUNT: Runs the make target without bindmounting the local
+# 	directory into the container. Useful if you're, say, running tests over a
+# 	network socket. Otherwise, we'll be doing the equivalent of 
+# 	-v ~/go/src/github.com/docker/swarmkit:/go/src/github.com/docker/swarmkit
+# DOCKER_SWARMKIT_USE_DELVE: Use the Delve debugger
+# DOCKER_SWARMKIT_DELVE_PORT: The port for hooking up the Delve debugger
+# DOCKER_SWARMKTI_USE_DOCKER_SYNC: uses the Docker Sync tool, which can speed
+# 	up operations when running on Docker for Windows or Docker for Mac
+# DOCKER_SWARMKIT_DOCKER_RUN_FLAGS: add extra flags to the docker run command
+# DOCKER_SWARMKIT_EXTRA_RUN_FLAGS: add even more extra flags to the docker run
+# 	command
+
 # don't bother writing every single make target. just pass the call through to
 # docker and make
 # we prefer `%:` to `.DEFAULT` as the latter doesn't run phony deps
@@ -39,8 +59,11 @@ ensure_sync_started:
 # to kill running containers (can't kill with ctrl-c)
 .PHONY: run
 run: ensure_image_exists
-	@ [ "$$DOCKER_SWARMKIT_DOCKER_RUN_CMD" ] || exit 1
-	@ DOCKER_RUN_COMMAND="docker run -t -v swarmkit-cache:${GOPATH}" \
+	[ "$$DOCKER_SWARMKIT_DOCKER_RUN_CMD" ] || exit 1
+	if [ "$$DOCKER_SWARMKIT_NOMOUNT" ]; then \
+			DOCKER_RUN_COMMAND="docker run -t"; \
+	else \
+		DOCKER_RUN_COMMAND="docker run -t -v swarmkit-cache:${GOPATH}" \
 		&& if [ "$$DOCKER_SWARMKIT_USE_DOCKER_SYNC" ]; then \
 			$(MAKE) ensure_sync_started && DOCKER_RUN_COMMAND+=" -v swarmkit-sync:${DOCKER_IMAGE_DIR}"; \
 		else \
@@ -48,10 +71,11 @@ run: ensure_image_exists
 		fi \
 		&& if [ "$$DOCKER_SWARMKIT_USE_DELVE" ]; then \
 			DOCKER_RUN_COMMAND="DOCKER_SWARMKIT_DELVE_PORT=${DOCKER_SWARMKIT_DELVE_PORT} $$DOCKER_RUN_COMMAND" ; \
-			DOCKER_RUN_COMMAND+=" -p ${DOCKER_SWARMKIT_DELVE_PORT}:${DOCKER_SWARMKIT_DELVE_PORT} -e DOCKER_SWARMKIT_DELVE_PORT"; \
+		DOCKER_RUN_COMMAND+=" -p ${DOCKER_SWARMKIT_DELVE_PORT}:${DOCKER_SWARMKIT_DELVE_PORT} -e DOCKER_SWARMKIT_DELVE_PORT"; \
 			`# see https://github.com/derekparker/delve/issues/515#issuecomment-214911481'` ; \
 			DOCKER_RUN_COMMAND+=" --security-opt=seccomp:unconfined"; \
 		fi \
-		&& DOCKER_RUN_COMMAND+=" $$DOCKER_SWARMKIT_DOCKER_RUN_FLAGS $$DOCKER_SWARMKIT_EXTRA_RUN_FLAGS ${IMAGE_NAME} $$DOCKER_SWARMKIT_DOCKER_RUN_CMD" \
-		&& echo $$DOCKER_RUN_COMMAND \
-		&& eval $$DOCKER_RUN_COMMAND
+	fi \
+	&& DOCKER_RUN_COMMAND+=" $$DOCKER_SWARMKIT_DOCKER_RUN_FLAGS $$DOCKER_SWARMKIT_EXTRA_RUN_FLAGS ${IMAGE_NAME} $$DOCKER_SWARMKIT_DOCKER_RUN_CMD" \
+	&& echo $$DOCKER_RUN_COMMAND \
+	&& eval $$DOCKER_RUN_COMMAND


### PR DESCRIPTION
Adds a flag, DOCKER_SWARMKIT_NOMOUNT, which, when used with DOCKER_SWARMKIT_USE_CONTAINER, avoids bind mounting the local directory into the container. This is useful if you are building and running the commands over a TCP socket.

Additionally, documents the various makefile flags we have available.

I did this because my local dev setup is weird. I'm running Windows Subsystem for Linux, so I can use most of my typical dev workflow on my local machine. However, I'm also using Docker for Windows, because Docker doesn't work natively in WSL. The easiest way to do this is to expose the Docker for Windows daemon on a TCP socket and point the Docker client in WSL at that TCP socket. This has the side-effect of making bind-mounting the directory in WSL not possible.

I'm not entirely sure that this doesn't break the existing code path, so I was hoping @wk8 could manually ensure there's no regression in the makefile