### PR TITLE
bump dustin/go-humanize v1.0.0

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -44,7 +44,7 @@ github.com/Microsoft/go-winio 6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
 github.com/beorn7/perks e7f67b54abbeac9c40a31de0f81159e4cafebd6a
 github.com/cloudflare/cfssl 1.3.2
-github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
+github.com/dustin/go-humanize 9f541cc9db5d55bce703bd99987c9d5cb8eea45e # v1.0.0
 github.com/fernet/fernet-go 9eac43b88a5efb8651d24de9b68e87567e029736
 github.com/google/certificate-transparency-go v1.0.20
 github.com/hashicorp/go-immutable-radix 826af9ccf0feeee615d546d69b11f8e98da8c8f1 git://github.com/tonistiigi/go-immutable-radix.git

--- a/vendor/github.com/dustin/go-humanize/README.markdown
+++ b/vendor/github.com/dustin/go-humanize/README.markdown
@@ -1,9 +1,9 @@
-# Humane Units
+# Humane Units [![Build Status](https://travis-ci.org/dustin/go-humanize.svg?branch=master)](https://travis-ci.org/dustin/go-humanize) [![GoDoc](https://godoc.org/github.com/dustin/go-humanize?status.svg)](https://godoc.org/github.com/dustin/go-humanize)
 
 Just a few functions for helping humanize times and sizes.
 
 `go get` it as `github.com/dustin/go-humanize`, import it as
