### PR TITLE
[bump_v19.03 backport] rerun vndr to appease CI

### DIFF
--- a/vendor/github.com/stretchr/testify/go.mod
+++ b/vendor/github.com/stretchr/testify/go.mod
@@ -1,0 +1,7 @@
+module github.com/stretchr/testify
+
+require (
+	github.com/davecgh/go-spew v1.1.0
+	github.com/pmezard/go-difflib v1.0.0
+	github.com/stretchr/objx v0.1.0
+)

--- a/vendor/golang.org/x/crypto/go.mod
+++ b/vendor/golang.org/x/crypto/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/crypto
+
+require golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a


### PR DESCRIPTION
Accomplishes the same thing as #2853, but on the bump_v19.03 branch. Is a new commit, because that's easier than a cherry-pick in this particular case.