### PR TITLE
Fix linting error

### DIFF
--- a/manager/allocator/network.go
+++ b/manager/allocator/network.go
@@ -184,7 +184,7 @@ func (a *Allocator) doNetworkAlloc(ctx context.Context, ev events.Event) {
 		}
 		if IsIngressNetwork(n) && nc.ingressNetwork != nil {
 			log.G(ctx).Errorf("Cannot allocate ingress network %s (%s) because another ingress network is already present: %s (%s)",
-				n.ID, n.Spec.Annotations.Name, nc.ingressNetwork.ID, nc.ingressNetwork.Spec.Annotations)
+				n.ID, n.Spec.Annotations.Name, nc.ingressNetwork.ID, nc.ingressNetwork.Spec.Annotations.Name)
 			break
 		}
 


### PR DESCRIPTION
Fixes;

    manager/allocator/network.go:186::error: Entry.Errorf format %s has arg nc.ingressNetwork.Spec.Annotations of wrong type github.com/docker/swarmkit/api.Annotations (vet)

