### PR TITLE
dispatcher: guard against missing volumes in assignments stream

### DIFF
--- a/manager/dispatcher/dispatcher.go
+++ b/manager/dispatcher/dispatcher.go
@@ -1174,6 +1174,9 @@ func (d *Dispatcher) Assignments(r *api.AssignmentsRequest, stream api.Dispatche
 				case api.EventUpdateVolume:
 					d.store.View(func(readTx store.ReadTx) {
 						vol := store.GetVolume(readTx, v.Volume.ID)
+						if vol == nil {
+							return
+						}
 						// check through the PublishStatus to see if there is
 						// one for this node.
 						for _, status := range vol.PublishStatus {


### PR DESCRIPTION
Assignments handles EventUpdateVolume by looking up the current volume from the store before updating the node assignment set. The lookup may return nil if the volume was removed after the event was queued but before it was processed.
In that case, the code currently dereferences the nil volume while iterating over PublishStatus, which can panic and terminate the assignments stream handler.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Fixed a possible nil pointer dereference in the dispatcher `Assignments` stream. When handling `EventUpdateVolume`, the dispatcher re-reads the volume from the store using `store.GetVolume`. That lookup can return nil if the volume has been removed by the time the queued event is processed. The code then immediately iterates over `vol.PublishStatus`, which can panic when `vol` is nil.

**- How I did it**

Check whether `store.GetVolume` returned nil before using the volume. Skip processing the stale volume update when the volume is no longer in the store.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fixed a possible dispatcher panic when processing a volume update for a volume that no longer exists in the store.