### PR TITLE
Dockerfile: update Golang 1.12.17 (security and runtime fixes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG GO_VERSION=1.12.17
+
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.12.9-stretch
+FROM golang:${GO_VERSION}-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 


### PR DESCRIPTION
Golang minor revisions:

- go1.12.10 includes security fixes to the net/http and net/textproto packages
- go1.12.11 includes security fixes to the crypto/dsa package
- go1.12.12 includes fixes to the go command, runtime, and the syscall and net packages
- go1.12.14 includes a fix to the runtime
- go1.12.15 includes fixes to the runtime and the net/http package
- go1.12.16 includes two security fixes to the crypto/x509 package
- go1.12.17 includes a fix to the runtime
