### PR TITLE
[18.09 backport] Switch to go 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Needed to install go
       OS: linux
       ARCH: amd64
-      GOVERSION: 1.10.3
+      GOVERSION: 1.11
       # Needed to install protoc
       PROTOC_VERSION: 3.6.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.10.3-stretch
+FROM golang:1.11.0-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.11.0-stretch
+FROM golang:1.11.13-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 

--- a/api/api.pb.txt
+++ b/api/api.pb.txt
@@ -2491,8 +2491,8 @@ file {
         label: LABEL_OPTIONAL
         type: TYPE_UINT32
         options {
-          65003: "os.FileMode"
           65001: 0
+          65003: "os.FileMode"
         }
         json_name: "mode"
       }
@@ -2646,8 +2646,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Duration"
       options {
-        65011: 1
         65001: 0
+        65011: 1
       }
       json_name: "delay"
     }
@@ -3090,8 +3090,8 @@ file {
         }
       }
       options {
-        62023: "PublishMode"
         62001: 0
+        62023: "PublishMode"
       }
     }
   }
@@ -3790,8 +3790,8 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_UINT32
       options {
-        65003: "os.FileMode"
         65001: 0
+        65003: "os.FileMode"
       }
       json_name: "mode"
     }
@@ -4207,8 +4207,8 @@ file {
       }
     }
     options {
-      62023: "NodeRole"
       62001: 0
+      62023: "NodeRole"
     }
   }
   syntax: "proto3"
@@ -8058,8 +8058,8 @@ file {
       type: TYPE_MESSAGE
       type_name: ".google.protobuf.Duration"
       options {
-        65011: 1
         65001: 0
+        65011: 1
       }
       json_name: "period"
     }
@@ -9106,11 +9106,11 @@ file {
     }
   }
   options {
-    63017: 1
-    63020: 1
-    63018: 1
     63001: 0
     63002: 0
+    63017: 1
+    63018: 1
+    63020: 1
   }
 }
 file {

--- a/api/dispatcher.pb.go
+++ b/api/dispatcher.pb.go
@@ -1664,7 +1664,7 @@ func (p *raftProxyDispatcherServer) Session(r *SessionRequest, stream Dispatcher
 			}
 			streamWrapper := Dispatcher_SessionServerWrapper{
 				Dispatcher_SessionServer: stream,
-				ctx: ctx,
+				ctx:                      ctx,
 			}
 			return p.local.Session(r, streamWrapper)
 		}
@@ -1785,7 +1785,7 @@ func (p *raftProxyDispatcherServer) Tasks(r *TasksRequest, stream Dispatcher_Tas
 			}
 			streamWrapper := Dispatcher_TasksServerWrapper{
 				Dispatcher_TasksServer: stream,
-				ctx: ctx,
+				ctx:                    ctx,
 			}
 			return p.local.Tasks(r, streamWrapper)
 		}
@@ -1836,7 +1836,7 @@ func (p *raftProxyDispatcherServer) Assignments(r *AssignmentsRequest, stream Di
 			}
 			streamWrapper := Dispatcher_AssignmentsServerWrapper{
 				Dispatcher_AssignmentsServer: stream,
-				ctx: ctx,
+				ctx:                          ctx,
 			}
 			return p.local.Assignments(r, streamWrapper)
 		}

--- a/api/logbroker.pb.go
+++ b/api/logbroker.pb.go
@@ -1335,7 +1335,7 @@ func (p *raftProxyLogsServer) SubscribeLogs(r *SubscribeLogsRequest, stream Logs
 			}
 			streamWrapper := Logs_SubscribeLogsServerWrapper{
 				Logs_SubscribeLogsServer: stream,
-				ctx: ctx,
+				ctx:                      ctx,
 			}
 			return p.local.SubscribeLogs(r, streamWrapper)
 		}
@@ -1458,7 +1458,7 @@ func (p *raftProxyLogBrokerServer) ListenSubscriptions(r *ListenSubscriptionsReq
 			}
 			streamWrapper := LogBroker_ListenSubscriptionsServerWrapper{
 				LogBroker_ListenSubscriptionsServer: stream,
-				ctx: ctx,
+				ctx:                                 ctx,
 			}
 			return p.local.ListenSubscriptions(r, streamWrapper)
 		}
