### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/api/deepcopy/copy.go
+++ b/api/deepcopy/copy.go
@@ -12,7 +12,7 @@ type CopierFrom interface {
 	// Copy takes the fields from src and copies them into the target object.
 	//
 	// Calling this method with a nil receiver or a nil src may panic.
-	CopyFrom(src interface{})
+	CopyFrom(src any)
 }
 
 // Copy copies src into dst. dst and src must have the same type.
@@ -24,7 +24,7 @@ type CopierFrom interface {
 //
 // If the copy cannot be performed, this function will panic. Make sure to test
 // types that use this function.
-func Copy(dst, src interface{}) {
+func Copy(dst, src any) {
 	switch dst := dst.(type) {
 	case *types.Any:
 		src := src.(*types.Any)

--- a/api/genericresource/parse.go
+++ b/api/genericresource/parse.go
@@ -9,7 +9,7 @@ import (
 	"github.com/moby/swarmkit/v2/api"
 )
 
-func newParseError(format string, args ...interface{}) error {
+func newParseError(format string, args ...any) error {
 	return fmt.Errorf("could not parse GenericResource: "+format, args...)
 }
 

--- a/api/storeobject.go
+++ b/api/storeobject.go
@@ -73,7 +73,7 @@ func customIndexer(kind string, annotations *Annotations) (bool, [][]byte, error
 	return len(converted) != 0, converted, nil
 }
 
-func fromArgs(args ...interface{}) ([]byte, error) {
+func fromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("must provide only a single argument")
 	}
@@ -86,7 +86,7 @@ func fromArgs(args ...interface{}) ([]byte, error) {
 	return []byte(arg), nil
 }
 
-func prefixFromArgs(args ...interface{}) ([]byte, error) {
+func prefixFromArgs(args ...any) ([]byte, error) {
 	val, err := fromArgs(args...)
 	if err != nil {
 		return nil, err

--- a/ca/external.go
+++ b/ca/external.go
@@ -214,7 +214,7 @@ func makeExternalSignRequest(ctx context.Context, client *http.Client, url strin
 		return nil, errors.New("certificate signing request failed")
 	}
 
-	result, ok := apiResponse.Result.(map[string]interface{})
+	result, ok := apiResponse.Result.(map[string]any)
 	if !ok {
 		return nil, errors.Errorf("invalid result type: %T", apiResponse.Result)
 	}

--- a/manager/allocator/allocator_test_suite.go
+++ b/manager/allocator/allocator_test_suite.go
@@ -2056,7 +2056,7 @@ func isValidSubnet(t assert.TestingT, subnet string) bool {
 
 type mockTester struct{}
 
-func (m mockTester) Errorf(_ string, _ ...interface{}) {
+func (m mockTester) Errorf(_ string, _ ...any) {
 }
 
 // Returns a timeout given whether we should expect a timeout:  In the case where we do expect a timeout,

--- a/manager/controlapi/ca_rotation.go
+++ b/manager/controlapi/ca_rotation.go
@@ -21,7 +21,7 @@ import (
 var minRootExpiration = 1 * helpers.OneYear
 
 // determines whether an api.RootCA, api.RootRotation, or api.CAConfig has a signing key (local signer)
-func hasSigningKey(a interface{}) bool {
+func hasSigningKey(a any) bool {
 	switch b := a.(type) {
 	case *api.RootCA:
 		return len(b.CAKey) > 0

--- a/manager/deallocator/deallocator_test.go
+++ b/manager/deallocator/deallocator_test.go
@@ -84,7 +84,7 @@ func TestServiceDelete(t *testing.T) {
 				createDBObjects(t, s, service)
 
 				taskIDs := make([]string, taskCount)
-				tasks := make([]interface{}, taskCount)
+				tasks := make([]any, taskCount)
 				for i := 0; i < taskCount; i++ {
 					taskIDs[i] = "task" + strconv.Itoa(i+1)
 					tasks[i] = newTask(taskIDs[i], service)
@@ -329,7 +329,7 @@ func ensureNoDeallocatorEvent(t *testing.T, deallocator *Deallocator) {
 	}
 }
 
-func createDBObjects(t *testing.T, s *store.MemoryStore, objects ...interface{}) {
+func createDBObjects(t *testing.T, s *store.MemoryStore, objects ...any) {
 	err := s.Update(func(tx store.Tx) (e error) {
 		for _, object := range objects {
 			switch typedObject := object.(type) {

--- a/manager/dispatcher/dispatcher_test.go
+++ b/manager/dispatcher/dispatcher_test.go
@@ -419,7 +419,7 @@ func TestAssignmentsSecretDriver(t *testing.T) {
 	}
 
 	var mux MockPluginClient
-	mux.HandleFunc(drivers.SecretsProviderAPI, func(body []byte) (interface{}, error) {
+	mux.HandleFunc(drivers.SecretsProviderAPI, func(body []byte) (any, error) {
 		var request drivers.SecretsProviderRequest
 		assert.NoError(t, json.Unmarshal(body, &request))
 		response := responses[request.SecretName]
@@ -1923,7 +1923,7 @@ func makeTasksAndDependenciesWithRedundantReferences(t *testing.T, nodeID string
 	return secrets, configs, resourceRefs, tasks
 }
 
-func taskSpecFromDependencies(dependencies ...interface{}) api.TaskSpec {
+func taskSpecFromDependencies(dependencies ...any) api.TaskSpec {
 	var secretRefs []*api.SecretReference
 	var configRefs []*api.ConfigReference
 	var resourceRefs []api.ResourceReference
@@ -2367,7 +2367,7 @@ func (m *MockPlugin) ScopedPath(_ string) string {
 	return ""
 }
 
-type MockPluginHandlerFn func(argsJSON []byte) (interface{}, error)
+type MockPluginHandlerFn func(argsJSON []byte) (any, error)
 
 type MockPluginClient struct {
 	handlers map[string]MockPluginHandlerFn
@@ -2383,7 +2383,7 @@ func (mc *MockPluginClient) HandleFunc(method string, fn MockPluginHandlerFn) {
 	mc.handlers[method] = fn
 }
 
-func (mc *MockPluginClient) Call(method string, args, ret interface{}) error {
+func (mc *MockPluginClient) Call(method string, args, ret any) error {
 	fn, ok := mc.handlers[method]
 	if !ok {
 		return fmt.Errorf("no handler for %s", method)

--- a/manager/logbroker/broker_test.go
+++ b/manager/logbroker/broker_test.go
@@ -819,7 +819,7 @@ func printLogMessages(msgs ...api.LogMessage) {
 }
 
 // newLogMessage is just a helper to build a new log message.
-func newLogMessage(msgctx api.LogContext, format string, vs ...interface{}) api.LogMessage {
+func newLogMessage(msgctx api.LogContext, format string, vs ...any) api.LogMessage {
 	return api.LogMessage{
 		Context:   msgctx,
 		Timestamp: ptypes.MustTimestampProto(time.Now()),

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -263,7 +263,7 @@ func New(config *Config) (*Manager, error) {
 	// they are not automatically tested. If you modify them later, make _sure_
 	// that they are correct. If you add substantial side effects, abstract
 	// these out and test them!
-	unaryInterceptorWrapper := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	unaryInterceptorWrapper := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		// pass the call down into the grpc_prometheus interceptor
 		resp, err := grpc_prometheus.UnaryServerInterceptor(ctx, req, info, handler)
 		if err != nil {
@@ -272,7 +272,7 @@ func New(config *Config) (*Manager, error) {
 		return resp, err
 	}
 
-	streamInterceptorWrapper := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	streamInterceptorWrapper := func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		// we can't re-write a stream context, so don't bother creating a
 		// sub-context like in unary methods
 		// pass the call down into the grpc_prometheus interceptor

--- a/manager/orchestrator/jobs/replicated/reconciler_test.go
+++ b/manager/orchestrator/jobs/replicated/reconciler_test.go
@@ -28,7 +28,7 @@ type uniqueSlotsMatcher struct {
 	duplicatedSlot uint64
 }
 
-func (u uniqueSlotsMatcher) Match(actual interface{}) (bool, error) {
+func (u uniqueSlotsMatcher) Match(actual any) (bool, error) {
 	tasks, ok := actual.([]*api.Task)
 	if !ok {
 		return false, fmt.Errorf("actual is not []*api.Tasks{}")
@@ -45,11 +45,11 @@ func (u uniqueSlotsMatcher) Match(actual interface{}) (bool, error) {
 	return true, nil
 }
 
-func (u uniqueSlotsMatcher) FailureMessage(_ interface{}) string {
+func (u uniqueSlotsMatcher) FailureMessage(_ any) string {
 	return fmt.Sprintf("expected tasks to have unique slots, but %v is duplicated", u.duplicatedSlot)
 }
 
-func (u uniqueSlotsMatcher) NegatedFailureMessage(_ interface{}) string {
+func (u uniqueSlotsMatcher) NegatedFailureMessage(_ any) string {
 	return fmt.Sprintf("expected tasks to have duplicate slots")
 }
 

--- a/manager/orchestrator/testutils/testutils.go
+++ b/manager/orchestrator/testutils/testutils.go
@@ -111,7 +111,7 @@ func Expect(t *testing.T, watch chan events.Event, specifiers ...api.Event) {
 }
 
 // FatalStack logs the stacks of all goroutines and immediately fails the test.
-func FatalStack(t *testing.T, msg string, args ...interface{}) {
+func FatalStack(t *testing.T, msg string, args ...any) {
 	stack := make([]byte, 1024*1024)
 	stack = stack[:runtime.Stack(stack, true)]
 	t.Logf("%s\n", stack)

--- a/manager/scheduler/nodeheap.go
+++ b/manager/scheduler/nodeheap.go
@@ -19,12 +19,12 @@ func (h nodeMaxHeap) Less(i, j int) bool {
 	return h.lessFunc(&h.nodes[j], &h.nodes[i])
 }
 
-func (h *nodeMaxHeap) Push(x interface{}) {
+func (h *nodeMaxHeap) Push(x any) {
 	h.nodes = append(h.nodes, x.(NodeInfo))
 	h.length++
 }
 
-func (h *nodeMaxHeap) Pop() interface{} {
+func (h *nodeMaxHeap) Pop() any {
 	h.length--
 	// return value is never used
 	return nil

--- a/manager/state/raft/wait.go
+++ b/manager/state/raft/wait.go
@@ -7,7 +7,7 @@ import (
 
 type waitItem struct {
 	// channel to wait up the waiter
-	ch chan interface{}
+	ch chan any
 	// callback which is called synchronously when the wait is triggered
 	cb func()
 	// callback which is called to cancel a waiter
@@ -23,19 +23,19 @@ func newWait() *wait {
 	return &wait{m: make(map[uint64]waitItem)}
 }
 
-func (w *wait) register(id uint64, cb func(), cancel func()) <-chan interface{} {
+func (w *wait) register(id uint64, cb func(), cancel func()) <-chan any {
 	w.l.Lock()
 	defer w.l.Unlock()
 	_, ok := w.m[id]
 	if !ok {
-		ch := make(chan interface{}, 1)
+		ch := make(chan any, 1)
 		w.m[id] = waitItem{ch: ch, cb: cb, cancel: cancel}
 		return ch
 	}
 	panic(fmt.Sprintf("duplicate id %x", id))
 }
 
-func (w *wait) trigger(id uint64, x interface{}) bool {
+func (w *wait) trigger(id uint64, x any) bool {
 	w.l.Lock()
 	waitItem, ok := w.m[id]
 	delete(w.m, id)

--- a/manager/state/store/extensions.go
+++ b/manager/state/store/extensions.go
@@ -153,36 +153,36 @@ func FindExtensions(tx ReadTx, by By) ([]*api.Extension, error) {
 
 type extensionIndexerByID struct{}
 
-func (indexer extensionIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionIndexerByID) FromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionIndexerByID{}.FromArgs(args...)
 }
-func (indexer extensionIndexerByID) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionIndexerByID) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionIndexerByID{}.PrefixFromArgs(args...)
 }
-func (indexer extensionIndexerByID) FromObject(obj interface{}) (bool, []byte, error) {
+func (indexer extensionIndexerByID) FromObject(obj any) (bool, []byte, error) {
 	return api.ExtensionIndexerByID{}.FromObject(obj.(extensionEntry).Extension)
 }
 
 type extensionIndexerByName struct{}
 
-func (indexer extensionIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionIndexerByName) FromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionIndexerByName{}.FromArgs(args...)
 }
-func (indexer extensionIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionIndexerByName) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionIndexerByName{}.PrefixFromArgs(args...)
 }
-func (indexer extensionIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+func (indexer extensionIndexerByName) FromObject(obj any) (bool, []byte, error) {
 	return api.ExtensionIndexerByName{}.FromObject(obj.(extensionEntry).Extension)
 }
 
 type extensionCustomIndexer struct{}
 
-func (indexer extensionCustomIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionCustomIndexer) FromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionCustomIndexer{}.FromArgs(args...)
 }
-func (indexer extensionCustomIndexer) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer extensionCustomIndexer) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ExtensionCustomIndexer{}.PrefixFromArgs(args...)
 }
-func (indexer extensionCustomIndexer) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (indexer extensionCustomIndexer) FromObject(obj any) (bool, [][]byte, error) {
 	return api.ExtensionCustomIndexer{}.FromObject(obj.(extensionEntry).Extension)
 }

--- a/manager/state/store/memory.go
+++ b/manager/state/store/memory.go
@@ -179,7 +179,7 @@ func (s *MemoryStore) Close() error {
 	return s.queue.Close()
 }
 
-func fromArgs(args ...interface{}) ([]byte, error) {
+func fromArgs(args ...any) ([]byte, error) {
 	if len(args) != 1 {
 		return nil, fmt.Errorf("must provide only a single argument")
 	}
@@ -192,7 +192,7 @@ func fromArgs(args ...interface{}) ([]byte, error) {
 	return []byte(arg), nil
 }
 
-func prefixFromArgs(args ...interface{}) ([]byte, error) {
+func prefixFromArgs(args ...any) ([]byte, error) {
 	val, err := fromArgs(args...)
 	if err != nil {
 		return nil, err

--- a/manager/state/store/nodes.go
+++ b/manager/state/store/nodes.go
@@ -121,11 +121,11 @@ func FindNodes(tx ReadTx, by By) ([]*api.Node, error) {
 
 type nodeIndexerByHostname struct{}
 
-func (ni nodeIndexerByHostname) FromArgs(args ...interface{}) ([]byte, error) {
+func (ni nodeIndexerByHostname) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ni nodeIndexerByHostname) FromObject(obj interface{}) (bool, []byte, error) {
+func (ni nodeIndexerByHostname) FromObject(obj any) (bool, []byte, error) {
 	n := obj.(*api.Node)
 
 	if n.Description == nil {
@@ -135,17 +135,17 @@ func (ni nodeIndexerByHostname) FromObject(obj interface{}) (bool, []byte, error
 	return true, []byte(strings.ToLower(n.Description.Hostname) + "\x00"), nil
 }
 
-func (ni nodeIndexerByHostname) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (ni nodeIndexerByHostname) PrefixFromArgs(args ...any) ([]byte, error) {
 	return prefixFromArgs(args...)
 }
 
 type nodeIndexerByRole struct{}
 
-func (ni nodeIndexerByRole) FromArgs(args ...interface{}) ([]byte, error) {
+func (ni nodeIndexerByRole) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ni nodeIndexerByRole) FromObject(obj interface{}) (bool, []byte, error) {
+func (ni nodeIndexerByRole) FromObject(obj any) (bool, []byte, error) {
 	n := obj.(*api.Node)
 
 	// Add the null character as a terminator
@@ -154,11 +154,11 @@ func (ni nodeIndexerByRole) FromObject(obj interface{}) (bool, []byte, error) {
 
 type nodeIndexerByMembership struct{}
 
-func (ni nodeIndexerByMembership) FromArgs(args ...interface{}) ([]byte, error) {
+func (ni nodeIndexerByMembership) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ni nodeIndexerByMembership) FromObject(obj interface{}) (bool, []byte, error) {
+func (ni nodeIndexerByMembership) FromObject(obj any) (bool, []byte, error) {
 	n := obj.(*api.Node)
 
 	// Add the null character as a terminator

--- a/manager/state/store/resources.go
+++ b/manager/state/store/resources.go
@@ -165,11 +165,11 @@ func FindResources(tx ReadTx, by By) ([]*api.Resource, error) {
 
 type resourceIndexerByKind struct{}
 
-func (ri resourceIndexerByKind) FromArgs(args ...interface{}) ([]byte, error) {
+func (ri resourceIndexerByKind) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ri resourceIndexerByKind) FromObject(obj interface{}) (bool, []byte, error) {
+func (ri resourceIndexerByKind) FromObject(obj any) (bool, []byte, error) {
 	r := obj.(resourceEntry)
 
 	// Add the null character as a terminator
@@ -179,36 +179,36 @@ func (ri resourceIndexerByKind) FromObject(obj interface{}) (bool, []byte, error
 
 type resourceIndexerByID struct{}
 
-func (indexer resourceIndexerByID) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceIndexerByID) FromArgs(args ...any) ([]byte, error) {
 	return api.ResourceIndexerByID{}.FromArgs(args...)
 }
-func (indexer resourceIndexerByID) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceIndexerByID) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ResourceIndexerByID{}.PrefixFromArgs(args...)
 }
-func (indexer resourceIndexerByID) FromObject(obj interface{}) (bool, []byte, error) {
+func (indexer resourceIndexerByID) FromObject(obj any) (bool, []byte, error) {
 	return api.ResourceIndexerByID{}.FromObject(obj.(resourceEntry).Resource)
 }
 
 type resourceIndexerByName struct{}
 
-func (indexer resourceIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceIndexerByName) FromArgs(args ...any) ([]byte, error) {
 	return api.ResourceIndexerByName{}.FromArgs(args...)
 }
-func (indexer resourceIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceIndexerByName) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ResourceIndexerByName{}.PrefixFromArgs(args...)
 }
-func (indexer resourceIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+func (indexer resourceIndexerByName) FromObject(obj any) (bool, []byte, error) {
 	return api.ResourceIndexerByName{}.FromObject(obj.(resourceEntry).Resource)
 }
 
 type resourceCustomIndexer struct{}
 
-func (indexer resourceCustomIndexer) FromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceCustomIndexer) FromArgs(args ...any) ([]byte, error) {
 	return api.ResourceCustomIndexer{}.FromArgs(args...)
 }
-func (indexer resourceCustomIndexer) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (indexer resourceCustomIndexer) PrefixFromArgs(args ...any) ([]byte, error) {
 	return api.ResourceCustomIndexer{}.PrefixFromArgs(args...)
 }
-func (indexer resourceCustomIndexer) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (indexer resourceCustomIndexer) FromObject(obj any) (bool, [][]byte, error) {
 	return api.ResourceCustomIndexer{}.FromObject(obj.(resourceEntry).Resource)
 }

--- a/manager/state/store/services.go
+++ b/manager/state/store/services.go
@@ -144,11 +144,11 @@ func FindServices(tx ReadTx, by By) ([]*api.Service, error) {
 
 type serviceIndexerByRuntime struct{}
 
-func (si serviceIndexerByRuntime) FromArgs(args ...interface{}) ([]byte, error) {
+func (si serviceIndexerByRuntime) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (si serviceIndexerByRuntime) FromObject(obj interface{}) (bool, []byte, error) {
+func (si serviceIndexerByRuntime) FromObject(obj any) (bool, []byte, error) {
 	s := obj.(*api.Service)
 	r, err := naming.Runtime(s.Spec.Task)
 	if err != nil {
@@ -157,17 +157,17 @@ func (si serviceIndexerByRuntime) FromObject(obj interface{}) (bool, []byte, err
 	return true, []byte(r + "\x00"), nil
 }
 
-func (si serviceIndexerByRuntime) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (si serviceIndexerByRuntime) PrefixFromArgs(args ...any) ([]byte, error) {
 	return prefixFromArgs(args...)
 }
 
 type serviceIndexerByNetwork struct{}
 
-func (si serviceIndexerByNetwork) FromArgs(args ...interface{}) ([]byte, error) {
+func (si serviceIndexerByNetwork) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (si serviceIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (si serviceIndexerByNetwork) FromObject(obj any) (bool, [][]byte, error) {
 	s := obj.(*api.Service)
 
 	var networkIDs [][]byte
@@ -188,11 +188,11 @@ func (si serviceIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, e
 
 type serviceIndexerBySecret struct{}
 
-func (si serviceIndexerBySecret) FromArgs(args ...interface{}) ([]byte, error) {
+func (si serviceIndexerBySecret) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (si serviceIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (si serviceIndexerBySecret) FromObject(obj any) (bool, [][]byte, error) {
 	s := obj.(*api.Service)
 
 	container := s.Spec.Task.GetContainer()
@@ -212,11 +212,11 @@ func (si serviceIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, er
 
 type serviceIndexerByConfig struct{}
 
-func (si serviceIndexerByConfig) FromArgs(args ...interface{}) ([]byte, error) {
+func (si serviceIndexerByConfig) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (si serviceIndexerByConfig) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (si serviceIndexerByConfig) FromObject(obj any) (bool, [][]byte, error) {
 	s, ok := obj.(*api.Service)
 	if !ok {
 		panic("unexpected type passed to FromObject")

--- a/manager/state/store/tasks.go
+++ b/manager/state/store/tasks.go
@@ -161,11 +161,11 @@ func FindTasks(tx ReadTx, by By) ([]*api.Task, error) {
 
 type taskIndexerByName struct{}
 
-func (ti taskIndexerByName) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByName) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerByName) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	name := naming.Task(t)
@@ -174,17 +174,17 @@ func (ti taskIndexerByName) FromObject(obj interface{}) (bool, []byte, error) {
 	return true, []byte(strings.ToLower(name) + "\x00"), nil
 }
 
-func (ti taskIndexerByName) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByName) PrefixFromArgs(args ...any) ([]byte, error) {
 	return prefixFromArgs(args...)
 }
 
 type taskIndexerByRuntime struct{}
 
-func (ti taskIndexerByRuntime) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByRuntime) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByRuntime) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerByRuntime) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 	r, err := naming.Runtime(t.Spec)
 	if err != nil {
@@ -193,17 +193,17 @@ func (ti taskIndexerByRuntime) FromObject(obj interface{}) (bool, []byte, error)
 	return true, []byte(r + "\x00"), nil
 }
 
-func (ti taskIndexerByRuntime) PrefixFromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByRuntime) PrefixFromArgs(args ...any) ([]byte, error) {
 	return prefixFromArgs(args...)
 }
 
 type taskIndexerByServiceID struct{}
 
-func (ti taskIndexerByServiceID) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByServiceID) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByServiceID) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerByServiceID) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
@@ -213,11 +213,11 @@ func (ti taskIndexerByServiceID) FromObject(obj interface{}) (bool, []byte, erro
 
 type taskIndexerByNodeID struct{}
 
-func (ti taskIndexerByNodeID) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByNodeID) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByNodeID) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerByNodeID) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
@@ -227,11 +227,11 @@ func (ti taskIndexerByNodeID) FromObject(obj interface{}) (bool, []byte, error) 
 
 type taskIndexerBySlot struct{}
 
-func (ti taskIndexerBySlot) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerBySlot) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerBySlot) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerBySlot) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
@@ -241,11 +241,11 @@ func (ti taskIndexerBySlot) FromObject(obj interface{}) (bool, []byte, error) {
 
 type taskIndexerByDesiredState struct{}
 
-func (ti taskIndexerByDesiredState) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByDesiredState) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByDesiredState) FromObject(obj interface{}) (bool, []byte, error) {
+func (ti taskIndexerByDesiredState) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	// Add the null character as a terminator
@@ -254,11 +254,11 @@ func (ti taskIndexerByDesiredState) FromObject(obj interface{}) (bool, []byte, e
 
 type taskIndexerByNetwork struct{}
 
-func (ti taskIndexerByNetwork) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByNetwork) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (ti taskIndexerByNetwork) FromObject(obj any) (bool, [][]byte, error) {
 	t := obj.(*api.Task)
 
 	var networkIDs [][]byte
@@ -273,11 +273,11 @@ func (ti taskIndexerByNetwork) FromObject(obj interface{}) (bool, [][]byte, erro
 
 type taskIndexerBySecret struct{}
 
-func (ti taskIndexerBySecret) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerBySecret) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (ti taskIndexerBySecret) FromObject(obj any) (bool, [][]byte, error) {
 	t := obj.(*api.Task)
 
 	container := t.Spec.GetContainer()
@@ -297,11 +297,11 @@ func (ti taskIndexerBySecret) FromObject(obj interface{}) (bool, [][]byte, error
 
 type taskIndexerByConfig struct{}
 
-func (ti taskIndexerByConfig) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByConfig) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByConfig) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (ti taskIndexerByConfig) FromObject(obj any) (bool, [][]byte, error) {
 	t, ok := obj.(*api.Task)
 	if !ok {
 		panic("unexpected type passed to FromObject")
@@ -324,11 +324,11 @@ func (ti taskIndexerByConfig) FromObject(obj interface{}) (bool, [][]byte, error
 
 type taskIndexerByVolumeAttachment struct{}
 
-func (ti taskIndexerByVolumeAttachment) FromArgs(args ...interface{}) ([]byte, error) {
+func (ti taskIndexerByVolumeAttachment) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ti taskIndexerByVolumeAttachment) FromObject(obj interface{}) (bool, [][]byte, error) {
+func (ti taskIndexerByVolumeAttachment) FromObject(obj any) (bool, [][]byte, error) {
 	t, ok := obj.(*api.Task)
 	if !ok {
 		panic("unexpected type passed to FromObject")
@@ -344,11 +344,11 @@ func (ti taskIndexerByVolumeAttachment) FromObject(obj interface{}) (bool, [][]b
 
 type taskIndexerByTaskState struct{}
 
-func (ts taskIndexerByTaskState) FromArgs(args ...interface{}) ([]byte, error) {
+func (ts taskIndexerByTaskState) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (ts taskIndexerByTaskState) FromObject(obj interface{}) (bool, []byte, error) {
+func (ts taskIndexerByTaskState) FromObject(obj any) (bool, []byte, error) {
 	t := obj.(*api.Task)
 
 	// Add the null character as a terminator

--- a/manager/state/store/volumes.go
+++ b/manager/state/store/volumes.go
@@ -121,11 +121,11 @@ func FindVolumes(tx ReadTx, by By) ([]*api.Volume, error) {
 
 type volumeIndexerByGroup struct{}
 
-func (vi volumeIndexerByGroup) FromArgs(args ...interface{}) ([]byte, error) {
+func (vi volumeIndexerByGroup) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (vi volumeIndexerByGroup) FromObject(obj interface{}) (bool, []byte, error) {
+func (vi volumeIndexerByGroup) FromObject(obj any) (bool, []byte, error) {
 	v := obj.(*api.Volume)
 	val := v.Spec.Group + "\x00"
 	return true, []byte(val), nil
@@ -133,11 +133,11 @@ func (vi volumeIndexerByGroup) FromObject(obj interface{}) (bool, []byte, error)
 
 type volumeIndexerByDriver struct{}
 
-func (vi volumeIndexerByDriver) FromArgs(args ...interface{}) ([]byte, error) {
+func (vi volumeIndexerByDriver) FromArgs(args ...any) ([]byte, error) {
 	return fromArgs(args...)
 }
 
-func (vi volumeIndexerByDriver) FromObject(obj interface{}) (bool, []byte, error) {
+func (vi volumeIndexerByDriver) FromObject(obj any) (bool, []byte, error) {
 	v := obj.(*api.Volume)
 	// this should never happen -- existence of the volume driver is checked
 	// at the controlapi level. However, guard against the unforeseen.

--- a/node/plugin/pluginapi.go
+++ b/node/plugin/pluginapi.go
@@ -14,7 +14,7 @@ type AddrPlugin interface {
 }
 
 type Client interface {
-	Call(method string, args, ret interface{}) error
+	Call(method string, args, ret any) error
 }
 
 type Getter interface {

--- a/protobuf/plugin/deepcopy/deepcopy.go
+++ b/protobuf/plugin/deepcopy/deepcopy.go
@@ -59,11 +59,11 @@ func (d *deepCopyGen) genMsgDeepCopy(m *generator.Descriptor) {
 	d.P()
 
 	if len(m.Field) == 0 {
-		d.P("func (m *", ccTypeName, ") CopyFrom(src interface{})", " {}")
+		d.P("func (m *", ccTypeName, ") CopyFrom(src any)", " {}")
 		return
 	}
 
-	d.P("func (m *", ccTypeName, ") CopyFrom(src interface{})", " {")
+	d.P("func (m *", ccTypeName, ") CopyFrom(src any)", " {")
 	d.P()
 
 	d.P("o := src.(*", ccTypeName, ")")

--- a/protobuf/plugin/storeobject/storeobject.go
+++ b/protobuf/plugin/storeobject/storeobject.go
@@ -615,7 +615,7 @@ func (d *storeObjectGen) genMsgStoreObject(m *generator.Descriptor, storeObject 
 	d.genFromArgs(ccTypeName + "IndexerByID")
 	d.genPrefixFromArgs(ccTypeName + "IndexerByID")
 
-	d.P("func (indexer ", ccTypeName, "IndexerByID) FromObject(obj interface{}) (bool, []byte, error) {")
+	d.P("func (indexer ", ccTypeName, "IndexerByID) FromObject(obj any) (bool, []byte, error) {")
 	d.In()
 	d.P("m := obj.(*", ccTypeName, ")")
 	// Add the null character as a terminator
@@ -631,7 +631,7 @@ func (d *storeObjectGen) genMsgStoreObject(m *generator.Descriptor, storeObject 
 	d.genFromArgs(ccTypeName + "IndexerByName")
 	d.genPrefixFromArgs(ccTypeName + "IndexerByName")
 
-	d.P("func (indexer ", ccTypeName, "IndexerByName) FromObject(obj interface{}) (bool, []byte, error) {")
+	d.P("func (indexer ", ccTypeName, "IndexerByName) FromObject(obj any) (bool, []byte, error) {")
 	d.In()
 	d.P("m := obj.(*", ccTypeName, ")")
 	if _, hasNoSpec := typesWithNoSpec[*m.Name]; hasNoSpec {
@@ -652,7 +652,7 @@ func (d *storeObjectGen) genMsgStoreObject(m *generator.Descriptor, storeObject 
 	d.genFromArgs(ccTypeName + "CustomIndexer")
 	d.genPrefixFromArgs(ccTypeName + "CustomIndexer")
 
-	d.P("func (indexer ", ccTypeName, "CustomIndexer) FromObject(obj interface{}) (bool, [][]byte, error) {")
+	d.P("func (indexer ", ccTypeName, "CustomIndexer) FromObject(obj any) (bool, [][]byte, error) {")
 	d.In()
 	d.P("m := obj.(*", ccTypeName, ")")
 	if _, hasNoSpec := typesWithNoSpec[*m.Name]; hasNoSpec {
@@ -665,7 +665,7 @@ func (d *storeObjectGen) genMsgStoreObject(m *generator.Descriptor, storeObject 
 }
 
 func (d *storeObjectGen) genFromArgs(indexerName string) {
-	d.P("func (indexer ", indexerName, ") FromArgs(args ...interface{}) ([]byte, error) {")
+	d.P("func (indexer ", indexerName, ") FromArgs(args ...any) ([]byte, error) {")
 	d.In()
 	d.P("return fromArgs(args...)")
 	d.Out()
@@ -673,7 +673,7 @@ func (d *storeObjectGen) genFromArgs(indexerName string) {
 }
 
 func (d *storeObjectGen) genPrefixFromArgs(indexerName string) {
-	d.P("func (indexer ", indexerName, ") PrefixFromArgs(args ...interface{}) ([]byte, error) {")
+	d.P("func (indexer ", indexerName, ") PrefixFromArgs(args ...any) ([]byte, error) {")
 	d.In()
 	d.P("return prefixFromArgs(args...)")
 	d.Out()

--- a/swarmd/cmd/swarmctl/common/print.go
+++ b/swarmd/cmd/swarmctl/common/print.go
@@ -22,7 +22,7 @@ func PrintHeader(w io.Writer, columns ...string) {
 // FprintfIfNotEmpty prints only if `s` is not empty.
 //
 // NOTE(stevvooe): Not even remotely a printf function.. doesn't take args.
-func FprintfIfNotEmpty(w io.Writer, format string, v interface{}) {
+func FprintfIfNotEmpty(w io.Writer, format string, v any) {
 	if v != nil && v != "" {
 		fmt.Fprintf(w, format, v)
 	}

--- a/swarmd/cmd/swarmctl/common/resolver.go
+++ b/swarmd/cmd/swarmctl/common/resolver.go
@@ -26,7 +26,7 @@ func NewResolver(cmd *cobra.Command, c api.ControlClient) *Resolver {
 	}
 }
 
-func (r *Resolver) get(t interface{}, id string) string {
+func (r *Resolver) get(t any, id string) string {
 	switch t.(type) {
 	case api.Node:
 		res, err := r.c.GetNode(r.ctx, &api.GetNodeRequest{NodeID: id})
@@ -61,7 +61,7 @@ func (r *Resolver) get(t interface{}, id string) string {
 // Resolve will attempt to resolve an ID to a Name by querying the manager.
 // Results are stored into a cache.
 // If the `-n` flag is used in the command-line, resolution is disabled.
-func (r *Resolver) Resolve(t interface{}, id string) string {
+func (r *Resolver) Resolve(t any, id string) string {
 	if r.cmd.Flags().Changed("no-resolve") {
 		return id
 	}

--- a/swarmd/dockerexec/adapter.go
+++ b/swarmd/dockerexec/adapter.go
@@ -66,7 +66,7 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 
 	dec := json.NewDecoder(rc)
 	dec.UseNumber()
-	m := map[string]interface{}{}
+	m := map[string]any{}
 	spamLimiter := rate.NewLimiter(rate.Every(1000*time.Millisecond), 1)
 
 	lastStatus := ""
@@ -81,7 +81,7 @@ func (c *containerAdapter) pullImage(ctx context.Context) error {
 		// limit pull progress logs unless the status changes
 		if spamLimiter.Allow() || lastStatus != m["status"] {
 			// if we have progress details, we have everything we need
-			if progress, ok := m["progressDetail"].(map[string]interface{}); ok {
+			if progress, ok := m["progressDetail"].(map[string]any); ok {
 				// first, log the image and status
 				l = l.WithFields(log.Fields{
 					"image":  c.container.image(),


### PR DESCRIPTION
Replace all occurrences of `interface{}` with `any` (available since Go 1.18) across 27 non-vendor, non-generated source files.