### PR TITLE
Include old error-message for backward compatibility

### DIFF
--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -682,7 +682,10 @@ func (s *Server) CreateService(ctx context.Context, request *api.CreateServiceRe
 	})
 	switch err {
 	case store.ErrNameConflict:
-		return nil, status.Errorf(codes.AlreadyExists, "service %s already exists", request.Spec.Annotations.Name)
+		// Enhance the name-confict error to include the service name. The original
+		// `ErrNameConflict` error-message is included for backward-compatibility
+		// with older consumers of the API performing string-matching.
+		return nil, status.Errorf(codes.AlreadyExists, "%s: service %s already exists", err.Error(), request.Spec.Annotations.Name)
 	case nil:
 		return &api.CreateServiceResponse{Service: service}, nil
 	default:

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -623,6 +623,10 @@ func TestCreateService(t *testing.T) {
 	r, err = ts.Client.CreateService(context.Background(), &api.CreateServiceRequest{Spec: spec})
 	assert.Error(t, err)
 	assert.Equal(t, codes.AlreadyExists, testutils.ErrorCode(err))
+
+	// Make sure the error contains "name conflicts with an existing object" for
+	// backward-compatibility with older clients doing string-matching...
+	assert.Contains(t, err.Error(), "name conflicts with an existing object")
 }
 
 func TestSecretValidation(t *testing.T) {


### PR DESCRIPTION
Commit 2061af766f61f6bc8d3e43d5553fba315f569597 (https://github.com/docker/swarmkit/pull/2779) fixed the API returning incorrect status codes, but also changed the error message for conflicting service-names to be in line with other objects (secrets, configs); "service XX already exists".

Unfortunately, there are existing consumers of the API that perform string-matching, and changing the error-message resulted in a breaking change.

This patch prepends the `ErrNameConflict` error-message to the error-message, so that those consumers still find the original message, but preserves the enhancement made in 2061af7 (inclusion of the conflicting service name).

With this patch applied, the error message will look like this;

    name conflicts with an existing object: service myservice already exists

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

```Markdown
- Include old error-message for backward compatibility [docker/swarmkit#2797](https://github.com/docker/swarmkit/pull/2797)
```