### PR TITLE
Fix panic in agent

### DIFF
--- a/agent/exec/errors.go
+++ b/agent/exec/errors.go
@@ -70,17 +70,14 @@ func (t temporary) Temporary() bool { return true }
 // IsTemporary returns true if the error or a recursive cause returns true for
 // temporary.
 func IsTemporary(err error) bool {
-	for err != nil {
-		if tmp, ok := err.(Temporary); ok && tmp.Temporary() {
-			return true
-		}
+	if tmp, ok := err.(Temporary); ok && tmp.Temporary() {
+		return true
+	}
 
-		cause := errors.Cause(err)
-		if cause == err {
-			break
-		}
+	cause := errors.Cause(err)
 
-		err = cause
+	if tmp, ok := cause.(Temporary); ok && tmp.Temporary() {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
Previously, there was an issue where the agent could panic while attempting to determine if an error was temporary.

Before the change, in `agent/exec/errors.go`, the function `IsTemporary` attempted to drill down to a root cause by iterating through the causes of an error by calling `errors.Cause`. If an error has no cause, then `errors.Cause` returns that same error.

The issue is that somewhere in the depths of some code, it was possible for the error to have an underlying type that was non-comparable; for example, maps and slices are uncomparable types. This would cause a panic, as the uncomparable type cannot be compared even to itself.

However, one can see that `errors.Cause` has its own loop, and drills down to the root cause in its own way. There is no need for us to iterate here.

Instead, we can just take a look at the error itself, and then take a look at its cause once. If neither is temporary, the error is not temporary, and we have nothing to worry about.