### PR TITLE
Fix update issue on where service doesn't roll back on failure

### DIFF
--- a/manager/orchestrator/update/updater.go
+++ b/manager/orchestrator/update/updater.go
@@ -280,6 +280,11 @@ slotsLoop:
 	wg.Wait()
 
 	if !stopped {
+		// if a delay is set we need to monitor for a period longer than the delay
+		// otherwise we will leave the monitorLoop before the task is done delaying
+		if updateConfig.Delay >= monitoringPeriod {
+			monitoringPeriod = updateConfig.Delay + 1*time.Second
+		}
 		// Keep watching for task failures for one more monitoringPeriod,
 		// before declaring the update complete.
 		doneMonitoring := time.After(monitoringPeriod)


### PR DESCRIPTION
Signed-off-by: Adam Williams <awilliams@mirantis.com>
**- What I did**
When the updateConfig delay parameter is larger than the monitor parameter an error in updating can be missed and rollback not performed.  This fix will check for the case where monitor < delay and use the larger of the two. 

Fixes [37972](https://github.com/moby/moby/issues/37972)
**- How I did it**

**- How to test it**
Manual testing that failed update will rollback.
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
