### PR TITLE
Dockerfile, circleci: update protoc to 3.12.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       ARCH: amd64
       GOVERSION: 1.12
       # Needed to install protoc
-      PROTOC_VERSION: 3.6.1
+      PROTOC_VERSION: 3.12.4
 
     # Note(cyli): We create a tmpfs mount to be used for temporary files created by tests
     # to mitigate the excessive I/O latencies that sometimes cause the tests to fail.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.12.9-stretch
+FROM golang:1.12.17-buster
 
 RUN apt-get update && apt-get install -y make git unzip
 
 # should stay consistent with the version in .circleci/config.yml
-ARG PROTOC_VERSION=3.6.1
+ARG PROTOC_VERSION=3.12.4
 # download and install protoc binary and .proto files
 RUN curl --silent --show-error --location --output protoc.zip \
   https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \


### PR DESCRIPTION
This update should be preparatory for golang 1.13 and later versions

https://github.com/docker/swarmkit/pull/2943
