### PR TITLE
Bump Golang 1.13.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Needed to install go
       OS: linux
       ARCH: amd64
-      GOVERSION: 1.12
+      GOVERSION: 1.13
       # Needed to install protoc
       PROTOC_VERSION: 3.6.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.12.9-stretch
+FROM golang:1.13.10-buster
 
 RUN apt-get update && apt-get install -y make git unzip
 


### PR DESCRIPTION
supersedes https://github.com/docker/swarmkit/pull/2912
closes https://github.com/docker/swarmkit/pull/2912


go1.13.10 (released 2020/04/08) includes fixes to the go command, the runtime,
os/exec, and time packages. See the Go 1.13.10 milestone on the issue tracker
for details:

https://github.com/golang/go/issues?q=milestone%3AGo1.13.10+label%3ACherryPickApproved

