### PR TITLE
bump beorn7/perks v1.0.1

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -42,7 +42,7 @@ github.com/ishidawataru/sctp 6e2cb1366111dcf547c13531e3a263a067715847
 github.com/davecgh/go-spew 8991bc29aa16c548c550c7ff78260e27b9ab7c73 # v1.1.1
 github.com/Microsoft/go-winio 6c72808b55902eae4c5943626030429ff20f3b63 # v0.4.14
 github.com/sirupsen/logrus 8bdbc7bcc01dcbb8ec23dc8a28e332258d25251f # v1.4.1
-github.com/beorn7/perks e7f67b54abbeac9c40a31de0f81159e4cafebd6a
+github.com/beorn7/perks 37c8de3658fcb183f997c4e13e8337516ab753e6 # v1.0.1
 github.com/cloudflare/cfssl 1.3.2
 github.com/dustin/go-humanize 8929fe90cee4b2cb9deb468b51fb34eba64d1bf0
 github.com/fernet/fernet-go 9eac43b88a5efb8651d24de9b68e87567e029736

--- a/vendor/github.com/beorn7/perks/go.mod
+++ b/vendor/github.com/beorn7/perks/go.mod
@@ -1,0 +1,3 @@
+module github.com/beorn7/perks
+
+go 1.11


### PR DESCRIPTION
full diff: https://github.com/beorn7/perks/compare/e7f67b54abbeac9c40a31de0f81159e4cafebd6a...v1.0.1

- Add go module support
- Create v1.0.0 (to play better with go modules)
- Lower Go requirement in go.mod