-`"github.com/dustin/go-humanize"`, use it as `humanize`
+`"github.com/dustin/go-humanize"`, use it as `humanize`.
 
 See [godoc](https://godoc.org/github.com/dustin/go-humanize) for
 complete documentation.
@@ -11,12 +11,12 @@ complete documentation.
 ## Sizes
 
 This lets you take numbers like `82854982` and convert them to useful
-strings like, `83MB` or `79MiB` (whichever you prefer).
+strings like, `83 MB` or `79 MiB` (whichever you prefer).
 
 Example:
 
 ```go
-fmt.Printf("That file is %s.", humanize.Bytes(82854982))
+fmt.Printf("That file is %s.", humanize.Bytes(82854982)) // That file is 83 MB.
 ```
 
 ## Times
@@ -27,11 +27,11 @@ For example, `12 seconds ago` or `3 days from now`.
 Example:
 
 ```go
-fmt.Printf("This was touched %s", humanize.Time(someTimeInstance))
+fmt.Printf("This was touched %s.", humanize.Time(someTimeInstance)) // This was touched 7 hours ago.
 ```
 
 Thanks to Kyle Lemons for the time implementation from an IRC
-conversation one day.  It's pretty neat.
+conversation one day. It's pretty neat.
 
 ## Ordinals
 
@@ -48,12 +48,12 @@ to label ordinals.
 Example:
 
 ```go
-fmt.Printf("You're my %s best friend.", humanize.Ordinal(193))
+fmt.Printf("You're my %s best friend.", humanize.Ordinal(193)) // You are my 193rd best friend.
 ```
 
 ## Commas
 
-Want to shove commas into numbers?  Be my guest.
+Want to shove commas into numbers? Be my guest.
 
     0 -> 0
     100 -> 100
@@ -64,7 +64,7 @@ Want to shove commas into numbers?  Be my guest.
 Example:
 
 ```go
-fmt.Printf("You owe $%s.\n", humanize.Comma(6582491))
+fmt.Printf("You owe $%s.\n", humanize.Comma(6582491)) // You owe $6,582,491.
 ```
 
 ## Ftoa
@@ -72,10 +72,10 @@ fmt.Printf("You owe $%s.\n", humanize.Comma(6582491))
 Nicer float64 formatter that removes trailing zeros.
 
 ```go
-fmt.Printf("%f", 2.24)                   // 2.240000
-fmt.Printf("%s", humanize.Ftoa(2.24))    // 2.24
-fmt.Printf("%f", 2.0)                    // 2.000000
-fmt.Printf("%s", humanize.Ftoa(2.0))     // 2
+fmt.Printf("%f", 2.24)                // 2.240000
+fmt.Printf("%s", humanize.Ftoa(2.24)) // 2.24
+fmt.Printf("%f", 2.0)                 // 2.000000
+fmt.Printf("%s", humanize.Ftoa(2.0))  // 2
 ```
 
 ## SI notation
@@ -85,7 +85,39 @@ Format numbers with [SI notation][sinotation].
 Example:
 
 ```go
-humanize.SI(0.00000000223, "M")    // 2.23nM
+humanize.SI(0.00000000223, "M") // 2.23 nM
+```
+
+## English-specific functions
+
+The following functions are in the `humanize/english` subpackage.
+
+### Plurals
+
+Simple English pluralization
+
+```go
+english.PluralWord(1, "object", "") // object
+english.PluralWord(42, "object", "") // objects
+english.PluralWord(2, "bus", "") // buses
+english.PluralWord(99, "locus", "loci") // loci
+
+english.Plural(1, "object", "") // 1 object
+english.Plural(42, "object", "") // 42 objects
+english.Plural(2, "bus", "") // 2 buses
+english.Plural(99, "locus", "loci") // 99 loci
+```
+
+### Word series
+
+Format comma-separated words lists with conjuctions:
+
+```go
+english.WordSeries([]string{"foo"}, "and") // foo
+english.WordSeries([]string{"foo", "bar"}, "and") // foo and bar
+english.WordSeries([]string{"foo", "bar", "baz"}, "and") // foo, bar and baz
+
+english.OxfordWordSeries([]string{"foo", "bar", "baz"}, "and") // foo, bar, and baz
 ```
 
 [odisc]: https://groups.google.com/d/topic/golang-nuts/l8NhI74jl-4/discussion

--- a/vendor/github.com/dustin/go-humanize/bigbytes.go
+++ b/vendor/github.com/dustin/go-humanize/bigbytes.go
@@ -113,7 +113,7 @@ func humanateBigBytes(s, base *big.Int, sizes []string) string {
 //
 // See also: ParseBigBytes.
 //
-// BigBytes(82854982) -> 83MB
+// BigBytes(82854982) -> 83 MB
 func BigBytes(s *big.Int) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 	return humanateBigBytes(s, bigSIExp, sizes)
@@ -123,7 +123,7 @@ func BigBytes(s *big.Int) string {
 //
 // See also: ParseBigBytes.
 //
-// BigIBytes(82854982) -> 79MiB
+// BigIBytes(82854982) -> 79 MiB
 func BigIBytes(s *big.Int) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 	return humanateBigBytes(s, bigIECExp, sizes)
@@ -134,19 +134,28 @@ func BigIBytes(s *big.Int) string {
 //
 // See also: BigBytes, BigIBytes.
 //
-// ParseBigBytes("42MB") -> 42000000, nil
-// ParseBigBytes("42mib") -> 44040192, nil
+// ParseBigBytes("42 MB") -> 42000000, nil
+// ParseBigBytes("42 mib") -> 44040192, nil
 func ParseBigBytes(s string) (*big.Int, error) {
 	lastDigit := 0
+	hasComma := false
 	for _, r := range s {
-		if !(unicode.IsDigit(r) || r == '.') {
+		if !(unicode.IsDigit(r) || r == '.' || r == ',') {
 			break
+		}
+		if r == ',' {
+			hasComma = true
 		}
 		lastDigit++
 	}
 
+	num := s[:lastDigit]
+	if hasComma {
+		num = strings.Replace(num, ",", "", -1)
+	}
+
 	val := &big.Rat{}
-	_, err := fmt.Sscanf(s[:lastDigit], "%f", val)
+	_, err := fmt.Sscanf(num, "%f", val)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/dustin/go-humanize/bytes.go
+++ b/vendor/github.com/dustin/go-humanize/bytes.go
@@ -84,7 +84,7 @@ func humanateBytes(s uint64, base float64, sizes []string) string {
 //
 // See also: ParseBytes.
 //
-// Bytes(82854982) -> 83MB
+// Bytes(82854982) -> 83 MB
 func Bytes(s uint64) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
 	return humanateBytes(s, 1000, sizes)
@@ -94,7 +94,7 @@ func Bytes(s uint64) string {
 //
 // See also: ParseBytes.
 //
-// IBytes(82854982) -> 79MiB
+// IBytes(82854982) -> 79 MiB
 func IBytes(s uint64) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
 	return humanateBytes(s, 1024, sizes)
@@ -105,18 +105,27 @@ func IBytes(s uint64) string {
 //
 // See Also: Bytes, IBytes.
 //
-// ParseBytes("42MB") -> 42000000, nil
-// ParseBytes("42mib") -> 44040192, nil
+// ParseBytes("42 MB") -> 42000000, nil
+// ParseBytes("42 mib") -> 44040192, nil
 func ParseBytes(s string) (uint64, error) {
 	lastDigit := 0
+	hasComma := false
 	for _, r := range s {
-		if !(unicode.IsDigit(r) || r == '.') {
+		if !(unicode.IsDigit(r) || r == '.' || r == ',') {
 			break
+		}
+		if r == ',' {
+			hasComma = true
 		}
 		lastDigit++
 	}
 
-	f, err := strconv.ParseFloat(s[:lastDigit], 64)
+	num := s[:lastDigit]
+	if hasComma {
+		num = strings.Replace(num, ",", "", -1)
+	}
+
+	f, err := strconv.ParseFloat(num, 64)
 	if err != nil {
 		return 0, err
 	}

--- a/vendor/github.com/dustin/go-humanize/comma.go
+++ b/vendor/github.com/dustin/go-humanize/comma.go
@@ -2,6 +2,7 @@ package humanize
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -13,6 +14,12 @@ import (
 // e.g. Comma(834142) -> 834,142
 func Comma(v int64) string {
 	sign := ""
+
+	// Min int64 can't be negated to a usable value, so it has to be special cased.
+	if v == math.MinInt64 {
+		return "-9,223,372,036,854,775,808"
+	}
+
 	if v < 0 {
 		sign = "-"
 		v = 0 - v
@@ -39,7 +46,7 @@ func Comma(v int64) string {
 // Commaf produces a string form of the given number in base 10 with
 // commas after every three orders of magnitude.
 //
-// e.g. Comma(834142.32) -> 834,142.32
+// e.g. Commaf(834142.32) -> 834,142.32
 func Commaf(v float64) string {
 	buf := &bytes.Buffer{}
 	if v < 0 {
@@ -67,6 +74,14 @@ func Commaf(v float64) string {
 		buf.WriteString(parts[1])
 	}
 	return buf.String()
+}
+
+// CommafWithDigits works like the Commaf but limits the resulting
+// string to the given number of decimal places.
+//
+// e.g. CommafWithDigits(834142.32, 1) -> 834,142.3
+func CommafWithDigits(f float64, decimals int) string {
+	return stripTrailingDigits(Commaf(f), decimals)
 }
 
 // BigComma produces a string form of the given big.Int in base 10

--- a/vendor/github.com/dustin/go-humanize/commaf.go
+++ b/vendor/github.com/dustin/go-humanize/commaf.go
@@ -1,0 +1,40 @@
+// +build go1.6
+
+package humanize
+
+import (
+	"bytes"
+	"math/big"
+	"strings"
+)
+
+// BigCommaf produces a string form of the given big.Float in base 10
+// with commas after every three orders of magnitude.
+func BigCommaf(v *big.Float) string {
+	buf := &bytes.Buffer{}
+	if v.Sign() < 0 {
+		buf.Write([]byte{'-'})
+		v.Abs(v)
+	}
+
+	comma := []byte{','}
+
+	parts := strings.Split(v.Text('f', -1), ".")
+	pos := 0
+	if len(parts[0])%3 != 0 {
+		pos += len(parts[0]) % 3
+		buf.WriteString(parts[0][:pos])
+		buf.Write(comma)
+	}
+	for ; pos < len(parts[0]); pos += 3 {
+		buf.WriteString(parts[0][pos : pos+3])
+		buf.Write(comma)
+	}
+	buf.Truncate(buf.Len() - 1)
+
+	if len(parts) > 1 {
+		buf.Write([]byte{'.'})
+		buf.WriteString(parts[1])
+	}
+	return buf.String()
+}

--- a/vendor/github.com/dustin/go-humanize/ftoa.go
+++ b/vendor/github.com/dustin/go-humanize/ftoa.go
@@ -1,6 +1,9 @@
 package humanize
 
-import "strconv"
+import (
+	"strconv"
+	"strings"
+)
 
 func stripTrailingZeros(s string) string {
 	offset := len(s) - 1
@@ -17,7 +20,27 @@ func stripTrailingZeros(s string) string {
 	return s[:offset+1]
 }
 
+func stripTrailingDigits(s string, digits int) string {
+	if i := strings.Index(s, "."); i >= 0 {
+		if digits <= 0 {
+			return s[:i]
+		}
+		i++
+		if i+digits >= len(s) {
+			return s
+		}
+		return s[:i+digits]
+	}
+	return s
+}
+
 // Ftoa converts a float to a string with no trailing zeros.
 func Ftoa(num float64) string {
 	return stripTrailingZeros(strconv.FormatFloat(num, 'f', 6, 64))
+}
+
+// FtoaWithDigits converts a float to a string but limits the resulting string
+// to the given number of decimal places, and no trailing zeros.
+func FtoaWithDigits(num float64, digits int) string {
+	return stripTrailingZeros(stripTrailingDigits(strconv.FormatFloat(num, 'f', 6, 64), digits))
 }

--- a/vendor/github.com/dustin/go-humanize/humanize.go
+++ b/vendor/github.com/dustin/go-humanize/humanize.go
@@ -2,7 +2,7 @@
 Package humanize converts boring ugly numbers to human-friendly strings and back.
 
 Durations can be turned into strings such as "3 days ago", numbers
-representing sizes like 82854982 into useful strings like, "83MB" or
-"79MiB" (whichever you prefer).
+representing sizes like 82854982 into useful strings like, "83 MB" or
+"79 MiB" (whichever you prefer).
 */
 package humanize

--- a/vendor/github.com/dustin/go-humanize/number.go
+++ b/vendor/github.com/dustin/go-humanize/number.go
@@ -160,7 +160,7 @@ func FormatFloat(format string, n float64) string {
 	intf, fracf := math.Modf(n + renderFloatPrecisionRounders[precision])
 
 	// generate integer part string
-	intStr := strconv.Itoa(int(intf))
+	intStr := strconv.FormatInt(int64(intf), 10)
 
 	// add thousand separator if required
 	if len(thousandStr) > 0 {

--- a/vendor/github.com/dustin/go-humanize/si.go
+++ b/vendor/github.com/dustin/go-humanize/si.go
@@ -41,7 +41,7 @@ func revfmap(in map[float64]string) map[string]float64 {
 var riParseRegex *regexp.Regexp
 
 func init() {
-	ri := `^([0-9.]+)\s?([`
+	ri := `^([\-0-9.]+)\s?([`
 	for _, v := range siPrefixTable {
 		ri += v
 	}
@@ -61,17 +61,20 @@ func ComputeSI(input float64) (float64, string) {
 	if input == 0 {
 		return 0, ""
 	}
-	exponent := math.Floor(logn(input, 10))
+	mag := math.Abs(input)
+	exponent := math.Floor(logn(mag, 10))
 	exponent = math.Floor(exponent/3) * 3
 
-	value := input / math.Pow(10, exponent)
+	value := mag / math.Pow(10, exponent)
 
 	// Handle special case where value is exactly 1000.0
-	// Should return 1M instead of 1000k
+	// Should return 1 M instead of 1000 k
 	if value == 1000.0 {
 		exponent += 3
-		value = input / math.Pow(10, exponent)
+		value = mag / math.Pow(10, exponent)
 	}
+
+	value = math.Copysign(value, input)
 
 	prefix := siPrefixTable[exponent]
 	return value, prefix
@@ -83,11 +86,21 @@ func ComputeSI(input float64) (float64, string) {
 //
 // See also: ComputeSI, ParseSI.
 //
-// e.g. SI(1000000, B) -> 1MB
-// e.g. SI(2.2345e-12, "F") -> 2.2345pF
+// e.g. SI(1000000, "B") -> 1 MB
+// e.g. SI(2.2345e-12, "F") -> 2.2345 pF
 func SI(input float64, unit string) string {
 	value, prefix := ComputeSI(input)
 	return Ftoa(value) + " " + prefix + unit
+}
+
+// SIWithDigits works like SI but limits the resulting string to the
+// given number of decimal places.
+//
+// e.g. SIWithDigits(1000000, 0, "B") -> 1 MB
+// e.g. SIWithDigits(2.2345e-12, 2, "F") -> 2.23 pF
+func SIWithDigits(input float64, decimals int, unit string) string {
+	value, prefix := ComputeSI(input)
+	return FtoaWithDigits(value, decimals) + " " + prefix + unit
 }
 
 var errInvalid = errors.New("invalid input")
@@ -96,7 +109,7 @@ var errInvalid = errors.New("invalid input")
 //
 // See also: SI, ComputeSI.
 //
-// e.g. ParseSI(2.2345pF) -> (2.2345e-12, "F", nil)
+// e.g. ParseSI("2.2345 pF") -> (2.2345e-12, "F", nil)
 func ParseSI(input string) (float64, string, error) {
 	found := riParseRegex.FindStringSubmatch(input)
 	if len(found) != 4 {


### PR DESCRIPTION
full diff: https://github.com/dustin/go-humanize/compare/8929fe90cee4b2cb9deb468b51fb34eba64d1bf0...v1.0.0

probably most relevant change:

- https://github.com/dustin/go-humanize/commit/64dbdae0d393b7d71480a6dace78456396b55286 Add space between the numbers and units
  - closes dustin/go-humanize#21 Space between numerical value and unit symbol for SI output
  - related: dustin/go-humanize#32 no space between bytes and units
