### PR TITLE
Fix make check

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,7 +9,6 @@
 		"gofmt",
 		"goimports",
 		"golint",
-		"gosimple",
 		"ineffassign",
 		"deadcode",
 		"unconvert"


### PR DESCRIPTION
gometalinter dropped support for gosimple, which is deprecated anyway and has been subsumed by staticcheck. This commit removes gosimple from our list of enabled linters (as it's no longer valid).

This PR is needed or CI will fail every time.