### PR TITLE
agent: use proto.Equal instead of reflect.DeepEqual for node comparison

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"math/rand"
-	"reflect"
 	"sync"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/moby/swarmkit/v2/agent/exec"
 	"github.com/moby/swarmkit/v2/api"
 	"github.com/moby/swarmkit/v2/log"
@@ -249,7 +249,7 @@ func (a *Agent) run(ctx context.Context) {
 		// if the node description has changed, update it to the new one
 		// and close the session. The old session will be stopped and a
 		// new one will be created with the updated description
-		if !reflect.DeepEqual(nodeDescription, newNodeDescription) {
+		if !nodeDescriptionsEqual(nodeDescription, newNodeDescription) {
 			nodeDescription = newNodeDescription
 			// close the session
 			log.G(ctx).Info("agent: found node update")
@@ -645,12 +645,19 @@ func (a *Agent) nodeDescriptionWithHostname(ctx context.Context, tlsInfo *api.No
 // nodesEqual returns true if the node states are functionally equal, ignoring status,
 // version and other superfluous fields.
 //
-// This used to decide whether or not to propagate a node update to executor.
+// This is used to decide whether to propagate a node update to the executor.
 func nodesEqual(a, b *api.Node) bool {
 	a, b = a.Copy(), b.Copy()
 
 	a.Status, b.Status = api.NodeStatus{}, api.NodeStatus{}
 	a.Meta, b.Meta = api.Meta{}, api.Meta{}
 
-	return reflect.DeepEqual(a, b)
+	return proto.Equal(a, b)
+}
+
+// nodeDescriptionsEqual reports whether two node descriptions are equal
+// according to protobuf semantics, which treat nil and empty repeated fields
+// as equivalent.
+func nodeDescriptionsEqual(a, b *api.NodeDescription) bool {
+	return proto.Equal(a, b)
 }

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -233,6 +233,33 @@ func TestHandleSessionMessageNodeChanges(t *testing.T) {
 	require.Empty(t, closedSessions)
 }
 
+// TestNodeDescriptionsEqual verifies that semantically equivalent protobuf
+// messages compare equal despite representation differences. A protobuf
+// round-trip may represent an empty repeated field as nil.
+//
+// regression test for https://github.com/moby/swarmkit/pull/3249
+func TestNodeDescriptionsEqual(t *testing.T) {
+	t.Run("nil and empty repeated field", func(t *testing.T) {
+		a := &api.NodeDescription{}
+		b := &api.NodeDescription{
+			CSIInfo: []*api.NodeCSIInfo{},
+		}
+
+		require.True(t, nodeDescriptionsEqual(a, b))
+	})
+
+	t.Run("different repeated field", func(t *testing.T) {
+		a := &api.NodeDescription{}
+		b := &api.NodeDescription{
+			CSIInfo: []*api.NodeCSIInfo{
+				{PluginName: "plugin"},
+			},
+		}
+
+		require.False(t, nodeDescriptionsEqual(a, b))
+	})
+}
+
 // when the node description changes, the session is restarted and propagated up to the dispatcher.
 // the node description includes the FIPSness of the agent.
 func TestSessionRestartedOnNodeDescriptionChange(t *testing.T) {


### PR DESCRIPTION
reflect.DeepEqual treats nil slices and empty slices as not equal, which causes spurious node description updates when protobuf repeated fields (like CSIInfo) are nil in the executor output but become empty slices after gRPC serialization/deserialization round-trip.

This triggers 'agent: found node update' every 20 seconds (the nodeUpdatePeriod), causing unnecessary session restarts, VXLAN reinitialization, and excessive Raft WAL writes (~388/day, ~429MB of WAL accumulation).

proto.Equal correctly handles protobuf semantics where nil slices and empty slices are equivalent, as well as treating zero values and unset fields as equal.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/moby/swarmkit/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to test it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
