### PR TITLE
Fix bad comment on capability_drop field in protobuf def

### DIFF
--- a/api/specs.pb.go
+++ b/api/specs.pb.go
@@ -1021,7 +1021,7 @@ type ContainerSpec struct {
 	Sysctls map[string]string `protobuf:"bytes,26,rep,name=sysctls,proto3" json:"sysctls,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// CapabilityAdd sets the list of capabilities to add to the default capability list
 	CapabilityAdd []string `protobuf:"bytes,27,rep,name=capability_add,json=capabilityAdd,proto3" json:"capability_add,omitempty"`
-	// CapabilityAdd sets the list of capabilities to drop from the default capability list
+	// CapabilityDrop sets the list of capabilities to drop from the default capability list
 	CapabilityDrop []string `protobuf:"bytes,28,rep,name=capability_drop,json=capabilityDrop,proto3" json:"capability_drop,omitempty"`
 }
 

--- a/api/specs.proto
+++ b/api/specs.proto
@@ -358,7 +358,7 @@ message ContainerSpec {
 
 	// CapabilityAdd sets the list of capabilities to add to the default capability list
 	repeated string capability_add = 27;
-	// CapabilityAdd sets the list of capabilities to drop from the default capability list
+	// CapabilityDrop sets the list of capabilities to drop from the default capability list
 	repeated string capability_drop = 28;
 }
 


### PR DESCRIPTION
This is a follow-up of #2965.
