### PR TITLE
[18.09 backport]  Remove hardcoded IPAM config subnet value for ingress network

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1202,12 +1202,8 @@ func newIngressNetwork() *api.Network {
 			},
 			DriverConfig: &api.Driver{},
 			IPAM: &api.IPAMOptions{
-				Driver: &api.Driver{},
-				Configs: []*api.IPAMConfig{
-					{
-						Subnet: "10.255.0.0/16",
-					},
-				},
+				Driver:  &api.Driver{},
+				Configs: []*api.IPAMConfig{},
 			},
 		},
 	}


### PR DESCRIPTION
backport of https://github.com/docker/swarmkit/pull/2890
Fixes: https://docker.atlassian.net/browse/ENGORC-2651

Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>
(cherry picked from commit 9ccb20b27fa9a0e7b88800d7e196fa030da2a6a7)
Signed-off-by: Arko Dasgupta <arko.dasgupta@docker.com>