### PR TITLE
[feature-volumes] Add VolumeEnforcer and respect VolumeAvailability

### DIFF
--- a/manager/orchestrator/volumeenforcer/volume_enforcer.go
+++ b/manager/orchestrator/volumeenforcer/volume_enforcer.go
@@ -1,0 +1,114 @@
+package volumeenforcer
+
+import (
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/log"
+	"github.com/docker/swarmkit/manager/state/store"
+)
+
+// VolumeEnforcer is a component, styled off of the ConstraintEnforcer, that
+// watches for updates to Volumes, and shuts down tasks if those Volumes are
+// being drained.
+type VolumeEnforcer struct {
+	store    *store.MemoryStore
+	stopChan chan struct{}
+	doneChan chan struct{}
+}
+
+func New(s *store.MemoryStore) *VolumeEnforcer {
+	return &VolumeEnforcer{
+		store:    s,
+		stopChan: make(chan struct{}),
+		doneChan: make(chan struct{}),
+	}
+}
+
+func (ve *VolumeEnforcer) Run() {
+	defer close(ve.doneChan)
+
+	var volumes []*api.Volume
+	watcher, cancelWatch, _ := store.ViewAndWatch(ve.store, func(tx store.ReadTx) error {
+		var err error
+		volumes, err = store.FindVolumes(tx, store.All)
+		return err
+	}, api.EventUpdateVolume{})
+	defer cancelWatch()
+
+	for _, volume := range volumes {
+		ve.rejectNoncompliantTasks(volume)
+	}
+
+	for {
+		select {
+		case event := <-watcher:
+			v := event.(api.EventUpdateVolume).Volume
+			ve.rejectNoncompliantTasks(v)
+		case <-ve.stopChan:
+			return
+		}
+	}
+
+}
+
+func (ve *VolumeEnforcer) Stop() {
+	close(ve.stopChan)
+	<-ve.doneChan
+}
+
+func (ve *VolumeEnforcer) rejectNoncompliantTasks(v *api.Volume) {
+	if v.Spec.Availability != api.VolumeAvailabilityDrain {
+		return
+	}
+
+	var volumeTasks []*api.Task
+
+	ve.store.View(func(tx store.ReadTx) {
+		// ignore the error, it only happens if you pass an invalid find by
+		volumeTasks, _ = store.FindTasks(tx, store.ByVolumeAttachment(v.ID))
+	})
+	if len(volumeTasks) != 0 {
+		err := ve.store.Batch(func(batch *store.Batch) error {
+			for _, t := range volumeTasks {
+				// skip any tasks we know are already shut down or shutting
+				// down. Do this before we open the transaction. This saves us
+				// copying volumeTasks while still avoiding unnecessary
+				// transactions. we will still need to check again once we
+				// start the transaction against the latest version of the
+				// task.
+				if t.DesiredState > api.TaskStateCompleted || t.Status.State >= api.TaskStateCompleted {
+					continue
+				}
+
+				err := batch.Update(func(tx store.Tx) error {
+					t = store.GetTask(tx, t.ID)
+					// another check for task liveness.
+					if t == nil || t.DesiredState > api.TaskStateCompleted || t.Status.State >= api.TaskStateCompleted {
+						return nil
+					}
+
+					// as documented in the ConstraintEnforcer:
+					//
+					// We set the observed state to
+					// REJECTED, rather than the desired
+					// state. Desired state is owned by the
+					// orchestrator, and setting it directly
+					// will bypass actions such as
+					// restarting the task on another node
+					// (if applicable).
+					t.Status.State = api.TaskStateRejected
+					t.Status.Message = "task rejected by volume enforcer"
+					t.Status.Err = "attached to volume which is being drained"
+					return store.UpdateTask(tx, t)
+				})
+				if err != nil {
+					log.L.WithField("module", "volumeenforcer").WithError(err).Errorf("failed to shut down task %s", t.ID)
+				}
+			}
+			return nil
+		})
+
+		if err != nil {
+			log.L.WithField("module", "volumeenforcer").WithError(err).Errorf("failed to shut down tasks for volume %s", v.ID)
+		}
+	}
+}

