### PR TITLE
Bump to golang 1.12.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Needed to install go
       OS: linux
       ARCH: amd64
-      GOVERSION: 1.11
+      GOVERSION: 1.12
       # Needed to install protoc
       PROTOC_VERSION: 3.6.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.11.13-stretch
+FROM golang:1.12.9-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.11.0-stretch
+FROM golang:1.11.13-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 

--- a/agent/worker.go
+++ b/agent/worker.go
@@ -257,13 +257,11 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 	}
 
 	closeManager := func(tm *taskManager) {
-		go func(tm *taskManager) {
-			defer w.closers.Done()
-			// when a task is no longer assigned, we shutdown the task manager
-			if err := tm.Close(); err != nil {
-				log.G(ctx).WithError(err).Error("error closing task manager")
-			}
-		}(tm)
+		defer w.closers.Done()
+		// when a task is no longer assigned, we shutdown the task manager
+		if err := tm.Close(); err != nil {
+			log.G(ctx).WithError(err).Error("error closing task manager")
+		}
 
 		// make an attempt at removing. this is best effort. any errors will be
 		// retried by the reaper later.

--- a/template/getter_test.go
+++ b/template/getter_test.go
@@ -160,7 +160,7 @@ func TestTemplatedSecret(t *testing.T) {
 				Data:       []byte("SECRET_VAL={{secret \"unknowntarget\"}}\n"),
 				Templating: &api.Driver{Name: "golang"},
 			},
-			expectedErr: `failed to expand templated secret templatedsecret: template: expansion:1:13: executing "expansion" at <secret "unknowntarge...>: error calling secret: secret target unknowntarget not found`,
+			expectedErr: `failed to expand templated secret templatedsecret: template: expansion:1:13: executing "expansion" at <secret "unknowntarget">: error calling secret: secret target unknowntarget not found`,
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{
@@ -185,7 +185,7 @@ func TestTemplatedSecret(t *testing.T) {
 				Data:       []byte("CONFIG_VAL={{config \"unknowntarget\"}}\n"),
 				Templating: &api.Driver{Name: "golang"},
 			},
-			expectedErr: `failed to expand templated secret templatedsecret: template: expansion:1:13: executing "expansion" at <config "unknowntarge...>: error calling config: config target unknowntarget not found`,
+			expectedErr: `failed to expand templated secret templatedsecret: template: expansion:1:13: executing "expansion" at <config "unknowntarget">: error calling config: config target unknowntarget not found`,
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{
@@ -440,7 +440,7 @@ func TestTemplatedConfig(t *testing.T) {
 				Data:       []byte("SECRET_VAL={{secret \"unknowntarget\"}}\n"),
 				Templating: &api.Driver{Name: "golang"},
 			},
-			expectedErr: `failed to expand templated config templatedconfig: template: expansion:1:13: executing "expansion" at <secret "unknowntarge...>: error calling secret: secret target unknowntarget not found`,
+			expectedErr: `failed to expand templated config templatedconfig: template: expansion:1:13: executing "expansion" at <secret "unknowntarget">: error calling secret: secret target unknowntarget not found`,
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{
@@ -465,7 +465,7 @@ func TestTemplatedConfig(t *testing.T) {
 				Data:       []byte("CONFIG_VAL={{config \"unknowntarget\"}}\n"),
 				Templating: &api.Driver{Name: "golang"},
 			},
-			expectedErr: `failed to expand templated config templatedconfig: template: expansion:1:13: executing "expansion" at <config "unknowntarge...>: error calling config: config target unknowntarget not found`,
+			expectedErr: `failed to expand templated config templatedconfig: template: expansion:1:13: executing "expansion" at <config "unknowntarget">: error calling config: config target unknowntarget not found`,
 			task: modifyTask(func(t *api.Task) {
 				t.Spec = api.TaskSpec{
 					Runtime: &api.TaskSpec_Container{


### PR DESCRIPTION
Did the bump in two steps, so that I can cherry-pick the intermediate 1.11.13 bump into older branches 