### PR TITLE
[19.03 backport] Update Golang to 1.13.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       # Needed to install go
       OS: linux
       ARCH: amd64
-      GOVERSION: 1.11
+      GOVERSION: 1.13
       # Needed to install protoc
       PROTOC_VERSION: 3.6.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 # NOTE(dperny): for some reason, alpine was giving me trouble
-FROM golang:1.11.0-stretch
+ARG GO_VERSION=1.13.15
+ARG DEBIAN_FRONTEND=noninteractive
+ARG BASE_DEBIAN_DISTRO="buster"
+ARG GOLANG_IMAGE="golang:${GO_VERSION}-${BASE_DEBIAN_DISTRO}"
+
+FROM ${GOLANG_IMAGE}
 
 RUN apt-get update && apt-get install -y make git unzip
 


### PR DESCRIPTION
 Update Golang to 1.13.15
(cherry picked from commit 584728ec0d40b2b717729ea77382dbf28e76c52c)




