### PR TITLE
[18.03 backport] use a custom grpc dialer when managers are joining

### DIFF
--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@ -1,6 +1,7 @@
 package raft
 
 import (
+	"net"
 	"time"
 
 	"golang.org/x/net/context"
@@ -15,11 +16,15 @@ import (
 
 // dial returns a grpc client connection
 func dial(addr string, protocol string, creds credentials.TransportCredentials, timeout time.Duration) (*grpc.ClientConn, error) {
+	// gRPC dialer connects to proxy first. Provide a custom dialer here avoid that.
 	grpcOptions := []grpc.DialOption{
 		grpc.WithBackoffMaxDelay(2 * time.Second),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("tcp", addr, timeout)
+		}),
 	}
 
 	if timeout != 0 {


### PR DESCRIPTION
backport of https://github.com/docker/swarmkit/pull/2802 for 18.03

Minor conflict in import statements, due to https://github.com/docker/swarmkit/pull/2750 not being in the 18.03 branch

```patch
diff --cc manager/state/raft/util.go
index da44dca6,1a49f76c..00000000
--- a/manager/state/raft/util.go
+++ b/manager/state/raft/util.go
@@@ -1,10 -1,10 +1,15 @@@
  package raft
  
  import (
++<<<<<<< HEAD
++=======
+       "context"
+       "net"
++>>>>>>> 3a531f45... use a custom grpc dialer when managers are joining
        "time"
  
 +      "golang.org/x/net/context"
 +
        "github.com/docker/swarmkit/api"
        "github.com/docker/swarmkit/manager/state"
        "github.com/docker/swarmkit/manager/state/store"
```