### PR TITLE
allocator: Unregister watch before reporting shutdown

### DIFF
--- a/manager/allocator/allocator.go
+++ b/manager/allocator/allocator.go
@@ -122,8 +122,8 @@ func (a *Allocator) Run(ctx context.Context) error {
 			wg.Add(1)
 			go func(watch <-chan events.Event, watchCancel func()) {
 				defer func() {
-					wg.Done()
 					watchCancel()
+					wg.Done()
 				}()
 				a.run(ctx, *aaPtr, watch)
 			}(watch, watchCancel)


### PR DESCRIPTION
- address: https://github.com/moby/moby/issues/50872

### allocator: Unregister watch before reporting shutdown

  Allocator.Run currently decrements its wait group before removing the store watch. This lets Stop return and store shutdown begin while watcher removal is still in flight, which can deadlock broadcaster closure.

  Cancel the watch before decrementing the wait group so Stop waits for all watch cleanup to complete.