### PR TITLE
[draft] manager/allocator/cnmallocator: remove unused nType argument

### DIFF
--- a/manager/allocator/cnmallocator/networkallocator.go
+++ b/manager/allocator/cnmallocator/networkallocator.go
@@ -980,7 +980,7 @@ func (na *cnmNetworkAllocator) allocatePools(n *api.Network) (map[string]string,
 
 func initializeDrivers(reg *drvregistry.DrvRegistry) error {
 	for _, i := range initializers {
-		if err := reg.AddDriver(i.ntype, i.fn, nil); err != nil {
+		if err := reg.AddDriver(i.fn, nil); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
this will fail currently, due to the circular docker -> swarm kit -> dependency

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
