### PR TITLE
Fix nil pointer deref in dump-snapshot --redacted [FIELD-2081]

### DIFF
--- a/cmd/swarm-rafttool/dump.go
+++ b/cmd/swarm-rafttool/dump.go
@@ -200,7 +200,9 @@ func dumpSnapshot(swarmdir, unlockKey string, redact bool) error {
 			if task != nil {
 				if container := task.Spec.GetContainer(); container != nil {
 					container.Env = []string{"ENVVARS REDACTED"}
-					container.PullOptions.RegistryAuth = "REDACTED"
+					if container.PullOptions != nil {
+						container.PullOptions.RegistryAuth = "REDACTED"
+					}
 				}
 			}
 		}
@@ -208,7 +210,9 @@ func dumpSnapshot(swarmdir, unlockKey string, redact bool) error {
 			if service != nil {
 				if container := service.Spec.Task.GetContainer(); container != nil {
 					container.Env = []string{"ENVVARS REDACTED"}
-					container.PullOptions.RegistryAuth = "REDACTED"
+					if container.PullOptions != nil {
+						container.PullOptions.RegistryAuth = "REDACTED"
+					}
 				}
 			}
 		}


### PR DESCRIPTION
container.PullOptions is nil if the service is deployed without
`--with-registry-auth`.  Observed on client+server 19.03.2.

**- What I did**

Fixed a panic in `swarm-rafttool dump-snapshot --redact`.

_stack and affected frame:_
```
$ echo -e 'c\nbt\nframe 4' | dlv exec bin/swarm-rafttool -- -d /tmp/swarmdump  dump-snapshot --redact
Type 'help' for list of commands.
2019-09-20 11:36:08.938888 W | wal: ignored file 0000000000000000-0000000000000000.wal.broken in wal
Active members:
 NodeID=p1rqbkyjtikf53p1rrov4wk81, RaftID=39c366065096262f, Addr=192.168.30.101:2377

Removed members:
 RaftID=2ae2e29a7ad988cc
 RaftID=31a2a4a4c22e495c
 RaftID=2c73df5477fe943e
 RaftID=791d06f8748db411
 RaftID=11143b659a8b722d

> [unrecovered-panic] runtime.fatalpanic() /usr/lib/go/src/runtime/panic.go:847 (hits goroutine(1):1 total:1) (PC: 0x42fef0)
Warning: debugging optimized function
        runtime.curg._panic.arg: interface {}(string) "runtime error: invalid memory address or nil pointer dereference"
   842: // fatalpanic implements an unrecoverable panic. It is like fatalthrow, except
   843: // that if msgs != nil, fatalpanic also prints panic messages and decrements
   844: // runningPanicDefers once main is blocked from exiting.
   845: //
   846: //go:nosplit
=> 847: func fatalpanic(msgs *_panic) {
   848:         pc := getcallerpc()
   849:         sp := getcallersp()
   850:         gp := getg()
   851:         var docrash bool
   852:         // Switch to the system stack to avoid any stack growth, which
 0  0x000000000042fef0 in runtime.fatalpanic
    at /usr/lib/go/src/runtime/panic.go:847
 1  0x000000000042f952 in runtime.gopanic
    at /usr/lib/go/src/runtime/panic.go:722
 2  0x000000000044453c in runtime.panicmem
    at /usr/lib/go/src/runtime/panic.go:199
 3  0x000000000044453c in runtime.sigpanic
    at /usr/lib/go/src/runtime/signal_unix.go:394
 4  0x0000000000dc17b3 in main.dumpSnapshot
    at ./cmd/swarm-rafttool/dump.go:203
 5  0x0000000000dc2f50 in main.glob..func3
    at ./cmd/swarm-rafttool/main.go:97
 6  0x0000000000db8b24 in github.com/docker/swarmkit/vendor/github.com/spf13/cobra.(*Command).execute
    at ./vendor/github.com/spf13/cobra/command.go:565
 7  0x0000000000db9235 in github.com/docker/swarmkit/vendor/github.com/spf13/cobra.(*Command).ExecuteC
    at ./vendor/github.com/spf13/cobra/command.go:656
 8  0x0000000000dc285d in main.main
    at ./cmd/swarm-rafttool/main.go:185
 9  0x000000000043169e in runtime.main
    at /usr/lib/go/src/runtime/proc.go:203
10  0x000000000045cc61 in runtime.goexit
    at /usr/lib/go/src/runtime/asm_amd64.s:1357
> [unrecovered-panic] runtime.fatalpanic() /usr/lib/go/src/runtime/panic.go:847 (hits goroutine(1):1 total:1) (PC: 0x42fef0)
Warning: debugging optimized function
Frame 4: ./cmd/swarm-rafttool/dump.go:203 (PC: dc17b3)
   198:                 }
   199:                 for _, task := range s.Store.Tasks {
   200:                         if task != nil {
   201:                                 if container := task.Spec.GetContainer(); container != nil {
   202:                                         container.Env = []string{"ENVVARS REDACTED"}
=> 203:                                         container.PullOptions.RegistryAuth = "REDACTED"
   204:                                 }
   205:                         }
   206:                 }
   207:                 for _, service := range s.Store.Services {
   208:                         if service != nil {
exit
```

_nil here:_
```
$ echo -e 'c\nbt\nframe 4\nlocals -v container' | dlv exec bin/swarm-rafttool -- -d /home/trapier/go/src/github.com/docker/certified-infrastructure/vagrant/swarm  dump-snapshot --redact  |& grep PullOptions |tail -n1
        PullOptions: *github.com/docker/swarmkit/api.ContainerSpec_PullOptions nil,
```


**- How I did it**


Test for `nil` on `container.PullOptions`.

**- How to test it**

Doubt it matters, but docker client+server 19.03.2.

1. Set the snapshot interval low enough to trigger rotation within a reasonable amount of time

       docker swarm update --snapshot-interval 200

2. Deploy a service without `--with-registry-auth` that will churn into the snapshot:

       docker service create --replicas 200 --update-parallelism 0 alpine sh -c 'exit 0'

3. Wait for mtime on `/var/lib/docker/swarm/raft/*snap*/*` to change.

4. Stop engine.

5. Run rafttool:

       swarm-rafttool -d /var/lib/docker/swarm dump-snapshot --redact

FAIL if panic.
PASS if no panic.

**- Description for the changelog**
N/A