### PR TITLE
Run coverage tests once

### DIFF
--- a/direct.mk
+++ b/direct.mk
@@ -124,7 +124,6 @@ coverage: ## generate coverprofiles from the unit tests
 	@echo "🐳 $@"
 	@( for pkg in $(filter-out ${INTEGRATION_PACKAGE},${PACKAGES}); do \
 		go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=atomic $$pkg || exit; \
-		go test ${RACE} -tags "${DOCKER_BUILDTAGS}" -test.short -coverprofile="../../../$$pkg/coverage.txt" -covermode=atomic $$pkg || exit; \
 	done )
 
 .PHONY: coverage-integration


### PR DESCRIPTION
For some weird reason, make coverage runs the exact same command twice in a row. I can't find any reason why this would be needed. Removes the duplicate line, so tests only run once.

Should result in a 2x speedup of CI jobs lol

/cc @kolyshkin, who was the last person to touch this line when he removed the `-i` flag from the first of the two lines.