### PR TITLE
manager: restore NewServer to v2 signature

### DIFF
--- a/manager/controlapi/apihooks.go
+++ b/manager/controlapi/apihooks.go
@@ -6,9 +6,10 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 )
 
-// ViewResponseMutator provides callbacks which may modify the response objects
-// for Get or List Control API requests before they are sent to the client.
-type ViewResponseMutator interface {
+// NetworkViewResponseMutator provides callbacks which may modify the response
+// objects for GetNetwork and ListNetworks Control API requests before they are
+// sent to the client.
+type NetworkViewResponseMutator interface {
 	OnGetNetwork(context.Context, *api.Network) error
 	OnListNetworks(context.Context, []*api.Network) error
 }
@@ -21,4 +22,11 @@ func (NoopViewResponseMutator) OnGetNetwork(ctx context.Context, n *api.Network)
 
 func (NoopViewResponseMutator) OnListNetworks(ctx context.Context, networks []*api.Network) error {
 	return nil
+}
+
+func (s *Server) networkhooks() NetworkViewResponseMutator {
+	if s.NetworkHooks != nil {
+		return s.NetworkHooks
+	}
+	return NoopViewResponseMutator{}
 }

--- a/manager/controlapi/network.go
+++ b/manager/controlapi/network.go
@@ -148,7 +148,7 @@ func (s *Server) GetNetwork(ctx context.Context, request *api.GetNetworkRequest)
 	if n == nil {
 		return nil, status.Errorf(codes.NotFound, "network %s not found", request.NetworkID)
 	}
-	if err := s.viewhooks.OnGetNetwork(ctx, n); err != nil {
+	if err := s.networkhooks().OnGetNetwork(ctx, n); err != nil {
 		return nil, err
 	}
 	return &api.GetNetworkResponse{
@@ -295,7 +295,7 @@ func (s *Server) ListNetworks(ctx context.Context, request *api.ListNetworksRequ
 		)
 	}
 
-	if err := s.viewhooks.OnListNetworks(ctx, networks); err != nil {
+	if err := s.networkhooks().OnListNetworks(ctx, networks); err != nil {
 		return nil, err
 	}
 

--- a/manager/controlapi/server.go
+++ b/manager/controlapi/server.go
@@ -20,17 +20,17 @@ type Server struct {
 	raft           *raft.Node
 	securityConfig *ca.SecurityConfig
 	netvalidator   networkallocator.DriverValidator
-	viewhooks      ViewResponseMutator
 	dr             *drivers.DriverProvider
+
+	// NetworkHooks intercept and mutate API server responses for GetNetwork
+	// and ListNetworks API requests when set.
+	NetworkHooks NetworkViewResponseMutator
 }
 
 // NewServer creates a Cluster API server.
-func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig, nv networkallocator.DriverValidator, vrm ViewResponseMutator, dr *drivers.DriverProvider) *Server {
+func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.SecurityConfig, nv networkallocator.DriverValidator, dr *drivers.DriverProvider) *Server {
 	if nv == nil {
 		nv = networkallocator.InertProvider{}
-	}
-	if vrm == nil {
-		vrm = NoopViewResponseMutator{}
 	}
 	return &Server{
 		store:          store,
@@ -38,6 +38,5 @@ func NewServer(store *store.MemoryStore, raft *raft.Node, securityConfig *ca.Sec
 		raft:           raft,
 		securityConfig: securityConfig,
 		netvalidator:   nv,
-		viewhooks:      vrm,
 	}
 }

--- a/manager/controlapi/server_test.go
+++ b/manager/controlapi/server_test.go
@@ -47,7 +47,7 @@ func newTestServer(t *testing.T) *testServer {
 	ts.Store = store.NewMemoryStore(&stateutils.MockProposer{})
 	assert.NotNil(t, ts.Store)
 
-	ts.Server = NewServer(ts.Store, nil, securityConfig, nil, nil, nil)
+	ts.Server = NewServer(ts.Store, nil, securityConfig, nil, nil)
 	assert.NotNil(t, ts.Server)
 
 	temp, err := os.CreateTemp("", "test-socket")

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -472,7 +472,8 @@ func (m *Manager) Run(parent context.Context) error {
 		return err
 	}
 
-	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.config.networkProvider(), m, drivers.New(m.config.PluginGetter))
+	baseControlAPI := controlapi.NewServer(m.raftNode.MemoryStore(), m.raftNode, m.config.SecurityConfig, m.config.networkProvider(), drivers.New(m.config.PluginGetter))
+	baseControlAPI.NetworkHooks = m
 	baseResourceAPI := resourceapi.New(m.raftNode.MemoryStore())
 	healthServer := health.NewHealthServer()
 	localHealthServer := health.NewHealthServer()

--- a/manager/orchestrator/jobs/orchestrator_controlapi_integration_test.go
+++ b/manager/orchestrator/jobs/orchestrator_controlapi_integration_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Integration between the controlapi and jobs orchestrator", fun
 		// but it's unexported. in any case, re-writing it in ginkgo isn't
 		// unwarranted.
 		s = store.NewMemoryStore(&stateutils.MockProposer{})
-		server = controlapi.NewServer(s, nil, nil, nil, nil, nil)
+		server = controlapi.NewServer(s, nil, nil, nil, nil)
 
 		// we need a temporary unix socket to server on
 		temp, err := os.CreateTemp("", "test-socket")


### PR DESCRIPTION
- Updates #3210 
- Closes #3211 

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Undid the breaking change introduced by the previous PR without loss of functionality.

**- How I did it**
While NewServer is probably not called by any code outside the swarmkit module, we should still be good maintainers by taking reasonable measures to avoid introducing breaking changes to the module. Instead provide a view-response mutator to controlapi by setting an exported struct field on the constructed Server.

Since for similar compatibility reasons we can't ever add new methods to the view-response interface, rename it to better reflect its narrow scope.

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
