### PR TITLE
Dockerfile, vendor, circleci: bump golang 1.13.15, bump protobuf to 1…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ jobs:
       # Needed to install go
       OS: linux
       ARCH: amd64
-      GOVERSION: 1.12
+      GOVERSION: 1.13
+      GO111MODULE: "off"
       # Needed to install protoc
       PROTOC_VERSION: 3.6.1
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       GOVERSION: 1.13
       GO111MODULE: "off"
       # Needed to install protoc
-      PROTOC_VERSION: 3.6.1
+      PROTOC_VERSION: 3.9.1
 
     # Note(cyli): We create a tmpfs mount to be used for temporary files created by tests
     # to mitigate the excessive I/O latencies that sometimes cause the tests to fail.

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:${GO_VERSION}-stretch
 RUN apt-get update && apt-get install -y make git unzip
 
 # should stay consistent with the version in .circleci/config.yml
-ARG PROTOC_VERSION=3.6.1
+ARG PROTOC_VERSION=3.9.1
 # download and install protoc binary and .proto files
 RUN curl --silent --show-error --location --output protoc.zip \
   https://github.com/google/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG GO_VERSION=1.13.15
+
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.12.9-stretch
+FROM golang:${GO_VERSION}-stretch
 
 RUN apt-get update && apt-get install -y make git unzip
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,7 +8,7 @@
 # In >=1.11, those errors were brought back but the string had changed again.
 # After updating GRPC, if integration test failures occur, verify that the
 # string matching there is correct.
-google.golang.org/grpc 5e8f83304c0563d1ba74db05fee83d9c18ab9a58 # v1.32.1
+google.golang.org/grpc 25c4f928eaa6d96443009bd842389fb4fa48664e # v1.20.1
 github.com/gogo/protobuf 5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf 84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,9 +8,9 @@
 # In >=1.11, those errors were brought back but the string had changed again.
 # After updating GRPC, if integration test failures occur, verify that the
 # string matching there is correct.
-google.golang.org/grpc 25c4f928eaa6d96443009bd842389fb4fa48664e # v1.20.1
-github.com/gogo/protobuf ba06b47c162d49f2af050fb4c75bcbc86a159d5c # v1.2.1
-github.com/golang/protobuf aa810b61a9c79d51363740d207bb46cf8e620ed5 # v1.2.0
+google.golang.org/grpc 5e8f83304c0563d1ba74db05fee83d9c18ab9a58 # v1.32.1
+github.com/gogo/protobuf 6c65a5562fc06764971b7c5d05c76c75e84bdbf7 # v1.3.2
+github.com/golang/protobuf 84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@
 # After updating GRPC, if integration test failures occur, verify that the
 # string matching there is correct.
 google.golang.org/grpc 5e8f83304c0563d1ba74db05fee83d9c18ab9a58 # v1.32.1
-github.com/gogo/protobuf 6c65a5562fc06764971b7c5d05c76c75e84bdbf7 # v1.3.2
+github.com/gogo/protobuf 5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
 github.com/golang/protobuf 84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
 github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9

--- a/vendor.conf
+++ b/vendor.conf
@@ -10,7 +10,7 @@
 # string matching there is correct.
 google.golang.org/grpc 25c4f928eaa6d96443009bd842389fb4fa48664e # v1.20.1
 github.com/gogo/protobuf 5628607bb4c51c3157aacc3a50f0ab707582b805 # v1.3.1
-github.com/golang/protobuf 84668698ea25b64748563aa20726db66a6b8d299 # v1.3.5
+github.com/golang/protobuf 6c65a5562fc06764971b7c5d05c76c75e84bdbf7 # v1.3.2
 github.com/matttproud/golang_protobuf_extensions c12348ce28de40eed0136aa2b644d0ee0650e56c # v1.0.1
 google.golang.org/genproto 694d95ba50e67b2e363f3483057db5d4910c18f9
 


### PR DESCRIPTION
supersedes #2982

Golang:

- go1.13.11 includes fixes to the compiler
- go1.13.12 includes fixes to the runtime, and the go/types and math/big packages
- go1.13.13 includes security fixes to the crypto/x509 and net/http packages
- go1.13.14 includes fixes to the compiler, vet, and the database/sql, net/http, and reflect packages
- go1.13.15 includes security fixes to the encoding/binary package

Protobuf:

- stop generating package "// import" comment
- deprecate {Unm,M}arshalMessageSet{JSON}
- different internal implementation of oneofs .pb.go files generated by protoc-gen-go@v1.3.0 will require the proto@v1.3.0 package to work

