### PR TITLE
Check that Placement is not null before trying to access it

### DIFF
--- a/manager/orchestrator/task.go
+++ b/manager/orchestrator/task.go
@@ -8,6 +8,7 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/api/defaults"
 	"github.com/moby/swarmkit/v2/identity"
+	"github.com/moby/swarmkit/v2/log"
 	"github.com/moby/swarmkit/v2/manager/constraint"
 	"github.com/moby/swarmkit/v2/protobuf/ptypes"
 )
@@ -119,7 +120,18 @@ func nodeMatches(s *api.Service, n *api.Node) bool {
 		return false
 	}
 
-	constraints, _ := constraint.Parse(s.Spec.Task.Placement.Constraints)
+	var pc []string
+	if s.Spec.Task.Placement != nil {
+		pc = s.Spec.Task.Placement.Constraints
+	}
+
+	constraints, err := constraint.Parse(pc)
+	if err != nil {
+		log.L.WithFields(map[string]any{
+			"error":       err,
+			"constraints": pc,
+		}).Debug("IsTaskDirty: nodeMatches: failed to parse placement constraints")
+	}
 	return constraint.NodeMatches(constraints, n)
 }
 


### PR DESCRIPTION
If Placement is missing after updating a service with previous placement constraints in a swarm with multiple nodes, it sends the swarm in an unrecoverable state.

- closes #2947 
- addresses https://github.com/moby/moby/issues/37883
- replaces https://github.com/moby/swarmkit/pull/2948
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I created a swarm with 2 nodes. I created a service using the docker api with a placement constraint. I then updated the service passing a json load with no `Placement` field.
https://github.com/moby/moby/issues/37883#issuecomment-633093827

**- How I did it**
I mainly used curl to issue docker api calls

**- How to test it**
I can provide more details

**- Description for the changelog**
Prevents nil pointer reference in nodeMatches when Placement is null

Signed-off-by: Simone Giacomel <sgiacomel@medstack.co>
