### PR TITLE
Increase the max size of a config object from 500k to 1000k

### DIFF
--- a/manager/controlapi/config.go
+++ b/manager/controlapi/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MaxConfigSize is the maximum byte length of the `Config.Spec.Data` field.
-const MaxConfigSize = 500 * 1024 // 500KB
+const MaxConfigSize = 1000 * 1024 // 1000KB
 
 // assumes spec is not nil
 func configFromConfigSpec(spec *api.ConfigSpec) *api.Config {


### PR DESCRIPTION
Signed-off-by: Adam Williams <awilliams@mirantis.com>

**- What I did**
Increased the maximum size of a config object. 

**- How I did it**
I changed the maximum size of a config object from 500k to 1000k

**- How to test it**
Created config objects over 500k and 1000k to verify that the larger configs work, and that the new upper bound works.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
