### PR TITLE
Remove hardcoded IPAM config subnet value for ingress network

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1224,12 +1224,8 @@ func newIngressNetwork() *api.Network {
 			},
 			DriverConfig: &api.Driver{},
 			IPAM: &api.IPAMOptions{
-				Driver: &api.Driver{},
-				Configs: []*api.IPAMConfig{
-					{
-						Subnet: "10.255.0.0/16",
-					},
-				},
+				Driver:  &api.Driver{},
+				Configs: []*api.IPAMConfig{},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes: https://docker.atlassian.net/browse/ENGORC-2651