### PR TITLE
Use two different interfaces for CSI plugins

### DIFF
--- a/agent/csi/plugin/manager.go
+++ b/agent/csi/plugin/manager.go
@@ -13,8 +13,9 @@ import (
 const (
 	// DockerCSIPluginCap is the capability name of the plugins we use with the
 	// PluginGetter to get only the plugins we need. The full name of the
-	// plugin interface is "swarm.csiplugin/1.0"
-	DockerCSIPluginCap = "csiplugin"
+	// plugin interface is "docker.csinode/1.0". This gets only plugins with
+	// Node capabilities.
+	DockerCSIPluginCap = "csinode"
 )
 
 // PluginManager manages the multiple CSI plugins that may be in use on the

--- a/manager/csi/manager.go
+++ b/manager/csi/manager.go
@@ -20,8 +20,9 @@ import (
 const (
 	// DockerCSIPluginCap is the capability name of the plugins we use with the
 	// PluginGetter to get only the plugins we need. The full name of the
-	// plugin interface is "swarm.csiplugin/1.0"
-	DockerCSIPluginCap = "csiplugin"
+	// plugin interface is "docker.csicontroller/1.0". This gets only the CSI
+	// plugins with Controller capability.
+	DockerCSIPluginCap = "csicontroller"
 )
 
 type Manager struct {

--- a/testutils/fake_plugingetter.go
+++ b/testutils/fake_plugingetter.go
@@ -9,18 +9,18 @@ import (
 	"github.com/docker/docker/pkg/plugins"
 )
 
-// DockerCSIPluginCap is the capability for CSI plugins.
-const DockerCSIPluginCap = "csiplugin"
+const DockerCSIPluginNodeCap = "csinode"
+const DockerCSIPluginControllerCap = "csicontroller"
 
 type FakePluginGetter struct {
 	Plugins map[string]*FakeCompatPlugin
 }
 
 func (f *FakePluginGetter) Get(name, capability string, _ int) (plugingetter.CompatPlugin, error) {
-	if capability != DockerCSIPluginCap {
+	if capability != DockerCSIPluginNodeCap && capability != DockerCSIPluginControllerCap {
 		return nil, fmt.Errorf(
-			"requested plugin with %s cap, but should only ever request %s",
-			capability, DockerCSIPluginCap,
+			"requested plugin with %s cap, but should only ever request %s or %s",
+			capability, DockerCSIPluginNodeCap, DockerCSIPluginControllerCap,
 		)
 	}
 
@@ -38,7 +38,7 @@ func (f *FakePluginGetter) GetAllByCap(_ string) ([]plugingetter.CompatPlugin, e
 // GetAllManagedPluginsByCap returns all of the fake's plugins. If capability
 // is anything other than DockerCSIPluginCap, it returns nothing.
 func (f *FakePluginGetter) GetAllManagedPluginsByCap(capability string) []plugingetter.CompatPlugin {
-	if capability != DockerCSIPluginCap {
+	if capability != DockerCSIPluginNodeCap && capability != DockerCSIPluginControllerCap {
 		return nil
 	}
 


### PR DESCRIPTION
Uses two different interfaces to specify which part of the CSI system a plugin is used as

* `docker.csinode/1.0` is the interface for Node plugins, which should run on the worker.
* `docker.csicontroller/1.0` is the interface for Controller plugins, which should run on the manager

If it is desirable to be able to schedule volumes to the manager node, the plugin can advertise both interfaces.