### PR TITLE
[18.09 backport] Fix make check

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -9,7 +9,6 @@
 		"gofmt",
 		"goimports",
 		"golint",
-		"gosimple",
 		"ineffassign",
 		"deadcode",
 		"unconvert"


### PR DESCRIPTION
backport of https://github.com/docker/swarmkit/pull/2811 for 18.09. cherry-pick was clean; no conflicts


gometalinter dropped support for gosimple, which is deprecated anyway
and has been subsumed by staticcheck. This commit removes gosimple from
our list of enabled linters (as it's no longer valid). It does not
enable staticcheck, because staticcheck throws too many errors.
