### PR TITLE
Revert "YOLO see if this works"

### DIFF
--- a/agent/worker.go
+++ b/agent/worker.go
@@ -257,11 +257,13 @@ func reconcileTaskState(ctx context.Context, w *worker, assignments []*api.Assig
 	}
 
 	closeManager := func(tm *taskManager) {
-		defer w.closers.Done()
-		// when a task is no longer assigned, we shutdown the task manager
-		if err := tm.Close(); err != nil {
-			log.G(ctx).WithError(err).Error("error closing task manager")
-		}
+		go func(tm *taskManager) {
+			defer w.closers.Done()
+			// when a task is no longer assigned, we shutdown the task manager
+			if err := tm.Close(); err != nil {
+				log.G(ctx).WithError(err).Error("error closing task manager")
+			}
+		}(tm)
 
 		// make an attempt at removing. this is best effort. any errors will be
 		// retried by the reaper later.


### PR DESCRIPTION
This reverts commit 42085d2f8e43a3ed90ed289d3f3ed3de57837100.

Turns out it's a bad idea to merge a commit with the word "YOLO" in it.

This commit, when vendored into the docker engine, causes a test to hang. See moby/moby#40309.

The thing this was attempting to fix was worked around in #2919.

/cc @thaJeztah 