### PR TITLE
[Jobs] Support job updates

### DIFF
--- a/manager/orchestrator/jobs/global/reconciler_test.go
+++ b/manager/orchestrator/jobs/global/reconciler_test.go
@@ -61,6 +61,9 @@ var _ = Describe("Global Job Reconciler", func() {
 			service = &api.Service{
 				ID: serviceID,
 				Spec: api.ServiceSpec{
+					Annotations: api.Annotations{
+						Name: "someService",
+					},
 					Mode: &api.ServiceSpec_GlobalJob{
 						// GlobalJob has no parameters
 						GlobalJob: &api.GlobalJob{},
@@ -425,7 +428,6 @@ var _ = Describe("Global Job Reconciler", func() {
 				})
 			})
 		})
-
 	})
 
 	Describe("FixTask", func() {

--- a/manager/orchestrator/jobs/replicated/reconciler.go
+++ b/manager/orchestrator/jobs/replicated/reconciler.go
@@ -183,6 +183,17 @@ func (r *Reconciler) ReconcileService(id string) error {
 	// finally, we can create these tasks. do this in a batch operation, to
 	// avoid exceeding transaction size limits
 	err := r.store.Batch(func(batch *store.Batch) error {
+		// first, shut down old tasks
+		for _, task := range tasks {
+			if task.JobIteration.Index != service.JobStatus.JobIteration.Index &&
+				task.DesiredState != api.TaskStateShutdown {
+				batch.Update(func(tx store.Tx) error {
+					t := store.GetTask(tx, task.ID)
+					t.DesiredState = api.TaskStateShutdown
+					return store.UpdateTask(tx, t)
+				})
+			}
+		}
 		for i := uint64(0); i < actualNewTasks; i++ {
 			if err := batch.Update(func(tx store.Tx) error {
 				var slot uint64


### PR DESCRIPTION
Adds code to put old tasks in the Shutdown state when jobs are updated, allowing updates to proceed correctly.
