### PR TITLE
Switch CPU Limit from CPU Period / Quota to Nano CPU

### DIFF
--- a/agent/exec/dockerapi/container.go
+++ b/agent/exec/dockerapi/container.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	enginecontainer "github.com/docker/docker/api/types/container"
@@ -25,10 +24,6 @@ import (
 )
 
 const (
-	// Explicitly use the kernel's default setting for CPU quota of 100ms.
-	// https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt
-	cpuQuotaPeriod = 100 * time.Millisecond
-
 	// systemLabelPrefix represents the reserved namespace for system labels.
 	systemLabelPrefix = "com.docker.swarm"
 )
@@ -459,9 +454,7 @@ func (c *containerConfig) resources() enginecontainer.Resources {
 	}
 
 	if r.Limits.NanoCPUs > 0 {
-		// CPU Period must be set in microseconds.
-		resources.CPUPeriod = int64(cpuQuotaPeriod / time.Microsecond)
-		resources.CPUQuota = r.Limits.NanoCPUs * resources.CPUPeriod / 1e9
+		resources.NanoCPUs = r.Limits.NanoCPUs
 	}
 
 	return resources


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

To try and fix https://github.com/moby/moby/issues/33538 and provide support for limiting CPU on Windows Workloads I have switched the CPU reservations from Period / Quota to Nano CPU. Making `$ docker service create --limit-cpu` the same as `$ docker run --cpu`. Today `$ docker service create --limit-cpu` is the same as `$ docker run -cpu-period --cpu-quota`. 

The reason this change was required is because CPU Period is not supported on Windows today: 

```
$ docker service create --limit-cpu "1.5" --name demo hello-world
8la8dhl7gml1biihijaxzrgwq
overall progress: 0 out of 1 tasks
1/1: invalid option: Windows does not support CPUPeriod
```

https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/resource-controls

I have tested this change locally on a Linux machine and it now sets the NanoCPU setting correctly and does not set CPU Period / Quota. Note I haven't actually tested this on a Windows Machine though.

@dperny PTAL :) 