--- a/manager/orchestrator/volumeenforcer/volume_enforcer_suite_test.go
+++ b/manager/orchestrator/volumeenforcer/volume_enforcer_suite_test.go
@@ -1,0 +1,13 @@
+package volumeenforcer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVolumeEnforcer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "VolumeEnforcer Suite")
+}

--- a/manager/orchestrator/volumeenforcer/volume_enforcer_test.go
+++ b/manager/orchestrator/volumeenforcer/volume_enforcer_test.go
@@ -1,0 +1,149 @@
+package volumeenforcer
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/docker/swarmkit/api"
+	"github.com/docker/swarmkit/manager/state/store"
+)
+
+var _ = Describe("VolumeEnforcer", func() {
+	var (
+		s  *store.MemoryStore
+		ve *VolumeEnforcer
+	)
+
+	BeforeEach(func() {
+		s = store.NewMemoryStore(nil)
+		ve = New(s)
+	})
+
+	Describe("rejectNoncompliantTasks", func() {
+		var (
+			n *api.Node
+			v *api.Volume
+			t *api.Task
+		)
+
+		BeforeEach(func() {
+			// we don't, strictly speaking, need a node for this test, but we
+			// might as well recreate the whole system rigging in case we
+			// change things in the future
+			n = &api.Node{
+				ID: "node",
+				Status: api.NodeStatus{
+					State: api.NodeStatus_READY,
+				},
+			}
+
+			v = &api.Volume{
+				ID: "volumeID",
+				Spec: api.VolumeSpec{
+					Annotations: api.Annotations{
+						Name: "volume",
+					},
+					Driver: &api.Driver{
+						Name: "driver",
+					},
+					Availability: api.VolumeAvailabilityPause,
+				},
+				VolumeInfo: &api.VolumeInfo{
+					VolumeID: "pluginID",
+				},
+				PublishStatus: []*api.VolumePublishStatus{
+					{
+						NodeID: "node",
+						State:  api.VolumePublishStatus_PUBLISHED,
+					},
+				},
+			}
+
+			t = &api.Task{
+				ID:     "task",
+				NodeID: "node",
+				Status: api.TaskStatus{
+					State: api.TaskStateRunning,
+				},
+				DesiredState: api.TaskStateRunning,
+				Volumes: []*api.VolumeAttachment{
+					{
+						ID:     "volumeID",
+						Source: "foo",
+						Target: "bar",
+					},
+				},
+			}
+
+			err := s.Update(func(tx store.Tx) error {
+				if err := store.CreateNode(tx, n); err != nil {
+					return err
+				}
+				if err := store.CreateVolume(tx, v); err != nil {
+					return err
+				}
+				return store.CreateTask(tx, t)
+			})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should skip volumes that do not have their availability as DRAIN", func() {
+			ve.rejectNoncompliantTasks(v)
+
+			var nt *api.Task
+			s.View(func(tx store.ReadTx) {
+				nt = store.GetTask(tx, t.ID)
+			})
+
+			Expect(nt).ToNot(BeNil())
+			Expect(nt.Status.State).To(Equal(api.TaskStateRunning))
+			Expect(nt.DesiredState).To(Equal(api.TaskStateRunning))
+		})
+
+		When("the Volume availability is DRAIN", func() {
+			var (
+				nv *api.Volume
+			)
+
+			BeforeEach(func() {
+				err := s.Update(func(tx store.Tx) error {
+					nv = store.GetVolume(tx, v.ID)
+					nv.Spec.Availability = api.VolumeAvailabilityDrain
+					return store.UpdateVolume(tx, nv)
+				})
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should reject tasks belonging to a volume with availability DRAIN", func() {
+				ve.rejectNoncompliantTasks(nv)
+
+				var nt *api.Task
+				s.View(func(tx store.ReadTx) {
+					nt = store.GetTask(tx, t.ID)
+				})
+				Expect(nt).ToNot(BeNil())
+				Expect(nt.Status.State).To(Equal(api.TaskStateRejected), "task state is %s", nt.Status.State)
+				Expect(nt.DesiredState).To(Equal(api.TaskStateRunning), "task desired state is %s", nt.DesiredState)
+			})
+
+			It("should skip tasks that are already shut down", func() {
+				err := s.Update(func(tx store.Tx) error {
+					nt := store.GetTask(tx, t.ID)
+					nt.Status.State = api.TaskStateCompleted
+					return store.UpdateTask(tx, nt)
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				ve.rejectNoncompliantTasks(nv)
+
+				var nt *api.Task
+				s.View(func(tx store.ReadTx) {
+					nt = store.GetTask(tx, t.ID)
+				})
+				Expect(nt).ToNot(BeNil())
+				Expect(nt.Status.State).To(Equal(api.TaskStateCompleted), "task state is %s", nt.Status.State)
+				Expect(nt.DesiredState).To(Equal(api.TaskStateRunning), "task desired state is %s", nt.DesiredState)
+			})
+		})
+	})
+})

--- a/manager/scheduler/volumes.go
+++ b/manager/scheduler/volumes.go
@@ -238,6 +238,11 @@ func (vs *volumeSet) isVolumeAvailableOnNode(mount *api.Mount, node *NodeInfo) s
 // on the given node.
 func (vs *volumeSet) checkVolume(id string, info *NodeInfo, readOnly bool) bool {
 	vi := vs.volumes[id]
+	// first, check if the volume's availability is even Active. If not. no
+	// reason to bother with anything further.
+	if vi.volume != nil && vi.volume.Spec.Availability != api.VolumeAvailabilityActive {
+		return false
+	}
 
 	// get the node topology for this volume
 	var top *api.Topology

--- a/manager/state/store/by.go
+++ b/manager/state/store/by.go
@@ -165,6 +165,16 @@ func ByReferencedConfigID(configID string) By {
 	return byReferencedConfigID(configID)
 }
 
+type byVolumeAttachment string
+
+func (b byVolumeAttachment) isBy() {}
+
+// ByVolumeAttachment creates an object to pass to Find to search for a Task
+// that has been assigned the given ID.
+func ByVolumeAttachment(volumeID string) By {
+	return byVolumeAttachment(volumeID)
+}
+
 type byKind string
 
 func (b byKind) isBy() {

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -22,23 +22,24 @@ import (
 )
 
 const (
-	indexID           = "id"
-	indexName         = "name"
-	indexRuntime      = "runtime"
-	indexServiceID    = "serviceid"
-	indexNodeID       = "nodeid"
-	indexSlot         = "slot"
-	indexDesiredState = "desiredstate"
-	indexTaskState    = "taskstate"
-	indexRole         = "role"
-	indexMembership   = "membership"
-	indexNetwork      = "network"
-	indexSecret       = "secret"
-	indexConfig       = "config"
-	indexKind         = "kind"
-	indexCustom       = "custom"
-	indexVolumeGroup  = "volumegroup"
-	indexDriver       = "driver"
+	indexID               = "id"
+	indexName             = "name"
+	indexRuntime          = "runtime"
+	indexServiceID        = "serviceid"
+	indexNodeID           = "nodeid"
+	indexSlot             = "slot"
+	indexDesiredState     = "desiredstate"
+	indexTaskState        = "taskstate"
+	indexRole             = "role"
+	indexMembership       = "membership"
+	indexNetwork          = "network"
+	indexSecret           = "secret"
+	indexConfig           = "config"
+	indexVolumeAttachment = "volumeattachment"
+	indexKind             = "kind"
+	indexCustom           = "custom"
+	indexVolumeGroup      = "volumegroup"
+	indexDriver           = "driver"
 
 	prefix = "_prefix"
 
@@ -734,6 +735,12 @@ func (tx readTx) findIterators(table string, by By, checkType func(By) error) ([
 		return []memdb.ResultIterator{it}, nil
 	case byReferencedConfigID:
 		it, err := tx.memDBTx.Get(table, indexConfig, string(v))
+		if err != nil {
+			return nil, err
+		}
+		return []memdb.ResultIterator{it}, nil
+	case byVolumeAttachment:
+		it, err := tx.memDBTx.Get(table, indexVolumeAttachment, string(v))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Updates the Scheduler to not use volumes in the Pause or Drain availability
* Creates a VolumeEnforcer, which is like the ConstraintEnforcer, except it rejects tasks belonging to Drained Volumes.
* Updates the store to include a new filter for Tasks by VolumeAttachment, allowing an efficient way to locate all tasks using a given volume.