### PR TITLE
[Jobs] Add global job orchestrator skeleton

### DIFF
--- a/manager/orchestrator/globaljob/globaljob_test.go
+++ b/manager/orchestrator/globaljob/globaljob_test.go
@@ -1,26 +1,311 @@
-package globaljob_test
+package globaljob
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/docker/swarmkit/manager/orchestrator/globaljob"
+	"time"
 
-	"context"
-
-	"github.com/docker/swarmkit/manager/orchestrator/testutils"
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state/store"
+	gogotypes "github.com/gogo/protobuf/types"
 )
 
 var _ = Describe("Global Job Orchestrator", func() {
 	var (
 		o *Orchestrator
+		s *store.MemoryStore
 	)
 
-	It("should stop when Stop is called", func(done Done) {
-		o = NewOrchestrator(nil)
-		stopped := testutils.EnsureRuns(func() { o.Run(context.Background()) })
-		o.Stop()
-		Expect(stopped).To(BeClosed())
-		close(done)
+	BeforeEach(func() {
+		s = store.NewMemoryStore(nil)
+		Expect(s).ToNot(BeNil())
+
+		o = NewOrchestrator(s)
+	})
+
+	AfterEach(func() {
+		s.Close()
+	})
+
+	Describe("reconcileService", func() {
+		var (
+			serviceID string
+			service   *api.Service
+			nodes     []*api.Node
+			tasks     []*api.Task
+		)
+
+		BeforeEach(func() {
+			serviceID = "someService"
+
+			// Set up the service and nodes. We can change these later
+			service = &api.Service{
+				ID: serviceID,
+				Spec: api.ServiceSpec{
+					Mode: &api.ServiceSpec_GlobalJob{
+						// GlobalJob has no parameters
+						GlobalJob: &api.GlobalJob{},
+					},
+				},
+				JobStatus: &api.JobStatus{
+					LastExecution: gogotypes.TimestampNow(),
+				},
+			}
+
+			// at the beginning of each test, initialize tasks to be empty
+			tasks = nil
+
+			// the Meta on nodes is not set automatically in tests, as setting
+			// the meta requires passing a Proposer to the memory store, which
+			// we do not do. in order to make these tests succeed, we will set
+			// the node creation time to be 10 seconds ago
+			tenSecondsAgoProto, err := gogotypes.TimestampProto(time.Now().Add(-10 * time.Second))
+			Expect(err).ToNot(HaveOccurred())
+			nodes = []*api.Node{
+				{
+					ID: "node1",
+					Meta: api.Meta{
+						CreatedAt: tenSecondsAgoProto,
+					},
+					Spec: api.NodeSpec{
+						Annotations: api.Annotations{
+							Name: "name1",
+						},
+						Availability: api.NodeAvailabilityActive,
+					},
+					Status: api.NodeStatus{
+						State: api.NodeStatus_READY,
+					},
+				},
+				{
+					ID: "node2",
+					Meta: api.Meta{
+						CreatedAt: tenSecondsAgoProto,
+					},
+					Spec: api.NodeSpec{
+						Annotations: api.Annotations{
+							Name: "name2",
+						},
+						Availability: api.NodeAvailabilityActive,
+					},
+					Status: api.NodeStatus{
+						State: api.NodeStatus_READY,
+					},
+				},
+				{
+					ID: "node3",
+					Meta: api.Meta{
+						CreatedAt: tenSecondsAgoProto,
+					},
+					Spec: api.NodeSpec{
+						Annotations: api.Annotations{
+							Name: "name3",
+						},
+						Availability: api.NodeAvailabilityActive,
+					},
+					Status: api.NodeStatus{
+						State: api.NodeStatus_READY,
+					},
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			// Just before the test executes, we'll create all of the objects
+			// needed by the test and execute reconcileService. If we need
+			// to change these objects, then we can do so in BeforeEach blocks
+			err := s.Update(func(tx store.Tx) error {
+				if service != nil {
+					if err := store.CreateService(tx, service); err != nil {
+						return err
+					}
+				}
+
+				for _, node := range nodes {
+					if err := store.CreateNode(tx, node); err != nil {
+						return err
+					}
+				}
+				for _, task := range tasks {
+					if err := store.CreateTask(tx, task); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+
+			err = o.reconcileService(serviceID)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		When("creating new tasks", func() {
+			It("should create a task for each node", func() {
+				s.View(func(tx store.ReadTx) {
+					for _, node := range nodes {
+						nodeTasks, err := store.FindTasks(tx, store.ByNodeID(node.ID))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(nodeTasks).To(HaveLen(1))
+					}
+
+				})
+			})
+
+			It("should set the desired state of each new task to COMPLETE", func() {
+				s.View(func(tx store.ReadTx) {
+					tasks, err := store.FindTasks(tx, store.All)
+					Expect(err).ToNot(HaveOccurred())
+					for _, task := range tasks {
+						Expect(task.DesiredState).To(Equal(api.TaskStateCompleted))
+					}
+				})
+			})
+
+			When("there are already existing tasks", func() {
+				BeforeEach(func() {
+					// create a random task for node 1 that's in state Running
+					tasks = append(tasks, &api.Task{
+						ID:           "existingTask1",
+						Spec:         service.Spec.Task,
+						ServiceID:    serviceID,
+						NodeID:       "node1",
+						DesiredState: api.TaskStateCompleted,
+						Status: api.TaskStatus{
+							State: api.TaskStateRunning,
+						},
+						JobIteration: &api.Version{},
+					})
+					tasks = append(tasks, &api.Task{
+						ID:           "existingTask2",
+						Spec:         service.Spec.Task,
+						ServiceID:    serviceID,
+						NodeID:       "node2",
+						DesiredState: api.TaskStateCompleted,
+						Status: api.TaskStatus{
+							State: api.TaskStateCompleted,
+						},
+						JobIteration: &api.Version{},
+					})
+				})
+
+				It("should only create tasks for nodes that need them", func() {
+					s.View(func(tx store.ReadTx) {
+						tasks, err := store.FindTasks(tx, store.All)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(tasks).To(HaveLen(3))
+						Expect(tasks).To(
+							ContainElement(
+								WithTransform(func(t *api.Task) string {
+									return t.ID
+								}, Equal("existingTask1")),
+							),
+						)
+					})
+				})
+			})
+
+			When("nodes have been added since the job was started", func() {
+				BeforeEach(func() {
+					// Before this test, change the creation time of "node0" to
+					// be 10 seconds from now. This should result in no task
+					// being created for this node
+					tenSecondsFromNowProto, err := gogotypes.TimestampProto(
+						time.Now().Add(10 * time.Second),
+					)
+					Expect(err).ToNot(HaveOccurred())
+					nodes[0].Meta.CreatedAt = tenSecondsFromNowProto
+				})
+				It("should not create tasks for those new nodes", func() {
+					s.View(func(tx store.ReadTx) {
+						node0Tasks, err := store.FindTasks(tx, store.ByNodeID(nodes[0].ID))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(node0Tasks).To(BeEmpty())
+
+						for _, node := range nodes[1:] {
+							tasks, err := store.FindTasks(tx, store.ByNodeID(node.ID))
+							Expect(err).ToNot(HaveOccurred())
+							Expect(tasks).To(HaveLen(1))
+						}
+					})
+				})
+			})
+
+			When("there are placement constraints", func() {
+				// This isn't a rigorous test of whether every placement
+				// constraint works. Constraints are handled by another
+				// package, so we have no need to test that. We just need to be
+				// sure that placement constraints are correctly checked and
+				// used.
+
+				BeforeEach(func() {
+					// set a constraint on the task to be only node1
+					service.Spec.Task.Placement = &api.Placement{
+						Constraints: []string{"node.id==node1"},
+					}
+				})
+
+				It("should only create tasks on nodes matching the constraints", func() {
+					s.View(func(tx store.ReadTx) {
+						tasks, err := store.FindTasks(tx, store.All)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(tasks).To(HaveLen(1))
+						Expect(tasks[0].NodeID).To(Equal("node1"))
+					})
+				})
+			})
+
+			When("the service no longer exists", func() {
+				BeforeEach(func() {
+					service = nil
+				})
+
+				It("should create no tasks", func() {
+					s.View(func(tx store.ReadTx) {
+						tasks, err := store.FindTasks(tx, store.All)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(tasks).To(BeEmpty())
+					})
+				})
+			})
+
+			When("a node is drained or paused", func() {
+				BeforeEach(func() {
+					// set node1 to drain, set node2 to pause
+					nodes[0].Spec.Availability = api.NodeAvailabilityDrain
+					nodes[1].Spec.Availability = api.NodeAvailabilityPause
+				})
+
+				It("should not create tasks for those nodes", func() {
+					s.View(func(tx store.ReadTx) {
+						tasks, err := store.FindTasks(tx, store.All)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(tasks).To(HaveLen(1))
+						Expect(tasks[0].NodeID).To(Equal("node3"))
+					})
+				})
+			})
+
+			When("a node is not READY", func() {
+				BeforeEach(func() {
+					nodes[0].Status.State = api.NodeStatus_DOWN
+				})
+				It("should not create tasks for that node", func() {
+					s.View(func(tx store.ReadTx) {
+						node0Tasks, err := store.FindTasks(tx, store.ByNodeID(nodes[0].ID))
+						Expect(err).ToNot(HaveOccurred())
+						Expect(node0Tasks).To(BeEmpty())
+
+						for _, node := range nodes[1:] {
+							tasks, err := store.FindTasks(tx, store.ByNodeID(node.ID))
+							Expect(err).ToNot(HaveOccurred())
+							Expect(tasks).To(HaveLen(1))
+						}
+					})
+				})
+			})
+		})
 	})
 })

--- a/manager/orchestrator/globaljob/orchestrator.go
+++ b/manager/orchestrator/globaljob/orchestrator.go
@@ -2,9 +2,14 @@ package globaljob
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/constraint"
+	"github.com/docker/swarmkit/manager/orchestrator"
 	"github.com/docker/swarmkit/manager/state/store"
+	gogotypes "github.com/gogo/protobuf/types"
 )
 
 type Orchestrator struct {
@@ -52,6 +57,148 @@ func (o *Orchestrator) run(ctx context.Context) {
 	// for now, just to get this whole code-writing thing going, we'll just
 	// block until Stop is called.
 	<-o.stopChan
+}
+
+// reconcileService determines whether a service has enough tasks, and creates
+// more if needed.
+func (o *Orchestrator) reconcileService(id string) error {
+	var (
+		service *api.Service
+		tasks   []*api.Task
+		nodes   []*api.Node
+	)
+
+	// we need to first get the latest iteration of the service, its tasks, and
+	// the nodes in the cluster.
+	o.store.View(func(tx store.ReadTx) {
+		service = store.GetService(tx, id)
+		if service == nil {
+			return
+		}
+
+		// getting tasks with FindTasks should only return an error if we've
+		// made a mistake coding; there's no user-input or even reasonable
+		// system state that can cause it. If it returns an error, we'll just
+		// panic and crash.
+		var err error
+		tasks, err = store.FindTasks(tx, store.ByServiceID(id))
+		if err != nil {
+			panic(fmt.Sprintf("error getting tasks: %v", err))
+		}
+
+		// same as with FindTasks
+		nodes, err = store.FindNodes(tx, store.All)
+		if err != nil {
+			panic(fmt.Sprintf("error getting nodes: %v", err))
+		}
+	})
+
+	// the service may be nil if the service has been deleted before we entered
+	// the View.
+	if service == nil {
+		return nil
+	}
+
+	if service.JobStatus == nil {
+		service.JobStatus = &api.JobStatus{}
+	}
+
+	// we need to compute the constraints on the service so we know which nodes
+	// to schedule it on
+	var constraints []constraint.Constraint
+	if service.Spec.Task.Placement != nil && len(service.Spec.Task.Placement.Constraints) != 0 {
+		// constraint.Parse does return an error, but we don't need to check
+		// it, because it was already checked when the service was created or
+		// updated.
+		constraints, _ = constraint.Parse(service.Spec.Task.Placement.Constraints)
+	}
+
+	// here's the tricky part: we only need to schedule the global job on nodes
+	// that existed when the job was created. of course, because this is a
+	// distributed system, time is meaningless and clock skew is a given;
+	// however, the consequences for getting this _wrong_ aren't
+	// earth-shattering, and the clock skew can't be _that_ bad because the PKI
+	// wouldn't work if it was. so this is just a best effort endeavor. we'll
+	// schedule to any node that says its creation time is before the
+	// LastExecution time.
+	//
+	// TODO(dperny): this only covers the case of nodes that were added after a
+	// global job is created. if nodes are paused or drained when a global job
+	// is started, then when they become un-paused or un-drained, the job will
+	// execute on them. i'm unsure if at this point it's better to accept and
+	// document this behavior, or spend rather a lot of time and energy coming
+	// up with a fix.
+	lastExecution, err := gogotypes.TimestampFromProto(service.JobStatus.LastExecution)
+	if err != nil {
+		// TODO(dperny): validate that lastExecution is set on service creation
+		// or update.
+		lastExecution, err = gogotypes.TimestampFromProto(service.Meta.CreatedAt)
+		if err != nil {
+			panic(fmt.Sprintf("service CreateAt time could not be parsed: %v", err))
+		}
+	}
+
+	var candidateNodes []string
+	for _, node := range nodes {
+		// instead of having a big ugly multi-line boolean expression in the
+		// if-statement, we'll have several if-statements, and bail out of
+		// this loop iteration with continue if the node is not acceptable
+		if !constraint.NodeMatches(constraints, node) {
+			continue
+		}
+		if node.Spec.Availability != api.NodeAvailabilityActive {
+			continue
+		}
+		if node.Status.State != api.NodeStatus_READY {
+			continue
+		}
+		nodeCreationTime, err := gogotypes.TimestampFromProto(node.Meta.CreatedAt)
+		if err != nil || !nodeCreationTime.Before(lastExecution) {
+			continue
+		}
+		// you can append to a nil slice and get a non-nil slice, which is
+		// pretty slick.
+		candidateNodes = append(candidateNodes, node.ID)
+	}
+
+	// now, we have a list of all nodes that match constraints. it's time to
+	// match running tasks to the nodes. we need to identify all nodes that
+	// need new tasks, which is any node that doesn't have a task of this job
+	// iteration. trade some space for some time by building a node ID to task
+	// ID mapping, so that we're just doing 2x linear operation, instead of a
+	// quadratic operation.
+	nodeToTask := map[string]string{}
+	for _, task := range tasks {
+		// only match tasks belonging to this job iteration, and running or
+		// completed, which are not desired to be shut down
+		if task.JobIteration != nil &&
+			task.JobIteration.Index == service.JobStatus.JobIteration.Index &&
+			task.Status.State <= api.TaskStateCompleted &&
+			task.DesiredState <= api.TaskStateCompleted {
+			nodeToTask[task.NodeID] = task.ID
+		}
+	}
+
+	return o.store.Batch(func(batch *store.Batch) error {
+		for _, node := range candidateNodes {
+			// check if there is a task for this node ID. If not, then we need
+			// to create one.
+			if _, ok := nodeToTask[node]; !ok {
+				if err := batch.Update(func(tx store.Tx) error {
+					// if the node does not already have a running or completed
+					// task, create a task for this node.
+					// TODO(dperny): pass non-nil orchestrator
+					task := orchestrator.NewTask(nil, service, 0, node)
+					task.JobIteration = &service.JobStatus.JobIteration
+					task.DesiredState = api.TaskStateCompleted
+					return store.CreateTask(tx, task)
+				}); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
 }
 
 func (o *Orchestrator) Stop() {


### PR DESCRIPTION
Adds basic logic for reconciling global jobs, in addition to tests for that logic. The global jobs counterpart to #2878. 