### PR TITLE
[feature-volumes] Handle leadership changes and startup.

### DIFF
--- a/manager/csi/fakes_test.go
+++ b/manager/csi/fakes_test.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -12,9 +13,16 @@ import (
 	"github.com/docker/swarmkit/api"
 )
 
-// failDeleteLabel is a label set on a Volume to cause DeleteVolume on the fake
-// plugin to fail
-const failDeleteLabel = "fakes_fail_delete"
+const (
+	// failDeleteLabel is a label set on a Volume to cause DeleteVolume on the
+	// fake plugin to fail
+	failDeleteLabel = "fakes_fail_delete"
+
+	// failPublishLabel is a label set on a Volume to cause PublishVolume or
+	// UnpublishVolume to fail. The value of the label is the Node ID to fail
+	// on.
+	failPublishLabel = "fakes_fail_publish"
+)
 
 // volumes_fakes_test.go includes the fakes for unit-testing parts of the
 // volumes code.
@@ -81,6 +89,10 @@ type fakeControllerClient struct {
 	createVolumeRequests []*csi.CreateVolumeRequest
 	// publishRequests is a log of all requests to ControllerPublishVolume
 	publishRequests []*csi.ControllerPublishVolumeRequest
+	// unpublishRequests is a log of all requests to ControllerUnpublishVolume
+	unpublishRequests []*csi.ControllerUnpublishVolumeRequest
+	// deleteRequests is a log of all requests to DeleteVolume
+	deleteRequests []*csi.DeleteVolumeRequest
 	// idCounter is a simple way to generate ids
 	idCounter int
 }
