### PR TITLE
Revert "Actually starting to use the deallocator to clean up services"

### DIFF
--- a/cmd/swarmctl/network/inspect.go
+++ b/cmd/swarmctl/network/inspect.go
@@ -51,10 +51,6 @@ func printNetworkSummary(network *api.Network) {
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", network.ID)
 	common.FprintfIfNotEmpty(w, "Name\t: %s\n", spec.Annotations.Name)
 
-	if network.PendingDelete {
-		common.FprintfIfNotEmpty(w, "[Network %s marked for removal]\n", spec.Annotations.Name)
-	}
-
 	fmt.Fprintln(w, "Spec:\t")
 	if len(spec.Annotations.Labels) > 0 {
 		fmt.Fprintln(w, "  Labels:\t")

--- a/cmd/swarmctl/service/inspect.go
+++ b/cmd/swarmctl/service/inspect.go
@@ -22,17 +22,12 @@ func printServiceSummary(service *api.Service, running int) {
 	w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
 	defer w.Flush()
 
-	spec := service.Spec
+	task := service.Spec.Task
 	common.FprintfIfNotEmpty(w, "ID\t: %s\n", service.ID)
-	common.FprintfIfNotEmpty(w, "Name\t: %s\n", spec.Annotations.Name)
-
-	if service.PendingDelete {
-		common.FprintfIfNotEmpty(w, "[Service %s marked for removal]\n", spec.Annotations.Name)
-	}
-
-	if len(spec.Annotations.Labels) > 0 {
+	common.FprintfIfNotEmpty(w, "Name\t: %s\n", service.Spec.Annotations.Name)
+	if len(service.Spec.Annotations.Labels) > 0 {
 		fmt.Fprintln(w, "Labels\t")
-		for k, v := range spec.Annotations.Labels {
+		for k, v := range service.Spec.Annotations.Labels {
 			fmt.Fprintf(w, "  %s\t: %s\n", k, v)
 		}
 	}
@@ -56,8 +51,7 @@ func printServiceSummary(service *api.Service, running int) {
 
 	fmt.Fprintln(w, "Template\t")
 	fmt.Fprintln(w, " Container\t")
-	task := spec.Task
-	ctr := task.GetContainer()
+	ctr := service.Spec.Task.GetContainer()
 	common.FprintfIfNotEmpty(w, "  Image\t: %s\n", ctr.Image)
 	common.FprintfIfNotEmpty(w, "  Command\t: %q\n", strings.Join(ctr.Command, " "))
 	common.FprintfIfNotEmpty(w, "  Args\t: [%s]\n", strings.Join(ctr.Args, ", "))
@@ -96,7 +90,7 @@ func printServiceSummary(service *api.Service, running int) {
 			printResources(w, res.Limits)
 		}
 	}
-	if len(spec.Task.Networks) > 0 {
+	if len(service.Spec.Task.Networks) > 0 {
 		fmt.Fprint(w, "  Networks:")
 		for _, n := range service.Spec.Task.Networks {
 			fmt.Fprintf(w, " %s", n.Target)

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -199,10 +199,8 @@ func (s *Server) removeNetwork(id string) error {
 			return status.Errorf(codes.Internal, "could not find services using network %s: %v", id, err)
 		}
 
-		for _, service := range services {
-			if !service.PendingDelete {
-				return status.Errorf(codes.FailedPrecondition, "network %s is in use by service %s", id, service.ID)
-			}
+		if len(services) != 0 {
+			return status.Errorf(codes.FailedPrecondition, "network %s is in use by service %s", id, services[0].ID)
 		}
 
 		tasks, err := store.FindTasks(tx, store.ByReferencedNetworkID(id))
@@ -216,12 +214,7 @@ func (s *Server) removeNetwork(id string) error {
 			}
 		}
 
-		network := store.GetNetwork(tx, id)
-		if network == nil {
-			return status.Errorf(codes.NotFound, "network %s not found", id)
-		}
-		network.PendingDelete = true
-		return store.UpdateNetwork(tx, network)
+		return store.DeleteNetwork(tx, id)
 	})
 }
 

--- a/manager/controlapi/network_test.go
+++ b/manager/controlapi/network_test.go
@@ -191,28 +191,9 @@ func TestRemoveNetworkWithAttachedService(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, nr.Network, nil)
 	assert.NotEqual(t, nr.Network.ID, "")
-	createServiceInNetwork(t, ts, "service1", "image", nr.Network.ID, 1)
+	createServiceInNetwork(t, ts, "name", "image", nr.Network.ID, 1)
 	_, err = ts.Client.RemoveNetwork(context.Background(), &api.RemoveNetworkRequest{NetworkID: nr.Network.ID})
 	assert.Error(t, err)
-}
-
-func TestRemoveNetworkWithAttachedServiceMarkedForRemoval(t *testing.T) {
-	ts := newTestServer(t)
-	defer ts.Stop()
-	nr, err := ts.Client.CreateNetwork(context.Background(), &api.CreateNetworkRequest{
-		Spec: createNetworkSpec("testnet5"),
-	})
-	assert.NoError(t, err)
-	assert.NotEqual(t, nr.Network, nil)
-	assert.NotEqual(t, nr.Network.ID, "")
-	service := createServiceInNetwork(t, ts, "service2", "image", nr.Network.ID, 1)
-	// then let's delete the service
-	r, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{ServiceID: service.ID})
-	assert.NoError(t, err)
-	assert.NotNil(t, r)
-	// now we should be able to delete the network
-	_, err = ts.Client.RemoveNetwork(context.Background(), &api.RemoveNetworkRequest{NetworkID: nr.Network.ID})
-	assert.NoError(t, err)
 }
 
 func TestCreateNetworkInvalidDriver(t *testing.T) {

--- a/manager/controlapi/service.go
+++ b/manager/controlapi/service.go
@@ -722,7 +722,6 @@ func (s *Server) GetService(ctx context.Context, request *api.GetServiceRequest)
 // - Returns `NotFound` if the Service is not found.
 // - Returns `InvalidArgument` if the ServiceSpec is malformed.
 // - Returns `Unimplemented` if the ServiceSpec references unimplemented features.
-// - Returns `FailedPrecondition` if the Service is marked for removal
 // - Returns an error if the update fails.
 func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRequest) (*api.UpdateServiceResponse, error) {
 	if request.ServiceID == "" || request.ServiceVersion == nil {
@@ -754,12 +753,6 @@ func (s *Server) UpdateService(ctx context.Context, request *api.UpdateServiceRe
 		service = store.GetService(tx, request.ServiceID)
 		if service == nil {
 			return status.Errorf(codes.NotFound, "service %s not found", request.ServiceID)
-		}
-
-		// we couldn't do this any sooner, as we do need to be holding the lock
-		// when checking for this flag
-		if service.PendingDelete {
-			return status.Errorf(codes.FailedPrecondition, "service %s is marked for removal", request.ServiceID)
 		}
 
 		// It's not okay to update Service.Spec.Networks on its own.
@@ -855,15 +848,12 @@ func (s *Server) RemoveService(ctx context.Context, request *api.RemoveServiceRe
 	}
 
 	err := s.store.Update(func(tx store.Tx) error {
-		service := store.GetService(tx, request.ServiceID)
-		if service == nil {
-			return status.Errorf(codes.NotFound, "service %s not found", request.ServiceID)
-		}
-		// mark service for removal
-		service.PendingDelete = true
-		return store.UpdateService(tx, service)
+		return store.DeleteService(tx, request.ServiceID)
 	})
 	if err != nil {
+		if err == store.ErrNotExist {
+			return nil, status.Errorf(codes.NotFound, "service %s not found", request.ServiceID)
+		}
 		return nil, err
 	}
 	return &api.RemoveServiceResponse{}, nil

--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -956,19 +956,6 @@ func TestUpdateService(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, testutils.ErrorCode(err))
 }
 
-func TestUpdateServiceMarkedForRemoval(t *testing.T) {
-	ts := newTestServer(t)
-	defer ts.Stop()
-
-	service := createService(t, ts, "name", "image", 1)
-	r, err := ts.Client.RemoveService(context.Background(), &api.RemoveServiceRequest{ServiceID: service.ID})
-	assert.NoError(t, err)
-	assert.NotNil(t, r)
-
-	_, err = ts.Client.UpdateService(context.Background(), &api.UpdateServiceRequest{ServiceID: service.ID, Spec: &service.Spec, ServiceVersion: &service.Meta.Version})
-	assert.Equal(t, codes.FailedPrecondition, testutils.ErrorCode(err))
-}
-
 func TestServiceUpdateRejectNetworkChange(t *testing.T) {
 	ts := newTestServer(t)
 	defer ts.Stop()

--- a/manager/deallocator/deallocator.go
+++ b/manager/deallocator/deallocator.go
@@ -2,7 +2,6 @@ package deallocator
 
 import (
 	"context"
-	"sync"
 
 	"github.com/docker/go-events"
 	"github.com/docker/swarmkit/api"
@@ -32,9 +31,6 @@ import (
 // https://github.com/docker/swarmkit/compare/a84c01f49091167dd086c26b45dc18b38d52e4d9...wk8:wk8/generic_deallocator#diff-75f4f75eee6a6a7a7268c672203ea0ac
 type Deallocator struct {
 	store *store.MemoryStore
-
-	// closeOnce ensures that stopChan is closed only once
-	closeOnce sync.Once
 
 	// for services that are shutting down, we keep track of how many
 	// tasks still exist for them
@@ -98,7 +94,6 @@ func (deallocator *Deallocator) Run(ctx context.Context) error {
 
 			return
 		},
-		api.EventUpdateTask{},
 		api.EventDeleteTask{},
 		api.EventUpdateService{},
 		api.EventUpdateNetwork{})
@@ -134,7 +129,7 @@ func (deallocator *Deallocator) Run(ctx context.Context) error {
 	for {
 		select {
 		case event := <-eventsChan:
-			if updated, err := deallocator.handleEvent(ctx, event); err == nil {
+			if updated, err := deallocator.processNewEvent(ctx, event); err == nil {
 				deallocator.notifyEventChan(updated)
 			} else {
 				log.G(ctx).WithError(err).Errorf("error processing deallocator event %#v", event)
@@ -147,16 +142,11 @@ func (deallocator *Deallocator) Run(ctx context.Context) error {
 	}
 }
 
-// Stop stops the deallocator's routine and wait for the main loop to exit
-// Stop can be called in two cases. One when the manager is
-// shutting down, and the other when the manager (the leader) is
-// becoming a follower. Since these two instances could race with
-// each other, we use closeOnce here to ensure that TaskReaper.Stop()
-// is called only once to avoid a panic.
+// Stop stops the deallocator's routine
+// FIXME (jrouge): see the comment on TaskReaper.Stop() and see when to properly stop this
+// plus unit test on this!
 func (deallocator *Deallocator) Stop() {
-	deallocator.closeOnce.Do(func() {
-		close(deallocator.stopChan)
-	})
+	close(deallocator.stopChan)
 	<-deallocator.doneChan
 }
 
@@ -190,21 +180,11 @@ func (deallocator *Deallocator) processService(ctx context.Context, service *api
 		// better to clean up resources that shouldn't be cleaned up yet
 		// than ending up with a service and some resources lost in limbo forever
 		return true, deallocator.deallocateService(ctx, service)
-	}
-
-	remainingTasks := 0
-	for _, task := range tasks {
-		if isTaskStillAlive(task) {
-			remainingTasks++
-		}
-	}
-
-	if remainingTasks == 0 {
+	} else if len(tasks) == 0 {
 		// no tasks remaining for this service, we can clean it up
 		return true, deallocator.deallocateService(ctx, service)
 	}
-
-	deallocator.services[service.ID] = &serviceWithTaskCounts{service: service, taskCount: remainingTasks}
+	deallocator.services[service.ID] = &serviceWithTaskCounts{service: service, taskCount: len(tasks)}
 	return false, nil
 }
 
@@ -283,16 +263,24 @@ func (deallocator *Deallocator) processNetwork(ctx context.Context, tx store.Tx,
 	return
 }
 
-// Handles new events, and dispatches to the right method depending on what
+// Processes new events, and dispatches to the right method depending on what
 // type of event it is.
 // The boolean part of the return tuple indicates whether anything was actually
 // removed from the store
-func (deallocator *Deallocator) handleEvent(ctx context.Context, event events.Event) (bool, error) {
+func (deallocator *Deallocator) processNewEvent(ctx context.Context, event events.Event) (bool, error) {
 	switch typedEvent := event.(type) {
-	case api.EventUpdateTask:
-		return deallocator.processTaskEvent(ctx, typedEvent.Task, typedEvent.OldTask)
 	case api.EventDeleteTask:
-		return deallocator.processTaskEvent(ctx, nil, typedEvent.Task)
+		serviceID := typedEvent.Task.ServiceID
+
+		if serviceWithCount, present := deallocator.services[serviceID]; present {
+			if serviceWithCount.taskCount <= 1 {
+				delete(deallocator.services, serviceID)
+				return deallocator.processService(ctx, serviceWithCount.service)
+			}
+			serviceWithCount.taskCount--
+		}
+
+		return false, nil
 	case api.EventUpdateService:
 		return deallocator.processService(ctx, typedEvent.Service)
 	case api.EventUpdateNetwork:
@@ -300,33 +288,4 @@ func (deallocator *Deallocator) handleEvent(ctx context.Context, event events.Ev
 	default:
 		return false, nil
 	}
-}
-
-// Common logic for handling task update/delete events
-// oldTask is the task object as it was before its update or deletion
-// newTask is nil for delete events, and the new object for updates
-func (deallocator *Deallocator) processTaskEvent(ctx context.Context, newTask, oldTask *api.Task) (bool, error) {
-	serviceID := oldTask.ServiceID
-	serviceWithCount, present := deallocator.services[serviceID]
-
-	if present && isTaskStillAlive(oldTask) && (newTask == nil || !isTaskStillAlive(newTask)) {
-		// this task belongs to a service that's shutting down, and in addition,
-		// prior to  its update or deletion it was still alive, but now it's
-		// not alive any more, so we decrement the counter of alive tasks for
-		// this service
-
-		if serviceWithCount.taskCount <= 1 {
-			delete(deallocator.services, serviceID)
-			return deallocator.processService(ctx, serviceWithCount.service)
-		}
-		serviceWithCount.taskCount--
-	}
-
-	return false, nil
-}
-
-// simple helper function to distinguish tasks that are still running
-// from ones that are done
-func isTaskStillAlive(task *api.Task) bool {
-	return task.Status.State <= api.TaskStateRunning
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -24,7 +24,6 @@ import (
 	"github.com/docker/swarmkit/manager/allocator/cnmallocator"
 	"github.com/docker/swarmkit/manager/allocator/networkallocator"
 	"github.com/docker/swarmkit/manager/controlapi"
-	"github.com/docker/swarmkit/manager/deallocator"
 	"github.com/docker/swarmkit/manager/dispatcher"
 	"github.com/docker/swarmkit/manager/drivers"
 	"github.com/docker/swarmkit/manager/health"
@@ -150,7 +149,6 @@ type Manager struct {
 	constraintEnforcer     *constraintenforcer.ConstraintEnforcer
 	scheduler              *scheduler.Scheduler
 	allocator              *allocator.Allocator
-	deallocator            *deallocator.Deallocator
 	keyManager             *keymanager.KeyManager
 	server                 *grpc.Server
 	localserver            *grpc.Server
@@ -694,9 +692,6 @@ func (m *Manager) Stop(ctx context.Context, clearData bool) {
 	if m.roleManager != nil {
 		m.roleManager.Stop()
 	}
-	if m.deallocator != nil {
-		m.deallocator.Stop()
-	}
 	if m.keyManager != nil {
 		m.keyManager.Stop()
 	}
@@ -1001,7 +996,6 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	m.scheduler = scheduler.New(s)
 	m.keyManager = keymanager.New(s, keymanager.DefaultConfig())
 	m.roleManager = newRoleManager(s, m.raftNode)
-	m.deallocator = deallocator.New(s)
 
 	// TODO(stevvooe): Allocate a context that can be used to
 	// shutdown underlying manager processes when leadership isTestUpdaterRollback
@@ -1103,10 +1097,6 @@ func (m *Manager) becomeLeader(ctx context.Context) {
 	go func(roleManager *roleManager) {
 		roleManager.Run(ctx)
 	}(m.roleManager)
-
-	go func(deallocator *deallocator.Deallocator) {
-		deallocator.Run(ctx)
-	}(m.deallocator)
 }
 
 // becomeFollower shuts down the subsystems that are only run by the leader.
@@ -1141,9 +1131,6 @@ func (m *Manager) becomeFollower() {
 
 	m.roleManager.Stop()
 	m.roleManager = nil
-
-	m.deallocator.Stop()
-	m.deallocator = nil
 
 	if m.keyManager != nil {
 		m.keyManager.Stop()

--- a/manager/orchestrator/global/global.go
+++ b/manager/orchestrator/global/global.go
@@ -109,14 +109,8 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 	var reconcileServiceIDs []string
 	for _, s := range existingServices {
 		if orchestrator.IsGlobalService(s) {
-			if s.PendingDelete {
-				// this service is marked for removal, we ask its tasks
-				// to shut down
-				orchestrator.SetServiceTasksRemove(ctx, g.store, s)
-			} else {
-				g.updateService(s)
-				reconcileServiceIDs = append(reconcileServiceIDs, s.ID)
-			}
+			g.updateService(s)
+			reconcileServiceIDs = append(reconcileServiceIDs, s.ID)
 		}
 	}
 
@@ -134,6 +128,7 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 	for {
 		select {
 		case event := <-watcher:
+			// TODO(stevvooe): Use ctx to limit running time of operation.
 			switch v := event.(type) {
 			case api.EventUpdateCluster:
 				g.cluster = v.Cluster
@@ -147,16 +142,16 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 				if !orchestrator.IsGlobalService(v.Service) {
 					continue
 				}
-				if v.Service.PendingDelete {
-					// ask the tasks to shut down
-					orchestrator.SetServiceTasksRemove(ctx, g.store, v.Service)
-					// delete the service from service map
-					delete(g.globalServices, v.Service.ID)
-					g.restarts.ClearServiceHistory(v.Service.ID)
-				} else {
-					g.updateService(v.Service)
-					g.reconcileServices(ctx, []string{v.Service.ID})
+				g.updateService(v.Service)
+				g.reconcileServices(ctx, []string{v.Service.ID})
+			case api.EventDeleteService:
+				if !orchestrator.IsGlobalService(v.Service) {
+					continue
 				}
+				orchestrator.SetServiceTasksRemove(ctx, g.store, v.Service)
+				// delete the service from service map
+				delete(g.globalServices, v.Service.ID)
+				g.restarts.ClearServiceHistory(v.Service.ID)
 			case api.EventCreateNode:
 				g.updateNode(v.Node)
 				g.reconcileOneNode(ctx, v.Node)
@@ -171,8 +166,6 @@ func (g *Orchestrator) Run(ctx context.Context) error {
 			}
 		case <-g.stopChan:
 			return nil
-		case <-ctx.Done():
-			return ctx.Err()
 		}
 		g.tickTasks(ctx)
 	}

--- a/manager/orchestrator/global/global_test.go
+++ b/manager/orchestrator/global/global_test.go
@@ -328,7 +328,7 @@ func TestDeleteService(t *testing.T) {
 
 	testutils.WatchTaskCreate(t, watch)
 
-	markServiceForDeletion(t, store, service1)
+	deleteService(t, store, service1)
 	// task should be deleted
 	observedTask := testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, observedTask.ServiceAnnotations.Name, "name1")
@@ -468,11 +468,9 @@ func updateService(t *testing.T, s *store.MemoryStore, service *api.Service, for
 	})
 }
 
-func markServiceForDeletion(t *testing.T, s *store.MemoryStore, service *api.Service) {
+func deleteService(t *testing.T, s *store.MemoryStore, service *api.Service) {
 	s.Update(func(tx store.Tx) error {
-		serviceCopy := service.Copy()
-		serviceCopy.PendingDelete = true
-		assert.NoError(t, store.UpdateService(tx, serviceCopy))
+		assert.NoError(t, store.DeleteService(tx, service.ID))
 		return nil
 	})
 }
@@ -542,7 +540,7 @@ func TestInitializationRejectedTasks(t *testing.T) {
 	defer s.Close()
 
 	// create nodes, services and tasks in store directly
-	// when orchestrator runs, it should fix tasks to declarative state
+	// where orchestrator runs, it should fix tasks to declarative state
 	addNode(t, s, node1)
 	addService(t, s, service1)
 	tasks := []*api.Task{

--- a/manager/orchestrator/replicated/replicated.go
+++ b/manager/orchestrator/replicated/replicated.go
@@ -61,7 +61,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 			return
 		}
 
-		if err = r.initServices(ctx, readTx); err != nil {
+		if err = r.initServices(readTx); err != nil {
 			return
 		}
 
@@ -78,6 +78,7 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 	for {
 		select {
 		case event := <-watcher:
+			// TODO(stevvooe): Use ctx to limit running time of operation.
 			r.handleTaskEvent(ctx, event)
 			r.handleServiceEvent(ctx, event)
 			switch v := event.(type) {
@@ -88,8 +89,6 @@ func (r *Orchestrator) Run(ctx context.Context) error {
 			}
 		case <-r.stopChan:
 			return nil
-		case <-ctx.Done():
-			return ctx.Err()
 		}
 	}
 }

--- a/manager/orchestrator/replicated/replicated_test.go
+++ b/manager/orchestrator/replicated/replicated_test.go
@@ -68,26 +68,25 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	assert.Equal(t, observedTask2.ServiceAnnotations.Name, "name1")
 
 	// Create a second service.
-	s2SpecMode := &api.ServiceSpec_Replicated{
-		Replicated: &api.ReplicatedService{
-			Replicas: 1,
-		},
-	}
-	s2 := &api.Service{
-		ID: "id2",
-		Spec: api.ServiceSpec{
-			Annotations: api.Annotations{
-				Name: "name2",
-			},
-			Task: api.TaskSpec{
-				Runtime: &api.TaskSpec_Container{
-					Container: &api.ContainerSpec{},
+	err = s.Update(func(tx store.Tx) error {
+		s2 := &api.Service{
+			ID: "id2",
+			Spec: api.ServiceSpec{
+				Annotations: api.Annotations{
+					Name: "name2",
+				},
+				Task: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+				},
+				Mode: &api.ServiceSpec_Replicated{
+					Replicated: &api.ReplicatedService{
+						Replicas: 1,
+					},
 				},
 			},
-			Mode: s2SpecMode,
-		},
-	}
-	err = s.Update(func(tx store.Tx) error {
+		}
 		assert.NoError(t, store.CreateService(tx, s2))
 		return nil
 	})
@@ -99,7 +98,24 @@ func TestReplicatedOrchestrator(t *testing.T) {
 
 	// Update a service to scale it out to 3 instances
 	err = s.Update(func(tx store.Tx) error {
-		s2SpecMode.Replicated.Replicas = 3
+		s2 := &api.Service{
+			ID: "id2",
+			Spec: api.ServiceSpec{
+				Annotations: api.Annotations{
+					Name: "name2",
+				},
+				Task: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+				},
+				Mode: &api.ServiceSpec_Replicated{
+					Replicated: &api.ReplicatedService{
+						Replicas: 3,
+					},
+				},
+			},
+		}
 		assert.NoError(t, store.UpdateService(tx, s2))
 		return nil
 	})
@@ -115,7 +131,24 @@ func TestReplicatedOrchestrator(t *testing.T) {
 
 	// Now scale it back down to 1 instance
 	err = s.Update(func(tx store.Tx) error {
-		s2SpecMode.Replicated.Replicas = 1
+		s2 := &api.Service{
+			ID: "id2",
+			Spec: api.ServiceSpec{
+				Annotations: api.Annotations{
+					Name: "name2",
+				},
+				Task: api.TaskSpec{
+					Runtime: &api.TaskSpec_Container{
+						Container: &api.ContainerSpec{},
+					},
+				},
+				Mode: &api.ServiceSpec_Replicated{
+					Replicated: &api.ReplicatedService{
+						Replicas: 1,
+					},
+				},
+			},
+		}
 		assert.NoError(t, store.UpdateService(tx, s2))
 		return nil
 	})
@@ -155,10 +188,9 @@ func TestReplicatedOrchestrator(t *testing.T) {
 	assert.Equal(t, observedTask6.Status.State, api.TaskStateNew)
 	assert.Equal(t, observedTask6.ServiceAnnotations.Name, "name2")
 
-	// Mark the service for deletion. Its remaining task should go away.
+	// Delete the service. Its remaining task should go away.
 	err = s.Update(func(tx store.Tx) error {
-		s2.PendingDelete = true
-		assert.NoError(t, store.UpdateService(tx, s2))
+		assert.NoError(t, store.DeleteService(tx, "id2"))
 		return nil
 	})
 	assert.NoError(t, err)
@@ -897,68 +929,4 @@ func TestInitializationDelayStart(t *testing.T) {
 	if after.Sub(before) < 100*time.Millisecond {
 		t.Fatalf("restart delay should have elapsed. Got: %v", after.Sub(before))
 	}
-}
-
-func TestInitializationRemovesTasksForServicesMarkedForRemoval(t *testing.T) {
-	s := store.NewMemoryStore(nil)
-	assert.NotNil(t, s)
-	defer s.Close()
-
-	service := &api.Service{
-		ID: "serviceid",
-		Spec: api.ServiceSpec{
-			Annotations: api.Annotations{
-				Name: "name",
-			},
-			Task: api.TaskSpec{
-				Runtime: &api.TaskSpec_Container{
-					Container: &api.ContainerSpec{},
-				},
-			},
-			Mode: &api.ServiceSpec_Replicated{
-				Replicated: &api.ReplicatedService{
-					Replicas: 2,
-				},
-			},
-		},
-		PendingDelete: true,
-	}
-
-	task := &api.Task{
-		ID:           "task",
-		Slot:         1,
-		DesiredState: api.TaskStateRunning,
-		Status: api.TaskStatus{
-			State: api.TaskStateNew,
-		},
-		Spec: api.TaskSpec{
-			Runtime: &api.TaskSpec_Container{
-				Container: &api.ContainerSpec{},
-			},
-		},
-		ServiceAnnotations: api.Annotations{
-			Name: "task1",
-		},
-		ServiceID: service.ID,
-	}
-
-	assert.NoError(t, s.Update(func(tx store.Tx) error {
-		assert.NoError(t, store.CreateService(tx, service))
-		assert.NoError(t, store.CreateTask(tx, task))
-		return nil
-	}))
-
-	// watch orchestration events
-	watch, cancel := state.Watch(s.WatchQueue(), api.EventUpdateTask{})
-	defer cancel()
-
-	orchestrator := NewReplicatedOrchestrator(s)
-	defer orchestrator.Stop()
-
-	go func() {
-		assert.NoError(t, orchestrator.Run(context.Background()))
-	}()
-
-	observedTask := testutils.WatchTaskUpdate(t, watch)
-	assert.Equal(t, api.TaskStateRemove, observedTask.DesiredState)
 }

--- a/manager/orchestrator/replicated/services.go
+++ b/manager/orchestrator/replicated/services.go
@@ -31,18 +31,14 @@ func (r *Orchestrator) initCluster(readTx store.ReadTx) error {
 	return nil
 }
 
-func (r *Orchestrator) initServices(ctx context.Context, readTx store.ReadTx) error {
+func (r *Orchestrator) initServices(readTx store.ReadTx) error {
 	services, err := store.FindServices(readTx, store.All)
 	if err != nil {
 		return err
 	}
 	for _, s := range services {
 		if orchestrator.IsReplicatedService(s) {
-			if s.PendingDelete {
-				orchestrator.SetServiceTasksRemove(ctx, r.store, s)
-			} else {
-				r.reconcileServices[s.ID] = s
-			}
+			r.reconcileServices[s.ID] = s
 		}
 	}
 	return nil
@@ -50,6 +46,13 @@ func (r *Orchestrator) initServices(ctx context.Context, readTx store.ReadTx) er
 
 func (r *Orchestrator) handleServiceEvent(ctx context.Context, event events.Event) {
 	switch v := event.(type) {
+	case api.EventDeleteService:
+		if !orchestrator.IsReplicatedService(v.Service) {
+			return
+		}
+		orchestrator.SetServiceTasksRemove(ctx, r.store, v.Service)
+		r.restarts.ClearServiceHistory(v.Service.ID)
+		delete(r.reconcileServices, v.Service.ID)
 	case api.EventCreateService:
 		if !orchestrator.IsReplicatedService(v.Service) {
 			return
@@ -59,13 +62,7 @@ func (r *Orchestrator) handleServiceEvent(ctx context.Context, event events.Even
 		if !orchestrator.IsReplicatedService(v.Service) {
 			return
 		}
-		if v.Service.PendingDelete {
-			orchestrator.SetServiceTasksRemove(ctx, r.store, v.Service)
-			r.restarts.ClearServiceHistory(v.Service.ID)
-			delete(r.reconcileServices, v.Service.ID)
-		} else {
-			r.reconcileServices[v.Service.ID] = v.Service
-		}
+		r.reconcileServices[v.Service.ID] = v.Service
 	}
 }
 

--- a/manager/orchestrator/taskreaper/task_reaper_test.go
+++ b/manager/orchestrator/taskreaper/task_reaper_test.go
@@ -557,11 +557,9 @@ func TestTaskStateRemoveOnServiceRemoval(t *testing.T) {
 	testutils.Expect(t, watch, api.EventUpdateTask{})
 	testutils.Expect(t, watch, state.EventCommit{})
 
-	// Mark the service for deletion. This should trigger both the task desired
-	// statuses to be set to REMOVE.
+	// Delete the service. This should trigger both the task desired statuses to be set to REMOVE.
 	err = s.Update(func(tx store.Tx) error {
-		service1.PendingDelete = true
-		assert.NoError(t, store.UpdateService(tx, service1))
+		assert.NoError(t, store.DeleteService(tx, service1.ID))
 		return nil
 	})
 
@@ -722,14 +720,13 @@ func TestServiceRemoveDeadTasks(t *testing.T) {
 	assert.Equal(t, api.TaskStateCompleted, observedTask4.Status.State)
 	assert.Equal(t, "original", observedTask4.ServiceAnnotations.Name)
 
-	// Mark the service for deletion.
+	// Delete the service.
 	err = s.Update(func(tx store.Tx) error {
-		service1.PendingDelete = true
-		assert.NoError(t, store.UpdateService(tx, service1))
+		assert.NoError(t, store.DeleteService(tx, service1.ID))
 		return nil
 	})
 
-	// That should trigger both the task desired statuses
+	// Service delete should trigger both the task desired statuses
 	// to be set to REMOVE.
 	observedTask3 = testutils.WatchTaskUpdate(t, watch)
 	assert.Equal(t, api.TaskStateRemove, observedTask3.DesiredState)


### PR DESCRIPTION
This reverts commit 2ba1cd9c6a5cd482b319e10ebfd0cb6fb394a165.

Reverting temporarily to unblock Swarmkit updates in the light
of changes requested on https://github.com/moby/moby/pull/38525