### PR TITLE
Avoid logging bogus error

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -959,7 +959,7 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 		}
 		err := store.CreateCluster(tx, clusterObj)
 
-		if err != nil && err != store.ErrExist {
+		if err != nil && (err != store.ErrExist || err != store.ErrNameConflict) {
 			log.G(ctx).WithError(err).Errorf("error creating cluster object")
 		}
 


### PR DESCRIPTION
When starting everything up, we try creating a cluster object. If this fails, we log an error, unless it fails because the cluster object already exists. However, we're checking for `store.ErrExist`, which is based on an ID conflict, when the real error returned in this case would be `store.ErrNameConflict`, because we check the name first.

Fixes one of the errors mentioned in moby/moby#38189