### PR TITLE
[Jobs] Add service reconciliation for replicated jobs

### DIFF
--- a/manager/orchestrator/replicatedjob/orchestrator.go
+++ b/manager/orchestrator/replicatedjob/orchestrator.go
@@ -2,8 +2,11 @@ package job
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
 )
 
@@ -12,6 +15,10 @@ import (
 type Orchestrator struct {
 	// we need the store, of course, to do updates
 	store *store.MemoryStore
+
+	// a copy of the cluster is needed, because we need it when creating tasks
+	// to set the default log driver
+	cluster *api.Cluster
 
 	// stopChan is a channel that is closed to signal the orchestrator to stop
 	// running
@@ -23,7 +30,7 @@ type Orchestrator struct {
 	doneChan chan struct{}
 }
 
-func NewReplicatedJobOrchestrator(store *store.MemoryStore) *Orchestrator {
+func NewOrchestrator(store *store.MemoryStore) *Orchestrator {
 	return &Orchestrator{
 		store:    store,
 		stopChan: make(chan struct{}),
@@ -43,6 +50,171 @@ func (o *Orchestrator) Run(ctx context.Context) {
 	// TODO(dperny): this will be a case in the main select loop, but for now
 	// just block until stopChan is closed.
 	<-o.stopChan
+}
+
+// reconcileService reconciles the replicated job service with the given ID by
+// checking to see if new replicas should be created. reconcileService returns
+// an error if there is some case prevent it from correctly reconciling the
+// service.
+func (o *Orchestrator) reconcileService(id string) error {
+	var (
+		service *api.Service
+		tasks   []*api.Task
+		viewErr error
+	)
+	// first, get the service and all of its tasks
+	o.store.View(func(tx store.ReadTx) {
+		service = store.GetService(tx, id)
+
+		tasks, viewErr = store.FindTasks(tx, store.ByServiceID(id))
+	})
+
+	if service == nil {
+		return nil
+	}
+
+	// errors during view should only happen in a few rather catastrophic
+	// cases, but here it's not unreasonable to just return an error anyway.
+	if viewErr != nil {
+		return viewErr
+	}
+
+	// if this is the first iteration of the service, it may not yet have a
+	// JobStatus, so we should create one if so. this won't actually be
+	// committed, though.
+	if service.JobStatus == nil {
+		service.JobStatus = &api.JobStatus{}
+	}
+
+	// Jobs can be run in multiple iterations. The JobStatus of the service
+	// indicates which Version of iteration we're on. We should only be looking
+	// at tasks of the latest Version
+
+	jobVersion := service.JobStatus.JobIteration.Index
+
+	// now, check how many tasks we need and how many we have running. note
+	// that some of these Running tasks may complete before we even finish this
+	// code block, and so we might have to immediately re-enter reconciliation,
+	// so this number is 100% definitive, but it is accurate for this
+	// particular moment in time, and it won't result in us going OVER the
+	// needed task count
+	//
+	// also, we don't care if tasks are failed here; that is, we make no
+	// distinction between tasks that have Failed and tasks in any other
+	// terminal non-Completed state.
+	//
+	// also also, for the math later, we need these values to be of type uint64.
+	runningTasks := uint64(0)
+	completeTasks := uint64(0)
+
+	// slots keeps track of the slot numbers available for tasks. as long as
+	// the orchestrator isn't broken, then this map will consist of the set of
+	// all integers from 0 to (MaxConcurrent - 1), with a boolean indicating if
+	// that slot is occupied. This slot handling code is much simpler than the
+	// code for replicated services, because we don't need to worry about
+	// restarts.
+	slots := map[uint64]bool{}
+	for _, task := range tasks {
+		// we only care about tasks from this job iteration. tasks from the
+		// previous job iteration are not important
+		// TODO(dperny): we need to stop any running tasks from older job
+		// iterations.
+		if task.JobIteration != nil && task.JobIteration.Index == jobVersion {
+			if task.Status.State == api.TaskStateCompleted {
+				completeTasks++
+			}
+
+			// any tasks that are created and running but not yet terminal are
+			// considered "running tasks" for our purpose, because they don't
+			// need to be created.
+			if task.Status.State <= api.TaskStateRunning && task.DesiredState == api.TaskStateCompleted {
+				runningTasks++
+				slots[task.Slot] = true
+			}
+		}
+	}
+
+	// now that we have our counts, we need to see how many new tasks to
+	// create. this number can never exceed MaxConcurrent, but also should not
+	// result in us exceeding TotalCompletions. first, get these numbers out of
+	// the service spec.
+	rj := service.Spec.GetReplicatedJob()
+
+	// possibleNewTasks gives us the upper bound for how many tasks we'll
+	// create. also, ugh, subtracting uints. there's no way this can ever go
+	// wrong.
+	possibleNewTasks := rj.MaxConcurrent - runningTasks
+
+	// allowedNewTasks is how many tasks we could create, if there were no
+	// restriction on maximum concurrency. This is the total number of tasks
+	// we want completed, minus the tasks that are already completed, minus
+	// the tasks that are in progress.
+	//
+	// seriously, ugh, subtracting unsigned ints. totally a fine and not at all
+	// risky operation, with no possibility for catastrophe
+	allowedNewTasks := rj.TotalCompletions - completeTasks - runningTasks
+
+	// the lower number of allowedNewTasks and possibleNewTasks is how many we
+	// can create. we'll just use an if statement instead of some fancy floor
+	// function.
+	actualNewTasks := allowedNewTasks
+	if possibleNewTasks < allowedNewTasks {
+		actualNewTasks = possibleNewTasks
+	}
+
+	// this check might seem odd, but it protects us from an underflow of the
+	// above subtractions, which, again, is a totally impossible thing that can
+	// never happen, ever, obviously.
+	if actualNewTasks > rj.TotalCompletions {
+		return fmt.Errorf(
+			"uint64 underflow, we're not going to create %v tasks",
+			actualNewTasks,
+		)
+	}
+
+	// finally, we can create these tasks. do this in a batch operation, to
+	// avoid exceeding transaction size limits
+	err := o.store.Batch(func(batch *store.Batch) error {
+		for i := uint64(0); i < actualNewTasks; i++ {
+			if err := batch.Update(func(tx store.Tx) error {
+				// find an unoccupied slot number that we can use, same as with
+				// replicated services.
+				var slot uint64
+				// the total number of slots we can have for a job is equal to
+				// the value of MaxConcurrent for the job iteration. This means
+				// if we iterate over values from 0 to MaxConcurrent, we'll
+				// find an available slot.
+				for s := uint64(0); s < rj.MaxConcurrent; s++ {
+					// when we're iterating through, if the service has slots
+					// that haven't been used yet (for example, if this is the
+					// first time we're running this iteration), then doing
+					// a map lookup for the number will return the 0-value
+					// (false) even if the number doesn't exist in the map.
+					if !slots[s] {
+						slot = s
+						// once we've found a slot, mark it as occupied, so we
+						// don't double assign in subsequent iterations.
+						slots[slot] = true
+						break
+					}
+				}
+
+				task := orchestrator.NewTask(o.cluster, service, slot, "")
+				// when we create the task, we also need to set the
+				// JobIteration.
+				task.JobIteration = &api.Version{Index: jobVersion}
+				task.DesiredState = api.TaskStateCompleted
+
+				// finally, create the task in the store.
+				return store.CreateTask(tx, task)
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	return err
 }
 
 // Stop stops the Orchestrator

--- a/manager/orchestrator/replicatedjob/orchestrator_test.go
+++ b/manager/orchestrator/replicatedjob/orchestrator_test.go
@@ -1,26 +1,313 @@
-package job_test
+package job
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/types"
 
-	. "github.com/docker/swarmkit/manager/orchestrator/replicatedjob"
-
-	"context"
-
-	"github.com/docker/swarmkit/manager/orchestrator/testutils"
+	"fmt"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/orchestrator"
+	"github.com/docker/swarmkit/manager/state/store"
 )
+
+// uniqueSlotsMatcher is used to verify that a set of tasks all have unique,
+// non-overlapping slot numbers
+type uniqueSlotsMatcher struct {
+	duplicatedSlot uint64
+}
+
+func (u uniqueSlotsMatcher) Match(actual interface{}) (bool, error) {
+	tasks, ok := actual.([]*api.Task)
+	if !ok {
+		return false, fmt.Errorf("actual is not []*api.Tasks{}")
+	}
+
+	slots := map[uint64]bool{}
+	for _, task := range tasks {
+		if filled, ok := slots[task.Slot]; ok || filled {
+			u.duplicatedSlot = task.Slot
+			return false, nil
+		}
+		slots[task.Slot] = true
+	}
+	return true, nil
+}
+
+func (u uniqueSlotsMatcher) FailureMessage(_ interface{}) string {
+	return fmt.Sprintf("expected tasks to have unique slots, but %v is duplicated", u.duplicatedSlot)
+}
+
+func (u uniqueSlotsMatcher) NegatedFailureMessage(_ interface{}) string {
+	return fmt.Sprintf("expected tasks to have duplicate slots")
+}
+
+func HaveUniqueSlots() GomegaMatcher {
+	return uniqueSlotsMatcher{}
+}
+
+func AllTasks(s *store.MemoryStore) []*api.Task {
+	var tasks []*api.Task
+	s.View(func(tx store.ReadTx) {
+		tasks, _ = store.FindTasks(tx, store.All)
+	})
+	return tasks
+}
 
 var _ = Describe("Replicated Job Orchestrator", func() {
 	var (
 		o *Orchestrator
+		s *store.MemoryStore
 	)
 
-	It("should stop when Stop is called", func(done Done) {
-		o = NewReplicatedJobOrchestrator(nil)
-		stopped := testutils.EnsureRuns(func() { o.Run(context.Background()) })
-		o.Stop()
-		Expect(stopped).To(BeClosed())
-		close(done)
+	Describe("reconcileService", func() {
+		BeforeEach(func() {
+			s = store.NewMemoryStore(nil)
+			Expect(s).ToNot(BeNil())
+
+			o = NewOrchestrator(s)
+		})
+
+		When("reconciling a service", func() {
+			var (
+				serviceID        string
+				service          *api.Service
+				maxConcurrent    uint64
+				totalCompletions uint64
+
+				reconcileErr error
+			)
+
+			BeforeEach(func() {
+				serviceID = "someService"
+				maxConcurrent = 10
+				totalCompletions = 30
+				service = &api.Service{
+					ID: serviceID,
+					Spec: api.ServiceSpec{
+						Mode: &api.ServiceSpec_ReplicatedJob{
+							ReplicatedJob: &api.ReplicatedJob{
+								MaxConcurrent:    maxConcurrent,
+								TotalCompletions: totalCompletions,
+							},
+						},
+					},
+				}
+
+			})
+
+			JustBeforeEach(func() {
+				err := s.Update(func(tx store.Tx) error {
+					if service != nil {
+						return store.CreateService(tx, service)
+					}
+					return nil
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				reconcileErr = o.reconcileService(serviceID)
+			})
+
+			When("the job has no tasks yet created", func() {
+				It("should create MaxConcurrent number of tasks", func() {
+					tasks := AllTasks(s)
+					// casting maxConcurrent to an int, which we know is safe
+					// because we set its value ourselves.
+					Expect(tasks).To(HaveLen(int(maxConcurrent)))
+
+					for _, task := range tasks {
+						Expect(task.ServiceID).To(Equal(service.ID))
+						Expect(task.JobIteration).ToNot(BeNil())
+						Expect(task.JobIteration.Index).To(Equal(uint64(0)))
+					}
+				})
+
+				It("should assign each task to a unique slot", func() {
+					tasks := AllTasks(s)
+
+					Expect(tasks).To(HaveUniqueSlots())
+				})
+
+				It("should return no error", func() {
+					Expect(reconcileErr).ToNot(HaveOccurred())
+				})
+
+				It("should set the desired state of each task to COMPLETE", func() {
+					tasks := AllTasks(s)
+					for _, task := range tasks {
+						Expect(task.DesiredState).To(Equal(api.TaskStateCompleted))
+					}
+				})
+			})
+
+			When("the job has some tasks already in progress", func() {
+				BeforeEach(func() {
+					s.Update(func(tx store.Tx) error {
+						// create 6 tasks before we reconcile the service.
+						// also, to fully exercise the slot picking code, we'll
+						// assign these tasks to every other slot
+						for i := uint64(0); i < 12; i += 2 {
+							task := orchestrator.NewTask(o.cluster, service, i, "")
+							task.JobIteration = &api.Version{}
+							task.DesiredState = api.TaskStateCompleted
+
+							if err := store.CreateTask(tx, task); err != nil {
+								return err
+							}
+						}
+
+						return nil
+					})
+				})
+
+				It("should create only the number of tasks needed to reach MaxConcurrent", func() {
+					tasks := AllTasks(s)
+
+					Expect(tasks).To(HaveLen(int(maxConcurrent)))
+				})
+
+				It("should assign each new task to a unique slot", func() {
+					tasks := AllTasks(s)
+					Expect(tasks).To(HaveUniqueSlots())
+				})
+			})
+
+			When("some running tasks are desired to be shutdown", func() {
+				BeforeEach(func() {
+					err := s.Update(func(tx store.Tx) error {
+						for i := uint64(0); i < maxConcurrent; i++ {
+							task := orchestrator.NewTask(o.cluster, service, i, "")
+							task.JobIteration = &api.Version{}
+							task.DesiredState = api.TaskStateShutdown
+
+							if err := store.CreateTask(tx, task); err != nil {
+								return err
+							}
+						}
+						return nil
+					})
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should ignore tasks shutting down when creating new ones", func() {
+					tasks := AllTasks(s)
+					Expect(tasks).To(HaveLen(int(maxConcurrent) * 2))
+
+				})
+
+				It("should reuse slots numbers", func() {
+					tasks := AllTasks(s)
+					Expect(tasks).ToNot(HaveUniqueSlots())
+				})
+			})
+
+			When("A job is almost complete, and doesn't need MaxConcurrent tasks running", func() {
+				BeforeEach(func() {
+					// we need to create a rather large number of tasks, all in
+					// COMPLETE state.
+					err := s.Update(func(tx store.Tx) error {
+						for i := uint64(0); i < totalCompletions-10; i++ {
+							// in a real system, if these tasks were all
+							// actually progressing, there would be no more
+							// than 30 tasks at any given time, which means no
+							// more than 30 slots.
+							slot := i % 30
+
+							task := orchestrator.NewTask(nil, service, slot, "")
+							task.JobIteration = &api.Version{}
+							task.Status.State = api.TaskStateCompleted
+							task.DesiredState = api.TaskStateCompleted
+
+							if err := store.CreateTask(tx, task); err != nil {
+								return err
+							}
+						}
+						return nil
+					})
+
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should create no more than the tasks needed to reach TotalCompletions", func() {
+					var newTasks []*api.Task
+					s.View(func(tx store.ReadTx) {
+						newTasks, _ = store.FindTasks(tx, store.ByTaskState(api.TaskStateNew))
+					})
+
+					Expect(newTasks).To(HaveLen(10))
+				})
+
+				It("should give each new task a unique slot", func() {
+					var newTasks []*api.Task
+					s.View(func(tx store.ReadTx) {
+						newTasks, _ = store.FindTasks(tx, store.ByTaskState(api.TaskStateNew))
+					})
+
+					Expect(newTasks).To(HaveUniqueSlots())
+				})
+			})
+
+			When("the service does not exist", func() {
+				BeforeEach(func() {
+					service = nil
+				})
+
+				It("should return no error", func() {
+					Expect(reconcileErr).ToNot(HaveOccurred())
+				})
+
+				It("should create no tasks", func() {
+					s.View(func(tx store.ReadTx) {
+						tasks, err := store.FindTasks(tx, store.All)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(tasks).To(BeEmpty())
+					})
+				})
+			})
+		})
+
+		It("should return an underflow error if there are more running tasks than TotalCompletions", func() {
+			// this is an error condition which should not happen in real life,
+			// but i want to make sure that we can't accidentally start
+			// creating nearly the maximum 64-bit unsigned int number of tasks.
+			maxConcurrent := uint64(10)
+			totalCompletions := uint64(20)
+			err := s.Update(func(tx store.Tx) error {
+				service := &api.Service{
+					ID: "someService",
+					Spec: api.ServiceSpec{
+						Mode: &api.ServiceSpec_ReplicatedJob{
+							ReplicatedJob: &api.ReplicatedJob{
+								MaxConcurrent:    maxConcurrent,
+								TotalCompletions: totalCompletions,
+							},
+						},
+					},
+				}
+				if err := store.CreateService(tx, service); err != nil {
+					return err
+				}
+
+				for i := uint64(0); i < totalCompletions+10; i++ {
+					task := orchestrator.NewTask(nil, service, 0, "")
+					task.JobIteration = &api.Version{}
+					task.DesiredState = api.TaskStateCompleted
+
+					if err := store.CreateTask(tx, task); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			reconcileErr := o.reconcileService("someService")
+			Expect(reconcileErr).To(HaveOccurred())
+			Expect(reconcileErr.Error()).To(ContainSubstring("underflow"))
+		})
+
+		AfterEach(func() {
+			s.Close()
+		})
 	})
 })

--- a/manager/orchestrator/service.go
+++ b/manager/orchestrator/service.go
@@ -28,6 +28,26 @@ func IsGlobalService(service *api.Service) bool {
 	return ok
 }
 
+// IsReplicatedJob returns true if the service is a replicated job.
+func IsReplicatedJob(service *api.Service) bool {
+	if service == nil {
+		return false
+	}
+
+	_, ok := service.Spec.GetMode().(*api.ServiceSpec_ReplicatedJob)
+	return ok
+}
+
+// IsGlobalJob returns true if the service is a global job.
+func IsGlobalJob(service *api.Service) bool {
+	if service == nil {
+		return false
+	}
+
+	_, ok := service.Spec.GetMode().(*api.ServiceSpec_GlobalJob)
+	return ok
+}
+
 // SetServiceTasksRemove sets the desired state of tasks associated with a service
 // to REMOVE, so that they can be properly shut down by the agent and later removed
 // by the task reaper.

--- a/manager/orchestrator/service_test.go
+++ b/manager/orchestrator/service_test.go
@@ -1,0 +1,61 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsReplicatedJob tests that IsReplicatedJob only returns true when the
+// service mod is ReplicatedJob
+func TestIsReplicatedJob(t *testing.T) {
+	// first, create a spec with no mode, that we can reuse for each subtest.
+	service := &api.Service{
+		ID:   "someService",
+		Spec: api.ServiceSpec{},
+	}
+	// this might seem like a good use-case for a table-based test, but the
+	// various service modes do not share a common public interface, and so
+	// cannot be easily assigned to the same type
+
+	service.Spec.Mode = &api.ServiceSpec_ReplicatedJob{}
+	assert.Equal(t, IsReplicatedJob(service), true)
+
+	service.Spec.Mode = &api.ServiceSpec_GlobalJob{}
+	assert.Equal(t, IsReplicatedJob(service), false)
+
+	service.Spec.Mode = &api.ServiceSpec_Replicated{}
+	assert.Equal(t, IsReplicatedJob(service), false)
+
+	service.Spec.Mode = &api.ServiceSpec_Global{}
+	assert.Equal(t, IsReplicatedJob(service), false)
+}
+
+// TestIsGlobalJob tests that IsGlobalJob only returns true when the
+// service mod is GlobalJob. This test is pretty much identical to
+// TestIsReplicatedJob. There is probably a clever DRY solution to encompass
+// both functions in one test, but these are really braindead simple tests so
+// it's just easier to cut and paste.
+func TestIsGlobalJob(t *testing.T) {
+	// first, create a spec with no mode, that we can reuse for each subtest.
+	service := &api.Service{
+		ID:   "someService",
+		Spec: api.ServiceSpec{},
+	}
+	// this might seem like a good use-case for a table-based test, but the
+	// various service modes do not share a common public interface, and so
+	// cannot be easily assigned to the same type
+
+	service.Spec.Mode = &api.ServiceSpec_ReplicatedJob{}
+	assert.Equal(t, IsGlobalJob(service), false)
+
+	service.Spec.Mode = &api.ServiceSpec_GlobalJob{}
+	assert.Equal(t, IsGlobalJob(service), true)
+
+	service.Spec.Mode = &api.ServiceSpec_Replicated{}
+	assert.Equal(t, IsGlobalJob(service), false)
+
+	service.Spec.Mode = &api.ServiceSpec_Global{}
+	assert.Equal(t, IsGlobalJob(service), false)
+}


### PR DESCRIPTION
Added the core reconciliation logic for handling services of replicated jobs. Does not include event-handling or initialization logic, just the function itself, and tests to exercise it.

This PR is against the `feature-jobs` branch, which is the branch upon which all jobs code is being merged until the feature is complete.
