### PR TITLE
Fixed a nil pointer that happened twice in swarm stack. Rare occurrence. 

### DIFF
--- a/manager/orchestrator/service.go
+++ b/manager/orchestrator/service.go
@@ -72,6 +72,12 @@ func SetServiceTasksRemove(ctx context.Context, s *store.MemoryStore, service *a
 				// within the boundaries of a transaction
 				latestTask := store.GetTask(tx, t.ID)
 
+				// in case the task is deleted
+				if latestTask == nil {
+					log.G(ctx).WithField("task_id", t.ID).Debug("task no longer exists in store")
+					return nil
+				}
+
 				// time travel is not allowed. if the current desired state is
 				// above the one we're trying to go to we can't go backwards.
 				// we have nothing to do and we should skip to the next task


### PR DESCRIPTION
store.GetTask() seems to have the nil pointer check in every other location we could find it to be used, so I'm sure this is just a small hiccup.

I don't really care if this PR is merged or if you clean it up on your side - the main thing is we need it fixed due to Swarm randomly crashing when you got hundreds of containers in many many services sending jobs back and forth. We have no clear way to reproduce it due to the goroutine madness. 

Ref issue from first time it occurred: [https://github.com/moby/swarmkit/issues/3216](https://github.com/moby/swarmkit/issues/3216)