### PR TITLE
ci: declare workflow-level `contents: read` on ci and validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ env:
   DOCKER_SWARMKIT_USE_CONTAINER: 1
   IMAGE_NAME: moby/swarmkit
 
+permissions:
+  contents: read
+
 jobs:
   build-dev:
     runs-on: ubuntu-22.04

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,9 @@ on:
 env:
   DOCKER_SWARMKIT_USE_CONTAINER: 1
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Both workflows just run Go test and lint validation. No GitHub API writes from the workflows.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.