@@ -117,7 +129,9 @@ func (f *fakeControllerClient) CreateVolume(ctx context.Context, in *csi.CreateV
 }
 
 func (f *fakeControllerClient) DeleteVolume(ctx context.Context, in *csi.DeleteVolumeRequest, _ ...grpc.CallOption) (*csi.DeleteVolumeResponse, error) {
-	return nil, nil
+	f.deleteRequests = append(f.deleteRequests, in)
+	// deleteVolumeResponse intentionally left blank
+	return &csi.DeleteVolumeResponse{}, nil
 }
 
 func (f *fakeControllerClient) ControllerPublishVolume(ctx context.Context, in *csi.ControllerPublishVolumeRequest, _ ...grpc.CallOption) (*csi.ControllerPublishVolumeResponse, error) {
@@ -131,7 +145,8 @@ func (f *fakeControllerClient) ControllerPublishVolume(ctx context.Context, in *
 }
 
 func (f *fakeControllerClient) ControllerUnpublishVolume(ctx context.Context, in *csi.ControllerUnpublishVolumeRequest, _ ...grpc.CallOption) (*csi.ControllerUnpublishVolumeResponse, error) {
-	return nil, nil
+	f.unpublishRequests = append(f.unpublishRequests, in)
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
 }
 
 func (f *fakeControllerClient) ValidateVolumeCapabilities(ctx context.Context, in *csi.ValidateVolumeCapabilitiesRequest, _ ...grpc.CallOption) (*csi.ValidateVolumeCapabilitiesResponse, error) {
@@ -176,13 +191,14 @@ func (fpm *fakePluginMaker) newFakePlugin(config *api.CSIConfig_Plugin, provider
 	fpm.Lock()
 	defer fpm.Unlock()
 	p := &fakePlugin{
-		name:             config.Name,
-		socket:           config.ControllerSocket,
-		swarmToCSI:       map[string]string{},
-		volumesCreated:   map[string]*api.Volume{},
-		volumesDeleted:   []string{},
-		volumesPublished: map[string][]string{},
-		removedIDs:       map[string]struct{}{},
+		name:               config.Name,
+		socket:             config.ControllerSocket,
+		swarmToCSI:         map[string]string{},
+		volumesCreated:     map[string]*api.Volume{},
+		volumesDeleted:     []string{},
+		volumesPublished:   map[string][]string{},
+		volumesUnpublished: map[string][]string{},
+		removedIDs:         map[string]struct{}{},
 	}
 	fpm.plugins[config.Name] = p
 	return p
@@ -202,6 +218,9 @@ type fakePlugin struct {
 	// volumesPublished maps the ID of a Volume to the Nodes it was published
 	// to
 	volumesPublished map[string][]string
+	// volumesUnpublished maps the ID of a volume to the Nodes it has been
+	// unpublished from
+	volumesUnpublished map[string][]string
 }
 
 func (f *fakePlugin) CreateVolume(ctx context.Context, v *api.Volume) (*api.VolumeInfo, error) {
@@ -224,11 +243,25 @@ func (f *fakePlugin) DeleteVolume(ctx context.Context, v *api.Volume) error {
 }
 
 func (f *fakePlugin) PublishVolume(ctx context.Context, v *api.Volume, nodeID string) (map[string]string, error) {
+	if fail, ok := v.Spec.Annotations.Labels[failPublishLabel]; ok {
+		if strings.Contains(fail, nodeID) {
+			return nil, fmt.Errorf("failing publish on %s since the label is set", nodeID)
+		}
+	}
 	f.volumesPublished[v.ID] = append(f.volumesPublished[v.ID], nodeID)
-	// TODO(dperny): return somethign here
 	return map[string]string{
 		"faked": "yeah",
 	}, nil
+}
+
+func (f *fakePlugin) UnpublishVolume(ctx context.Context, v *api.Volume, nodeID string) error {
+	if fail, ok := v.Spec.Annotations.Labels[failPublishLabel]; ok {
+		if strings.Contains(fail, nodeID) {
+			return fmt.Errorf("failing unpublish on %s since the label is set", nodeID)
+		}
+	}
+	f.volumesUnpublished[v.ID] = append(f.volumesUnpublished[v.ID], nodeID)
+	return nil
 }
 
 func (f *fakePlugin) AddNode(swarmID, csiID string) {

--- a/manager/csi/manager.go
+++ b/manager/csi/manager.go
@@ -3,6 +3,7 @@ package csi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/docker/go-events"
@@ -277,6 +278,8 @@ func (vm *Manager) enqueueVolume(id string) {
 // occurred, and does the required work to handle that update if so.
 //
 // returns an error if handling the volume failed and needs to be retried.
+//
+// even if an error is returned, the store may still be updated.
 func (vm *Manager) handleVolume(ctx context.Context, id string) error {
 	var volume *api.Volume
 	vm.store.View(func(tx store.ReadTx) {
@@ -297,16 +300,58 @@ func (vm *Manager) handleVolume(ctx context.Context, id string) error {
 	}
 
 	updated := false
-	for _, status := range volume.PublishStatus {
-		if status.State == api.VolumePublishStatus_PENDING_PUBLISH {
+	// TODO(dperny): it's just pointers, but copying the entire PublishStatus
+	// on each update might be intensive.
+
+	// we take a copy of the PublishStatus slice, because if we succeed in an
+	// unpublish operation, we will delete that status from PublishStatus.
+	statuses := make([]*api.VolumePublishStatus, len(volume.PublishStatus))
+	copy(statuses, volume.PublishStatus)
+
+	// failedPublishOrUnpublish is a slice of nodes where publish or unpublish
+	// operations failed. Publishing or unpublishing a volume can succeed or
+	// fail in part. If any failures occur, we will add the node ID of the
+	// publish operation that failed to this slice. Then, at the end of this
+	// function, after we update the store, if there are any failed operations,
+	// we will still return an error.
+	failedPublishOrUnpublish := []string{}
+
+	// adjustIndex is the number of entries deleted from volume.PublishStatus.
+	// when we're deleting entries from volume.PublishStatus, the index of the
+	// entry in statuses will no longer match the index of the same entry in
+	// volume.PublishStatus. we subtract adjustIndex from i to get the index
+	// where the entry is found after taking into account the deleted entries.
+	adjustIndex := 0
+
+	for i, status := range statuses {
+		switch status.State {
+		case api.VolumePublishStatus_PENDING_PUBLISH:
 			plug := vm.plugins[volume.Spec.Driver.Name]
 			publishContext, err := plug.PublishVolume(ctx, volume, status.NodeID)
 			if err == nil {
 				// TODO(dperny): handle error
 				status.State = api.VolumePublishStatus_PUBLISHED
 				status.PublishContext = publishContext
-				updated = true
+				status.Message = ""
+			} else {
+				status.Message = fmt.Sprintf("error publishing volume: %v", err)
+				failedPublishOrUnpublish = append(failedPublishOrUnpublish, status.NodeID)
 			}
+			updated = true
+		case api.VolumePublishStatus_PENDING_UNPUBLISH:
+			plug := vm.plugins[volume.Spec.Driver.Name]
+			err := plug.UnpublishVolume(ctx, volume, status.NodeID)
+			if err == nil {
+				// if there is no error with unpublishing, then we delete the
+				// status from the statuses slice.
+				j := i - adjustIndex
+				volume.PublishStatus = append(volume.PublishStatus[:j], volume.PublishStatus[j+1:]...)
+				adjustIndex++
+			} else {
+				status.Message = fmt.Sprintf("error unpublishing volume: %v", err)
+			}
+
+			updated = true
 		}
 	}
 
@@ -316,7 +361,7 @@ func (vm *Manager) handleVolume(ctx context.Context, id string) error {
 			// volume object.
 			v := store.GetVolume(tx, volume.ID)
 			if v == nil {
-				// volume should never be deleted with pending publishes.
+				// TODO(dperny): volume should never be deleted with pending publishes.
 				// either handle this error otherwise document why we don't.
 				return nil
 			}
@@ -326,6 +371,10 @@ func (vm *Manager) handleVolume(ctx context.Context, id string) error {
 		}); err != nil {
 			return err
 		}
+	}
+
+	if len(failedPublishOrUnpublish) > 0 {
+		return fmt.Errorf("error publishing or unpublishing to some nodes: %v", failedPublishOrUnpublish)
 	}
 	return nil
 }

--- a/manager/csi/manager_test.go
+++ b/manager/csi/manager_test.go
@@ -29,6 +29,9 @@ var _ = Describe("Manager", func() {
 		// nodes is a slice of all nodes to create during setup
 		nodes []*api.Node
 
+		// volumes is a slice of all volumes to create during setup
+		volumes []*api.Volume
+
 		pluginMaker *fakePluginMaker
 
 		// watch contains an event channel, which is produced by
@@ -67,6 +70,7 @@ var _ = Describe("Manager", func() {
 
 		plugins = []*api.CSIConfig_Plugin{}
 		nodes = []*api.Node{}
+		volumes = []*api.Volume{}
 
 		vm = NewManager(s)
 		vm.newPlugin = pluginMaker.newFakePlugin
@@ -88,6 +92,11 @@ var _ = Describe("Manager", func() {
 		err := s.Update(func(tx store.Tx) error {
 			for _, node := range nodes {
 				if err := store.CreateNode(tx, node); err != nil {
+					return err
+				}
+			}
+			for _, volume := range volumes {
+				if err := store.CreateVolume(tx, volume); err != nil {
 					return err
 				}
 			}
@@ -167,6 +176,34 @@ var _ = Describe("Manager", func() {
 					},
 				},
 			)
+
+			volumes = append(volumes,
+				&api.Volume{
+					ID: "volumeID1",
+					Spec: api.VolumeSpec{
+						Annotations: api.Annotations{
+							Name: "volume1",
+						},
+						Driver: &api.Driver{
+							Name: "newPlugin",
+						},
+					},
+				},
+				&api.Volume{
+					ID: "volumeID2",
+					Spec: api.VolumeSpec{
+						Annotations: api.Annotations{
+							Name: "volume2",
+						},
+						Driver: &api.Driver{
+							Name: "newPlugin",
+						},
+					},
+					VolumeInfo: &api.VolumeInfo{
+						VolumeID: "volumePluginID",
+					},
+				},
+			)
 		})
 
 		JustBeforeEach(func() {
@@ -194,6 +231,10 @@ var _ = Describe("Manager", func() {
 				HaveKeyWithValue("nodeID1", "differentPluginNode1"),
 				HaveKeyWithValue("nodeID2", "differentPluginNode2"),
 			))
+		})
+
+		It("should enqueue all volumes", func() {
+			Expect(vm.pendingVolumes.outstanding).To(HaveLen(2))
 		})
 	})
 
@@ -548,39 +589,33 @@ var _ = Describe("Manager", func() {
 					VolumeContext: map[string]string{"foo": "bar"},
 					VolumeID:      "plug1VolID1",
 				},
+				PublishStatus: []*api.VolumePublishStatus{
+					{
+						NodeID: "node1",
+						State:  api.VolumePublishStatus_PENDING_PUBLISH,
+					}, {
+						NodeID:         "node3",
+						PublishContext: map[string]string{"unpublish": "thisone"},
+						State:          api.VolumePublishStatus_PENDING_UNPUBLISH,
+					}, {
+						NodeID: "node2",
+						State:  api.VolumePublishStatus_PENDING_PUBLISH,
+					}, {
+						NodeID:         "node4",
+						PublishContext: map[string]string{"unpublish": "thisone"},
+						State:          api.VolumePublishStatus_PENDING_UNPUBLISH,
+					},
+				},
 			}
-
-			err := s.Update(func(tx store.Tx) error {
-				return store.CreateVolume(tx, v1)
-			})
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
 			vm.init()
-			v1.PublishStatus = append(v1.PublishStatus,
-				&api.VolumePublishStatus{
-					NodeID: "node1",
-					State:  api.VolumePublishStatus_PENDING_PUBLISH,
-				},
-				&api.VolumePublishStatus{
-					NodeID:         "node3",
-					PublishContext: map[string]string{"unpublish": "thisone"},
-					State:          api.VolumePublishStatus_PENDING_UNPUBLISH,
-				},
-				&api.VolumePublishStatus{
-					NodeID: "node2",
-					State:  api.VolumePublishStatus_PENDING_PUBLISH,
-				},
-				&api.VolumePublishStatus{
-					NodeID:         "node4",
-					PublishContext: map[string]string{"unpublish": "thisone"},
-					State:          api.VolumePublishStatus_PENDING_UNPUBLISH,
-				},
-			)
 
+			// do the creation after the initialization, so that the init does
+			// not enqueue the volumes for processing.
 			err := s.Update(func(tx store.Tx) error {
-				return store.UpdateVolume(tx, v1)
+				return store.CreateVolume(tx, v1)
 			})
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -627,6 +662,7 @@ var _ = Describe("Manager", func() {
 				ConsistOf("node3", "node4"),
 			)
 
+			// check that there are no outstandinv volumes
 			Expect(vm.pendingVolumes.outstanding).To(HaveLen(0))
 		})
 
@@ -688,6 +724,10 @@ var _ = Describe("Manager", func() {
 		})
 
 		JustBeforeEach(func() {
+			vm.init()
+
+			// do creation after initialization to avoid init enqueuing the
+			// volume
 			volume := &api.Volume{
 				ID: "volumeID",
 				Spec: api.VolumeSpec{
@@ -708,7 +748,6 @@ var _ = Describe("Manager", func() {
 				return store.CreateVolume(tx, volume)
 			})
 			Expect(err).ToNot(HaveOccurred())
-			vm.init()
 		})
 
 		It("should delete the Volume", func() {
@@ -730,6 +769,8 @@ var _ = Describe("Manager", func() {
 			})
 			Expect(v).To(BeNil())
 
+			// check that pendingVolumes is empty, which will not be the case
+			// if the delete operation failed.
 			Expect(vm.pendingVolumes.outstanding).To(HaveLen(0))
 		})
 

--- a/manager/csi/plugin_test.go
+++ b/manager/csi/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"context"
+	"fmt"
 
 	// "google.golang.org/grpc"
 
@@ -20,6 +21,8 @@ func newPluginFromClients(name string, provider SecretProvider, idClient csi.Ide
 		provider:         provider,
 		idClient:         idClient,
 		controllerClient: controllerClient,
+		swarmToCSI:       map[string]string{},
+		csiToSwarm:       map[string]string{},
 	}
 }
 
@@ -197,6 +200,281 @@ var _ = Describe("Plugin manager", func() {
 			It("should return the volume name as the VolumeID", func() {
 				Expect(volumeInfo.VolumeID).To(Equal(v.Spec.Annotations.Name))
 			})
+		})
+	})
+
+	Describe("makeControllerPublishVolumeRequest", func() {
+		BeforeEach(func() {
+			plugin.AddNode("swarmNode1", "csiNode1")
+			plugin.AddNode("swarmNode2", "csiNode2")
+		})
+
+		It("should make a csi.ControllerPublishVolumeRequest for the given volume", func() {
+			v := &api.Volume{
+				ID: "volumeID1",
+				Spec: api.VolumeSpec{
+					Annotations: api.Annotations{
+						Name: "volumeName1",
+					},
+					Driver: &api.Driver{
+						Name: plugin.name,
+					},
+					Secrets: []*api.VolumeSecret{
+						{
+							Key:    "secretKey1",
+							Secret: "secretID1",
+						}, {
+							Key:    "secretKey2",
+							Secret: "secretID2",
+						},
+					},
+					AccessMode: &api.VolumeAccessMode{
+						Scope:   api.VolumeScopeMultiNode,
+						Sharing: api.VolumeSharingOneWriter,
+					},
+				},
+				VolumeInfo: &api.VolumeInfo{
+					VolumeID: "volumePluginID1",
+					VolumeContext: map[string]string{
+						"foo": "bar",
+					},
+				},
+				PublishStatus: []*api.VolumePublishStatus{
+					{
+						NodeID: "swarmNode1",
+						State:  api.VolumePublishStatus_PENDING_PUBLISH,
+					}, {
+						NodeID: "swarmNode2",
+						State:  api.VolumePublishStatus_PENDING_PUBLISH,
+					},
+				},
+			}
+
+			request := plugin.makeControllerPublishVolumeRequest(v, "swarmNode1")
+
+			Expect(request).ToNot(BeNil())
+			Expect(request.VolumeId).To(Equal("volumePluginID1"))
+			Expect(request.NodeId).To(Equal("csiNode1"))
+			Expect(request.Secrets).To(SatisfyAll(
+				HaveLen(2),
+				HaveKeyWithValue("secretKey1", "superdupersecret1"),
+				HaveKeyWithValue("secretKey2", "superdupersecret2"),
+			))
+			Expect(request.VolumeContext).To(Equal(map[string]string{"foo": "bar"}))
+			Expect(request.VolumeCapability).ToNot(BeNil())
+			Expect(request.VolumeCapability.AccessType).To(Equal(
+				&csi.VolumeCapability_Mount{Mount: &csi.VolumeCapability_MountVolume{}},
+			))
+			Expect(request.VolumeCapability.AccessMode).To(Equal(
+				&csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
+				},
+			))
+		})
+	})
+
+	Describe("PublishVolume", func() {
+		var (
+			v *api.Volume
+
+			// publishContext holds the map return value of PublishVolume
+			publishContext map[string]string
+			// publishError holds the error return value
+			publishError error
+		)
+
+		BeforeEach(func() {
+			v = &api.Volume{
+				ID: "volumeID",
+				Spec: api.VolumeSpec{
+					Annotations: api.Annotations{
+						Name: "volumeName",
+					},
+					Driver: &api.Driver{
+						Name: plugin.name,
+					},
+					AccessMode: &api.VolumeAccessMode{
+						Scope:   api.VolumeScopeMultiNode,
+						Sharing: api.VolumeSharingOneWriter,
+					},
+				},
+				VolumeInfo: &api.VolumeInfo{
+					VolumeID:      "volumePluginID1",
+					VolumeContext: map[string]string{"foo": "bar"},
+				},
+				PublishStatus: []*api.VolumePublishStatus{
+					{
+						State:  api.VolumePublishStatus_PENDING_PUBLISH,
+						NodeID: "node1",
+					},
+				},
+			}
+			plugin.AddNode("swarmNode1", "pluginNode1")
+		})
+
+		JustBeforeEach(func() {
+			publishContext, publishError = plugin.PublishVolume(context.Background(), v, "node1")
+			fmt.Printf("publishContext: %v\n", publishContext)
+		})
+
+		It("should call the ControllerPublishVolume RPC", func() {
+			Expect(controller.publishRequests).To(HaveLen(1))
+			Expect(controller.publishRequests[0]).ToNot(BeNil())
+			Expect(controller.publishRequests[0].VolumeId).To(Equal("volumePluginID1"))
+		})
+
+		It("should return the PublishContext", func() {
+			Expect(publishContext).To(Equal(map[string]string{"bruh": "dude"}))
+		})
+
+		It("should not return an error", func() {
+			Expect(publishError).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("Unpublishing Volumes", func() {
+		var v *api.Volume
+
+		BeforeEach(func() {
+			v = &api.Volume{
+				ID: "volumeID1",
+				Spec: api.VolumeSpec{
+					Annotations: api.Annotations{
+						Name: "volumeName1",
+					},
+					Driver: &api.Driver{
+						Name: plugin.name,
+					},
+					Secrets: []*api.VolumeSecret{
+						{
+							Key:    "secretKey1",
+							Secret: "secretID1",
+						}, {
+							Key:    "secretKey2",
+							Secret: "secretID2",
+						},
+					},
+					AccessMode: &api.VolumeAccessMode{
+						Scope:   api.VolumeScopeMultiNode,
+						Sharing: api.VolumeSharingOneWriter,
+					},
+				},
+				VolumeInfo: &api.VolumeInfo{
+					VolumeID: "volumePluginID1",
+					VolumeContext: map[string]string{
+						"foo": "bar",
+					},
+				},
+				PublishStatus: []*api.VolumePublishStatus{
+					{
+						NodeID: "swarmNode1",
+						State:  api.VolumePublishStatus_PENDING_UNPUBLISH,
+					}, {
+						NodeID: "swarmNode2",
+						State:  api.VolumePublishStatus_PENDING_UNPUBLISH,
+					},
+				},
+			}
+
+			plugin.AddNode("swarmNode1", "csiNode1")
+			plugin.AddNode("swarmNode2", "csiNode2")
+		})
+
+		It("should make a csi.ControllerUnpublishVolumeRequest for the given volume", func() {
+			request := plugin.makeControllerUnpublishVolumeRequest(v, "swarmNode1")
+			Expect(request).ToNot(BeNil())
+			Expect(request.VolumeId).To(Equal("volumePluginID1"))
+			Expect(request.NodeId).To(Equal("csiNode1"))
+			Expect(request.Secrets).To(SatisfyAll(
+				HaveLen(2),
+				HaveKeyWithValue("secretKey1", "superdupersecret1"),
+				HaveKeyWithValue("secretKey2", "superdupersecret2"),
+			))
+		})
+
+		Describe("UnpublishVolume", func() {
+			var (
+				unpublishError error
+			)
+
+			JustBeforeEach(func() {
+				unpublishError = plugin.UnpublishVolume(context.Background(), v, "swarmNode1")
+			})
+
+			It("should not return an error", func() {
+				Expect(unpublishError).ToNot(HaveOccurred())
+			})
+
+			It("should call the ControllerUnpublishVolume RPC", func() {
+				Expect(controller.unpublishRequests).To(HaveLen(1))
+				Expect(controller.unpublishRequests[0]).ToNot(BeNil())
+				Expect(controller.unpublishRequests[0].VolumeId).To(Equal("volumePluginID1"))
+			})
+		})
+	})
+
+	Describe("Deleting a volume", func() {
+		var (
+			v *api.Volume
+
+			deleteError error
+		)
+
+		BeforeEach(func() {
+			v = &api.Volume{
+				ID: "volumeID1",
+				Spec: api.VolumeSpec{
+					Annotations: api.Annotations{
+						Name: "volumeName1",
+					},
+					Driver: &api.Driver{
+						Name: plugin.name,
+					},
+					Secrets: []*api.VolumeSecret{
+						{
+							Key:    "secretKey1",
+							Secret: "secretID1",
+						}, {
+							Key:    "secretKey2",
+							Secret: "secretID2",
+						},
+					},
+					AccessMode: &api.VolumeAccessMode{
+						Scope:   api.VolumeScopeMultiNode,
+						Sharing: api.VolumeSharingOneWriter,
+					},
+				},
+				VolumeInfo: &api.VolumeInfo{
+					VolumeID: "volumePluginID1",
+					VolumeContext: map[string]string{
+						"foo": "bar",
+					},
+				},
+				PublishStatus: []*api.VolumePublishStatus{},
+				PendingDelete: true,
+			}
+		})
+
+		JustBeforeEach(func() {
+			deleteError = plugin.DeleteVolume(context.Background(), v)
+		})
+
+		It("should call the DeleteVolume RPC with a correct request", func() {
+			Expect(controller.deleteRequests).To(HaveLen(1))
+
+			request := controller.deleteRequests[0]
+
+			Expect(request).ToNot(BeNil())
+			Expect(request.VolumeId).To(Equal("volumePluginID1"))
+			Expect(request.Secrets).To(SatisfyAll(
+				HaveLen(2),
+				HaveKeyWithValue("secretKey1", "superdupersecret1"),
+				HaveKeyWithValue("secretKey2", "superdupersecret2"),
+			))
+		})
+
+		It("should not return an error", func() {
+			Expect(deleteError).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
The CSI manager now reads out and checks all volumes on initialization, which occurs at start up or leadership change. This means that work interrupted by an outage or leadership change is picked up where it was left off.

Depends on #2989 