### PR TITLE
Revert "Make Service.UpdateStatus non-ambiguous"

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -141,17 +141,10 @@ func (u *Updater) Run(ctx context.Context, slots []orchestrator.Slot) {
 	}
 	// Abort immediately if all tasks are clean.
 	if len(dirtySlots) == 0 {
-		if service.UpdateStatus == nil {
-			if u.annotationsUpdated(service) {
-				// Annotation-only update; mark the update as completed
-				u.completeUpdate(ctx, service.ID, true)
-			}
-			return
-		}
-		if service.UpdateStatus.State == api.UpdateStatus_UPDATING || service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
-			// Update or rollback was started, and is now complete
-			u.completeUpdate(ctx, service.ID, true)
-			return
+		if service.UpdateStatus != nil &&
+			(service.UpdateStatus.State == api.UpdateStatus_UPDATING ||
+				service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED) {
+			u.completeUpdate(ctx, service.ID)
 		}
 		return
 	}
@@ -310,7 +303,7 @@ slotsLoop:
 	// have reached RUNNING by this point.
 
 	if !stopped {
-		u.completeUpdate(ctx, service.ID, false)
+		u.completeUpdate(ctx, service.ID)
 	}
 }
 
@@ -623,32 +616,25 @@ func (u *Updater) rollbackUpdate(ctx context.Context, serviceID, message string)
 	}
 }
 
-func (u *Updater) completeUpdate(ctx context.Context, serviceID string, force bool) {
+func (u *Updater) completeUpdate(ctx context.Context, serviceID string) {
 	log.G(ctx).Debugf("update of service %s complete", serviceID)
 
 	err := u.store.Update(func(tx store.Tx) error {
 		service := store.GetService(tx, serviceID)
-		switch {
-		case service == nil:
+		if service == nil {
 			return nil
-		case service.UpdateStatus == nil && force:
-			// Force marking the status as updated; to account for annotation-only updates.
-			service.UpdateStatus = &api.UpdateStatus{
-				StartedAt: ptypes.MustTimestampProto(time.Now()),
-				State:     api.UpdateStatus_COMPLETED,
-				Message:   "update completed",
-			}
-		case service.UpdateStatus == nil:
+		}
+		if service.UpdateStatus == nil {
 			// The service was changed since we started this update
 			return nil
-		case service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED:
+		}
+		if service.UpdateStatus.State == api.UpdateStatus_ROLLBACK_STARTED {
 			service.UpdateStatus.State = api.UpdateStatus_ROLLBACK_COMPLETED
 			service.UpdateStatus.Message = "rollback completed"
-		default:
+		} else {
 			service.UpdateStatus.State = api.UpdateStatus_COMPLETED
 			service.UpdateStatus.Message = "update completed"
 		}
-
 		service.UpdateStatus.CompletedAt = ptypes.MustTimestampProto(time.Now())
 
 		return store.UpdateService(tx, service)
@@ -657,11 +643,4 @@ func (u *Updater) completeUpdate(ctx context.Context, serviceID string, force bo
 	if err != nil {
 		log.G(ctx).WithError(err).Errorf("failed to mark update of service %s complete", serviceID)
 	}
-}
-
-func (u *Updater) annotationsUpdated(service *api.Service) bool {
-	if service.PreviousSpec == nil {
-		return false
-	}
-	return !reflect.DeepEqual(service.Spec, service.PreviousSpec)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Revert #2804 for reasons outlined in #2861.

**- How I did it**

I ran `git revert 171d814`, but then realized I forgot to add `--signoff`, so I emptied the commit message to abort the commit. Then, I made this same mistake 2 more times in a row. I am not a clever man.

/cc @thaJeztah

Additionally, this change will be backported to 19.03