### PR TITLE
Add validation to CredentialSpec configs

### DIFF
--- a/manager/controlapi/service_test.go
+++ b/manager/controlapi/service_test.go
@@ -788,6 +788,21 @@ func TestConfigValidation(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
+	// test CredentialSpec without ConfigReference
+	serviceSpec = createSpec("missingruntimetarget", "imagemissingruntimetarget", 1)
+	serviceSpec.Task.GetContainer().Privileges = &api.Privileges{
+		CredentialSpec: &api.Privileges_CredentialSpec{
+			Source: &api.Privileges_CredentialSpec_Config{
+				Config: configRefCredSpec.ConfigID,
+			},
+		},
+	}
+	_, err = ts.Client.CreateService(
+		context.Background(), &api.CreateServiceRequest{Spec: serviceSpec},
+	)
+	t.Logf("error when missing configreference: %v", err)
+	assert.Error(t, err)
+
 	// test config target conflicts on update
 	serviceSpec1 := createServiceSpecWithConfigs("service5", configRef2, configRef3)
 	// Copy this service, but delete the configs for creation


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Adds validation assuring that if a service uses a Config as a CredentialSpec, then the Config is included in the ConfigRefs with a RuntimeTarget.

**- How to test it**

Includes a test case, which I verified fails before this change and passes after.