@@ -1509,7 +1509,7 @@ func (p *raftProxyLogBrokerServer) PublishLogs(stream LogBroker_PublishLogsServe
 			}
 			streamWrapper := LogBroker_PublishLogsServerWrapper{
 				LogBroker_PublishLogsServer: stream,
-				ctx: ctx,
+				ctx:                         ctx,
 			}
 			return p.local.PublishLogs(streamWrapper)
 		}

--- a/api/raft.pb.go
+++ b/api/raft.pb.go
@@ -1746,7 +1746,7 @@ func (p *raftProxyRaftServer) StreamRaftMessage(stream Raft_StreamRaftMessageSer
 			}
 			streamWrapper := Raft_StreamRaftMessageServerWrapper{
 				Raft_StreamRaftMessageServer: stream,
-				ctx: ctx,
+				ctx:                          ctx,
 			}
 			return p.local.StreamRaftMessage(streamWrapper)
 		}

--- a/api/types.pb.go
+++ b/api/types.pb.go
@@ -594,7 +594,7 @@ var MaybeEncryptedRecord_Algorithm_name = map[int32]string{
 	2: "FERNET_AES_128_CBC",
 }
 var MaybeEncryptedRecord_Algorithm_value = map[string]int32{
-	"NONE": 0,
+	"NONE":                       0,
 	"SECRETBOX_SALSA20_POLY1305": 1,
 	"FERNET_AES_128_CBC":         2,
 }

--- a/manager/scheduler/constraint_test.go
+++ b/manager/scheduler/constraint_test.go
@@ -54,7 +54,7 @@ func setupEnv() {
 				Addr:  "186.17.9.41",
 			},
 		},
-		Tasks: make(map[string]*api.Task),
+		Tasks:                     make(map[string]*api.Task),
 		ActiveTasksCountByService: make(map[string]int),
 	}
 }

--- a/manager/scheduler/nodeinfo.go
+++ b/manager/scheduler/nodeinfo.go
@@ -45,8 +45,8 @@ type NodeInfo struct {
 
 func newNodeInfo(n *api.Node, tasks map[string]*api.Task, availableResources api.Resources) NodeInfo {
 	nodeInfo := NodeInfo{
-		Node:  n,
-		Tasks: make(map[string]*api.Task),
+		Node:                      n,
+		Tasks:                     make(map[string]*api.Task),
 		ActiveTasksCountByService: make(map[string]int),
 		AvailableResources:        availableResources.Copy(),
 		usedHostPorts:             make(map[hostPortSpec]struct{}),

--- a/protobuf/plugin/raftproxy/test/service.pb.go
+++ b/protobuf/plugin/raftproxy/test/service.pb.go
@@ -1070,7 +1070,7 @@ func (p *raftProxyRouteGuideServer) ListFeatures(r *Rectangle, stream RouteGuide
 			}
 			streamWrapper := RouteGuide_ListFeaturesServerWrapper{
 				RouteGuide_ListFeaturesServer: stream,
-				ctx: ctx,
+				ctx:                           ctx,
 			}
 			return p.local.ListFeatures(r, streamWrapper)
 		}
@@ -1121,7 +1121,7 @@ func (p *raftProxyRouteGuideServer) RecordRoute(stream RouteGuide_RecordRouteSer
 			}
 			streamWrapper := RouteGuide_RecordRouteServerWrapper{
 				RouteGuide_RecordRouteServer: stream,
-				ctx: ctx,
+				ctx:                          ctx,
 			}
 			return p.local.RecordRoute(streamWrapper)
 		}
@@ -1178,7 +1178,7 @@ func (p *raftProxyRouteGuideServer) RouteChat(stream RouteGuide_RouteChatServer)
 			}
 			streamWrapper := RouteGuide_RouteChatServerWrapper{
 				RouteGuide_RouteChatServer: stream,
-				ctx: ctx,
+				ctx:                        ctx,
 			}
 			return p.local.RouteChat(streamWrapper)
 		}


### PR DESCRIPTION
backport of;

- https://github.com/docker/swarmkit/pull/2752 Switch to go 1.11
- daf87201f686710974b282d4c0b0c8422e55dac9 Bump Golang 1.11.13
  - taken from `#2880`  

Whitespace changes are caused by the fact that gofmt from go-1.11
uses a different heuristic as to how to format the file, making
the source code that was OK for go-1.10 causing a warning with
go-1.11.

NOTE this whitespace change makes the gofmt from go-1.10 complain,
so please upgrade your golang.

[v2: regen pb files]

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>
(cherry picked from commit fd2d7f2ef925282e8cd2920efa253151749102ad)
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
