### PR TITLE
manager/logbroker: avoid panic when sending subscription messages

### DIFF
--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -340,7 +340,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 		}
 
 		if err := stream.Send(sub.message); err != nil {
-			logger.Error(err)
+			logger.WithError(err).Error("failed to send initial subscription")
 			return err
 		}
 		activeSubscriptions[sub.ID()] = sub
@@ -362,7 +362,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 				activeSubscriptions[sub.ID()] = sub
 			}
 			if err := stream.Send(sub.message); err != nil {
-				logger.Error(err)
+				logger.WithError(err).Error("failed to send subscription update")
 				return err
 			}
 		case <-stream.Context().Done():

--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -123,20 +123,20 @@ func (lb *LogBroker) getSubscription(id string) *subscription {
 	return sub
 }
 
-func (lb *LogBroker) registerSubscription(subscription *subscription) {
+func (lb *LogBroker) registerSubscription(sub *subscription) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	lb.registeredSubscriptions[subscription.message.ID] = subscription
-	lb.subscriptionQueue.Publish(subscription)
+	lb.registeredSubscriptions[sub.ID()] = sub
+	lb.subscriptionQueue.Publish(sub)
 
-	for _, node := range subscription.Nodes() {
+	for _, node := range sub.Nodes() {
 		if _, ok := lb.subscriptionsByNode[node]; !ok {
 			// Mark nodes that won't receive the message as done.
-			subscription.Done(node, fmt.Errorf("node %s is not available", node))
+			sub.Done(node, fmt.Errorf("node %s is not available", node))
 		} else {
 			// otherwise, add the subscription to the node's subscriptions list
-			lb.subscriptionsByNode[node][subscription] = struct{}{}
+			lb.subscriptionsByNode[node][sub] = struct{}{}
 		}
 	}
 }
@@ -145,7 +145,7 @@ func (lb *LogBroker) unregisterSubscription(subscription *subscription) {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 
-	delete(lb.registeredSubscriptions, subscription.message.ID)
+	delete(lb.registeredSubscriptions, subscription.ID())
 
 	// remove the subscription from all of the nodes
 	for _, node := range subscription.Nodes() {
@@ -239,12 +239,12 @@ func (lb *LogBroker) SubscribeLogs(request *api.SubscribeLogsRequest, stream api
 	logger := log.G(ctx).WithFields(
 		log.Fields{
 			"method":          "(*LogBroker).SubscribeLogs",
-			"subscription.id": sub.message.ID,
+			"subscription.id": sub.ID(),
 		},
 	)
 	logger.Debug("subscribed")
 
-	publishCh, publishCancel := lb.subscribe(sub.message.ID)
+	publishCh, publishCancel := lb.subscribe(sub.ID())
 	defer publishCancel()
 
 	lb.registerSubscription(sub)
@@ -271,7 +271,7 @@ func (lb *LogBroker) SubscribeLogs(request *api.SubscribeLogsRequest, stream api
 			completed = nil
 			lb.logQueue.Publish(&logMessage{
 				PublishLogsMessage: &api.PublishLogsMessage{
-					SubscriptionID: sub.message.ID,
+					SubscriptionID: sub.ID(),
 				},
 				completed: true,
 				err:       sub.Err(),
@@ -343,7 +343,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 			logger.Error(err)
 			return err
 		}
-		activeSubscriptions[sub.message.ID] = sub
+		activeSubscriptions[sub.ID()] = sub
 	}
 
 	// Send down new subscriptions.
@@ -353,13 +353,13 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 			sub := v.(*subscription)
 
 			if sub.Closed() {
-				delete(activeSubscriptions, sub.message.ID)
+				delete(activeSubscriptions, sub.ID())
 			} else {
 				// Avoid sending down the same subscription multiple times
-				if _, ok := activeSubscriptions[sub.message.ID]; ok {
+				if _, ok := activeSubscriptions[sub.ID()]; ok {
 					continue
 				}
-				activeSubscriptions[sub.message.ID] = sub
+				activeSubscriptions[sub.ID()] = sub
 			}
 			if err := stream.Send(sub.message); err != nil {
 				logger.Error(err)
@@ -406,7 +406,7 @@ func (lb *LogBroker) PublishLogs(stream api.LogBroker_PublishLogsServer) (err er
 				return status.Errorf(codes.NotFound, "unknown subscription ID")
 			}
 		} else {
-			if logMsg.SubscriptionID != currentSubscription.message.ID {
+			if logMsg.SubscriptionID != currentSubscription.ID() {
 				return status.Errorf(codes.InvalidArgument, "different subscription IDs in the same session")
 			}
 		}

--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -339,7 +339,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 		default:
 		}
 
-		if err := stream.Send(sub.message); err != nil {
+		if err := stream.Send(sub.Message()); err != nil {
 			logger.WithError(err).Error("failed to send initial subscription")
 			return err
 		}
@@ -361,7 +361,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 				}
 				activeSubscriptions[sub.ID()] = sub
 			}
-			if err := stream.Send(sub.message); err != nil {
+			if err := stream.Send(sub.Message()); err != nil {
 				logger.WithError(err).Error("failed to send subscription update")
 				return err
 			}

--- a/manager/logbroker/broker.go
+++ b/manager/logbroker/broker.go
@@ -105,24 +105,22 @@ func (lb *LogBroker) newSubscription(selector *api.LogSelector, options *api.Log
 	lb.mu.RLock()
 	defer lb.mu.RUnlock()
 
-	subscription := newSubscription(lb.store, &api.SubscriptionMessage{
+	return newSubscription(lb.store, &api.SubscriptionMessage{
 		ID:       identity.NewID(),
 		Selector: selector,
 		Options:  options,
 	}, lb.subscriptionQueue)
-
-	return subscription
 }
 
 func (lb *LogBroker) getSubscription(id string) *subscription {
 	lb.mu.RLock()
 	defer lb.mu.RUnlock()
 
-	subscription, ok := lb.registeredSubscriptions[id]
+	sub, ok := lb.registeredSubscriptions[id]
 	if !ok {
 		return nil
 	}
-	return subscription
+	return sub
 }
 
 func (lb *LogBroker) registerSubscription(subscription *subscription) {
@@ -234,25 +232,25 @@ func (lb *LogBroker) SubscribeLogs(request *api.SubscribeLogsRequest, stream api
 		return errNotRunning
 	}
 
-	subscription := lb.newSubscription(request.Selector, request.Options)
-	subscription.Run(pctx)
-	defer subscription.Stop()
+	sub := lb.newSubscription(request.Selector, request.Options)
+	sub.Run(pctx)
+	defer sub.Stop()
 
 	logger := log.G(ctx).WithFields(
 		log.Fields{
 			"method":          "(*LogBroker).SubscribeLogs",
-			"subscription.id": subscription.message.ID,
+			"subscription.id": sub.message.ID,
 		},
 	)
 	logger.Debug("subscribed")
 
-	publishCh, publishCancel := lb.subscribe(subscription.message.ID)
+	publishCh, publishCancel := lb.subscribe(sub.message.ID)
 	defer publishCancel()
 
-	lb.registerSubscription(subscription)
-	defer lb.unregisterSubscription(subscription)
+	lb.registerSubscription(sub)
+	defer lb.unregisterSubscription(sub)
 
-	completed := subscription.Wait(ctx)
+	completed := sub.Wait(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -273,10 +271,10 @@ func (lb *LogBroker) SubscribeLogs(request *api.SubscribeLogsRequest, stream api
 			completed = nil
 			lb.logQueue.Publish(&logMessage{
 				PublishLogsMessage: &api.PublishLogsMessage{
-					SubscriptionID: subscription.message.ID,
+					SubscriptionID: sub.message.ID,
 				},
 				completed: true,
-				err:       subscription.Err(),
+				err:       sub.Err(),
 			})
 		}
 	}
@@ -332,7 +330,7 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 	activeSubscriptions := make(map[string]*subscription)
 
 	// Start by sending down all active subscriptions.
-	for _, subscription := range subscriptions {
+	for _, sub := range subscriptions {
 		select {
 		case <-stream.Context().Done():
 			return stream.Context().Err()
@@ -341,29 +339,29 @@ func (lb *LogBroker) ListenSubscriptions(_ *api.ListenSubscriptionsRequest, stre
 		default:
 		}
 
-		if err := stream.Send(subscription.message); err != nil {
+		if err := stream.Send(sub.message); err != nil {
 			logger.Error(err)
 			return err
 		}
-		activeSubscriptions[subscription.message.ID] = subscription
+		activeSubscriptions[sub.message.ID] = sub
 	}
 
 	// Send down new subscriptions.
 	for {
 		select {
 		case v := <-subscriptionCh:
-			subscription := v.(*subscription)
+			sub := v.(*subscription)
 
-			if subscription.Closed() {
-				delete(activeSubscriptions, subscription.message.ID)
+			if sub.Closed() {
+				delete(activeSubscriptions, sub.message.ID)
 			} else {
 				// Avoid sending down the same subscription multiple times
-				if _, ok := activeSubscriptions[subscription.message.ID]; ok {
+				if _, ok := activeSubscriptions[sub.message.ID]; ok {
 					continue
 				}
-				activeSubscriptions[subscription.message.ID] = subscription
+				activeSubscriptions[sub.message.ID] = sub
 			}
-			if err := stream.Send(subscription.message); err != nil {
+			if err := stream.Send(sub.message); err != nil {
 				logger.Error(err)
 				return err
 			}

--- a/manager/logbroker/broker_test.go
+++ b/manager/logbroker/broker_test.go
@@ -52,7 +52,7 @@ func TestLogBrokerLogs(t *testing.T) {
 		t.Fatalf("error subscribing: %v", err)
 	}
 
-	subscription, err := subStream.Recv()
+	sub, err := subStream.Recv()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,7 +100,7 @@ func TestLogBrokerLogs(t *testing.T) {
 					}
 					for i := 0; i < nLogMessagesPerTask; i++ {
 						require.NoError(t, publisher.Send(&api.PublishLogsMessage{
-							SubscriptionID: subscription.ID,
+							SubscriptionID: sub.ID,
 							Messages:       []api.LogMessage{newLogMessage(msgctx, "log message number %d", i)},
 						}))
 					}
@@ -552,13 +552,13 @@ func TestLogBrokerNoFollowMissingNode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Grab the subscription and publish a log message from the connected agent.
-	subscription := ensureSubscription(t, agentSubscriptions)
-	require.Equal(t, subscription.Selector.ServiceIDs[0], "service")
+	sub := ensureSubscription(t, agentSubscriptions)
+	require.Equal(t, sub.Selector.ServiceIDs[0], "service")
 	publisher, err := agent.PublishLogs(ctx)
 	require.NoError(t, err)
 	require.NoError(t,
 		publisher.Send(&api.PublishLogsMessage{
-			SubscriptionID: subscription.ID,
+			SubscriptionID: sub.ID,
 			Messages: []api.LogMessage{
 				newLogMessage(api.LogContext{
 					NodeID:    agentSecurity.ServerTLSCreds.NodeID(),

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -15,6 +15,8 @@ import (
 )
 
 type subscription struct {
+	id string
+
 	mu sync.RWMutex
 	wg sync.WaitGroup
 
@@ -32,6 +34,7 @@ type subscription struct {
 
 func newSubscription(store *store.MemoryStore, message *api.SubscriptionMessage, changed *watch.Queue) *subscription {
 	return &subscription{
+		id:           message.ID,
 		store:        store,
 		message:      message,
 		changed:      changed,
@@ -42,6 +45,10 @@ func newSubscription(store *store.MemoryStore, message *api.SubscriptionMessage,
 
 func (s *subscription) follow() bool {
 	return s.message.Options != nil && s.message.Options.Follow
+}
+
+func (s *subscription) ID() string {
+	return s.id
 }
 
 func (s *subscription) Contains(nodeID string) bool {

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -17,6 +17,8 @@ import (
 type subscription struct {
 	id string
 
+	follow bool
+
 	mu sync.RWMutex
 	wg sync.WaitGroup
 
@@ -35,16 +37,13 @@ type subscription struct {
 func newSubscription(store *store.MemoryStore, message *api.SubscriptionMessage, changed *watch.Queue) *subscription {
 	return &subscription{
 		id:           message.ID,
+		follow:       message.Options != nil && message.Options.Follow,
 		store:        store,
 		message:      message,
 		changed:      changed,
 		nodes:        make(map[string]struct{}),
 		pendingTasks: make(map[string]struct{}),
 	}
-}
-
-func (s *subscription) follow() bool {
-	return s.message.Options != nil && s.message.Options.Follow
 }
 
 func (s *subscription) ID() string {
@@ -73,12 +72,12 @@ func (s *subscription) Nodes() []string {
 func (s *subscription) Run(ctx context.Context) {
 	s.ctx, s.cancel = context.WithCancel(ctx)
 
-	if s.follow() {
+	if s.follow {
 		wq := s.store.WatchQueue()
 		ch, cancel := state.Watch(wq, api.EventCreateTask{}, api.EventUpdateTask{})
 		go func() {
 			defer cancel()
-			s.watch(ch)
+			_ = s.watch(ch)
 		}()
 	}
 
@@ -93,7 +92,7 @@ func (s *subscription) Stop() {
 
 func (s *subscription) Wait(_ context.Context) <-chan struct{} {
 	// Follow subscriptions never end
-	if s.follow() {
+	if s.follow {
 		return nil
 	}
 
@@ -113,7 +112,7 @@ func (s *subscription) Done(nodeID string, err error) {
 		s.errors = append(s.errors, err)
 	}
 
-	if s.follow() {
+	if s.follow {
 		return
 	}
 
@@ -190,7 +189,7 @@ func (s *subscription) match() {
 			}
 			for _, task := range tasks {
 				// if we're not following, don't add tasks that aren't running yet
-				if !s.follow() && task.Status.State < api.TaskStateRunning {
+				if !s.follow && task.Status.State < api.TaskStateRunning {
 					continue
 				}
 				add(task)

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -158,6 +158,7 @@ func (s *subscription) Closed() bool {
 func (s *subscription) match() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	selector := s.message.Selector
 
 	add := func(t *api.Task) {
 		if t.NodeID == "" {
@@ -171,17 +172,17 @@ func (s *subscription) match() {
 	}
 
 	s.store.View(func(tx store.ReadTx) {
-		for _, nid := range s.message.Selector.NodeIDs {
+		for _, nid := range selector.NodeIDs {
 			s.nodes[nid] = struct{}{}
 		}
 
-		for _, tid := range s.message.Selector.TaskIDs {
+		for _, tid := range selector.TaskIDs {
 			if task := store.GetTask(tx, tid); task != nil {
 				add(task)
 			}
 		}
 
-		for _, sid := range s.message.Selector.ServiceIDs {
+		for _, sid := range selector.ServiceIDs {
 			tasks, err := store.FindTasks(tx, store.ByServiceID(sid))
 			if err != nil {
 				log.L.Warning(err)
@@ -199,13 +200,15 @@ func (s *subscription) match() {
 }
 
 func (s *subscription) watch(ch <-chan events.Event) error {
+	selector := s.message.Selector
+
 	matchTasks := map[string]struct{}{}
-	for _, tid := range s.message.Selector.TaskIDs {
+	for _, tid := range selector.TaskIDs {
 		matchTasks[tid] = struct{}{}
 	}
 
 	matchServices := map[string]struct{}{}
-	for _, sid := range s.message.Selector.ServiceIDs {
+	for _, sid := range selector.ServiceIDs {
 		matchServices[sid] = struct{}{}
 	}
 

--- a/manager/logbroker/subscription.go
+++ b/manager/logbroker/subscription.go
@@ -266,3 +266,18 @@ func (s *subscription) watch(ch <-chan events.Event) error {
 		}
 	}
 }
+
+// Message returns a snapshot of the current subscription message.
+//
+// The underlying message is owned by the subscription and may be updated
+// as part of its lifecycle. Callers should use this accessor rather than
+// accessing the underlying message directly.
+func (s *subscription) Message() *api.SubscriptionMessage {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a snapshot of the message to avoid races while it is being
+	// marshaled. See https://github.com/moby/moby/issues/47322.
+	msg := *s.message
+	return &msg
+}

--- a/manager/logbroker/subscription_test.go
+++ b/manager/logbroker/subscription_test.go
@@ -1,0 +1,29 @@
+package logbroker
+
+import (
+	"testing"
+
+	"github.com/moby/swarmkit/v2/api"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSubscriptionMessageMarshalSnapshot verifies that a subscription message
+// remains unchanged between calculating its encoded size and marshaling it.
+// This matches the operations performed by gRPC when sending the message.
+//
+// Regression test for https://github.com/moby/moby/issues/47322.
+func TestSubscriptionMessageMarshalSnapshot(t *testing.T) {
+	sub := newSubscription(nil, &api.SubscriptionMessage{
+		ID: "subscription-id",
+	}, nil)
+
+	msg := sub.Message()
+	size := msg.Size()
+
+	sub.Close()
+
+	require.NotPanics(t, func() {
+		_, err := msg.MarshalToSizedBuffer(make([]byte, size))
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
- relates to / addresses https://github.com/moby/moby/issues/47322

### manager/logbroker: rename vars that shadowed type

### manager/logbroker: add subscription ID accessor

The subscription ID is immutable and represents the subscription's
identity. Expose it through an ID() accessor instead of reaching into
the underlying message directly.

### manager/logbroker: store follow flag on subscription

The follow option is immutable for the lifetime of a subscription, so
store it directly on the subscription instead of deriving it from the
underlying message.

### manager/logbroker: capture subscription selector locally

The subscription selector is immutable, so capture it once instead of
repeatedly accessing it through the underlying message.

### manager/logbroker: improve ListenSubscriptions error logging

Log stream send failures with a descriptive message and structured error
instead of logging the error value directly.


### manager/logbroker: snapshot subscription messages before sending

Closing a subscription mutates its message while the same message may be
marshaled by gRPC. If the Close field changes from false to true during
serialization, the encoded message grows after the buffer size has
already been calculated, which can trigger the observed "index out of
range [-1]" panic while encoding protobuf messages.

Return a snapshot under the subscription lock before passing the message
to stream.Send.



**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
